### PR TITLE
fixed chaining for PlotShape.plot().mark

### DIFF
--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -704,6 +704,7 @@ class _PlotShapePlot(_WrapperPlot):
               y = np.interp(seg_l, arc3d, y3d)
               z = np.interp(seg_l, arc3d, z3d)
               self.plot([x], [y], [z], marker)
+              return self
 
 
 


### PR DESCRIPTION
Allows e.g.

```ps = h.PlotShape(False)
ps.plot(pyplot).mark(h.soma[0](0.5)).mark(h.apical_dendrite[68](1))
```