### PR TITLE
Fix memory leak when coreneuron_embeded mode is used

### DIFF
--- a/src/nrniv/nrnbbcore_write.cpp
+++ b/src/nrniv/nrnbbcore_write.cpp
@@ -1248,6 +1248,7 @@ static int nrnthread_dat2_mech(int tid, size_t i, int dsz_inst, int*& nodeindice
         for (int i=0; i < nn; ++i) {
           pdata[i] = pdata1[i];
         }
+        delete [] pdata1;
       }else{
         pdata = pdata1;
       }


### PR DESCRIPTION
pdata1 wasn't freed when copy mode is used