### PR TITLE
bugfix: added call to nrn_shape_update

### DIFF
--- a/src/ivoc/ocnoiv1.cpp
+++ b/src/ivoc/ocnoiv1.cpp
@@ -9,12 +9,13 @@ extern "C" {
 
 extern void hoc_ret();
 extern void hoc_pushx(double);
+extern void nrn_shape_update();
 
 void ivoc_help(const char*){}
 void ivoc_cleanup() {}
 int hoc_readcheckpoint(char*){ return 0; }
 
-void hoc_notify_iv() {hoc_ret(); hoc_pushx(0.);}
+void hoc_notify_iv() {nrn_shape_update(); hoc_ret(); hoc_pushx(0.);}
 void hoc_xpvalue() {	hoc_ret(); hoc_pushx(0.);}
 void hoc_xlabel() { hoc_ret(); hoc_pushx(0.);}
 void hoc_xbutton() { hoc_ret(); hoc_pushx(0.);}


### PR DESCRIPTION
So the h.doNotify() call triggers an update to the number of rxd nodes when nseg has changed.