### PR TITLE
templates always True. 

### DIFF
--- a/share/lib/python/neuron/tests/test_neuron.py
+++ b/share/lib/python/neuron/tests/test_neuron.py
@@ -47,7 +47,8 @@ class NeuronTestCase(unittest.TestCase):
 
         # Py_nb_bool
         assert True if h else False
-        assert False if h.List else True
+        assert True if h.List else False
+        # ensure creating a List doesn't change the truth value
         l = h.List()
         assert True if h.List else False
         assert False if l else True

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -1402,7 +1402,7 @@ static int hocobj_nonzero(PyObject* self) {
     Arrayinfo* a = hocobj_aray(po->sym_, po->ho_);
     b = araylen(a, po) > 0;
   } else if (po->sym_ && po->sym_->type == TEMPLATE) {
-    b = po->sym_->u.ctemplate->count > 0;
+    b = 1; // prior behavior: po->sym_->u.ctemplate->count > 0;
   }
   return b;
 }


### PR DESCRIPTION
Potentially breaking commit for some code, but more Pythonic, and causes tests to give consistent results regardless of if a List exists at the beginning or not.

Previously the truth values of templates changed:

Python 3.6.3 |Anaconda custom (64-bit)| (default, Oct 15 2017, 03:27:45) [MSC v.1900 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from neuron import h
>>> bool(h.List)
False
>>> foo = h.List()
>>> bool(h.List)
True
