### PR TITLE
Make load_mechanisms already loaded warning optional

### DIFF
--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -188,7 +188,7 @@ else:
 # global list of paths already loaded by load_mechanisms
 nrn_dll_loaded = []
 
-def load_mechanisms(path):
+def load_mechanisms(path, warn_if_already_loaded=True):
     """
     load_mechanisms(path)
 
@@ -204,7 +204,8 @@ def load_mechanisms(path):
     
     global nrn_dll_loaded
     if path in nrn_dll_loaded:
-        print("Mechanisms already loaded from path: %s.  Aborting." % path)
+        if warn_if_already_loaded:
+            print("Mechanisms already loaded from path: %s.  Aborting." % path)
         return True
     
     # in case NEURON is assuming a different architecture to Python,


### PR DESCRIPTION
I have a case where I need to call load_mechanisms(path) for different models without knowing if the mechanisms have been previously loaded. When called multiple times, I receive the 'Mechanisms already loaded from path' message.

This PR keeps the existing behavior by default but allows users to disable the message with a new flag.