### PR TITLE
save_test() shall attempt to create out dir

### DIFF
--- a/src/nrniv/bbsavestate.cpp
+++ b/src/nrniv/bbsavestate.cpp
@@ -169,6 +169,7 @@ callback to bbss_early when needed.
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 #include "ocfile.h"
 #include "nrnoc2iv.h"
 #include "classreg.h"
@@ -593,14 +594,17 @@ static double save_test(void* v) {
 	BBSaveState* ss = (BBSaveState*)v;
 	usebin_ = 0;
 	if (nrnmpi_myid == 0) { // save global time
-		BBSS_IO* io = new BBSS_TxtFileOut("out/tmp");
+		mkdir("bbss_out", 0770);
+		BBSS_IO* io = new BBSS_TxtFileOut("bbss_out/tmp");
 		io->d(1, nrn_threads->_t);
 		delete io;
 	}
+ 	nrnmpi_barrier();
+
 	int len = ss->counts(&gids, &sizes);
 	for (int i = 0; i < len; ++i) {
 		char fn[200];
-		sprintf(fn, "out/tmp.%d.%d", gids[i], nrnmpi_myid);
+		sprintf(fn, "bbss_out/tmp.%d.%d", gids[i], nrnmpi_myid);
 		BBSS_IO* io = new BBSS_TxtFileOut(fn);
 		ss->f = io;
 		ss->gidobj(gids[i]);


### PR DESCRIPTION
Without source code knowledge the user will get puzzled with the following error after calling test_save():
`Assertion failed: (f), function BBSS_TxtFileOut`
It turns out it is simply because files are to be created in `out/` and no check/attempt to create is made.
Plus, `out` as a name is little insightful.

This patch attempts to create  `bbss_out`