### PR TITLE
crxd: equality and inequality crxd.Section1D and nrn.Section

### DIFF
--- a/share/lib/python/neuron/crxd/section1d.py
+++ b/share/lib/python/neuron/crxd/section1d.py
@@ -1,5 +1,5 @@
 import weakref
-from neuron import h
+from neuron import h, nrn
 from . import node, rxdsection, nodelist
 import numpy
 from .rxdException import RxDException
@@ -108,6 +108,24 @@ class Section1D(rxdsection.RxDSection):
             _rxd_sec_lookup[sec].append(weakref.ref(self))
         else:
             _rxd_sec_lookup[sec] = [weakref.ref(self)]
+
+    def __req__(self, other):
+        if isinstance(other, nrn.Section):
+            return self._sec == other
+        return id(self) == id(other)
+    
+    def __rne__(self, other):
+        # necessary for Python 2 but not for Python 3
+        return not (self == other)
+
+    def __eq__(self, other):
+        if isinstance(other, nrn.Section):
+            return self._sec == other
+        return id(self) == id(other)
+    
+    def __ne__(self, other):
+        # necessary for Python 2 but not for Python 3
+        return not (self == other)
 
     def _init_diffusion_rates(self):
         # call only after roots are set

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -159,7 +159,7 @@ typedef struct {
 
 static PyObject* rvp_plot = NULL;
 
-static PyTypeObject* hocobject_type;
+PyTypeObject* hocobject_type;
 static PyObject* hocobj_call(PyHocObject* self, PyObject* args,
                              PyObject* kwrds);
 

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -70,6 +70,7 @@ static PyTypeObject* range_type;
 PyObject* pmech_types;  // Python map for name to Mechanism
 PyObject* rangevars_;   // Python map for name to Symbol
 
+extern PyTypeObject* hocobject_type;
 extern Section* nrnpy_newsection(NPySecObj*);
 extern void simpleconnectsection();
 extern void nrn_change_nseg(Section*, int);
@@ -905,8 +906,14 @@ static PyObject* pysec_richcmp(NPySecObj* self, PyObject* other, int op) {
   if (PyObject_TypeCheck(other, psection_type)) {
     void* self_ptr = (void*)(self->sec_);
     other_ptr = (void*)(((NPySecObj*)other)->sec_);
+    return nrn_ptr_richcmp(self_ptr, other_ptr, op);
   }
-  return nrn_ptr_richcmp(self_ptr, other_ptr, op);
+  if (PyObject_TypeCheck(other, hocobject_type) || PyObject_TypeCheck(other, psegment_type)) {
+    // preserves comparison with NEURON objects as it existed prior to 7.7
+    return nrn_ptr_richcmp(self_ptr, other_ptr, op);
+  }
+  Py_INCREF(Py_NotImplemented);
+  return Py_NotImplemented;
 }
 
 static PyObject* pysec_same(NPySecObj* self, PyObject* args) {


### PR DESCRIPTION
Eliminates a long-standing difficulty of rxd's internal use of Section1D wrappers for Sections,
which made checking the section of a given rxd Node opaque.

Involved a modification to Section richcmps to return NotImplemented to allow __req__.

The below now behaves as most users would probably expect:

from neuron import h, crxd as rxd
soma = h.Section()
dend = h.Section()
r = rxd.Region(h.allsec())
c = rxd.Species(r)
print(c.nodes)
print(c.nodes[0].sec == soma)
print(soma == c.nodes[0].sec)