### PR TITLE
Fixes for readline and osx builds:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,8 @@ find_package(FLEX)
 
 if (ENABLE_MPI)
   find_package(MPI REQUIRED)
+  # TODO : include this for only selective target
+  include_directories(${MPI_INCLUDE_PATH})
   set(NRNMPI 1)
   set(PARANEURON 1)
 else()
@@ -339,11 +341,18 @@ install(FILES ${inst_inc} ${PROJECT_BINARY_DIR}/src/oc/nrnpthread.h
   DESTINATION ${CMAKE_INSTALL_PREFIX}/include
 )
 
-# build readline if on OSX
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+find_package(readline)
+
+# if readline not found or if we are on OSX, use internal readline
+# also clear library variable
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin" OR NOT ${READLINE_FOUND})
     add_subdirectory(src/readline)
-else()
-    find_package(readline REQUIRED)
+    set(INTERNAL_READLINE readline)
+    unset(Readline_LIBRARY CACHE)
+endif()
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -undefined dynamic_lookup")
 endif()
 
 add_subdirectory(src/nrniv)

--- a/cmake/Findreadline.cmake
+++ b/cmake/Findreadline.cmake
@@ -1,0 +1,49 @@
+# Code copied from sethhall@github
+#
+# - Try to find readline include dirs and libraries
+#
+# Usage of this module as follows:
+#
+#     find_package(Readline)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  Readline_ROOT_DIR         Set this variable to the root installation of
+#                            readline if the module has problems finding the
+#                            proper installation path.
+#
+# Variables defined by this module:
+#
+#  READLINE_FOUND            System has readline, include and lib dirs found
+#  Readline_INCLUDE_DIR      The readline include directories.
+#  Readline_LIBRARY          The readline library.
+
+find_path(Readline_ROOT_DIR
+    NAMES include/readline/readline.h
+)
+
+find_path(Readline_INCLUDE_DIR
+    NAMES readline/readline.h
+    HINTS ${Readline_ROOT_DIR}/include
+)
+
+find_library(Readline_LIBRARY
+    NAMES readline
+    HINTS ${Readline_ROOT_DIR}/lib
+)
+
+if(Readline_INCLUDE_DIR AND Readline_LIBRARY AND Ncurses_LIBRARY)
+  set(READLINE_FOUND TRUE)
+else(Readline_INCLUDE_DIR AND Readline_LIBRARY AND Ncurses_LIBRARY)
+  FIND_LIBRARY(Readline_LIBRARY NAMES readline)
+  include(FindPackageHandleStandardArgs)
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(Readline DEFAULT_MSG Readline_INCLUDE_DIR Readline_LIBRARY )
+  MARK_AS_ADVANCED(Readline_INCLUDE_DIR Readline_LIBRARY)
+endif(Readline_INCLUDE_DIR AND Readline_LIBRARY AND Ncurses_LIBRARY)
+
+mark_as_advanced(
+    Readline_ROOT_DIR
+    Readline_INCLUDE_DIR
+    Readline_LIBRARY
+)

--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -366,15 +366,19 @@ set_source_files_properties(${ocsrcdir}/hocusr.c
 
 include_directories(${base_include} ${PYTHON_INCLUDE_DIRS})
 
-# handy trick to see that the correct iv headers are visible:
-get_target_property(iv_interface_includes iv_interviews INTERFACE_INCLUDE_DIRECTORIES)
-message("IV interface includes: ${iv_interface_includes}")
-include_directories(${base_include} ${iv_interface_includes})
-
 add_library(nrniv_lib SHARED ${nrnivlibsrc})
-target_link_libraries(nrniv_lib iv_interviews ${X11_LIBRARIES}
-  ${MPI_C_LIBRARIES} ${PYTHON_LIBRARIES} readline "-undefined dynamic_lookup"
+target_link_libraries(nrniv_lib ${X11_LIBRARIES}
+  ${MPI_C_LIBRARIES} ${PYTHON_LIBRARIES} readline
 )
+
+if (ENABLE_INTERVIEWS)
+  # handy trick to see that the correct iv headers are visible:
+  get_target_property(iv_interface_includes iv_interviews INTERFACE_INCLUDE_DIRECTORIES)
+  message("IV interface includes: ${iv_interface_includes}")
+  include_directories(${iv_interface_includes})
+  target_link_libraries(nrniv_lib iv_interviews)
+endif()
+
 set_property(TARGET nrniv_lib PROPERTY OUTPUT_NAME nrniv)
 
 mymklist(nrnbinsrc "${PROJECT_SOURCE_DIR}/src/ivoc/"
@@ -387,7 +391,7 @@ mymklist(nrnbinsrc "${PROJECT_SOURCE_DIR}/src/oc/"
 
 add_executable(nrniv ${nrnbinsrc})
 #set(IV_LIBRARIES ${PROJECT_SOURCE_DIR}/../ivcmake/build/install/lib/libinterviews.so)
-target_link_libraries(nrniv nrniv_lib readline)
+target_link_libraries(nrniv nrniv_lib ${INTERNAL_READLINE} ${Readline_LIBRARY})
 
 install(TARGETS nrniv nocmodl DESTINATION bin)
 install(TARGETS nrniv_lib DESTINATION lib)

--- a/src/readline/CMakeLists.txt
+++ b/src/readline/CMakeLists.txt
@@ -9,7 +9,7 @@ set(READLINE_SOURCE_FILES
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-find_package(curses REQUIRED)
+find_package(Curses REQUIRED)
 
 # =============================================================================
 # readline library


### PR DESCRIPTION
  - dynamic_lookup flags for osx is only portable with clang
  - add missing mpi includes
  - use internal readline on OSX or iff readline not found
  - add Findreadline.cmake
  - WIP : make interviews optional