### PR TITLE
fix links to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and a discusson forum.
 Basic installation on Linux from the nrn...tar.gz file is:
 
   Build InterViews first from the git repository at
-  http://github.org/neuronsimulator/iv or the iv...tar.gz file at
+  http://github.com/neuronsimulator/iv or the iv...tar.gz file at
   http://neuron.yale.edu/ftp/neuron/versions/alpha/
 
 ```
@@ -18,7 +18,7 @@ Basic installation on Linux from the nrn...tar.gz file is:
 ```
 
 If sources are obtained from the git repository,
-http://github.org/neuronsimulator/nrn ,
+http://github.com/neuronsimulator/nrn ,
 create the automake, autoconf, libtool generated files by:
   sh build.sh
 


### PR DESCRIPTION
Current links to github are broken as they use `.org` ending.