### PR TITLE
prefer pkg-config to find ncurses

### DIFF
--- a/m4/acinclude.m4
+++ b/m4/acinclude.m4
@@ -48,11 +48,15 @@ AC_MSG_CHECKING(which library has the termcap functions)
 _nrn_needmsg=
 fi
 AC_CACHE_VAL(nrn_cv_termcap_lib,
-[AC_CHECK_LIB(ncurses, tgetent, nrn_cv_termcap_lib=libncurses,
+[PKG_CHECK_MODULES([NCURSES], [ncurses], nrn_cv_termcap_lib=pkgconfig_ncurses,
+  [AC_CHECK_LIB(ncurses, tgetent, nrn_cv_termcap_lib=libncurses,
     [AC_CHECK_LIB(curses, tgetent, nrn_cv_termcap_lib=libcurses,
-	[AC_CHECK_LIB(termcap, tgetent, nrn_cv_termcap_lib=libtermcap,
-		[PKG_CHECK_MODULES([NCURSES], [ncurses], nrn_cv_termcap_lib=pkgconfig_ncurses,
-	    [AC_MSG_ERROR([cannot find one of ncurses, curses, or termcap])])])])])])
+	    [AC_CHECK_LIB(termcap, tgetent, nrn_cv_termcap_lib=libtermcap,
+	      [AC_MSG_ERROR([cannot find one of ncurses, curses, or termcap])]
+      )]
+    )]
+  )]
+)])
 if test "X$_nrn_needmsg" = "Xyes"; then
 AC_MSG_CHECKING(which library has the termcap functions)
 fi
@@ -60,7 +64,7 @@ AC_MSG_RESULT(using $nrn_cv_termcap_lib)
 if test $nrn_cv_termcap_lib = libtermcap ; then
 TERMCAP_LIB=-ltermcap
 TERMCAP_DEP=
-TERMCAP_CFLAGS= 
+TERMCAP_CFLAGS=
 elif test $nrn_cv_termcap_lib = libncurses ; then
 TERMCAP_LIB=-lncurses
 TERMCAP_DEP=


### PR DESCRIPTION
This gets a better chance of finding ncurses if available, as recent versions may need additional flags such as `-ltinfo`. The checks are the same, but pkg-config is checked first instead of last.

Additionally, this allows NCURSES_LIBS, NCURSES_CFLAGS overrides to take highest priority, which was previously not possible unless the previous checks failed.

This is coming up for me because I want to build with a specific `libncurses` for portability and it needs `-ltinfo`. I cannot make it load my libncurses because the ncurses check fails (due to missing tinfo) but the curses check succeeds, with a system library I don't want it to use.