### PR TITLE
Fix nrniv link in nrnmech_makefile.in

### DIFF
--- a/bin/nrnmech_makefile.in
+++ b/bin/nrnmech_makefile.in
@@ -46,7 +46,7 @@ LINK = $(LIBTOOL) --mode=link $(CCLD) -module $(AM_CFLAGS) $(CFLAGS) \
 
 NRNOCLIBS = -L"$(libdir)" -lnrnoc -loc @MEMACSLIB@ \
 	$(lnrnmpi) -lscopmath -lsparse13 @READLINE_LIBS@
-NRNIVLIBS = -L"$(libdir)" "$(libdir)/libnrniv.la" -livoc \
+NRNIVLIBS = -L"$(libdir)" -lnrniv -livoc \
 	-lneuron_gnu -lmeschach -lsundials \
 	$(IVOS_LIB) $(IV_LIBS) $(NJ_LIBS) $(PY_LIBS) $(NRNNI_LIBS) $(PVM_LIBS)
 


### PR DESCRIPTION
rather than targeting libnrniv.la intermediate file, which shouldn't be present after installation.