### PR TITLE
Remove legacy options for purify and mpitrace library of bg-q

### DIFF
--- a/bin/nrniv_makefile.in
+++ b/bin/nrniv_makefile.in
@@ -11,22 +11,16 @@ sbindir = @sbindir@
 libexecdir = @libexecdir@
 datadir = @datadir@
 sysconfdir = @sysconfdir@
-sharedstatedir = @sharedstatedir@
-localstatedir = @localstatedir@
 libdir = @libdir@
-infodir = @infodir@
-mandir = @mandir@
 includedir = @includedir@
 
 pkgdatadir = $(datadir)/@PACKAGE@
-pkglibdir = $(libdir)/@PACKAGE@
 pkgincludedir = $(includedir)/@PACKAGE@
 libobjdir = $(libdir)
 
 DEFS = @DEFS@
 LDFLAGS = $(UserLDFLAGS) @LDFLAGS@
 LIBS = $(BGTRACE_LIBS) @LIBS@
-X_CFLAGS = @X_CFLAGS@
 X_LIBS = @X_LIBS@
 X_EXTRA_LIBS = @X_EXTRA_LIBS@
 X_PRE_LIBS = @X_PRE_LIBS@
@@ -37,7 +31,6 @@ NJ_LIBS = @NRNJAVA_LIBS@
 PY_LIBS = @NRNPYTHON_LIBS@
 NRNNI_LIBS = @NRNNI_LIBS@
 
-PTHREAD_CC=@PTHREAD_CC@
 PTHREAD_CFLAGS=@PTHREAD_CFLAGS@
 PTHREAD_LIBS=@PTHREAD_LIBS@
 
@@ -54,8 +47,6 @@ CCLD = $(CC)
 CXXLD = $(CXX)
 
 CXXLINK = $(LIBTOOL) --mode=link $(CXXLD) $(AM_CXXFLAGS) $(CXXFLAGS) $(LDFLAGS)
-@NRNPURIFY_TRUE@CXXPURELINK = $(LIBTOOL) --tag=purify --mode=link purify $(CXXLD) $(AM_CXXFLAGS) $(CXXFLAGS) $(LDFLAGS)
-LINK = $(LIBTOOL) --mode=link $(CCLD) $(AM_CFLAGS) $(CFLAGS) $(LDFLAGS)
 
 @BUILD_NRNMPI_DYNAMIC_TRUE@lnrnmpi =
 @BUILD_NRNMPI_DYNAMIC_FALSE@lnrnmpi = -lnrnmpi
@@ -79,7 +70,7 @@ NRNIVOBJS = $(libobjdir)/nrnmain.o $(libobjdir)/ivocmain.o $(libobjdir)/nvkludge
 # a .mod to a .o file because otherwise GNU make will try to use a rule
 # involving m2c.  Argh!!  Why did they have to build in so many implicit
 # rules?
-# 
+#
 #.mod.o:
 #	$(bindir)/nocmodl $* || (rm -f $*.c; exit 1)
 #	$(COMPILE) -c $*.c
@@ -93,7 +84,7 @@ NRNIVOBJS = $(libobjdir)/nrnmain.o $(libobjdir)/ivocmain.o $(libobjdir)/nvkludge
 
 .mod.c:
 	$(bindir)/nocmodl $*
-	
+
 .c.o:
 	$(COMPILE) -c $*.c
 
@@ -101,19 +92,8 @@ NRNIVOBJS = $(libobjdir)/nrnmain.o $(libobjdir)/ivocmain.o $(libobjdir)/nvkludge
 	$(bindir)/nocmodl $*
 	$(COMPILE) -c $*.c
 
-
 mod_func.o: mod_func.c
 	$(COMPILE) -c $<
 
-@NRNPURIFY_FALSE@special: $(MODOBJFILES) $(COBJFILES) mod_func.o
-@NRNPURIFY_FALSE@	$(CXXLINK) -o special $(NRNIVOBJS) $(MODOBJFILES) mod_func.o $(COBJFILES) $(NRNLIBS) $(LIBS)
-
-@NRNPURIFY_TRUE@special: $(MODOBJFILES) $(COBJFILES) mod_func.o
-@NRNPURIFY_TRUE@	if test "$(USEPURIFY)" = "yes" ; then \
-@NRNPURIFY_TRUE@	$(CXXPURELINK) -o special $(NRNIVOBJS) $(MODOBJFILES) mod_func.o $(COBJFILES) $(NRNLIBS) $(LIBS) ;\
-@NRNPURIFY_TRUE@	echo "if there is an error perhaps you need '/opt/Rational/config/start_lmgrd_on_NeuronDev'"; \
-@NRNPURIFY_TRUE@	echo 'if you cannot run then perhaps you need a LD_LIBRARY_PATH as in:'; \
-@NRNPURIFY_TRUE@	echo 'export LD_LIBRARY_PATH=/home/hines/pcache/home/hines/neuron/iv/i686/lib:/home/hines/pcache/home/hines/neuron/purify/i686/lib:/home/hines/neuron/iv/i686/lib:/home/hines/neuron/purify/i686/lib:/usr/X11R6/lib:/usr/X11R6/lib/modules'; \
-@NRNPURIFY_TRUE@	else \
-@NRNPURIFY_TRUE@	$(CXXLINK) -o special $(NRNIVOBJS) $(MODOBJFILES) mod_func.o $(COBJFILES) $(NRNLIBS) $(LIBS) ;\
-@NRNPURIFY_TRUE@	fi
+special: $(MODOBJFILES) $(COBJFILES) mod_func.o
+	$(CXXLINK) -o special $(NRNIVOBJS) $(MODOBJFILES) mod_func.o $(COBJFILES) $(NRNLIBS) $(LIBS)

