### PR TITLE
h.Vector objects now support basic arithmetic

### DIFF
--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -638,6 +638,42 @@ if not embedded:
     print("Failed to setup nrnpy_pr")
     pass
 
+
+def nrnpy_vec_math(op, flag, arg1, arg2=None):
+  import numbers
+  valid_types = (numbers.Number, hoc.HocObject)
+  if isinstance(arg1, valid_types):
+    if flag == 2:
+      # unary
+      arg1 = arg1.c()
+      if op == 'uneg':
+        return arg1.mul(-1)
+      if op == 'upos':
+        return arg1
+      if op == 'uabs':
+        return arg1.abs()
+    elif isinstance(arg2, valid_types):
+      if flag == 1:
+        # either reversed (flag=1) or unary (flag=2)
+        arg2 = arg2.c()
+        if op in ('mul', 'add'):
+          return getattr(arg2, op)(arg1)
+        if op == 'div':
+          return arg2.pow(-1).mul(arg1)
+        if op == 'sub':
+          return arg2.mul(-1).add(arg1)
+      else:
+        arg1 = arg1.c()
+        return getattr(arg1, op)(arg2)
+
+  return NotImplemented
+
+try:
+  nrnpy_vec_math_register = nrn_dll_sym('nrnpy_vec_math_register')
+  nrnpy_vec_math_register(ctypes.py_object(nrnpy_vec_math))
+except:
+  print("Failed to setup nrnpy_vec_math")
+
 try:
   from neuron.psection import psection
   nrn.set_psection(psection)

--- a/src/nrnpython/nrnpy_hoc_2.h
+++ b/src/nrnpython/nrnpy_hoc_2.h
@@ -2,16 +2,16 @@
 // there has to be a better way to get working __nonzero__
 // but putting it into hocobj_methods did not work.
 static PyNumberMethods hocobj_as_number = {
-    0,                       /* nb_add */
-    0,                       /* nb_subtract */
-    0,                       /* nb_multiply */
-    0,                       /* nb_divide */
+    py_hocobj_add,           /* nb_add */
+    py_hocobj_sub,           /* nb_subtract */
+    py_hocobj_mul,           /* nb_multiply */
+    py_hocobj_div,           /* nb_divide */
     0,                       /* nb_remainder */
     0,                       /* nb_divmod */
     0,                       /* nb_power */
-    0,                       /* nb_negative */
-    0,                       /* nb_positive */
-    0,                       /* nb_absolute */
+    py_hocobj_uneg,          /* nb_negative */
+    py_hocobj_upos,          /* nb_positive */
+    py_hocobj_uabs,          /* nb_absolute */
     (inquiry)hocobj_nonzero, /* nb_nonzero */
     0,                       /* nb_invert */
     0,                       /* nb_lshift */
@@ -39,7 +39,7 @@ static PyNumberMethods hocobj_as_number = {
     0,                       /* nb_floor_divide */
     0,                       /* nb_true_divide */
     0,                       /* nb_inplace_floor_divide */
-    0,                       /* nb_inplace_true_divide */
+    py_hocobj_div,           /* nb_inplace_true_divide */
 #if PYTHON_API_VERSION > 1012
     0, /* nb_index */
 #endif
@@ -77,7 +77,7 @@ static PyTypeObject nrnpy_HocObjectType = {
     hocobj_getattro,                          /*tp_getattro*/
     hocobj_setattro,                          /*tp_setattro*/
     0,                                        /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE| Py_TPFLAGS_CHECKTYPES, /*tp_flags*/
     ccast hocobj_docstring,                   /* tp_doc */
     0,                                        /* tp_traverse */
     0,                                        /* tp_clear */

--- a/src/nrnpython/nrnpy_hoc_3.h
+++ b/src/nrnpython/nrnpy_hoc_3.h
@@ -1,3 +1,48 @@
+#include "nrnpython.h"
+
+
+static PyNumberMethods hocobj_as_number = {
+     py_hocobj_add, /* nb_add */
+     py_hocobj_sub, /* nb_subtract */
+     py_hocobj_mul, /* nb_multiply */
+     NULL, /* nb_remainder */
+     NULL, /* nb_divmod */
+     NULL, /* nb_power */
+     py_hocobj_uneg, /* nb_negative */
+     py_hocobj_upos, /* nb_positive */
+     py_hocobj_uabs, /* nb_absolute */
+     NULL, /* nb_bool */
+     NULL, /* nb_invert */
+     NULL, /* nb_lshift */
+     NULL, /* nb_rshift */
+     NULL, /* nb_and */
+     NULL, /* nb_xor */
+     NULL, /* nb_or */
+     NULL, /* nb_int */
+     NULL, /*nb_reserved */
+     NULL, /* nb_float */
+
+     NULL, /* nb_inplace_add */
+     NULL, /* nb_inplace_subtract */
+     NULL, /* nb_inplace_multiply */
+     NULL, /* nb_inplace_remainder */
+     NULL, /* nb_inplace_power */
+     NULL, /* nb_inplace_lshift */
+     NULL, /* nb_inplace_rshift */
+     NULL, /* nb_inplace_and */
+     NULL, /* nb_inplace_xor */
+     NULL, /* nb_inplace_or */
+
+     NULL, /* nb_floor_divide */
+     py_hocobj_div, /* nb_true_divide */
+     NULL, /* nb_inplace_floor_divide */
+     NULL, /* nb_inplace_true_divide */
+
+     NULL, /* nb_index */
+
+     NULL, /* nb_matrix_multiply */
+     NULL /* nb_inplace_matrix_multiply */
+};
 
 static PyType_Slot nrnpy_HocObjectType_slots[] = {
     {Py_tp_dealloc, (void*)hocobj_dealloc},


### PR DESCRIPTION
The original motivation for this was the unpleasantness when I wanted to
add a bunch of pointers together and change the units where I had to use
as_numpy on the first Vector to get objects that support the basic
arithmetic operators:

pt = (p0vec.as_numpy() + p1vec + p2vec + cvec + cnvec) / nM

(Obviously, it is possible to do the same directly before using many
calls to .c() and .add(), but that was not very pythonic.)

The above was from the example in:
https://neuron.yale.edu/neuron/docs/example-circadian-rhythm

A set of tests (ran with both Python 2 and Python 3) for arithmetic
operations between two Vectors, a Vector and a number (in either order),
and a Vector and a numpy array (in either order). In the latter case,
the previous behavior is unchanged, and the result is a numpy array:

from neuron import h
import numpy

v1 = h.Vector([1, 2, 3])
v2 = h.Vector([4, 5, 6])
v3 = numpy.array([7, 8, 9])

(-v1).printf()
(+v1).printf()
(abs(h.Vector([-1, 5, -17]))).printf()

(v1 + 2).printf()
(2 + v1).printf()
(2 * v1).printf()
(v1 * 2).printf()
(2 - v1).printf()
(v1 - 2).printf()
(2 / v1).printf()
(v1 / 2).printf()

(v1 + v2).printf()
(v1 * v2).printf()
(v1 - v2).printf()
(v1 / v2).printf()

'combining vectors and numpy makes a numpy'
print(v1 + v3)
print(v1 * v3)
print(v1 - v3)
print(v1 / v3)

print(v3 + v2)
print(v3 * v2)
print(v3 - v2)
print(v3 / v2)