### PR TITLE
Avoid bash warning/error for empty if block

### DIFF
--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -174,5 +174,5 @@ fi
 @NRNMECH_DLL_STYLE_TRUE@@MAC_DARWIN_TRUE@if false ; then
 @NRNMECH_DLL_STYLE_TRUE@@MAC_DARWIN_FALSE@if false ; then
 @NRNMECH_DLL_STYLE_FALSE@if false ; then
-  : #for empty if block
+  false #for empty if block
 fi

--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -174,4 +174,5 @@ fi
 @NRNMECH_DLL_STYLE_TRUE@@MAC_DARWIN_TRUE@if false ; then
 @NRNMECH_DLL_STYLE_TRUE@@MAC_DARWIN_FALSE@if false ; then
 @NRNMECH_DLL_STYLE_FALSE@if false ; then
+  : #for empty if block
 fi


### PR DESCRIPTION
With #296, we get following warning (syntax error) from bash:

```
libtool: link: (cd ".libs" && rm -f "libnrnmech.so" && ln -s "libnrnmech.so.0.0.0" "libnrnmech.so")
libtool: link: ( cd ".libs" && rm -f "libnrnmech.la" && ln -s "../libnrnmech.la" "libnrnmech.la" )
Successfully created x86_64/special
neuron/x86_64/bin/nrnivmodl: line 177: syntax error near unexpected token `fi'
```

This is because the resultant section in nrnivmodl in:

```
if false ; then
#if false ; then
fi
```
So resultant empty `if block` is not allowed. 

In this PR I added empty bash statement using `:`

Thanks to @jorblancoa for pointing this out!