### PR TITLE
Remove early return from nrnhash key generation

### DIFF
--- a/src/nrniv/nrnbbcore_write.cpp
+++ b/src/nrniv/nrnbbcore_write.cpp
@@ -282,7 +282,8 @@ size_t nrnbbcore_write() {
 
 int nrncore_art2index(double* d) {
   int i;
-  assert(artdata2index_->find(d, i));
+  int result = artdata2index_->find(d, i);
+  assert(result);
   return i;
 }
 

--- a/src/nrniv/nrnhash_alt.h
+++ b/src/nrniv/nrnhash_alt.h
@@ -111,7 +111,6 @@ inline bool NrnHashIterator(NrnHash)::more() { return entry_ <= last_; }
 // google integer hash function
 // http://www.concentric.net/~Ttwang/tech/inthash.htm
 static uint32_t nrn_uint32hash( uint32_t a) {
-    return a;
     a = (a ^ 61) ^ (a >> 16);
     a = a + (a << 3);  
     a = a ^ (a >> 4);  


### PR DESCRIPTION
The hash generation had a return prior to executing numeric operations.  This seems unintentional
since the following code lines were never able to be executed.

This was noticed during bbcorewrite where the key comes from a void pointer.  The early return
meant that the hashes used were not evenly distributed.