### PR TITLE
Only binary special's, linking against nrnivmech

### DIFF
--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -163,30 +163,15 @@ if test -n "$cfiles" ; then
 	COBJS=`echo "$cfiles" | sed 's/\.c/.o/g'`
 fi
 
-@NRNMECH_DLL_STYLE_FALSE@make -j 4 -f "${MAKEFILEDIR}/nrniv_makefile" "$PURIFY" "$TRACE" "MODOBJFILES=$MODOBJS" "COBJFILES=$COBJS" "UserLDFLAGS=$UserLDFLAGS" "UserINCFLAGS=$UserINCFLAGS" special &&
-@NRNMECH_DLL_STYLE_FALSE@  echo "Successfully created $MODSUBDIR/special"
+@NRNMECH_DLL_STYLE_FALSE@make -j 4 -f "${MAKEFILEDIR}/nrniv_makefile" "$PURIFY" "$TRACE" "MODOBJFILES=$MODOBJS" "COBJFILES=$COBJS" "UserLDFLAGS=$UserLDFLAGS" "UserINCFLAGS=$UserINCFLAGS" special
 
 @NRNMECH_DLL_STYLE_TRUE@MODLO=`echo "$MODOBJS" | sed 's/\.o/.lo/g'`
 @NRNMECH_DLL_STYLE_TRUE@CLO=`echo "$COBJS" | sed 's/\.o/.lo/g'`
 @NRNMECH_DLL_STYLE_TRUE@if test "${mdir}" = "${prefix}/share/nrn/demo/release/powerpc" ; then
 @NRNMECH_DLL_STYLE_TRUE@  mdir='${NRNHOME}'/share/nrn/demo/release/${MODSUBDIR}
 @NRNMECH_DLL_STYLE_TRUE@fi
-@NRNMECH_DLL_STYLE_TRUE@make -j 4 -f "$MAKEFILEDIR/nrnmech_makefile" "MODOBJFILES=$MODLO" "COBJFILES=$CLO" "UserLDFLAGS=$UserLDFLAGS" "UserINCFLAGS=$UserINCFLAGS" libnrnmech.la &&
-@NRNMECH_DLL_STYLE_TRUE@  echo '#!/bin/sh
-@NRNMECH_DLL_STYLE_TRUE@if test "x${NRNHOME}" = "x" ; then
-@NRNMECH_DLL_STYLE_TRUE@	NRNHOME='"\"${prefix}\""'
-@NRNMECH_DLL_STYLE_TRUE@fi'> special &&
-@NRNMECH_DLL_STYLE_TRUE@  echo 'if test "x${NRNBIN}" = "x" ; then
-@NRNMECH_DLL_STYLE_TRUE@	NRNBIN='"\"${bindir}/\""'
-@NRNMECH_DLL_STYLE_TRUE@fi'>> special &&
-@NRNMECH_DLL_STYLE_TRUE@echo 'if test "@enable_carbon@" = "yes" ; then
-@NRNMECH_DLL_STYLE_TRUE@	NRNIV="${NRNBIN}nrniv.app/Contents/MacOS/nrniv"
-@NRNMECH_DLL_STYLE_TRUE@else
-@NRNMECH_DLL_STYLE_TRUE@	NRNIV="${NRNBIN}nrniv"
-@NRNMECH_DLL_STYLE_TRUE@fi' >> special &&
-@NRNMECH_DLL_STYLE_TRUE@  echo '"${NRNIV}"'" -dll \"${mdir}/.libs/libnrnmech.so\" \"\$@\"" >> special &&
-@NRNMECH_DLL_STYLE_TRUE@  chmod 755 special &&
-@NRNMECH_DLL_STYLE_TRUE@  echo "Successfully created $MODSUBDIR/special"
+@NRNMECH_DLL_STYLE_TRUE@make -j 4 -f "$MAKEFILEDIR/nrnmech_makefile" "MODOBJFILES=$MODLO" "COBJFILES=$CLO" "UserLDFLAGS=$UserLDFLAGS" "UserINCFLAGS=$UserINCFLAGS" special
+echo "Successfully created $MODSUBDIR/special"
 
 @NRNMECH_DLL_STYLE_TRUE@@MAC_DARWIN_TRUE@if false ; then
 @NRNMECH_DLL_STYLE_TRUE@@MAC_DARWIN_FALSE@if false ; then

--- a/bin/nrnmech_makefile.in
+++ b/bin/nrnmech_makefile.in
@@ -27,7 +27,9 @@ NJ_LIBS = @NRNJAVA_LIBS@
 PY_LIBS =
 NRNNI_LIBS = @NRNNI_LIBS@
 
