### PR TITLE
modified basicRxD3D test to allow multiple runs

### DIFF
--- a/share/lib/python/neuron/tests/test_neuron.py
+++ b/share/lib/python/neuron/tests/test_neuron.py
@@ -99,7 +99,7 @@ def basicRxD3D():
     s.L = s.diam = 1
     cyt = rxd.Region([s])
     ca = rxd.Species(cyt)
-    rxd.set_solve_type([s], dimension=3)
+    rxd.set_solve_type(dimension=3)
     h.finitialize(-65)
     h.fadvance()
     return 1


### PR DESCRIPTION
Now setting the default dimension to 3 instead of any specific Section's dimension. This means that when new Sections are created they will default to 3D simulation so there will be no conflict with a pre-existing 3D matrix.

The underlying issue is that NEURON currently requires nodes to be grouped with like nodes (e.g. all 1D then all 3D) and thus changing things after the matrices are constructed is fragile.