### PR TITLE
Support for dynamic MPI initalization : Part II (alternative to #266)

### DIFF
--- a/src/nrnpython/inithoc.cpp
+++ b/src/nrnpython/inithoc.cpp
@@ -118,20 +118,24 @@ void inithoc() {
   }
 #ifdef NRNMPI
 
-  int flag = 0;
-  int mpi_mes = 0;  // for printing an mpi message only once.
-  char* pmes = 0;
+  int flag = 0;                 // true if MPI_Initialized is called
+  int mpi_mes = 0;              // for printing mpi message only once
+  int libnrnmpi_is_loaded = 1;  // becomes 0 if NEURON_INIT_MPI == 0 with dynamic mpi
+  char* pmes = NULL;            // error message
+  char* env_mpi = getenv("NEURON_INIT_MPI");
 
 #if NRNMPI_DYNAMICLOAD
   nrnmpi_stubs();
-  int init_mpi = 1;
-  char* env_mpi = getenv("NEURON_INIT_MPI");
-  // We dont load dynamically MPI if NEURON_INIT_MPI exists and is 0
+  /**
+   * In case of dynamic mpi build we load MPI unless NEURON_INIT_MPI is explicitly set to 0.
+   * We call nrnmpi_load to load MPI library which returns:
+   *  - nil if loading is successfull
+   *  - error message in case of loading error
+   */
   if(env_mpi != NULL && strcmp(env_mpi, "0") == 0) {
-    init_mpi = 0;
+    libnrnmpi_is_loaded = 0;
   }
-  if (init_mpi) {
-    // if nrnmpi_load succeeds (MPI available), pmes is nil.
+  if (libnrnmpi_is_loaded) {
     pmes = nrnmpi_load(1);
     if (pmes) {
       printf(
@@ -139,36 +143,38 @@ void inithoc() {
         "because:\n%s\n",
         pmes);
       exit(1);
-    } else {
+    }
+  }
+#endif
+
+  /**
+   * In case of non-dynamic mpi build mpi library is already linked. We add -mpi
+   * argument in following scenario:
+   * - if user has not explicitly set NEURON_INIT_MPI to 0 and mpi is already initialized
+   * - if user has explicitly set NEURON_INIT_MPI to 1 to load mpi initialization
+   */
+  if (libnrnmpi_is_loaded) {
+    nrnmpi_wrap_mpi_init(&flag);
+    if (flag) {
+      mpi_mes = 1;
+      argc = argc_mpi;
+      argv = (char**)argv_mpi;
+    } else if(env_mpi != NULL && strcmp(env_mpi, "1") == 0) {
       mpi_mes = 2;
       argc = argc_mpi;
       argv = (char**)argv_mpi;
+    }else{
+      mpi_mes = 3;
     }
   } else {
     // no mpi
     mpi_mes = 3;
   }
-#else
-  // avoid having to include the c++ version of mpi.h
-  if (!pmes) {
-    nrnmpi_wrap_mpi_init(&flag);
-  }
-  if (flag) {
-    mpi_mes = 1;
-    argc = argc_mpi;
-    argv = (char**)argv_mpi;
-  } else if (getenv("NEURON_INIT_MPI")) {
-    // force NEURON to initialize MPI
-    mpi_mes = 2;
-    argc = argc_mpi;
-    argv = (char**)argv_mpi;
-  } else {
-    //no mpi
-    mpi_mes = 3;
-  }
-#endif
 
-  if (pmes && mpi_mes == 2){exit(1);}  // avoid unused variable warning
+  // merely avoids unused variable warning
+  if (pmes && mpi_mes == 2){
+      exit(1);
+  }
 
 #endif //NRNMPI
 
@@ -189,7 +195,9 @@ void inithoc() {
   nrn_is_python_extension = (pyver[0]-'0')*10 + (pyver[2] - '0');
   p_nrnpython_finalize = nrnpython_finalize;
 #if NRNMPI
-  nrnmpi_init(1, &argc, &argv);  // may change argc and argv
+  if (libnrnmpi_is_loaded) {
+    nrnmpi_init(1, &argc, &argv);  // may change argc and argv
+  }
 #if 0 && !defined(NRNMPI_DYNAMICLOAD)
 	if (nrnmpi_myid == 0) {
 		switch(mpi_mes) {


### PR DESCRIPTION
Due to portability concerns in #266, this PR uses pure `NEURON_INIT_MPI` variable
to decide if library shouldnt be loaded:
  - in case of non-dynamic mpi build, mpi library is already linked so
    one can call mpi routine MPI_Initialized
  - in case of dynamic mpi build, mpi library is loaded unless user
    has explicitly disabled by setting NEURON_INIT_MPI=0

Same analysis as in #266:

## Tests


* **test1** : no mpi initialisation 

```python
from neuron import h
pc = h.ParallelContext()
id = int(pc.id())
nhost = int(pc.nhost())
print("I am {} of {}".format(id, nhost))
h.quit()
```

* **test2** : mpi externally initialised by mpi4py

```python
from mpi4py import MPI
from neuron import h
pc = h.ParallelContext()
id = int(pc.id())
nhost = int(pc.nhost())
print("I am {} of {}".format(id, nhost))
h.quit()
```

* **test3** : mpi explicitly initialised using NEURON api

```python
from neuron import h
h.nrnmpi_init()
pc = h.ParallelContext()
id = int(pc.id())
nhost = int(pc.nhost())
print("I am {} of {}".format(id, nhost))
h.quit()
```

## Test Runs : on Mac

test script is:

```bash
cd /usr/local/lib

for pypath in "/Users/kumbhar/workarena/repos/bbp/nrn/dynamic/install/lib/python/" "/Users/kumbhar/workarena/repos/bbp/nrn/nodynamic/install/lib/python/";
do
    export PYTHONPATH=$pypath
    echo "PYTHONPATH : $PYTHONPATH \n\n"
    for file in "test1.py" "test2.py" "test3.py";
    do
        echo "Running : $file"
        python $HOME/$file;
        NEURON_INIT_MPI=0 python $HOME/$file;
        NEURON_INIT_MPI=1 python $HOME/$file;
    done
done
```

and output is:

```bash
○ → bash test.sh
PYTHONPATH : /Users/kumbhar/workarena/repos/bbp/nrn/dynamic/install/lib/python/ \n\n
Running : test1.py
I am 0 of 1
I am 0 of 1
numprocs=1
I am 0 of 1
Running : test2.py
numprocs=1
I am 0 of 1
I am 0 of 1
numprocs=1
I am 0 of 1
Running : test3.py
numprocs=1
I am 0 of 1
numprocs=1
I am 0 of 1
numprocs=1
I am 0 of 1
PYTHONPATH : /Users/kumbhar/workarena/repos/bbp/nrn/nodynamic/install/lib/python/ \n\n
Running : test1.py
I am 0 of 1
I am 0 of 1
numprocs=1
I am 0 of 1
Running : test2.py
numprocs=1
I am 0 of 1
numprocs=1
I am 0 of 1
numprocs=1
I am 0 of 1
Running : test3.py
numprocs=1
I am 0 of 1
numprocs=1
I am 0 of 1
numprocs=1
I am 0 of 1
```

## Test Runs : on BB5 with HPE-MPI

HPE-MPI is special in the sense that it doesn't allow running MPI linked programs without MPI launcher.

Here is test script:

```bash
# neuron/developfix is this PR
for module in "neuron/7.6.6" "neuron/developfix";
do
    module purge
    module load $module/python3/parallel py-mpi4py
    echo "Module : $module"
    for file in "test1.py" "test2.py" "test3.py";
    do
        echo "Running : $file"
        python $file;
        NEURON_INIT_MPI=0 python $file;
        NEURON_INIT_MPI=1 python $file;
    done
done
```

And output on BB5 under SLURM allocation is:

```
$ bash test.sh
Autoloading python/3.6.5
Autoloading hpe-mpi/2.16
Module : neuron/7.6.6
Running : test1.py
MPT ERROR: PMI2_Init
MPT ERROR: PMI2_Init
MPT ERROR: PMI2_Init
Running : test2.py
MPT ERROR: PMI2_Init
MPT ERROR: PMI2_Init
MPT ERROR: PMI2_Init
Running : test3.py
MPT ERROR: PMI2_Init
MPT ERROR: PMI2_Init
MPT ERROR: PMI2_Init
Autoloading python/3.6.5
Autoloading hpe-mpi/2.16
Module : neuron/developfix
Running : test1.py
MPT ERROR: PMI2_Init
I am 0 of 1
MPT ERROR: PMI2_Init
Running : test2.py
MPT ERROR: PMI2_Init
MPT ERROR: PMI2_Init
MPT ERROR: PMI2_Init
Running : test3.py
MPT ERROR: PMI2_Init
MPT ERROR: PMI2_Init
MPT ERROR: PMI2_Init
```

- [x] Test on Mac
- [x] Test on BB5 with HPE-MPI

So, this is bit different wrt #266 in the sense that user (with HPE-MPI) has to explicitly set `NEURON_INIT_MPI=0` but this is OK.

cc : @jorblancoa  @ferdonline  @ohm314 