### PR TITLE
Added i_membrane_ to direct memory transfer to CoreNeuron

### DIFF
--- a/src/nrniv/nrnbbcore_write.cpp
+++ b/src/nrniv/nrnbbcore_write.cpp
@@ -729,7 +729,11 @@ void datumtransform(CellGroup* cgs) {
   }
 }
 
-// Limited to pointers to voltage or data of non-artificial cell mechanisms.
+// This function is related to stdindex2ptr in CoreNeuron to determine which values should
+// be transferred from CoreNeuron. Types correspond to the value to be transferred based on
+// mech_type enum or non-artificial cell mechanisms.
+// Limited to pointers to voltage, nt._nrn_fast_imem->_nrn_sav_rhs (fast_imem value) or
+// data of non-artificial cell mechanisms.
 // Requires cache_efficient mode.
 // Input double* and NrnThread. Output type and index.
 // type == 0 means could not determine index.

--- a/src/nrniv/nrnbbcore_write.h
+++ b/src/nrniv/nrnbbcore_write.h
@@ -76,7 +76,9 @@ extern int nrn_dblpntr2nrncore(double*, NrnThread&, int& type, int& etype);
 }
 #endif
 
-// Mechanism type to be used from stdindex2ptr (in CoreNeuron) and nrn_dblpntr2nrncore
+// Mechanism type to be used from stdindex2ptr (in CoreNeuron) and nrn_dblpntr2nrncore.
+// Values of the mechanism types should be negative numbers to avoid any conflict with
+// mechanism types of Memb_list(>0) or time(0) passed to CoreNeuron
 enum mech_type {voltage = -1, i_membrane_ = -2};
 
 #endif

--- a/src/nrniv/nrnbbcore_write.h
+++ b/src/nrniv/nrnbbcore_write.h
@@ -76,5 +76,7 @@ extern int nrn_dblpntr2nrncore(double*, NrnThread&, int& type, int& etype);
 }
 #endif
 
+// Mechanism type to be used from stdindex2ptr (in CoreNeuron) and nrn_dblpntr2nrncore
+enum mech_type {voltage = -1, i_membrane_ = -2};
 
 #endif


### PR DESCRIPTION
This PR is related to https://github.com/BlueBrain/CoreNeuron/pull/196 and it should be merged together otherwise the functionality breaks