### PR TITLE
h.SectionList constructor now accepts an iterable

### DIFF
--- a/src/nrnoc/seclist.c
+++ b/src/nrnoc/seclist.c
@@ -19,11 +19,21 @@
 extern int hoc_return_type_code;
 Section* (*nrnpy_o2sec_p_)(Object* o);
 
+void (*nrnpy_sectionlist_helper_)(List*, Object*) = 0;
+
+void lvappendsec_and_ref(void* sl, Section* sec) {
+	lappendsec((List*) sl, sec);
+	section_ref(sec);
+}
+
 /*ARGSUSED*/
 static void* constructor(Object* ho)
 {
 	List* sl;
-	sl = newlist();	
+	sl = newlist();
+	if (nrnpy_sectionlist_helper_ && ifarg(1)) {
+		nrnpy_sectionlist_helper_(sl, *hoc_objgetarg(1));
+	}
 	return (void*)sl;
 }
 
@@ -48,8 +58,7 @@ static Section* arg1() {
 static double append(void* v)
 {
 	Section* sec = arg1();
-	lappendsec((List*)v, sec);
-	section_ref(sec);
+	lvappendsec_and_ref(v, sec);
 	return 1.;
 }
 

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -61,7 +61,7 @@ typedef struct {
   int attr_from_sec_; // so section.xraxial[0] = e assigns to all segments.
 } NPyRangeVar;
 
-static PyTypeObject* psection_type;
+PyTypeObject* psection_type;
 static PyTypeObject* pallsegiter_type;
 static PyTypeObject* psegment_type;
 static PyTypeObject* pmech_generic_type;


### PR DESCRIPTION
Example:

from neuron import h

soma = h.Section(name='soma')
dend = h.Section(name='dend')

h.SectionList([soma, dend, soma]).printnames()