### PR TITLE
Fix issue when python dynamic support is enabled

### DIFF
--- a/bin/nrnpyenv.sh
+++ b/bin/nrnpyenv.sh
@@ -273,7 +273,11 @@ def nrnpylib_linux():
   #in case it was dynamically loaded by python
   pid = os.getpid()
   cmd = "lsof -p %d"%pid
-  f = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT).stdout
+  f = []
+  try: # in case lsof does not exist
+    f = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT).stdout
+  except:
+    pass
   nrn_pylib = None
   for bline in f:
     fields = bline.decode().split()

--- a/src/nrniv/nrnpy.cpp
+++ b/src/nrniv/nrnpy.cpp
@@ -144,7 +144,8 @@ static void set_nrnpylib() {
     free(bfnrnhome);
     #else
     char* line = new char[linesz+1];
-    sprintf(line, "bash nrnpyenv.sh %s",
+    sprintf(line, "bash %s/../../%s/bin/nrnpyenv.sh %s",
+     neuron_home, NRNHOSTCPU,
       (nrnpy_pyexe && strlen(nrnpy_pyexe) > 0) ? nrnpy_pyexe : "");
    #endif
     FILE* p = popen(line, "r");


### PR DESCRIPTION
  - I build neuron with below flags:
    ```
    ./configure '--without-iv' '--without-x' '--with-nrnpython=dynamic' --prefix=`pwd`/install-dir  -    with-readline=no '--disable-rx3d'
    make
    make install
    ```
  - I see below error when trying to run test:
    ```
    nrn/install-dir/x86_64/bin/nrniv -python -pyexe python3.7 -c 'import neuron ; neuron.test() ;'
    NEURON -- VERSION 7.7.1-24-g4524ea3c master (4524ea3c) 2019-07-31
    Duke, Yale, and the BlueBrain Project -- Copyright 1984-2018
    See http://neuron.yale.edu/neuron/credits

    bash: nrnpyenv.sh: No such file or directory
    Python not available
    ```

  - This is because popen fails for `bash nrnpyenv.sh` fails due to incomplete path (?):
    ```
    sprintf(line, "bash nrnpyenv.sh %s",
    (nrnpy_pyexe && strlen(nrnpy_pyexe) > 0) ? nrnpy_pyexe : "");
     #endif
     FILE* p = popen(line, "r");
    ```

This also fix the issue I mentioned in #254.

Also, fix error when `lsof` not installed on Ubuntu/Linux.

@nrnhines  : I have tested this on OSX only. So may be you should take careful look before merge.

cc: @ohm314  @ferdonline 