### PR TITLE
Removed 'rxdmath.h' 

### DIFF
--- a/src/nrnpython/Makefile.am
+++ b/src/nrnpython/Makefile.am
@@ -27,8 +27,6 @@ libnrnpython@npy_pyver10@_la_SOURCES = nrnpython.cpp nrnpy_hoc.cpp nrnpy_nrn.cpp
 
 librxdmath_la_SOURCES = rxdmath.c $(EXTEND)
 
-pkginclude_HEADERS = rxdmath.h
-
 noinst_HEADERS = nrnpython.h nrnwrap_Python.h nrnpy_reg.h \
 	nrnpy_hoc_2.h nrnpy_hoc_3.h \
 	nrnpy_nrn_2.h nrnpy_nrn_3.h hoccontext.h \

--- a/src/nrnpython/rxdmath.c
+++ b/src/nrnpython/rxdmath.c
@@ -1,5 +1,4 @@
 #include <math.h>
-#include "rxdmath.h"
 
 /*Some functions supported by numpy that aren't included in math.h
  * names and arguments match the wrappers used in rxdmath.py

--- a/src/nrnpython/rxdmath.h
+++ b/src/nrnpython/rxdmath.h
@@ -1,8 +1,0 @@
-/*Some functions supported by numpy that aren't included in math.h
- * names and arguments match the wrappers used in rxdmath.py
- */
-
-double factorial(const double);
-double degrees(const double);
-void radians(const double, double*);
-double log1p(const double);


### PR DESCRIPTION
The declarations are now in a string in nrn/share/lib/python/neuron/crxd/rxd.py