### PR TITLE
Fix to prcellstate for root cell

### DIFF
--- a/src/nrniv/prcellstate.cpp
+++ b/src/nrniv/prcellstate.cpp
@@ -154,7 +154,7 @@ printf("%s\n", ps.ssrc_?secname(ps.ssrc_):"unknown");
   for (int i=0; i < nt.end; ++i) if (cellnodes[i] >= 0) {
     Node* nd = nt._v_node[i]; //if not cach_efficient then _actual_area=NULL
     fprintf(f, "%d %d %.*g %.*g %.*g\n",
-      cellnodes[i], cellnodes[nt._v_parent_index[i]],
+      cellnodes[i], i < nt.ncell ? -1 : cellnodes[nt._v_parent_index[i]],
       precision, NODEAREA(nd), precision, nt._actual_a[i], precision, nt._actual_b[i]);
   }
   fprintf(f, "inode v\n");


### PR DESCRIPTION
This patch fixes the parent id for root nodes in prcellstate.

Before the patch the parent was always calculated as cellnodes[nt._v_parent_index[i]] which can be invalid, and indeed yielded different results with different execution, even just different number of MPI ranks.