### PR TITLE
Built in NEURON methods may now return ints and bools to Python (in addition to doubles)

### DIFF
--- a/src/ivoc/graph.cpp
+++ b/src/ivoc/graph.cpp
@@ -6,6 +6,8 @@
 #include <math.h>
 #include <assert.h>
 
+extern "C" int hoc_return_type_code;
+
 #if HAVE_IV
 #include <InterViews/glyph.h>
 #include <InterViews/hit.h>
@@ -990,6 +992,7 @@ ENDGUI
 }
 
 static double gr_view_count(void* v) {
+	hoc_return_type_code = 1; // integer
 #if HAVE_IV
 	int n = 0;
 IFGUI

--- a/src/ivoc/ivocvect.cpp
+++ b/src/ivoc/ivocvect.cpp
@@ -138,6 +138,8 @@ extern "C" {
         extern int nrn_mlh_gsort (double* vec, int *base_ptr, int total_elems, doubleComparator cmp);
 };
 
+extern "C" int hoc_return_type_code;
+
 IvocVect::IvocVect(Object* o) : ParentVect(){obj_ = o; label_ = NULL; MUTCONSTRUCT(0)}
 IvocVect::IvocVect(int l, Object* o) : ParentVect(l){obj_ = o; label_ = NULL; MUTCONSTRUCT(0)}
 IvocVect::IvocVect(int l, double fill_value, Object* o) : ParentVect(l, fill_value){obj_ = o; label_ = NULL; MUTCONSTRUCT(0)}
@@ -394,6 +396,7 @@ static double v_fwrite(void* v) {
 	int x_max = vp->capacity()-1;
 	int start = 0;
 	int end = x_max;
+	hoc_return_type_code = 1; // integer
 	if (ifarg(2)) {
 	  start = int(chkarg(2,0,x_max));
 	  end = int(chkarg(3,0,x_max));
@@ -418,6 +421,7 @@ static double v_fread(void* v) {
 	void* s = (void*)(vp->vec());
 
         Object* ob = *hoc_objgetarg(1);
+
 	check_obj_type(ob, "File");
 	OcFile* f = (OcFile*)(ob->u.this_pointer);
 
@@ -761,6 +765,7 @@ static double v_printf(void *v) {
 	   }
            if(extra_newline) {printf("\n");}
 	 }
+	hoc_return_type_code = 1; // integer
 	return double(end-start+1);
 }
 
@@ -774,6 +779,8 @@ static double v_scanf(void *v) {
         Object* ob = *hoc_objgetarg(1);
     	check_obj_type(ob, "File");
         OcFile* f = (OcFile*)(ob->u.this_pointer);
+
+    hoc_return_type_code = 1; // integer
 
 	if (ifarg(4)) {
 	  n = int(*getarg(2));
@@ -831,6 +838,7 @@ static double v_scantil(void *v) {
     	check_obj_type(ob, "File");
         OcFile* f = (OcFile*)(ob->u.this_pointer);
 
+    hoc_return_type_code = 1; // integer
 	til = *getarg(2);
 	if (ifarg(4)) {
 	  c = int(*getarg(3));
@@ -1252,6 +1260,7 @@ static Object** v_ind(void* v) {
 
 static double v_size(void* v) {
 	Vect* x = (Vect*)v;
+	hoc_return_type_code = 1;
 	return double(x->capacity());
 }
 
@@ -1261,6 +1270,7 @@ static double v_buffer_size(void* v) {
 		int n = (int)chkarg(1, (double)x->capacity(), dmaxint_);
 		x->buffer_size(n);
 	}
+	hoc_return_type_code = 1;
 	return x->buffer_size();
 }
 
@@ -1386,6 +1396,7 @@ static Object** v_remove(void* v) {
 static double v_contains(void* v) {
         Vect* x = (Vect*)v;
         double g = *getarg(1);
+        hoc_return_type_code = 2;
         for (int i=0;i<x->capacity();i++) {
            if (Math::equal(x->elem(i), g, hoc_epsilon)) return 1.;
         }
@@ -1728,7 +1739,7 @@ static double v_indwhere(void* v) {
   int i, iarg, m=0;
   char* op;
   double value,value2;
-
+  hoc_return_type_code = 1;
     op = gargstr(1);
     value = *getarg(2);
     iarg = 3;
@@ -2065,6 +2076,7 @@ static double v_min_ind(void* v)
 {
   Vect* x = (Vect*)v;
   int x_max = x->capacity()-1;
+  hoc_return_type_code = 1; // integer
   if (ifarg(1)) {
     int start = int(chkarg(1,0,x_max));
     int end = int(chkarg(2,0,x_max));
@@ -2091,6 +2103,7 @@ static double v_max_ind(void* v)
 {
   Vect* x = (Vect*)v;
   int x_max = x->capacity()-1;
+  hoc_return_type_code = 1; // integer
   if (ifarg(1)) {
     int start = int(chkarg(1,0,x_max));
     int end = int(chkarg(2,0,x_max));

--- a/src/ivoc/matrix.cpp
+++ b/src/ivoc/matrix.cpp
@@ -11,6 +11,8 @@
 #define EPS hoc_epsilon
 static Symbol* smat_;
 
+extern "C" int hoc_return_type_code;
+
 extern "C" {
 	extern double hoc_scan(FILE*);
 	extern FILE* hoc_obj_file_arg(int i);
@@ -63,11 +65,13 @@ Object** Matrix::temp_objvar() {
 }
 
 static double m_nrow(void* v) {
+	hoc_return_type_code = 1; // integer
 	Matrix* m = (Matrix*)v;
 	return (double)m->nrow();
 }
 
 static double m_ncol(void* v) {
+	hoc_return_type_code = 1; // integer
 	Matrix* m = (Matrix*)v;
 	return (double)m->ncol();
 }
@@ -95,6 +99,7 @@ static double m_getval(void* v) {
 static double m_sprowlen(void* v) {
 	Matrix* m = (Matrix*)v;
 	int i;
+	hoc_return_type_code = 1; // integer
 	i = (int)chkarg(1, 0, m->nrow()-1);
 	return double(m->sprowlen(i));
 }

--- a/src/ivoc/mlinedit.cpp
+++ b/src/ivoc/mlinedit.cpp
@@ -1,4 +1,7 @@
 #include <../../nrnconf.h>
+
+extern "C" int hoc_return_type_code;
+
 #if HAVE_IV // to end of file
 
 #include <stdio.h>
@@ -46,6 +49,7 @@ static double map(void* v) {
 
 static double readonly(void* v) {
 	OcMLineEditor* e = (OcMLineEditor*)v;
+	hoc_return_type_code = 2; // boolean
 	if (ifarg(1)) {
 		e->txt_->readOnly(int(chkarg(1, 0, 1)));
 	}

--- a/src/ivoc/mymath.cpp
+++ b/src/ivoc/mymath.cpp
@@ -6,6 +6,8 @@
 #include <math.h>
 #include <stdio.h>
 
+extern "C" int hoc_return_type_code;
+
 static double distance_to_line(void*) {
 	return MyMath::distance_to_line(*getarg(1), *getarg(2),
 		*getarg(3), *getarg(4),	*getarg(5), *getarg(6));
@@ -17,6 +19,7 @@ static double distance_to_line_segment(void*) {
 }
 
 static double inside(void*) {
+	hoc_return_type_code = 2; // boolean
 	return MyMath::inside(*getarg(1), *getarg(2), *getarg(3), *getarg(4),
 		*getarg(5), *getarg(6));
 }
@@ -54,6 +57,7 @@ int nrn_feround(int mode) {
 
 static double feround(void*) {
 	int arg = 0;
+	hoc_return_type_code = 1; // integer
 	if (ifarg(1)) {
 		arg = (int)chkarg(1, 0, 4);
 	}

--- a/src/ivoc/ocbox.cpp
+++ b/src/ivoc/ocbox.cpp
@@ -22,6 +22,8 @@
 #include "oc2iv.h"
 #include "classreg.h"
 
+extern "C" int hoc_return_type_code;
+
 #if HAVE_IV
 
 class NrnFixedLayout : public Layout {
@@ -250,6 +252,7 @@ ENDGUI
 }
 
 static double ismapped(void* v) {
+	hoc_return_type_code = 2;
 #if HAVE_IV
 	bool b = false;
 IFGUI

--- a/src/ivoc/ocfile.cpp
+++ b/src/ivoc/ocfile.cpp
@@ -9,6 +9,8 @@
 #include <unistd.h>
 #endif
 
+extern "C" int hoc_return_type_code;
+
 #ifdef WIN32
 #include <errno.h>
 #include <io.h>
@@ -257,6 +259,7 @@ static double f_seek(void* v){
 
 static double f_tell(void* v){
 	OcFile* f = (OcFile*)v;
+	hoc_return_type_code = 1;
 	BinaryMode(f)
 	return (double)ftell(f->file());
 }

--- a/src/ivoc/oclist.cpp
+++ b/src/ivoc/oclist.cpp
@@ -31,6 +31,7 @@ int ivoc_list_count(Object*);
 Object* ivoc_list_item(Object*, int);
 }
 
+extern "C" int hoc_return_type_code;
 void handle_old_focus();
 
 #if HAVE_IV
@@ -177,6 +178,7 @@ void OcList::insert(long i, Object* ob) {
 
 static double l_count(void* v) {
 	OcList* o = (OcList*)v;
+	hoc_return_type_code = 1;
 	return o->count();
 }
 long OcList::count() { return oli_->count();}
@@ -204,6 +206,7 @@ void OcList::remove(long i) {
 static double l_index(void* v) {
 	OcList* o = (OcList*)v;
 	Object* ob = *hoc_objgetarg(1);
+	hoc_return_type_code = 1; // integer
 	return o->index(ob);
 }
 long OcList::index(Object* ob) {
@@ -306,6 +309,7 @@ ENDGUI
 	return 1.;
 }
 static double l_selected(void* v) {
+	hoc_return_type_code = 1; // integer
 #if HAVE_IV
 	long i = -1;
 IFGUI

--- a/src/ivoc/ocptrvector.cpp
+++ b/src/ivoc/ocptrvector.cpp
@@ -15,6 +15,7 @@
 #include "objcmd.h"
 #include "ivocvect.h"
 
+extern "C" int hoc_return_type_code;
 static double dummy;
 
 OcPtrVector::OcPtrVector(int sz) {
@@ -87,11 +88,13 @@ double OcPtrVector::getval(int i) {
 }
 
 static double resize(void* v) {
+	hoc_return_type_code = 1; // integer
 	((OcPtrVector*)v)->resize((int(chkarg(1, 1., 2e9))));
 	return double(((OcPtrVector*)v)->size());
 }
 
 static double get_size(void* v){
+	hoc_return_type_code = 1; // integer
 	return ((OcPtrVector*)v)->size();
 }
 

--- a/src/ivoc/pwman.cpp
+++ b/src/ivoc/pwman.cpp
@@ -1,6 +1,7 @@
 #include <../../nrnconf.h>
 
 extern char* ivoc_get_temp_file();
+extern "C" int hoc_return_type_code;
 
 #if HAVE_IV
 #if (MAC && !defined(carbon)) || defined(WIN32)
@@ -472,6 +473,7 @@ static void pwman_destruct(void* v) {
 
 static double pwman_count(void* v) {
 	int cnt = 0;
+	hoc_return_type_code = 1; // integer
 #if HAVE_IV
 IFGUI
 	PWMImpl* p = PrintableWindowManager::current()->pwmi_;
@@ -481,6 +483,7 @@ ENDGUI
 	return double(cnt);
 }
 static double pwman_is_mapped(void* v) {
+	hoc_return_type_code = 2; // boolean
 #if HAVE_IV
 IFGUI
 	PWMImpl* p = PrintableWindowManager::current()->pwmi_;
@@ -587,6 +590,7 @@ ENDGUI
 	return 0.;
 }
 static double pwman_leader(void* v) {
+	hoc_return_type_code = 1; // integer
 #if HAVE_IV
 IFGUI
 	PWMImpl* p = PrintableWindowManager::current()->pwmi_;
@@ -603,6 +607,7 @@ ENDGUI
 	return -1.;
 }
 static double pwman_manager(void* v) {
+	hoc_return_type_code = 1; // integer
 #if HAVE_IV
 IFGUI
 	PWMImpl* p = PrintableWindowManager::current()->pwmi_;
@@ -676,6 +681,7 @@ ENDGUI
 
 // position size and show/hide a java window on session retrieve
 static double pwman_jwindow(void* v) {
+	hoc_return_type_code = 1; // integer
 #if HAVE_IV
 IFGUI
 	PWMImpl* p = PrintableWindowManager::current()->pwmi_;

--- a/src/ivoc/strfun.cpp
+++ b/src/ivoc/strfun.cpp
@@ -21,6 +21,8 @@ extern Symlist* hoc_built_in_symlist;
 extern int nrn_is_artificial(int);
 }
 
+extern "C" int hoc_return_type_code;
+
 inline unsigned long key_to_hash(String& s) {return s.hash();}
 implementTable(SymbolTable, String, Symbol*)
 
@@ -36,6 +38,7 @@ static double l_substr(void*) {
 }
 
 static double l_len(void*) {
+	hoc_return_type_code = 1; // integer
 	return double(strlen(gargstr(1)));
 }
 
@@ -87,6 +90,7 @@ static double l_right(void*) {
 }
 
 static double l_is_name(void*) {
+	hoc_return_type_code = 2; // boolean
 	return hoc_lookup(gargstr(1)) ? 1. : 0.;
 }
 
@@ -285,12 +289,14 @@ static double l_ref(void*) {
 
 static double l_is_point(void*) {
 	Object* ob = *hoc_objgetarg(1);
+	hoc_return_type_code = 1; // integer
 	return double(ob ? ob->ctemplate->is_point_ : 0);
 }
 
 static double l_is_artificial(void*) {
 	Object* ob = *hoc_objgetarg(1);
 	int type = ob ? ob->ctemplate->is_point_ : 0;
+	hoc_return_type_code = 1; // integer
 	if (type == 0) { return 0.; }
 	return nrn_is_artificial(type) ? type : 0;
 }

--- a/src/nrncvode/cvodeobj.cpp
+++ b/src/nrncvode/cvodeobj.cpp
@@ -10,6 +10,8 @@ void cvode_finitialize();
 extern void (*nrn_multisplit_setup_)();
 }
 
+extern "C" int hoc_return_type_code;
+
 #include <math.h>
 #include <stdlib.h>
 #include "classreg.h"
@@ -303,6 +305,7 @@ static double statename(void* v) {
 
 static double use_local_dt(void* v) {
 	NetCvode* d = (NetCvode*)v;
+	hoc_return_type_code = 2; // boolean
 	if (ifarg(1)) {
 		int i = (int)chkarg(1, 0, 1);
 		d->localstep(i);
@@ -312,6 +315,7 @@ static double use_local_dt(void* v) {
 
 static double use_daspk(void* v) {
 	NetCvode* d = (NetCvode*)v;
+	hoc_return_type_code = 2; // boolean
 	if (ifarg(1)) {
 		int i = (int)chkarg(1, 0, 1);
 		if ((i != 0) != d->use_daspk()) {
@@ -333,6 +337,7 @@ static double dae_init_dteps(void* v) {
 
 static double use_mxb(void* v) {
 	NetCvode* d = (NetCvode*)v;
+	hoc_return_type_code = 2; // boolean
 	if (ifarg(1)) {
 		int i = (int)chkarg(1,0,1);
 		if (use_sparse13 != i) {
@@ -354,6 +359,7 @@ static double cache_efficient(void* v) {
 
 static double use_long_double(void* v) {
 	NetCvode* d = (NetCvode*)v;
+	hoc_return_type_code = 2; // boolean
 	if (ifarg(1)) {
 		int i = (int)chkarg(1,0,1);
 		d->use_long_double_ = i;
@@ -560,6 +566,7 @@ static double extra_scatter_gather_remove(void* v) {
 
 static double use_fast_imem(void* v) {
 	int i = nrn_use_fast_imem;
+	hoc_return_type_code = 2; // boolean
 	if (ifarg(1)) {
 		nrn_use_fast_imem = int(chkarg(1, 0., 1.));
 		nrn_fast_imem_alloc();

--- a/src/nrncvode/netcvode.cpp
+++ b/src/nrncvode/netcvode.cpp
@@ -114,6 +114,8 @@ Object* (*nrnpy_seg_from_sec_x)(Section*, double);
 extern void nrnmusic_injectlist(void*, double);
 #endif
 
+extern "C" int hoc_return_type_code;
+
 extern int nrn_fornetcon_cnt_;
 extern int* nrn_fornetcon_index_;
 extern int* nrn_fornetcon_type_;
@@ -699,6 +701,7 @@ static double nc_setpost(void* v) {
 
 static double nc_valid(void* v) {
 	NetCon* d = (NetCon*)v;
+	hoc_return_type_code = 2;
 	if (d->src_ && d->target_) {
 		return 1.;
 	}
@@ -711,6 +714,7 @@ static double nc_active(void* v) {
 	if (d->target_ && ifarg(1)) {
 		d->active_ = bool(chkarg(1, 0, 1));
 	}
+	hoc_return_type_code = 2;
 	return double(a);
 }
 
@@ -766,6 +770,7 @@ static double nc_record(void* v) {
 
 static double nc_srcgid(void* v) {
 	NetCon* d = (NetCon*)v;
+	hoc_return_type_code = 1;
 	if (d->src_) {
 		return (double)d->src_->gid_;
 	}

--- a/src/nrniv/nrnmenu.cpp
+++ b/src/nrniv/nrnmenu.cpp
@@ -15,7 +15,7 @@
 #include "classreg.h"
 
 typedef void (*ReceiveFunc)(Point_process*, double*, double);
-
+extern "C" int hoc_return_type_code;
 extern "C" {
 // from nrnoc
 #include "membfunc.h"
@@ -593,6 +593,7 @@ static double ms_get(void* v) {
 	return ((MechanismStandard*)v)->get(gargstr(1), i);
 }
 static double ms_count(void* v) {
+	hoc_return_type_code = 1;
 	return ((MechanismStandard*)v)->count();
 }
 static double ms_name(void* v) {
@@ -605,6 +606,7 @@ static double ms_name(void* v) {
    	n = ms->name();
    }
    hoc_assign_str(hoc_pgargstr(1), n);
+   hoc_return_type_code = 1;
    return double(rval);
 }
 
@@ -954,6 +956,7 @@ static double mt_selected(void* v) {
 	if (ifarg(1)) {
 		hoc_assign_str(hoc_pgargstr(1), mt->selected());
 	}
+	hoc_return_type_code = 1;
 	return double(i);
 }
 static double mt_internal_type(void* v) {
@@ -976,6 +979,7 @@ static double mt_remove(void* v) {
 }
 static double mt_count(void* v) {
 	MechanismType* mt = (MechanismType*)v;
+	hoc_return_type_code = 1;
 	return double(mt->count());
 }
 static double mt_menu(void* v) {
@@ -998,14 +1002,17 @@ static double mt_action(void* v) {
 }
 static double mt_is_target(void* v) {
 	MechanismType* mt = (MechanismType*)v;
+	hoc_return_type_code = 2;
 	return double(mt->is_netcon_target(int(chkarg(1, 0, mt->count()))));
 }
 static double mt_has_net_event(void* v) {
 	MechanismType* mt = (MechanismType*)v;
+	hoc_return_type_code = 2;
 	return double(mt->has_net_event(int(chkarg(1, 0, mt->count()))));
 }
 static double mt_is_artificial(void* v) {
 	MechanismType* mt = (MechanismType*)v;
+	hoc_return_type_code = 2;
 	return double(mt->is_artificial(int(chkarg(1, 0, mt->count()))));
 }
 static Object** mt_pp_begin(void* v) {

--- a/src/nrniv/nrnste.cpp
+++ b/src/nrniv/nrnste.cpp
@@ -9,6 +9,8 @@
 #include <nrnste.h>
 #include <netcon.h>
 
+extern "C" int hoc_return_type_code;
+
 static double ste_transition(void* v) {
 	StateTransitionEvent* ste = (StateTransitionEvent*)v;
 	int src = (int)chkarg(1, 0, ste->nstate()-1);
@@ -36,6 +38,7 @@ static double ste_transition(void* v) {
 
 static double ste_state(void* v) {
 	StateTransitionEvent* ste = (StateTransitionEvent*)v;
+	hoc_return_type_code = 1; // integer
 	int state = ste->state();
 	if (ifarg(1)) {
 		ste->state((int)chkarg(1, 0, ste->nstate()-1));

--- a/src/nrnoc/seclist.c
+++ b/src/nrnoc/seclist.c
@@ -7,6 +7,8 @@
 #include "code.h"
 #include "hoc_membf.h"
 
+extern int hoc_return_type_code;
+
 /*ARGSUSED*/
 static void* constructor(Object* ho)
 {
@@ -168,6 +170,7 @@ static double unique(void* v)
 	Section* s;
 	Item* q, *q1;
 	List* sl = (List*)v;
+	hoc_return_type_code = 1; /* integer */
 	ITERATE(q, sl) {
 		s = hocSEC(q);
 		s->volatile_mark = 0;
@@ -190,6 +193,7 @@ static double contains(void* v)
 	Section* s;
 	Item* q;
 	List* sl = (List*)v;
+	hoc_return_type_code = 2; /* boolean */
 	s = chk_access();
 	ITERATE(q, sl) {
 		if (hocSEC(q) == s) {

--- a/src/nrnoc/secref.c
+++ b/src/nrnoc/secref.c
@@ -20,6 +20,8 @@ access s1.sec	// soma becomes the default section
 #include "parse.h"
 #include "hoc_membf.h"
 
+extern int hoc_return_type_code; 
+
 Symbol* nrn_sec_sym, *nrn_parent_sym, *nrn_root_sym, *nrn_child_sym;
 Symbol* nrn_trueparent_sym;
 
@@ -218,12 +220,14 @@ int nrn_secref_nchild(Section* sec) {
 
 static double s_nchild(void* v) {
 	int n;
+	hoc_return_type_code = 1; /* integer */
 	return (double)nrn_secref_nchild((Section*)v);
 }
 
 static double s_has_parent(void* v) {
 	int n;
 	Section* sec = (Section*)v;
+	hoc_return_type_code = 2; /* boolean */
 	if (!sec->prop) {
 		hoc_execerror("Section was deleted", (char*)0);
 	}
@@ -233,6 +237,7 @@ static double s_has_parent(void* v) {
 static double s_has_trueparent(void* v) {
 	int n;
 	Section* sec = (Section*)v;
+	hoc_return_type_code = 2; /* boolean */
 	if (!sec->prop) {
 		hoc_execerror("Section was deleted", (char*)0);
 	}
@@ -241,6 +246,7 @@ static double s_has_trueparent(void* v) {
 
 static double s_exists(void* v) {
 	int n;
+	hoc_return_type_code = 2; /* boolean */
 	Section* sec = (Section*)v;
 	return (double)(sec->prop != (Prop*)0);
 }
@@ -248,6 +254,7 @@ static double s_exists(void* v) {
 static double s_cas(void* v) { /* return 1 if currently accessed section */
 	Section* sec = (Section*)v;
 	Section* cas = chk_access();
+	hoc_return_type_code = 2; /* boolean */
 	if (!sec->prop) {
 		hoc_execerror("Section was deleted", (char*)0);
 	}

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -70,6 +70,9 @@ extern int nrn_matrix_dim(void*, int);
 extern PyObject* pmech_types;  // Python map for name to Mechanism
 extern PyObject* rangevars_;   // Python map for name to Symbol
 
+extern "C" int hoc_max_builtin_class_id;
+extern "C" int hoc_return_type_code;
+
 static cTemplate* hoc_vec_template_;
 static cTemplate* hoc_list_template_;
 static cTemplate* hoc_sectionlist_template_;
@@ -398,8 +401,11 @@ static Symbol* getsym(char* name, Object* ho, int fail) {
 
 // on entry the stack order is indices, args, object
 // on exit all that is popped and the result is on the stack
-static void component(PyHocObject* po) {
+// returns hoc_return_is_int if called on a builtin (i.e. 2 if bool, 1 if int, 0 otherwise)
+static int component(PyHocObject* po) {
   Inst fc[6];
+  int var_type = 0;
+  hoc_return_type_code = 0;
   fc[0].sym = po->sym_;
   fc[1].i = 0;
   fc[2].i = 0;
@@ -418,6 +424,12 @@ static void component(PyHocObject* po) {
   Inst* pcsav = save_pc(fc);
   hoc_object_component();
   hoc_pc = pcsav;
+  // only return a type if we're calling a built-in (these are all registered first)
+  if (po->ho_->ctemplate->id <= hoc_max_builtin_class_id) {
+    var_type = hoc_return_type_code;
+  }
+  hoc_return_type_code = 0;
+  return(var_type);
 }
 
 int nrnpy_numbercheck(PyObject* po) {
@@ -565,6 +577,15 @@ static int set_final_from_stk(PyObject* po) {
   return err;
 }
 
+
+static void* nrnpy_hoc_int_pop() {
+  return (void*) Py_BuildValue("i", (long) hoc_xpop());
+}
+
+static void* nrnpy_hoc_bool_pop() {
+  return (void*) PyBool_FromLong((long) hoc_xpop());
+}
+
 static void* fcall(void* vself, void* vargs) {
   PyHocObject* self = (PyHocObject*)vself;
   if (self->ho_) {
@@ -572,11 +593,19 @@ static void* fcall(void* vself, void* vargs) {
   }
   std::vector<char*> strings_to_free;
   int narg = hocobj_pushargs((PyObject*)vargs, strings_to_free);
+  int var_type;
   if (self->ho_) {
     self->nindex_ = narg;
-    component(self);
+    var_type = component(self);
     hocobj_pushargs_free_strings(strings_to_free);
-    return (void*)nrnpy_hoc_pop();
+    switch(var_type) {
+      case 2:
+        return nrnpy_hoc_bool_pop();
+      case 1:
+        return nrnpy_hoc_int_pop();
+      default:
+        return(void*) nrnpy_hoc_pop();
+    }
   }
   if (self->sym_->type == BLTIN) {
     if (narg != 1) {
@@ -604,6 +633,7 @@ static void* fcall(void* vself, void* vargs) {
     HocContextRestore
   }
   hocobj_pushargs_free_strings(strings_to_free);
+
   return (void*)nrnpy_hoc_pop();
 }
 

--- a/src/oc/code.c
+++ b/src/oc/code.c
@@ -32,6 +32,8 @@ int nrn_isecstack();
 #define BBSPOLL /**/
 #endif
 
+int hoc_return_type_code = 0; /* flag for allowing integers (1) and booleans (2) to be recognized as such */
+
 # define	STACKCHK	if (stackp >= stacklast) \
 					execerror("Stack too deep.", "Increase with -NSTACK stacksize option");
 

--- a/src/oc/hoc_oop.c
+++ b/src/oc/hoc_oop.c
@@ -46,6 +46,8 @@ static void free_objectdata(Objectdata*, Template*);
 
 int hoc_print_first_instance = 1;
 
+int hoc_max_builtin_class_id = -1;
+
 static Symbol* hoc_obj_;
 
 void hoc_install_hoc_obj(void) {
@@ -1512,6 +1514,9 @@ void class2oc(
 	tsym->subtype = CPLUSOBJECT;
 	hoc_begintemplate(tsym);
 	t = tsym->u.template;
+	if (t->id > hoc_max_builtin_class_id) {
+		hoc_max_builtin_class_id = t->id;
+	}
 	t->constructor = cons;
 	t->destructor = destruct;
 	t->steer = 0;

--- a/src/parallel/ocbbs.cpp
+++ b/src/parallel/ocbbs.cpp
@@ -17,6 +17,8 @@
 #undef MD
 #define MD 2147483647.
 
+extern "C" int hoc_return_type_code;
+
 extern "C" {
 	extern int vector_arg_px(int, double**);
 	Symbol* hoc_which_template(Symbol*);
@@ -204,6 +206,7 @@ static double working(void* v) {
 	OcBBS* bbs = (OcBBS*)v;
 	int id;
 	bool b = bbs->working(id, bbs->retval_, bbs->userid_);
+	hoc_return_type_code = 1; // integer
 	if (b) {
 		return double(id);
 	}else{
@@ -222,26 +225,32 @@ static double userid(void* v) {
 }
 
 static double nhost(void* v) {
+	hoc_return_type_code = 1;
 	return nrnmpi_numprocs;
 }
 
 static double nrn_rank(void* v) {
+	hoc_return_type_code = 1;
 	return nrnmpi_myid;
 }
 
 static double nhost_world(void* v) {
+	hoc_return_type_code = 1; // integer
 	return nrnmpi_numprocs_world;
 }
 
 static double rank_world(void* v) {
+	hoc_return_type_code = 1;
 	return nrnmpi_myid_world;
 }
 
 static double nhost_bbs(void* v) {
+	hoc_return_type_code = 1;
 	return nrnmpi_numprocs_bbs;
 }
 
 static double rank_bbs(void* v) {
+	hoc_return_type_code = 1;
 	return nrnmpi_myid_bbs;
 }
 
@@ -426,6 +435,7 @@ static double take(void* v) {
 
 static double look(void* v) {
 	OcBBS* bbs = (OcBBS*)v;
+	hoc_return_type_code = 2; // boolean
 	if (bbs->look(key_help())) {
 		unpack_help(2, bbs);
 		return 1.;
@@ -435,6 +445,7 @@ static double look(void* v) {
 
 static double look_take(void* v) {
 	OcBBS* bbs = (OcBBS*)v;
+	hoc_return_type_code = 2; // boolean
 	if (bbs->look_take(key_help())) {
 		unpack_help(2, bbs);
 		return 1.;
@@ -533,6 +544,7 @@ static double set_gid2node(void* v) {
 
 static double gid_exists(void* v) {
 	OcBBS* bbs = (OcBBS*)v;
+	hoc_return_type_code = 1; // NOTE: possible returns are integers 0 - 3
 	return int(bbs->gid_exists(int(chkarg(1, 0, MD))));
 }
 
@@ -636,6 +648,7 @@ static double set_maxstep(void* v) {
 static double spike_stat(void* v) {
 	OcBBS* bbs = (OcBBS*)v;
 	int nsend, nsendmax, nrecv, nrecv_useful;
+	hoc_return_type_code = 1; // integer
 	nsend = nsendmax = nrecv = nrecv_useful = 0;
 	bbs->netpar_spanning_statistics(&nsend, &nsendmax, &nrecv, &nrecv_useful);
 	if (ifarg(1)) { *hoc_pgetarg(1) = nsend; }
@@ -850,6 +863,7 @@ static double checkpoint(void*) {
 
 static double nthrd(void*) {
 	int ip = 1;
+	hoc_return_type_code = 1; // integer
 	if (ifarg(1)) {
 		if (ifarg(2)) { ip = int(chkarg(2, 0, 1)); }
 		nrn_threads_create(int(chkarg(1, 1, 1e5)), ip);
@@ -888,11 +902,13 @@ static double thread_busywait(void*) {
 }
 
 static double thread_how_many_proc(void*) {
+	hoc_return_type_code = 1; // integer
 	int i = nrn_how_many_processors();
 	return double(i);
 }
 
 static double sec_in_thread(void*) {
+	hoc_return_type_code = 2; // boolean
 	Section* sec = chk_access();
 	return double(sec->pnode[0]->_nt->id);
 }


### PR DESCRIPTION
Example (previously all the returns were doubles):

>>> v = h.Vector([2,62,15.1])
>>> v.x[2]
15.1
>>> v.size()
3
>>> v.contains(142)
False
>>> v.contains(62)
True
>>> pc = h.ParallelContext()
>>> pc.nhost()
1
>>> pc.id()
0
>>> s = h.Section()
>>> h.define_shape()
1.0
>>> h.x3d(1)
50.0