### PR TITLE
Unsetting LC_ALL in nrnivmodl `ls` for consistent mod ordering

### DIFF
--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -51,7 +51,7 @@ fi
 UserLDFLAGS=""
 if [ "$1" = "-loadflags" ] ; then
        UserLDFLAGS="$2"
-       shift 
+       shift
        shift
 fi
 
@@ -69,15 +69,16 @@ if test $# -gt 0 ; then
 	for i in "$@" ; do
 		if test -d "$i" ; then
 			set +e
-			files="$files $(ls $i/*.mod)"
-			incs="$incs $(ls $i/*.inc)"
+			files="$files $(unset LC_ALL; ls $i/*.mod)"
+			incs="$incs $(unset LC_ALL; ls $i/*.inc)"
 			set -e
 		else
 			files="$files $i"
 		fi
 	done
 else
-	files=$(ls *.mod)
+	# Unset LC_ALL for consistent mod order
+	files=$(unset LC_ALL; ls *.mod)
 fi
 
 mfiles=""


### PR DESCRIPTION
After a lot of debugging we found out that the reason why LC_ALL changed results was that mechanisms are being discovered in a different order (by ls) and are therefore added to mod_func in that new order.

This patch fixes that situation by unsetting LC_ALL. Therefore the ordering shall be done according  to the system locale which typically supports alphabetic comparison (and not ascii-numeral-based) which sounds the best.