### PR TITLE
Fix attempt to #219 where readline wrongly links

### DIFF
--- a/m4/readline.m4
+++ b/m4/readline.m4
@@ -41,6 +41,7 @@ AC_HELP_STRING([-with-readline=dir],[Specify the location of the readline librar
  elif test "$with_readline" = "no" ; then # build our own
    echo "build our own version of libreadline"
    READLINE_LIBS="-lreadline $TERMCAP_LIB"
+   READLINE_SOSUFFIX=0
    build_readline=yes
    NRN_READLINE_LIBS="../readline/libreadline.la $TERMCAP_LIB"
    NRN_READLINE_DEP="../readline/libreadline.la"
@@ -96,7 +97,10 @@ exit 1
 MEMACSLIB="-lmemacs"
 MEMACSLIBLA="../memacs/libmemacs.la"
 
+AC_SUBST(READLINE_SOSUFFIX)
+
 else dnl end of with_memacs and beginning of without_memacs
+
 echo "no memacs or anything else that depends on terminal capabilities"
 READLINE_LIBS=""
 NRN_READLINE_LIBS=""

--- a/src/nrnpython/setup.py.in
+++ b/src/nrnpython/setup.py.in
@@ -69,25 +69,24 @@ libdirs = [destdir + "@NRN_LIBDIR@",
 ]
 epre='-Wl,-R'
 
-@MAC_DARWIN_FALSE@readline="readline"
-@MAC_DARWIN_TRUE@readline="readline"
+@MAC_DARWIN_FALSE@readline="readline@READLINE_SOSUFFIX@"
+@MAC_DARWIN_TRUE@readline="readline@READLINE_SOSUFFIX@"
 
 
 hoc_module = Extension(
-      "neuron.hoc",
-      ["inithoc.cpp"],
-      library_dirs=libdirs,
-      @setup_extra_link_args@ = [ epre+libdirs[0],epre+libdirs[1] ],
-      #extra_objects = [],
-      libraries = [
-	"nrnpython@npy_pyver10@",
+    "neuron.hoc",
+    ["inithoc.cpp"],
+    library_dirs=libdirs,
+    @setup_extra_link_args@ = [ epre+libdirs[0],epre+libdirs[1] ],
+    #extra_objects = [],
+    libraries = [
+        "nrnpython@npy_pyver10@",
         "nrnoc", "oc", "nrniv", "ivoc",
-        @BUILD_MEMACS_TRUE@"memacs",
-	"meschach", "neuron_gnu",
-	@BUILD_NRNMPI_DYNAMIC_FALSE@"nrnmpi",
+        @BUILD_MEMACS_TRUE@"memacs", readline,
+        "meschach", "neuron_gnu",
+        @BUILD_NRNMPI_DYNAMIC_FALSE@"nrnmpi",
         "scopmath", "sparse13", "sundials",
-	readline,
-	"@IVHINES@",
+        "@IVHINES@",
       ],
       include_dirs = include_dirs,
       define_macros=defines

--- a/src/readline/Makefile.am
+++ b/src/readline/Makefile.am
@@ -6,4 +6,5 @@ libreadline_la_SOURCES = readline.c history.c funmap.c keymaps.c
 noinst_HEADERS = chardefs.h emacs_keymap.h history.h keymaps.h \
 	readline.h vi_keymap.h
 
-
+install-exec-hook:
+	$(LN_S) $(DESTDIR)$(libdir)/libreadline.so $(DESTDIR)$(libdir)/libreadline0.so


### PR DESCRIPTION
From #219 attepts at solving
  (1) By specifying readline after the conditional @BUILD_MEMACS_TRUE@
  (2) By creating a softlink on the built internal readline (named libreadline0.so) and linking against it. Apparently Python link locations always take precedence so we have to be specific on the  library version.

Tested with both configurations:
- `./configure --without-readline --without-memacs`
- `./configure --with-readline=no`
