### PR TITLE
src/nrnoc/nrnversion.h changes if 'git describe' changes.

### DIFF
--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -149,9 +149,17 @@ set(NRN_INCLUDE_DIRS
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/src/sundials/shared)
 
 # generate version information file
+# nrnversion.h does not depend on another file but on the output of
+# git2version_h.sh and nrnversion.h should only be changed if that output
+# is different from the contents of nrnversion.h
+add_custom_target(nrnversion_h
+                   ${PROJECT_SOURCE_DIR}/git2nrnversion_h.sh ${PROJECT_SOURCE_DIR} >
+                           nrnversion.h.tmp
+                   COMMAND ${CMAKE_COMMAND} -E copy_if_different nrnversion.h.tmp ${NRN_NRNOC_SRC_DIR}/nrnversion.h
+                   DEPENDS ${PROJECT_SOURCE_DIR}/git2nrnversion_h.sh)
+
 add_custom_command(OUTPUT ${NRN_NRNOC_SRC_DIR}/nrnversion.h
-                   COMMAND ${PROJECT_SOURCE_DIR}/git2nrnversion_h.sh ${PROJECT_SOURCE_DIR} >
-                           ${NRN_NRNOC_SRC_DIR}/nrnversion.h)
+                   DEPENDS nrnversion_h)
 
 # generate hocusr.h
 add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/src/nrnoc/hocusr.h


### PR DESCRIPTION
 nrnversion.h was not being updated when 'git describe' changed since the custom command did not depend on anything. However nrnversion.h should changed if the output of git2nrnversion_h.sh is different from the existing contents of nrnversion.h. I don't see how this can be done with a custom
command so I added a custom target, nrnversion_h , and make the custom command depend on that.
However I don't know if keeping the custom command is good style (as there is no command in it anymore) or if it should be replaced by a set command that sets the nrnversion_h dependency property for nrnversion.h