### PR TITLE
rxd: registering ions on species creation

### DIFF
--- a/share/lib/python/neuron/crxd/species.py
+++ b/share/lib/python/neuron/crxd/species.py
@@ -623,6 +623,8 @@ class Species(_SpeciesMathable):
         # declare an update to the structure of the model (the number of differential equations has changed)
         nrn_dll_sym('structure_change_cnt', ctypes.c_int).value += 1
 
+        self._ion_register() 
+
         # initialize self if the rest of rxd is already initialized
         if initializer.is_initialized():
             if _has_3d:

--- a/share/lib/python/neuron/rxd/species.py
+++ b/share/lib/python/neuron/rxd/species.py
@@ -280,6 +280,8 @@ class Species(_SpeciesMathable):
         # declare an update to the structure of the model (the number of differential equations has changed)
         neuron.nrn_dll_sym('structure_change_cnt', ctypes.c_int).value += 1
 
+        self._ion_register()
+
         # initialize self if the rest of rxd is already initialized
         if initializer.is_initialized():
             if _has_3d:


### PR DESCRIPTION
This allows getting pointers to NEURON states immediately instead of
waiting for initialization.

Update to both crxd and rxd.

What works now but didn't before:

from neuron import h, crxd as rxd

s = h.Section(name='s')
cyt = rxd.Region([s], name='cyt', nrn_region='i')
ca = rxd.Species(cyt, name='ca', charge=2)

'previously we would have to do an finitialize before the next line'
foo = s(0.5)._ref_cai