### PR TITLE
extracellular rxd simulation enabled by default

### DIFF
--- a/share/lib/python/neuron/crxd/options.py
+++ b/share/lib/python/neuron/crxd/options.py
@@ -12,7 +12,7 @@ fixed_step_factor = 1
 
 class _OverrideLockouts:
 	def __init__(self):
-		self._extracellular = False
+		self._extracellular = True
 	@property
 	def extracellular(self):
 		return self._extracellular


### PR DESCRIPTION
There is no longer any reason to not have extracellular rxd simulation enabled, but the option is kept to avoid breaking old code that explicitly enabled it.