-INCLUDES = -I. -I.. -I"$(pkgincludedir)" -I"$(libdir)" $(UserINCFLAGS) 
+INCLUDES = -I. -I.. -I"$(pkgincludedir)" -I"$(libdir)" $(UserINCFLAGS)
+# Use pwd by default, but user should override
+LIB_INSTALL_DIR = $(shell pwd)
 
 LIBTOOL = "$(pkgdatadir)/libtool" @LIBTOOLTAG@
 CC = @CC@
@@ -53,16 +55,29 @@ NRNIVLIBS = -L"$(libdir)" -lnrniv -livoc \
 NRNOCOBJS = "$(libobjdir)/ocmain.o" "$(libobjdir)/nrnnoiv.o" "$(libobjdir)/ocnoiv.o"
 NRNIVOBJS = "$(libobjdir)/nrnmain.o" "$(libobjdir)/ivocmain.o" "$(libobjdir)/nvkludge.o"
 
-.SUFFIXES:
+libnrnmech_la_OBJECTS = $(MODOBJFILES) mod_func.lo $(COBJFILES)
+libnrnmech_la_LIBADD = $(NRNOCLIBS) $(NRNIVLIBS)
 
 .SUFFIXES: .c .mod .lo
+
+
+# Create special similar to the original one but depend on libnrnmech.so
+special: libnrnmech.la
+	$(LINK) -rpath $(LIB_INSTALL_DIR) -lnrnmech $(NRNOCOBJS) $(libnrnmech_la_LIBADD) $(LIBS)
+
+
+libnrnmech.la: $(libnrnmech_la_OBJECTS) $(libnrnmech_la_DEPENDENCIES)
+	$(LINK) -rpath "$(libdir)" $(libnrnmech_la_LDFLAGS) $(libnrnmech_la_OBJECTS) $(libnrnmech_la_LIBADD) $(LIBS)
+	$(LIBTOOL) --mode=install install libnrnmech.la $(LIB_INSTALL_DIR)
+
+
 #
 # How to make a .o file from a .mod file.  Note that we have to delete the
 # .c file, or else make will get confused.  We have to go directly from
 # a .mod to a .o file because otherwise GNU make will try to use a rule
 # involving m2c.  Argh!!  Why did they have to build in so many implicit
 # rules?
-# 
+#
 #.mod.o:
 #	$(bindir)/nocmodl $* || (rm -f $*.c; exit 1)
 #	$(COMPILE) -c $*.c
@@ -76,7 +91,7 @@ NRNIVOBJS = "$(libobjdir)/nrnmain.o" "$(libobjdir)/ivocmain.o" "$(libobjdir)/nvk
 
 .mod.c:
 	"$(bindir)/nocmodl" $*
-	
+
 .c.lo:
 	$(LTCOMPILE) -c -o $@ `test -f '$<' || echo '$(srcdir)/'`$<
 
@@ -86,9 +101,3 @@ NRNIVOBJS = "$(libobjdir)/nrnmain.o" "$(libobjdir)/ivocmain.o" "$(libobjdir)/nvk
 
 mod_func.lo: mod_func.c
 	$(LTCOMPILE) -c -o $@ $*.c
-
-libnrnmech_la_OBJECTS = $(MODOBJFILES) mod_func.lo $(COBJFILES)
-libnrnmech_la_LIBADD = $(NRNOCLIBS) $(NRNIVLIBS)
-
-libnrnmech.la: $(libnrnmech_la_OBJECTS) $(libnrnmech_la_DEPENDENCIES)
-	$(LINK) -rpath "$(libdir)" $(libnrnmech_la_LDFLAGS) $(libnrnmech_la_OBJECTS) $(libnrnmech_la_LIBADD) $(LIBS)


### PR DESCRIPTION
Disclaimer: This is an initial version following up the ideas proposed in issue #193

**Problem**:
When building additional mechanisms it is often useful having a shared library. nrnivmodl can build such lib when linux_nrnmech=yes (NRNMECH_DLL_STYLE_TRUE is true).
However, special is not a binary anymore but a shell script which basically does `nrniv -dll libnrnmech.so`. For situation like debugging this can be problematic.

**This PR**
Implements creating a binary special with the makefile which links against libnrnmech.
Using libtool we install the lib to the intended rpath, with the slight benefit that libtool no longer creates special in .libs

To be better understood: 
- Are there cases where having the shell script is required? Or can we drop that mode?