### PR TITLE
RangeVarPlot Python interface enhancements.

### DIFF
--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -655,7 +655,6 @@ try:
   _rvp_plot_callback = ctypes.py_object(_rvp_plot)
   set_rvp_plot(_rvp_plot_callback)
 except:
-  raise()
   pass
 
 def _has_scipy():

--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -583,6 +583,81 @@ except:
   pass
 
 
+class _RangeVarPlot:
+  """Plots the current state of the RangeVarPlot on the graph.
+
+  Additional arguments and keyword arguments are passed to the graph's
+  plotting method.
+
+  Example, showing plotting to NEURON graphics, bokeh, and matplotlib:
+
+  .. code::
+
+    from matplotlib import pyplot
+    from neuron import h, gui
+    import bokeh.plotting as b
+    import math
+
+    dend = h.Section(name='dend')
+    dend.nseg = 55
+    dend.L = 6.28
+
+    # looping over dend.allseg instead of dend to set 0 and 1 ends
+    for seg in dend.allseg():
+        seg.v = math.sin(dend.L * seg.x)
+
+    r = h.RangeVarPlot('v', dend(0), dend(1))
+
+    # matplotlib
+    graph = pyplot.gca()
+    r.plot(graph, linewidth=10, color='r')
+
+    # NEURON Interviews graph
+    g = h.Graph()
+    r.plot(g, 2, 3)
+    g.exec_menu('View = plot')
+
+    # Bokeh
+    bg = b.Figure()
+    r.plot(bg, line_width=10)
+    b.show(bg)
+
+    pyplot.show()"""
+    
+  def __init__(self, rvp):
+    '''do not call directly'''
+    self._rvp = rvp
+  def __repr__(self):
+    return '{}.plot()'.format(repr(self._rvp))
+  def __call__(self, graph, *args, **kwargs):
+      
+      yvec = h.Vector()
+      xvec = h.Vector()
+      self._rvp.to_vector(yvec, xvec)
+      if isinstance(graph, hoc.HocObject):
+        return yvec.line(graph, xvec, *args)
+      if hasattr(graph, 'plot'):
+        # works with e.g. pyplot or a matplotlib axis
+        return graph.plot(xvec, yvec, *args, **kwargs)
+      if hasattr(graph, 'line'):
+        # works with e.g. bokeh
+        return graph.line(xvec, yvec, *args, **kwargs)
+      if str(type(graph)) == "<class 'matplotlib.figure.Figure'>":
+        raise Exception('plot to a matplotlib axis not a matplotlib figure')
+      raise Exception('Unable to plot to graphs of type {}'.format(type(graph)))
+
+try:
+  import ctypes
+  def _rvp_plot(rvp):
+    return _RangeVarPlot(rvp)
+
+  set_rvp_plot = nrn_dll_sym('nrnpy_set_rvp_plot')
+  _rvp_plot_callback = ctypes.py_object(_rvp_plot)
+  set_rvp_plot(_rvp_plot_callback)
+except:
+  raise()
+  pass
+
 def _has_scipy():
     """
     to check for scipy:

--- a/src/nrniv/spaceplt.cpp
+++ b/src/nrniv/spaceplt.cpp
@@ -264,6 +264,8 @@ static Member_func s_members[] = {
 static void* s_cons(Object*) {
 	char* var = NULL;
 	Object* pyobj = NULL;
+	Section* sec;
+	double x;
 	if (hoc_is_str_arg(1)) {
 		var = gargstr(1);
 	}else{
@@ -273,6 +275,14 @@ static void* s_cons(Object*) {
 #if HAVE_IV
 	s->ref();
 #endif
+    if (ifarg(2)) {
+    	nrn_seg_or_x_arg(2, &sec, &x);
+    	s->x_begin(x, sec);
+    }
+    if (ifarg(3)) {
+    	nrn_seg_or_x_arg(3, &sec, &x);
+    	s->x_end(x, sec);
+    }
 	return (void*)s;
 }
 

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -157,6 +157,8 @@ typedef struct {
   PyHoc::ObjectType type_;
 } PyHocObject;
 
+static PyObject* rvp_plot = NULL;
+
 static PyTypeObject* hocobject_type;
 static PyObject* hocobj_call(PyHocObject* self, PyObject* args,
                              PyObject* kwrds);
@@ -943,6 +945,8 @@ static PyObject* hocobj_getattr(PyObject* subself, PyObject* pyname) {
 
       if (is_obj_type(self->ho_, "Vector")) {
         PyDict_SetItemString(dict, "__array_interface__", Py_None);
+      } else if (is_obj_type(self->ho_, "RangeVarPlot")) {
+        PyDict_SetItemString(dict, "plot", Py_None);
       }
       return dict;
     } else if (strncmp(n, "_ref_", 5) == 0) {
@@ -976,6 +980,9 @@ static PyObject* hocobj_getattr(PyObject* subself, PyObject* pyname) {
                            array_interface_typestr, "version", 3, "data",
                            PyLong_FromVoidPtr(x), Py_True);
 
+    } else if (is_obj_type(self->ho_, "RangeVarPlot") && strcmp(n, "plot") == 0) {
+      //Py_INCREF(rvp_plot);
+      return PyObject_CallFunctionObjArgs(rvp_plot, (PyObject*) self, NULL);
     } else if (strcmp(n, "__doc__") == 0) {
       if (setup_doc_system()) {
         PyObject* docobj = NULL;
@@ -2093,6 +2100,11 @@ static IvocVect* nrnpy_vec_from_python(void* v) {
 static PyObject* (*vec_as_numpy)(int, double*);
 int nrnpy_set_vec_as_numpy(PyObject* (*p)(int, double*)) {
   vec_as_numpy = p;
+  return 0;
+}
+
+int nrnpy_set_rvp_plot(PyObject* p) {
+  rvp_plot = p;
   return 0;
 }
 


### PR DESCRIPTION
RangeVarPlot's constructor now takes optional begin and end arguments.
In Python, these would typically be segments, but they can also be
normalized position on a single segment.

RangeVarPlot has a new method: plot
RangeVarPlot.plot plots the current state of the path on any of a number of
types of graphs, including NEURON Graph objects, matplotlib, bokeh, and
anything with a .plot or .line method taking x and y values. Any additional
arguments or keyword arguments are passed to the graph's plotting method.

For example, plotting voltage from the center of the soma to the 1 end of
the apical in matplotlib is now as simple as:

from matplotlib import pyplot
h.RangeVarPlot('v', soma(0.5), dend(1)).plot(pyplot)
pyplot.show()

In this case, the RangeVarPlot object does not need to be saved as it is
not needed after the plot line.

Here is a more elaborate example, plotting to a matplotlib axis (instead
of pyplot itself), bokeh, and NEURON's Graph objects and passing optional
arguments to each:

from matplotlib import pyplot
from neuron import h, gui
import bokeh.plotting as b
import math

dend = h.Section(name='dend')
dend.nseg = 55
dend.L = 6.28

'looping over dend.allseg instead of dend to set 0 and 1 ends'
for seg in dend.allseg():
    seg.v = math.sin(dend.L * seg.x)

r = h.RangeVarPlot('v', dend(0), dend(1))

'matplotlib test'
graph = pyplot.gca()
r.plot(graph, linewidth=10, color='r')

'NEURON graph test'
g = h.Graph()
r.plot(g, 2, 3)
g.exec_menu('View = plot')

'Bokeh test'
bg = b.Figure()
r.plot(bg, line_width=10)
b.show(bg)

pyplot.show()