### PR TITLE
Update Random123 gcc compiler configuration for Arm

### DIFF
--- a/src/Random123/features/gccfeatures.h
+++ b/src/Random123/features/gccfeatures.h
@@ -34,7 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define R123_GNUC_VERSION (__GNUC__*10000 + __GNUC_MINOR__*100 + __GNUC_PATCHLEVEL__)
 
-#if !defined(__x86_64__) && !defined(__i386__) && !defined(__powerpc__)
+#if !defined(__x86_64__) && !defined(__i386__) && !defined(__powerpc__) && !defined(__aarch64__)
 #  error "This code has only been tested on x86 and powerpc platforms."
 #include <including_a_nonexistent_file_will_stop_some_compilers_from_continuing_with_a_hopeless_task>
 { /* maybe an unbalanced brace will terminate the compilation */


### PR DESCRIPTION
@nrnhines  : I have tested neuron build on Arm 64 arch (thunderx2 platform) with gcc.