### PR TITLE
nrnivmodl now allows CURIEs with a REPRESENTS keyword

### DIFF
--- a/src/nmodl/init.c
+++ b/src/nmodl/init.c
@@ -106,6 +106,7 @@ static struct {			/* Keywords */
 			"PROTECT", PROTECT,
 			"MUTEXLOCK", NRNMUTEXLOCK,
 			"MUTEXUNLOCK", NRNMUTEXUNLOCK,
+			"REPRESENTS", REPRESENTS,
 	                0, 0
 };
 

--- a/src/nmodl/lex.l
+++ b/src/nmodl/lex.l
@@ -98,6 +98,14 @@ ELSE	{ /* translate to lower case */
 	return s->type;
 }
 
+[a-zA-Z][a-zA-Z0-9_]*:[a-zA-Z0-9_]* { /*ONTOLOGY_ID*/
+	Symbol *s;
+
+	yylval.qp = putintoken(yytext, ONTOLOGY_ID);
+	s = SYM(yylval.qp);
+	return s->type;
+}
+
 {D}+	{ /*INTEGER*/
 	yylval.qp = putintoken(yytext, INTEGER); /* Numbers are not looked for */
 	return INTEGER;

--- a/src/nmodl/lex.l
+++ b/src/nmodl/lex.l
@@ -98,7 +98,7 @@ ELSE	{ /* translate to lower case */
 	return s->type;
 }
 
-[a-zA-Z][a-zA-Z0-9_]*:[a-zA-Z0-9_]* { /*ONTOLOGY_ID*/
+\[[a-zA-Z][a-zA-Z0-9_]*:[a-zA-Z0-9_]*\] { /*ONTOLOGY_ID*/
 	Symbol *s;
 
 	yylval.qp = putintoken(yytext, ONTOLOGY_ID);

--- a/src/nmodl/lex.l
+++ b/src/nmodl/lex.l
@@ -30,6 +30,9 @@ extern int unput();
 %}
 D	[0-9]
 E	[Ee][-+]?{D}+
+
+%x ontology
+
 %%
 [a-zA-Z][a-zA-Z0-9_]*'+ { /*PRIME possibly high order*/
 	char *cp, buf[256];
@@ -88,6 +91,19 @@ ELSE	{ /* translate to lower case */
 	return SYM(yylval.qp)->type;
 	}
 
+REPRESENTS	{
+	BEGIN(ontology);
+	Symbol *s;
+
+	yylval.qp = putintoken(yytext, NAME);
+	s = SYM(yylval.qp);
+	return s->type;
+}
+
+<ontology>\n {
+	BEGIN(INITIAL);
+}
+
 [a-zA-Z][a-zA-Z0-9_]* { /*NAME*/
 	Symbol *s;
 
@@ -98,11 +114,12 @@ ELSE	{ /* translate to lower case */
 	return s->type;
 }
 
-\[[a-zA-Z][a-zA-Z0-9_]*:[a-zA-Z0-9_]*\] { /*ONTOLOGY_ID*/
+<ontology>\[[a-zA-Z][a-zA-Z0-9_]*:[a-zA-Z0-9_]*\]|[a-zA-Z][a-zA-Z0-9_]*:[a-zA-Z0-9_]* { /*ONTOLOGY_ID*/
 	Symbol *s;
 
 	yylval.qp = putintoken(yytext, ONTOLOGY_ID);
 	s = SYM(yylval.qp);
+	BEGIN(INITIAL);
 	return s->type;
 }
 

--- a/src/nmodl/parse1.y
+++ b/src/nmodl/parse1.y
@@ -1229,7 +1229,7 @@ nrnuse: USEION NAME READ nrnlist valence
 	|USEION NAME READ nrnlist WRITE nrnlist valence REPRESENTS ONTOLOGY_ID
 		{nrn_use($2, $4, $6, $7);}
 	|USEION error
-		{myerr("syntax is: USEION ion READ list WRITE list REPRESENTS cui");}
+		{myerr("syntax is: USEION ion READ list WRITE list REPRESENTS curie");}
 	;
 nrnlist: NAME
 	| nrnlist ',' NAME

--- a/src/nmodl/parse1.y
+++ b/src/nmodl/parse1.y
@@ -116,7 +116,7 @@ static int nr_argcnt_, argcnt_; /* for matching number of args in NET_RECEIVE
 %token	<qp>	NEURON SUFFIX NONSPECIFIC READ WRITE USEION VALENCE THREADSAFE REPRESENTS
 %token	<qp>	GLOBAL SECTION RANGE POINTER BBCOREPOINTER EXTERNAL BEFORE AFTER WATCH
 %token	<qp>	ELECTRODE_CURRENT CONSTRUCTOR DESTRUCTOR NETRECEIVE FOR_NETCONS
-%type	<qp>	neuronblk nrnuse nrnlist optnrnlist valence initstmt bablk
+%type	<qp>	neuronblk nrnuse nrnlist optnrnlist valence initstmt bablk optontology
 %token	<qp>	CONDUCTANCE
 %type	<qp>	conducthint
 
@@ -1216,21 +1216,18 @@ nrnstmt: /*nothing*/
 	| nrnstmt THREADSAFE optnrnlist
 		{ threadsafe_seen($2, $3); }
 	;
-nrnuse: USEION NAME READ nrnlist valence
+nrnuse: USEION NAME READ nrnlist valence optontology
 		{nrn_use($2, $4, ITEM0, $5);}
-	|USEION NAME WRITE nrnlist valence
+	|USEION NAME WRITE nrnlist valence optontology
 		{nrn_use($2, ITEM0, $4, $5);}
-	|USEION NAME READ nrnlist WRITE nrnlist valence
-		{nrn_use($2, $4, $6, $7);}
-	|USEION NAME READ nrnlist valence REPRESENTS ONTOLOGY_ID
-		{nrn_use($2, $4, ITEM0, $5);}
-	|USEION NAME WRITE nrnlist valence REPRESENTS ONTOLOGY_ID
-		{nrn_use($2, ITEM0, $4, $5);}
-	|USEION NAME READ nrnlist WRITE nrnlist valence REPRESENTS ONTOLOGY_ID
+	|USEION NAME READ nrnlist WRITE nrnlist valence optontology
 		{nrn_use($2, $4, $6, $7);}
 	|USEION error
 		{myerr("syntax is: USEION ion READ list WRITE list REPRESENTS curie");}
 	;
+optontology: { $$ = NULL; }
+           | REPRESENTS ONTOLOGY_ID
+             { $$ = $2; }
 nrnlist: NAME
 	| nrnlist ',' NAME
 		{ delete($2); $$ = $3;}

--- a/src/nmodl/parse1.y
+++ b/src/nmodl/parse1.y
@@ -90,7 +90,7 @@ static int nr_argcnt_, argcnt_; /* for matching number of args in NET_RECEIVE
 %token	<qp>	'{' '}' '(' ')' '[' ']' '@' '+' '*' '-' '/' '=' '^' ':' ','
 %token	<qp>	'~'
 %token	<qp>	OR AND GT LT LE EQ NE NOT
-%token	<qp>	NAME PRIME REAL INTEGER DEFINEDVAR
+%token	<qp>	NAME PRIME REAL INTEGER DEFINEDVAR ONTOLOGY_ID
 %type	<qp>	Name NUMBER real intexpr integer
 %token	<qp>	STRING PLOT VS LAG RESET MATCH MODEL_LEVEL SWEEP FIRST LAST
 %type	<str>	line model units optindex unit limits abstol
@@ -113,7 +113,7 @@ static int nr_argcnt_, argcnt_; /* for matching number of args in NET_RECEIVE
 %type	<lp>	tablst tablst1 dependlst arglist arglist1
 %type	<i>	locoptarray
 /* interface to NEURON */
-%token	<qp>	NEURON SUFFIX NONSPECIFIC READ WRITE USEION VALENCE THREADSAFE
+%token	<qp>	NEURON SUFFIX NONSPECIFIC READ WRITE USEION VALENCE THREADSAFE REPRESENTS
 %token	<qp>	GLOBAL SECTION RANGE POINTER BBCOREPOINTER EXTERNAL BEFORE AFTER WATCH
 %token	<qp>	ELECTRODE_CURRENT CONSTRUCTOR DESTRUCTOR NETRECEIVE FOR_NETCONS
 %type	<qp>	neuronblk nrnuse nrnlist optnrnlist valence initstmt bablk
@@ -1196,6 +1196,7 @@ nrnstmt: /*nothing*/
 	| nrnstmt SUFFIX NAME
 		{ nrn_list($2, $3);}
 	| nrnstmt nrnuse
+	| nrnstmt REPRESENTS ONTOLOGY_ID
 	| nrnstmt NONSPECIFIC nrnlist
 		{ nrn_list($2,$3);}
 	| nrnstmt ELECTRODE_CURRENT nrnlist
@@ -1221,8 +1222,14 @@ nrnuse: USEION NAME READ nrnlist valence
 		{nrn_use($2, ITEM0, $4, $5);}
 	|USEION NAME READ nrnlist WRITE nrnlist valence
 		{nrn_use($2, $4, $6, $7);}
+	|USEION NAME READ nrnlist valence REPRESENTS ONTOLOGY_ID
+		{nrn_use($2, $4, ITEM0, $5);}
+	|USEION NAME WRITE nrnlist valence REPRESENTS ONTOLOGY_ID
+		{nrn_use($2, ITEM0, $4, $5);}
+	|USEION NAME READ nrnlist WRITE nrnlist valence REPRESENTS ONTOLOGY_ID
+		{nrn_use($2, $4, $6, $7);}
 	|USEION error
-		{myerr("syntax is: USEION ion READ list WRITE list");}
+		{myerr("syntax is: USEION ion READ list WRITE list REPRESENTS cui");}
 	;
 nrnlist: NAME
 	| nrnlist ',' NAME

--- a/src/nrnoc/hh.mod
+++ b/src/nrnoc/hh.mod
@@ -22,10 +22,10 @@ UNITS {
 ? interface
 NEURON {
         SUFFIX hh
-        REPRESENTS [NCIT:C17145]   : sodium channel
-        REPRESENTS [NCIT:C17008]   : potassium channel
-        USEION na READ ena WRITE ina REPRESENTS [CHEBI:29101]
-        USEION k READ ek WRITE ik REPRESENTS [CHEBI:29103]
+        REPRESENTS NCIT:C17145   : sodium channel
+        REPRESENTS NCIT:C17008   : potassium channel
+        USEION na READ ena WRITE ina REPRESENTS CHEBI:29101
+        USEION k READ ek WRITE ik REPRESENTS CHEBI:29103
         NONSPECIFIC_CURRENT il
         RANGE gnabar, gkbar, gl, el, gna, gk
         GLOBAL minf, hinf, ninf, mtau, htau, ntau

--- a/src/nrnoc/hh.mod
+++ b/src/nrnoc/hh.mod
@@ -18,12 +18,14 @@ UNITS {
         (mV) = (millivolt)
 	(S) = (siemens)
 }
- 
+
 ? interface
 NEURON {
         SUFFIX hh
-        USEION na READ ena WRITE ina
-        USEION k READ ek WRITE ik
+        REPRESENTS NCIT:C17145   : sodium channel
+        REPRESENTS NCIT:C17008   : potassium channel
+        USEION na READ ena WRITE ina REPRESENTS CHEBI:29101
+        USEION k READ ek WRITE ik REPRESENTS CHEBI:29103
         NONSPECIFIC_CURRENT il
         RANGE gnabar, gkbar, gl, el, gna, gk
         GLOBAL minf, hinf, ninf, mtau, htau, ntau

--- a/src/nrnoc/hh.mod
+++ b/src/nrnoc/hh.mod
@@ -22,10 +22,10 @@ UNITS {
 ? interface
 NEURON {
         SUFFIX hh
-        REPRESENTS NCIT:C17145   : sodium channel
-        REPRESENTS NCIT:C17008   : potassium channel
-        USEION na READ ena WRITE ina REPRESENTS CHEBI:29101
-        USEION k READ ek WRITE ik REPRESENTS CHEBI:29103
+        REPRESENTS [NCIT:C17145]   : sodium channel
+        REPRESENTS [NCIT:C17008]   : potassium channel
+        USEION na READ ena WRITE ina REPRESENTS [CHEBI:29101]
+        USEION k READ ek WRITE ik REPRESENTS [CHEBI:29103]
         NONSPECIFIC_CURRENT il
         RANGE gnabar, gkbar, gl, el, gna, gk
         GLOBAL minf, hinf, ninf, mtau, htau, ntau


### PR DESCRIPTION
This adds the ability to use ontology annotated MOD files, where REPRESENTS and a CURIE are used as stand alones to indicate the channels etc the mod file represents, or with a USEION to indicate the chemical ion unambiguously.

No action is taken based on the CURIEs, but this is being added sooner rather than later to ensure 7.7 and all later versions of NEURON are able to use ontology annotated NMODL files. It is possible that nrnivmodl will never take an action based on REPRESENTS and that this will only ever be used by static code analysis routines.

The Hodgkin-Huxley model implementation distributed with NEURON (hh.mod) has been extended with these annotations.