### PR TITLE
Array for spike compression may not be allocated in some circumstances.

### DIFF
--- a/src/nrnmpi/mpispike.c
+++ b/src/nrnmpi/mpispike.c
@@ -176,6 +176,8 @@ int nrnmpi_spike_exchange_compressed() {
 		np = nrnmpi_numprocs;
 		displs = (int*)hoc_Emalloc(np*sizeof(int)); hoc_malchk();
 		displs[0] = 0;
+	}
+	if (!byteovfl) {
 		byteovfl = (int*)hoc_Emalloc(np*sizeof(int)); hoc_malchk();
 	}
 	nrnbbs_context_wait();


### PR DESCRIPTION
If normal uncompressed spike exchange occurs, then a later request
for compressed spike exchange will fail to allocate an overflow array
and access of a NULL pointer will occur