### PR TITLE
Fix for using rxd with nrniv and python3

### DIFF
--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -104,6 +104,7 @@ embedded = True if 'hoc' in sys.modules else False
 
 try:
     import hoc
+    hoc.__file__
 except:
   try:
     #Python3.1 extending needs to look into the module explicitly


### PR DESCRIPTION
The wrong nrn_dll was returned when running nrniv -python with python3.