### PR TITLE
allow setting vec, e.g. vec[3] = 42

### DIFF
--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -1719,6 +1719,22 @@ static int hocobj_setitem(PyObject* self, Py_ssize_t i, PyObject* arg) {
     }
     return 0;
   }
+  if (po->ho_) {
+    if (po->ho_->ctemplate == hoc_vec_template_) {
+      Vect* vec = (Vect*)po->ho_->u.this_pointer;
+      int vec_size = vector_capacity(vec);
+      // allow Python style negative indices
+      if (i < 0) {
+        i += vec_size;
+      }
+      if (i >= vec_size || i < 0) {
+        PyErr_SetString(PyExc_IndexError, "index out of bounds");
+        return -1;
+      }
+      PyArg_Parse(arg, "d", vector_vec(vec) + i);
+      return 0;
+    }
+  }
   if (!po->sym_ || po->type_ != PyHoc::HocArray) {
     PyErr_SetString(PyExc_TypeError, "unsubscriptable object");
     return -1;


### PR DESCRIPTION
Removes the need to use vec.x to set items in a vector. Supports both positive and negative indices using Python wrap-around rules. Catches overflow.

What works now that didn't before:

from neuron import h
v = h.Vector([0, 1, 2, 3])
v[3] = 42  # <-- previously this was an error; need to do v.x[3] = 42 instead
v.printf()