### PR TITLE
bugfix: neuron.rxd.rxdmath.radians should only take one argument inst…

### DIFF
--- a/share/lib/python/neuron/crxd/rxdmath.py
+++ b/share/lib/python/neuron/crxd/rxdmath.py
@@ -224,8 +224,8 @@ def modf(obj):
 # this seems to be okay; just have to avoid using pow in any other context
 def pow(obj1, obj2):
     return _Arithmeticed(_Function2(obj1, obj2, 'rxdmath._power', 'pow'), valid_reaction_term=False)
-def radians(obj1, obj2):
-    return _Arithmeticed(_Function2(obj1, obj2, 'numpy.radians', 'radians'), valid_reaction_term=False)
+def radians(obj):
+    return _Arithmeticed(_Function(obj, 'numpy.radians', 'radians'), valid_reaction_term=False)
 def sin(obj):
     return _Arithmeticed(_Function(obj, 'numpy.sin', 'sin'), valid_reaction_term=False)
 def sinh(obj):

--- a/share/lib/python/neuron/rxd/rxdmath.py
+++ b/share/lib/python/neuron/rxd/rxdmath.py
@@ -191,8 +191,8 @@ def modf(obj):
 # this seems to be okay; just have to avoid using pow in any other context
 def pow(obj1, obj2):
     return _Arithmeticed(_Function2(obj1, obj2, 'rxdmath._power', 'pow'), valid_reaction_term=False)
-def radians(obj1, obj2):
-    return _Arithmeticed(_Function2(obj1, obj2, 'numpy.radians', 'radians'), valid_reaction_term=False)
+def radians(obj):
+    return _Arithmeticed(_Function(obj, 'numpy.radians', 'radians'), valid_reaction_term=False)
 def sin(obj):
     return _Arithmeticed(_Function(obj, 'numpy.sin', 'sin'), valid_reaction_term=False)
 def sinh(obj):


### PR DESCRIPTION
…ead of two; same for crxd