--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -10,7 +10,7 @@ if test "x${NRNHOME}" = x ; then
 	bindir=@bindir@
 	libdir=@libdir@
 else
-        prefix="$NRNHOME"
+	prefix="$NRNHOME"
 	exec_prefix="${prefix}/${ARCH}"
 	bindir="${prefix}/${ARCH}/bin"
 	libdir="${prefix}/${ARCH}/lib"
@@ -28,18 +28,6 @@ export bindir
 export libdir
 
 MAKEFILEDIR="${bindir}"
-
-PURIFY="USEPURIFY=no"
-if [ "$1" = "-p" ] ; then
-	PURIFY="USEPURIFY=yes"
-	shift
-fi
-
-TRACE="BGTRACE_LIBS="
-if [ "$1" = "-trace" ] ; then
-	TRACE="BGTRACE_LIBS = -L/bgl/hpct_bgl/mp_profiler/lib -lmpitrace.rts -L/bgl/hpct_bgl/binutils-2.14/lib -lbfd -liberty -lhandle_MPID_Win_start_error.rts"
-	shift
-fi
 
 UserINCFLAGS=""
 if [ "$1" = "-incflags" ] ; then
@@ -138,16 +126,11 @@ void modl_reg(){
     fprintf(stderr, "Additional mechanisms from files'$newline'");
 ' >> mod_func.c
 
-if true ; then # the standard order
 for i in $files
-	do
-		echo '    fprintf(stderr," '$i'.mod");' >>mod_func.c
-	done
-else
-	# use "ls -x" to sort alphabetically by lines
-	# use "ls -C" to sort alphabetically by columns
-	ls -C $mfiles | sed 's/\(.*\)/    fprintf(stderr,"\1\\n");/' >> mod_func.c
-fi
+do
+	echo '    fprintf(stderr," '$i'.mod");' >>mod_func.c
+done
+
 echo '    fprintf(stderr, "'$newline'");
   }' >>mod_func.c
 
@@ -163,7 +146,7 @@ if test -n "$cfiles" ; then
 	COBJS=`echo "$cfiles" | sed 's/\.c/.o/g'`
 fi
 
-@NRNMECH_DLL_STYLE_FALSE@make -j 4 -f "${MAKEFILEDIR}/nrniv_makefile" "$PURIFY" "$TRACE" "MODOBJFILES=$MODOBJS" "COBJFILES=$COBJS" "UserLDFLAGS=$UserLDFLAGS" "UserINCFLAGS=$UserINCFLAGS" special &&
+@NRNMECH_DLL_STYLE_FALSE@make -j 4 -f "${MAKEFILEDIR}/nrniv_makefile" "MODOBJFILES=$MODOBJS" "COBJFILES=$COBJS" "UserLDFLAGS=$UserLDFLAGS" "UserINCFLAGS=$UserINCFLAGS" special &&
 @NRNMECH_DLL_STYLE_FALSE@  echo "Successfully created $MODSUBDIR/special"
 
 @NRNMECH_DLL_STYLE_TRUE@MODLO=`echo "$MODOBJS" | sed 's/\.o/.lo/g'`
@@ -191,13 +174,4 @@ fi
 @NRNMECH_DLL_STYLE_TRUE@@MAC_DARWIN_TRUE@if false ; then
 @NRNMECH_DLL_STYLE_TRUE@@MAC_DARWIN_FALSE@if false ; then
 @NRNMECH_DLL_STYLE_FALSE@if false ; then
-vv=`sw_vers -productVersion|sed 's/.*\.\(.*\)\..*/\1/'`
-#if test $vv -gt 6 ; then
-if false ; then
-echo "use @executable_path prefix for install_name for dylib absolute paths"
-ff="${mdir}/.libs/libnrnmech.so"
-f=`otool -L "$ff" | sed -n "s,.*$libdir/\(.*dylib\).*,\
--change $libdir/\1 @executable_path/../lib/\1,p"`
-install_name_tool $f "$ff"
-fi
 fi


### PR DESCRIPTION
Intention of this PR is to remove old/legacy options which are no longer used (and unlikely will be used):
  - purify is no longer available (there is a new product PurifyPlus but thats not commonly used in our environments)
  - as bluegene is discontinued, no need to keep mpitrace library
  - cleaned up some code sections/variables those were not used
