### PR TITLE
include stdio.h in hocdec.h

### DIFF
--- a/src/oc/hocdec.h
+++ b/src/oc/hocdec.h
@@ -8,6 +8,7 @@
 extern "C" {
 #endif
 
+#include    <stdio.h>
 #include	"nrnapi.h"
 #include	"hocassrt.h"
 #include	<string.h>


### PR DESCRIPTION
compilation with gcc >= 7 can fail with

    oc_ansi.h:109:24: error: unknown type name 'FILE'

due to stdio.h not being included. There is a conditional include of stdio.h in hocassrt.h that may be related to why this only occurs sometimes.