### PR TITLE
Cleanup and cmake formatting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ option(NRN_ENABLE_CORENEURON "Enable CoreNEURON support" ON)
 # =============================================================================
 # Build options (string)
 # =============================================================================
-
+# ~~~
 # NEURON module installation:
 #   - OFF       : do not install
 #   - ON        : install with --home in ${CMAKE_INSTALL_PREFIX}
@@ -56,10 +56,10 @@ option(NRN_ENABLE_CORENEURON "Enable CoreNEURON support" ON)
 #                 libnrnmpi_xxx.so interface for each. When nrniv is launched with the -mpi argument,
 #                 the first mpi found will determine which interface is dynamically loaded."
 # Rx3D Cython generated files compiler optimization level. 0 is default.
-
+# ~~~
 option(NRN_ENABLE_MODULE_INSTALL "Enable installation of NEURON Python module" ON)
 set(NRN_MODULE_INSTALL_OPTIONS ""
-    CACHE STRING "setup.py options, leave empty for --home <install prefix>")
+    CACHE STRING "setup.py options, leave empty for --home <build dir>")
 
 option(NRN_ENABLE_PYTHON_DYNAMIC "Enable dynamic Python version support" OFF)
 set(
@@ -77,8 +77,7 @@ set(
   )
 
 set(NRN_RX3D_OPT_LEVEL "0"
-    CACHE STRING
-          "Integer optimization level for cython generated files. Nonzero may compile very slowly.")
+    CACHE STRING "Optimization level for Cython generated files (non-zero may compile slowly)")
 
 # =============================================================================
 # Include cmake modules
@@ -101,11 +100,13 @@ find_package(readline)
 if(NRN_ENABLE_RX3D)
   find_package(Cython)
 endif()
+if(MINGW)
+  find_package(Termcap REQUIRED)
+endif()
 
 # =============================================================================
-# Enable MPI/Python/IV/Pthead if found
+# Enable MPI
 # =============================================================================
-# enable mpi if found
 if(NRN_ENABLE_MPI)
   find_package(MPI REQUIRED)
   include_directories(${MPI_INCLUDE_PATH})
@@ -116,28 +117,31 @@ else()
   set(PARANEURON 0)
 endif()
 
-# enable interviews if found
-if(NRN_ENABLE_INTERVIEWS AND NOT NRN_WINDOWS_BUILD)
-  find_package(X11 QUIET)
-  if(NOT X11_FOUND)
-    if(APPLE)
-      message(FATAL_ERROR "You must install XQuartz from https://www.xquartz.org/ to build iv")
-    else()
-      message(
-        FATAL_ERROR
-          "You must install X11 to build iv e.g. 'apt install libx11-dev libxcomposite-dev' on Ubuntu"
-        )
-    endif()
-  endif()
-  include_directories(${X11_INCLUDE_DIR})
-endif()
+# =============================================================================
+# Enable Interviews
+# =============================================================================
 if(NRN_ENABLE_INTERVIEWS)
+  # on windows x11 is not required
+  if(NOT NRN_WINDOWS_BUILD)
+    find_package(X11 QUIET)
+    if(NOT X11_FOUND)
+      if(APPLE)
+        message(FATAL_ERROR "You must install XQuartz from https://www.xquartz.org/ to build iv")
+      else()
+        message(
+          FATAL_ERROR
+            "You must install X11 to build iv e.g. 'apt install libx11-dev libxcomposite-dev' on Ubuntu"
+          )
+      endif()
+    endif()
+    include_directories(${X11_INCLUDE_DIR})
+  endif()
+
   find_package(iv QUIET PATHS ${IV_DIR}/share/cmake ${IV_DIR})
   if(${iv_FOUND})
     message(STATUS "Using external Interviews from ${IV_DIR}")
     get_target_property(IV_INCLUDE_DIR interviews INTERFACE_INCLUDE_DIRECTORIES)
   else()
-    message(STATUS "Building Interviews from submodule")
     add_external_project(iv)
     include_directories(external/iv/src/include)
     set(IV_DIR ${PROJECT_SOURCE_DIR}/external/iv)
@@ -148,7 +152,9 @@ else()
   set(HAVE_IV 0)
 endif()
 
-# enable python support (interpreter needed to make hocusr.h from neuron.h, prefer Python 3)
+# =============================================================================
+# Enable Python support
+# =============================================================================
 find_package(PythonInterp REQUIRED)
 if(NRN_ENABLE_PYTHON)
   find_package(PythonLibsNew ${PYTHON_VERSION_MAJOR} REQUIRED)
@@ -160,7 +166,9 @@ else()
   set(USE_PYTHON 0)
 endif()
 
-# enable threads if found
+# =============================================================================
+# Enable Threads support
+# =============================================================================
 if(NRN_ENABLE_THREADS)
   set(THREADS_PREFER_PTHREAD_FLAG ON)
   find_package(Threads REQUIRED)
@@ -169,12 +177,9 @@ else()
   set(USE_PTHREAD 0)
 endif()
 
-# TODO check if this is optional with ncurses
-if(MINGW)
-  find_package(Termcap REQUIRED)
-endif()
-
-# enable CoreNEURON support
+# =============================================================================
+# Enable CoreNEURON support
+# =============================================================================
 if(NRN_ENABLE_CORENEURON)
   find_package(coreneuron QUIET PATHS ${CORENEURON_DIR}/share/cmake ${CORENEURON_DIR})
   if(${coreneuron_FOUND})
@@ -186,6 +191,18 @@ if(NRN_ENABLE_CORENEURON)
   endif()
 endif()
 
+# =============================================================================
+# Add helpder CMake modules AFTER setting options
+# =============================================================================
+include(NeuronFileLists)
+include(MPIDynamicHelper)
+include(ConfigFileSetting)
+include(PythonDynamicHelper)
+
+# =============================================================================
+# Set install location for libraries (before src/nrniv)
+# =============================================================================
+# ~~~
 # Classically, the install destination of the share folder for mac/linux has
 # been <prefix>/share/nrn but for linux it has been <prefix>. For now we keep
 # this distinction.
@@ -194,36 +211,20 @@ endif()
 # expected these shared libraries in <prefix>/bin (reduces the PATH and expected
 # by ctypes in the neuron module.) So for now we keep that distinction as
 # well. Setting these here as setup.py.in needs it.
-set(nrn_dest_share_dir ${CMAKE_INSTALL_PREFIX}/share/nrn)
-set(nrn_dest_sharedlibs ${CMAKE_INSTALL_PREFIX}/lib)
+# ~~~
 if(MINGW)
-  set(nrn_dest_share_dir ${CMAKE_INSTALL_PREFIX})
-  set(nrn_dest_sharedlibs ${CMAKE_INSTALL_PREFIX}/bin)
+  set(NRN_INSTALL_SHARE_DIR ${CMAKE_INSTALL_PREFIX})
+  set(NRN_INSTALL_SHARE_LIB_DIR ${CMAKE_INSTALL_PREFIX}/bin)
+else()
+  set(NRN_INSTALL_SHARE_DIR ${CMAKE_INSTALL_PREFIX}/share/nrn)
+  set(NRN_INSTALL_SHARE_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib)
 endif()
 
 # =============================================================================
-# Add CMake modules AFTER setting options
-# =============================================================================
-include(NeuronFileLists)
-include(MPIDynamicHelper)
-include(ConfigFileSetting)
-include(PythonDynamicHelper)
-
-# =============================================================================
-# Project version from git and project directories
+# Add project directories AFTER CMake modules
 # =============================================================================
 add_subdirectory(src/nrniv)
 add_subdirectory(bin)
-
-# =============================================================================
-# CMake format and Clang format
-# =============================================================================
-if(NEURON_CMAKE_FORMAT)
-  if(NOT EXISTS external/coding-conventions/cpp)
-    initialize_submodule(external/coding-conventions)
-  endif()
-  add_subdirectory(external/coding-conventions/cpp)
-endif()
 
 if(NRN_ENABLE_PYTHON)
   add_subdirectory(src/nrnpython)
@@ -237,6 +238,16 @@ endif()
 
 if(NRN_ENABLE_RX3D)
   add_subdirectory(share/lib/python/neuron/rxd/geometry3d)
+endif()
+
+# =============================================================================
+# Add coding-conventions submodule if code formatting enabled
+# =============================================================================
+if(NEURON_CMAKE_FORMAT)
+  if(NOT EXISTS external/coding-conventions/cpp)
+    initialize_submodule(external/coding-conventions)
+  endif()
+  add_subdirectory(external/coding-conventions/cpp)
 endif()
 
 # =============================================================================
@@ -259,42 +270,47 @@ endif()
 # =============================================================================
 # Install targets
 # =============================================================================
-# find headers to install
-nrn_find_project_files(NRN_HEADERS_PATHS ${HEADER_FILES_TO_INSTALL})
-
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/share/lib DESTINATION ${nrn_dest_share_dir})
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/share/demo DESTINATION ${nrn_dest_share_dir})
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/share/lib DESTINATION ${NRN_INSTALL_SHARE_DIR})
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/share/demo DESTINATION ${NRN_INSTALL_SHARE_DIR})
 install(FILES ${PROJECT_BINARY_DIR}/share/lib/nrnunits.lib
               ${PROJECT_BINARY_DIR}/share/lib/nrn.defaults
-        DESTINATION ${nrn_dest_share_dir}/lib)
+        DESTINATION ${NRN_INSTALL_SHARE_DIR}/lib)
 install(FILES ${PROJECT_BINARY_DIR}/share/lib/python/neuron/rxd/constants.py
-        DESTINATION ${nrn_dest_share_dir}/lib/python/neuron/rxd)
-
+        DESTINATION ${NRN_INSTALL_SHARE_DIR}/lib/python/neuron/rxd)
 install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/share/lib/cleanup
-        DESTINATION ${nrn_dest_share_dir}/lib)
+        DESTINATION ${NRN_INSTALL_SHARE_DIR}/lib)
+
+# find headers to install
+nrn_find_project_files(NRN_HEADERS_PATHS ${HEADER_FILES_TO_INSTALL})
 install(FILES ${NRN_HEADERS_PATHS} ${PROJECT_BINARY_DIR}/src/oc/nrnpthread.h
         DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
 
 # for external coreneuron, nrnivmodl-core should be install
-if(NRN_ENABLE_CORENEURON AND coreneuron_FOUND)
+if(coreneuron_FOUND)
   install(PROGRAMS ${CORENEURON_DIR}/bin/nrnivmodl-core DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
   install(FILES ${CORENEURON_DIR}/bin/nrnivmodl_core_makefile
           DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 endif()
 
+# =============================================================================
+# Copy bash executable for windows
+# =============================================================================
 if(MINGW)
+  # ~~~
   # nrniv.cpp calls nrnpyenv.sh with absolute path to bash.exe
   # this is sufficient on the build machine since a full
   # development environment exists. On the users install machine
   # using a setup.exe distribution, the setup.ex will contain a
   # minimal development environment with sufficient mingw programs
   # to allow nrnpyenv.sh to work. (see nrn/mingw_files/nrnmingwenv.sh)
-  find_file(nrnbash bash.exe DOC "DOS path to bash.exe")
-  message(STATUS "Found bash.exe at ${nrnbash}")
-  if("${nrnbash}" STREQUAL "nrnbash-NOTFOUND")
-    set(nrnbash "f:/msys64/usr/bin/bash.exe")
+  # ~~~
+  find_file(BASH_EXE bash.exe DOC "DOS path to bash.exe")
+  message(STATUS "Found bash.exe at ${BASH_EXE}")
+  if("${BASH_EXE}" STREQUAL "BASH_EXE-NOTFOUND")
+    set(BASH_EXE "f:/msys64/usr/bin/bash.exe")
+    message(WARNING "Can not find bash.exe, trying to use ${BASH_EXE}")
   endif()
-  install(PROGRAMS ${nrnbash} DESTINATION ${CMAKE_INSTALL_PREFIX}/mingw/usr/bin)
+  install(PROGRAMS ${BASH_EXE} DESTINATION ${CMAKE_INSTALL_PREFIX}/mingw/usr/bin)
 endif()
 
 # =============================================================================
@@ -312,11 +328,13 @@ if(cmake_generator_tolower MATCHES "makefile")
   message(STATUS "make install  | Will install NEURON to: ${CMAKE_INSTALL_PREFIX}")
   message(STATUS "              | Change the install location of NEURON using:")
   message(STATUS "              |     cmake <src_path> -DCMAKE_INSTALL_PREFIX=<install_path>")
-  message(STATUS "make doc      | Build the API documentation, requires Sphinx (todo)")
+  message(STATUS "make docs     | Build the API documentation")
   message(STATUS "make uninstall| Removes files installed by make install (todo)")
   message(STATUS "--------------+--------------------------------------------------------------")
   message(STATUS " Build option | Status")
   message(STATUS "--------------+--------------------------------------------------------------")
+  message(STATUS "Shared        | ${NRN_ENABLE_SHARED}")
+  message(STATUS "Legacy FR     | ${NRN_ENABLE_LEGACY_FR}")
   message(STATUS "MPI           | ${NRN_ENABLE_MPI}")
   if(NRN_ENABLE_MPI)
     message(STATUS "  INC         | ${MPI_INCLUDE_PATH}")
@@ -347,7 +365,6 @@ if(cmake_generator_tolower MATCHES "makefile")
   if(${NRN_ENABLE_RX3D})
     message(STATUS "  OptLevel    | ${NRN_RX3D_OPT_LEVEL}")
   endif()
-  message(STATUS "Shared        | ${NRN_ENABLE_SHARED}")
   message(STATUS "Interviews    | ${NRN_ENABLE_INTERVIEWS}")
   if(NRN_ENABLE_INTERVIEWS)
     message(STATUS "  PATH        | ${IV_DIR}")

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -28,7 +28,7 @@ set(CMAKE_INSTALL_INCLUDEDIR include)
 set(CMAKE_INSTALL_DATADIR share/nrn)
 
 # =============================================================================
-# Inclode nrnivmodl Makefile generator, adapted from CoreNEURON
+# Include nrnivmodl makefile generator
 # =============================================================================
 include(CMakeListsNrnMech)
 

--- a/bin/nrnivmodl_makefile_cmake.in
+++ b/bin/nrnivmodl_makefile_cmake.in
@@ -1,8 +1,3 @@
-#
-# This makefile has the rules necessary for making the custom version of coreneuron
-# executable called "special-core" from various mod files.
-# Mod files are looked up in the cwd, unless MODS_PATH is set
-
 # Modified to replace the autoconf processed file nrnmech_makefile.in
 
 # Mechanisms version are by default 0.0, but should be overriden
@@ -17,7 +12,7 @@ bindir := @CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@
 libdir := @CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
 incdir := @CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@
 datadir:= @CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_DATADIR@/
-datadir_mod2c := @CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_DATADIR@/lib
+datadir_lib := @CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_DATADIR@/lib
 
 # Additional variables set in CMAKE usable here
 # - @NRN_COMPILE_DEFS
@@ -30,7 +25,6 @@ _cm =,
 # We rebuild the include dirs since a lot of stuff changes place
 INCLUDES = $(INCFLAGS) -I$(incdir)
 INCLUDES += $(if @MPI_C_INCLUDE_PATH@, -I$(subst ;, -I,@MPI_C_INCLUDE_PATH@),)
-INCLUDES += $(if @reportinglib_INCLUDE_DIR@, -I$(subst ;, -I,@reportinglib_INCLUDE_DIR@),)
 INCLUDES += $(if @CMAKE_OSX_SYSROOT@, -isysroot @CMAKE_OSX_SYSROOT@)
 
 CC = @CMAKE_C_COMPILER@
@@ -96,11 +90,11 @@ $(OBJS_DIR)/%.o: $(MODC_DIR)/%.c | $(OBJS_DIR)
 # Build c files with nocmodl
 $(MODC_DIR)/%.c: $(MODS_PATH)/%.mod | $(MODC_DIR)
 	@printf " -> $(C_GREEN)MOD2C$(C_RESET) $<\n"
-	MODLUNIT=$(datadir_mod2c)/nrnunits.lib \
+	MODLUNIT=$(datadir_lib)/nrnunits.lib \
 	  $(bindir)/nocmodl $<
 
 # If .mod doesnt exist attempt from previously built opt mods in shared/
-$(MODC_DIR)/%.cpp: $(datadir_mod2c)/%.cpp | $(MODC_DIR)
+$(MODC_DIR)/%.cpp: $(datadir_lib)/%.cpp | $(MODC_DIR)
 	ln -s $< $@
 
 install: $(special) $(mech_lib)

--- a/cmake/CMakeListsNrnMech.cmake
+++ b/cmake/CMakeListsNrnMech.cmake
@@ -1,14 +1,14 @@
-# modified from CoreNEURON/extra/CMakeLists.txt included by nrn/CMakeLists.txt to define
-# substitutions needed to create nrnmech_makefile that is called by nrnivmodl
+# =============================================================================
+# Prepare nrnivmodl script with correct flags
+# =============================================================================
 
+# extract the COMPILE_DEFINITIONS property from the directory
 get_directory_property(NRN_COMPILE_DEFS COMPILE_DEFINITIONS)
-
 if(NRN_COMPILE_DEFS)
-  set(NRN_COMPILE_DEFS "-D${NRN_COMPILE_DEFS}")
-  string(REPLACE ";"
-                 " -D"
-                 NRN_COMPILE_DEFS
-                 "${NRN_COMPILE_DEFS}")
+  set(NRN_COMPILE_DEFS "")
+  foreach(flag ${NRN_COMPILE_DEFS})
+    set(NRN_COMPILE_DEFS "${NRN_COMPILE_DEFS} -D${flag}")
+  endforeach()
 endif()
 
 # extract link defs to the whole project
@@ -44,7 +44,7 @@ string(REPLACE ";"
                CXX11_STANDARD_COMPILE_OPTION
                "${CMAKE_CXX11_STANDARD_COMPILE_OPTION}")
 
-# Compiler flags depending on BUILD_TYPE shared as BUILD_TYPE_<LANG>_FLAGS
+# Compiler flags depending on cmake build type from BUILD_TYPE_<LANG>_FLAGS
 string(TOUPPER "${CMAKE_BUILD_TYPE}" _BUILD_TYPE)
 set(BUILD_TYPE_C_FLAGS "${CMAKE_C_FLAGS_${_BUILD_TYPE}}")
 set(BUILD_TYPE_CXX_FLAGS "${CMAKE_CXX_FLAGS_${_BUILD_TYPE}}")

--- a/cmake/ConfigFileSetting.cmake
+++ b/cmake/ConfigFileSetting.cmake
@@ -5,8 +5,11 @@ set(PACKAGE_NAME "${PACKAGE}")
 set(PACKAGE_TARNAME "${PACKAGE}")
 set(PACKAGE_BUGREPORT "\"\"")
 set(PACKAGE_URL "\"\"")
-# some of the variables need to be double quoted strings as they are used in the above mentioned
-# template files name for libraries
+
+# ~~~
+# some of the variables need to be double quoted strings as they are
+# used in the above mentioned template files name for libraries
+# ~~~
 nrn_set_string(PACKAGE "nrn")
 nrn_set_string(NRNHOST "${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
 nrn_set_string(NRNHOSTCPU "${CMAKE_SYSTEM_PROCESSOR}")
@@ -43,9 +46,12 @@ set(libdir \${exec_prefix}/lib)
 set(USING_CMAKE_FALSE "#")
 set(USING_CMAKE_TRUE "")
 
-# TODO : these two don't start out as #undef but as #define so need their explicit @...@ replacments
+# ~~~
+# TODO : these two don't start out as #undef but as #define so need their
+# explicit @...@ replacments
 # set(NEURON_BIN_DIR "\"${CMAKE_INSTALL_PREFIX}/${CMAKE_SYSTEM_PROCESSOR}/bin\"")
 # set(NRN_CONFIG_ARGS "\"unknown\"") # ends up as "" since no @...@
+# ~~~
 
 # =============================================================================
 # Platform specific options (get expanded to comments)

--- a/cmake/MPIDynamicHelper.cmake
+++ b/cmake/MPIDynamicHelper.cmake
@@ -1,9 +1,12 @@
 # =============================================================================
 # Configure support for dynamic MPI initialization
 # =============================================================================
+# ~~~
 # TODO : verify that NRN_ENABLE_MPI_DYNAMIC is valid and determine an include
 # directory for each MPI package building libnrnmpi_<mpipkg>.so.
 # Depending on the MPIs used NRNMPI_INCLUDE_<mpipkg> will be defined.
+# Currently dynamic MPI support is not implemented.
+# ~~~
 
 if(NRN_ENABLE_MPI)
   if(NRN_ENABLE_MPI_DYNAMIC)

--- a/cmake/MacroHelper.cmake
+++ b/cmake/MacroHelper.cmake
@@ -8,6 +8,7 @@ include(CheckSymbolExists)
 include(CheckCXXSymbolExists)
 
 set(CMAKE_REQUIRED_QUIET TRUE)
+
 # =============================================================================
 # Check if directory related to DIR exist by compiling code
 # =============================================================================
@@ -97,6 +98,7 @@ endmacro()
 # =============================================================================
 # Transform CMAKE_CURRENT_SOURCE_DIR/file.in to CMAKE_CURRENT_BINARY_DIR/file
 # =============================================================================
+# ~~~
 # Just as autoconf transforms file.in into file, this macro transforms
 # CMAKE_CURRENT_SOURCE_DIR/file.in into CMAKE_CURRENT_BINARY_DIR/file.
 # This first copies with some replacement the file.in to cmake_file.in
@@ -105,6 +107,7 @@ endmacro()
 # if different copies file_cmk to file. This prevent recompilation of
 # .o files that depend on file. The dir arg is the path relative to
 # PROJECT_SOURCE_DIR and PROJECT_BINARY_DIR.
+# ~~~
 macro(nrn_configure_file file dir)
   set(bin_dir ${PROJECT_BINARY_DIR}/${dir})
   file(MAKE_DIRECTORY ${bin_dir})

--- a/cmake/NeuronFileLists.cmake
+++ b/cmake/NeuronFileLists.cmake
@@ -576,7 +576,6 @@ set(NRN_IVOS_SRC_DIR ${PROJECT_SOURCE_DIR}/src/ivos)
 # =============================================================================
 # Create source file lists by gathering from various directories
 # =============================================================================
-# ~~~
 nrn_create_file_list(NRN_OC_SRC_FILES ${NRN_OC_SRC_DIR} ${OC_FILE_LIST})
 nrn_create_file_list(NRN_NRNOC_SRC_FILES ${NRN_NRNOC_SRC_DIR} ${NRNOC_FILE_LIST})
 nrn_create_file_list(NRN_IVOC_SRC_FILES ${NRN_IVOC_SRC_DIR} ${IVOC_FILE_LIST})
@@ -604,4 +603,3 @@ nrn_create_file_list(NRNMPI_DYNAMIC_INCLUDE_FILE ${PROJECT_SOURCE_DIR}/src/nrnmp
                      ${MPI_DYNAMIC_INCLUDE})
 nrn_create_file_list(NRN_IVOS_SRC_FILES ${NRN_IVOS_SRC_DIR} ${IVOS_FILES_LIST})
 list(APPEND NRN_NRNOC_SRC_FILES ${PROJECT_BINARY_DIR}/src/nrnoc/hocusr.h)
-# ~~~

--- a/cmake/PythonDynamicHelper.cmake
+++ b/cmake/PythonDynamicHelper.cmake
@@ -1,13 +1,13 @@
 # =============================================================================
 # Configure support for dynamic Python to use multiple Python versions
 # =============================================================================
-#
+# ~~~
 # NEURON can be built with python modules that can be usable from multiple
 # versions of Python. Here we check if NRN_ENABLE_PYTHON_DYNAMIC is valid
 # and determine an include directory for version 2 and/or 3 to build
 # libnrnpython<major>.so. Depending on the pythons used, either or both of
 # NRNPYTHON_INCLUDE3 or NRNPYTHON_INCLUDE2 will be defined.
-
+#
 # The above is good for mac and linux. Sadly, for MINGW, a distinct
 # NRNPYTHON_INCLUDE<major><minor> is needed for each python in the
 # NRN_PYTHON_DYNAMIC list. This is because libnrnpython<major><minor>.dll
@@ -15,16 +15,19 @@
 # Thus, at least for MINGW, parallel to the NRN_PYTHON_DYNAMIC list
 # we construct the lists NRN_PYTHON_VER_LIST, NRN_PYTHON_INCLUDE_LIST,
 # and NRN_PYTHON_LIB_LIST
+# ~~~
 
 set(LINK_AGAINST_PYTHON ${MINGW})
 set(NRN_PYTHON_VER_LIST "" CACHE INTERNAL "" FORCE)
 set(NRN_PYTHON_INCLUDE_LIST "" CACHE INTERNAL "" FORCE)
 set(NRN_PYTHON_LIB_LIST "" CACHE INTERNAL "" FORCE)
 
+# ~~~
 # Inform setup.py and nrniv/nrnpy.cpp whether libnrnpython name is libnrnpython<major>
 # or libnrnpython<major><minor> . The latter is required for mingw.
 # This is here instead of in src/nrnpython/CMakeLists.txt as src/nrniv/CMakeLists
 # needs it for nrniv/nrnpy.cpp
+# ~~~
 set(USE_LIBNRNPYTHON_MAJORMINOR 0)
 if(LINK_AGAINST_PYTHON)
   set(USE_LIBNRNPYTHON_MAJORMINOR 1)

--- a/cmake/modules/FindCython.cmake
+++ b/cmake/modules/FindCython.cmake
@@ -1,3 +1,4 @@
+# ~~~~~~
 # Find the Cython compiler.
 #
 # This code sets the following variables:
@@ -62,3 +63,4 @@ find_package_handle_standard_args( Cython
     )
 
 mark_as_advanced( CYTHON_EXECUTABLE )
+# ~~~~~~

--- a/cmake/modules/FindPythonLibsNew.cmake
+++ b/cmake/modules/FindPythonLibsNew.cmake
@@ -1,3 +1,4 @@
+# ~~~~~~
 # =============================================================================
 # Find libraries corresponding to Python interpreter
 # =============================================================================
@@ -208,3 +209,4 @@ find_package_message(PYTHON
     "${PYTHON_EXECUTABLE}${PYTHON_VERSION}")
 
 set(PYTHONLIBS_FOUND TRUE)
+# ~~~~~~

--- a/cmake/modules/FindTermcap.cmake
+++ b/cmake/modules/FindTermcap.cmake
@@ -1,3 +1,4 @@
+# ~~~~~~
 # Copyright (c) 2014, Matthias Vallentin
 # All rights reserved.
 # 
@@ -66,3 +67,4 @@ mark_as_advanced(
   TERMCAP_LIBRARIES
   TERMCAP_INCLUDE_DIR
   )
+# ~~~~~~

--- a/cmake/modules/Findreadline.cmake
+++ b/cmake/modules/Findreadline.cmake
@@ -1,3 +1,4 @@
+# ~~~~~~
 # Code copied from sethhall@github
 #
 # - Try to find readline include dirs and libraries
@@ -47,3 +48,4 @@ mark_as_advanced(
     Readline_INCLUDE_DIR
     Readline_LIBRARY
 )
+# ~~~~~~

--- a/share/lib/python/neuron/rxd/geometry3d/CMakeLists.txt
+++ b/share/lib/python/neuron/rxd/geometry3d/CMakeLists.txt
@@ -1,17 +1,22 @@
-# pyx->cpp
-# the cpp files are consumed to make modules in src/nrnpython/setup.py
-
+# =============================================================================
+# Cython (pyx) to CPP conversion
+# =============================================================================
+# ~~~
+# The cpp files are consumed to make modules in src/nrnpython/setup.py
+#
 # Because of problems building modules with MINGW containing Cython
 # generated files, the cpp files are consumed to make modules from here,
 # just as with the autotools strategy, so that these modules can be
 # built with the msvc toolchain. Maybe someday the src/nrnpython/setup.py
 # can build all the extension modules for windows.
-
-# Following set in src/nrnpython/CMakeLists.txt so should be made global.
-# These are used in setup.py
+#
+# Following set in src/nrnpython/CMakeLists.txt should be made global.
+# These are used in setup.py.
+# ~~~
 set(NRN_SRCDIR ${PROJECT_SOURCE_DIR})
 set(CC ${CMAKE_C_COMPILER})
 set(CXX ${CMAKE_CXX_COMPILER})
+
 if(NRN_WINDOWS_BUILD)
   set(BUILD_MINGW_TRUE "")
   set(BUILD_MINGW_FALSE "#")
@@ -20,19 +25,20 @@ else()
   set(BUILD_MINGW_FALSE "")
 endif()
 
+# generate setup.py from setup.py.in
 nrn_configure_file(setup.py share/lib/python/neuron/rxd/geometry3d)
 
 set(basenames ctng surfaces graphicsPrimitives)
 
 if(NRN_ENABLE_RX3D AND NRN_ENABLE_MODULE_INSTALL AND NRN_ENABLE_PYTHON)
-
-
+  # ~~~
   # After many failures, now following the autotools Makefile.am details.
   # ie. for MINGW, python3 uses msvc and python2 uses mingw32
   # The latter needs changes to the cpp files and to rerun gcc build of
   # the dll. The following shell script carries out the craziness when
   # ${pyexe} setup.py build_ext --inplace
   # may not be enough
+  # ~~~
 
   # Prepare a shell script to transform cython generated cpp files for mingw
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cy_cpp_filt.sh "\
@@ -77,11 +83,13 @@ else #mac/linux does not need anything special\n\
 fi\n\
 ")
 
+  # ~~~
   # Cython generates *.cpp from *.pyx. Make a list of the cpp files
   # so the rxd_extensions targets can depend on them.
   # These cpp files are given a false dependency on setup.py so that a change
   # to setup.py.in in the end causes setup.py to execute and which apparently
   # rebuilds only if a cpp file has changed.
+  # ~~~
   foreach(basename ${basenames})
     set(bname ${CMAKE_CURRENT_BINARY_DIR}/${basename}.cpp)
     set(sname ${CMAKE_CURRENT_SOURCE_DIR}/${basename}.pyx)
@@ -96,14 +104,16 @@ fi\n\
 
   endforeach(basename)
 
-  # want the cython custom command to generate only once no matter how many pythons
+  # Want the cython custom command to generate only once no matter how many pythons
   add_custom_target(rxd_cython_generated DEPENDS ${rxd_cython_cpp_files})
 
-  # for each python detected / provided by user, build the extensions
+  # ~~~
+  # For each python detected / provided by user, build the extensions
   # we do not care about the target names but they must be unique, hence the
   # index at the end of each name. Notice that the unique target runs
   # its COMMAND only if a DEPENDS is out of date (which is the case if setup.py.in)
   # is out of date (see the CYTHON executable custom_command)
+  # ~~~
   list(LENGTH NRN_PYTHON_EXE_LIST _num_pythons)
   math(EXPR num_pythons "${_num_pythons} - 1")
   foreach(val RANGE ${num_pythons})
@@ -115,8 +125,10 @@ fi\n\
     list(APPEND rx3dextensions rx3dextensions_${val})
   endforeach(val)
 
-  # always out of date but that does not imply any of the rx3dextension targets
+  # ~~~
+  # Always out of date but that does not imply any of the rx3dextension targets
   # are out of date
+  # ~~~
   add_custom_target(rx3d ALL DEPENDS ${rx3dextensions})
 
 endif()

--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -2,11 +2,15 @@
 # Build nrniv binary and corresponding library
 # =============================================================================
 
-# The old build (autoconf) built executables in oc, nrnoc, ivoc, nrniv as well as libraries there
-# and in a dozen or so other places. For cmake we are experimenting with a single libnrniv.so that
-# combines many of files in those folders, both for simplicity, and to avoid issues of dependency
-# among the old libraries. Also the oc, nrnoc, and ivoc executables are pretty well useless these
-# days. Other groups can, and should be, factored out
+# ~~~
+# The old build (autoconf) built executables in oc, nrnoc, ivoc, nrniv as
+# well as libraries there and in a dozen or so other places. For cmake we
+# are experimenting with a single libnrniv.so that combines many of files
+# in those folders, both for simplicity, and to avoid issues of dependency
+# among the old libraries.
+# Also the oc, nrnoc, and ivoc executables are pretty well useless these
+# days. Other groups can, and should be, factored out.
+# ~~~
 
 # =============================================================================
 # Build modlunit : Mod file unitx checker
@@ -141,14 +145,12 @@ set(NRN_INCLUDE_DIRS
 # =============================================================================
 # Helper commands : generate various headers
 # =============================================================================
-
-# avoid error with nvector_serial.c for #include <../../../nrnconf.h>
-file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/src/sundials/shared)
-
+# ~~~
 # generate version information file
 # nrnversion.h does not depend on another file but on the output of
 # git2version_h.sh and nrnversion.h should only be changed if that output
 # is different from the contents of nrnversion.h
+# ~~~
 add_custom_target(nrnversion_h
                   ${PROJECT_SOURCE_DIR}/git2nrnversion_h.sh
                   ${PROJECT_SOURCE_DIR}
@@ -159,6 +161,9 @@ add_custom_target(nrnversion_h
                   DEPENDS ${PROJECT_SOURCE_DIR}/git2nrnversion_h.sh)
 
 add_custom_command(OUTPUT ${NRN_NRNOC_SRC_DIR}/nrnversion.h DEPENDS nrnversion_h)
+
+# avoid error with nvector_serial.c for #include <../../../nrnconf.h>
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/src/sundials/shared)
 
 # generate hocusr.h
 add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/src/nrnoc/hocusr.h
@@ -289,7 +294,7 @@ if(NRN_ENABLE_MPI)
       target_link_libraries(nrnmpi_lib nrniv_lib)
     endif()
     set_property(TARGET nrnmpi_lib PROPERTY OUTPUT_NAME nrnmpi)
-    install(TARGETS nrnmpi_lib DESTINATION ${nrn_dest_sharedlibs})
+    install(TARGETS nrnmpi_lib DESTINATION ${NRN_INSTALL_SHARE_LIB_DIR})
   else()
     target_link_libraries(nrniv_lib ${MPI_C_LIBRARIES})
   endif()
@@ -319,8 +324,10 @@ endif()
 # =============================================================================
 # Install binary and library targets
 # =============================================================================
+# ~~~
 # classically, the autotools windows version installed dlls in <inst>/bin
 # For now, we keep this distinction as it reduces the PATH and is
 # expected when ctypes looks for dlls
+# ~~~
 install(TARGETS nrniv nocmodl modlunit DESTINATION bin)
-install(TARGETS nrniv_lib DESTINATION ${nrn_dest_sharedlibs})
+install(TARGETS nrniv_lib DESTINATION ${NRN_INSTALL_SHARE_LIB_DIR})

--- a/src/nrnpython/CMakeLists.txt
+++ b/src/nrnpython/CMakeLists.txt
@@ -4,15 +4,17 @@
 set(NRN_SRCDIR ${PROJECT_SOURCE_DIR})
 set(NRNPYTHON_DEFINES "")
 
-# if NRN_PYTHON_DYNAMIC then the following three will be determined from the actual pyexe that runs
-# setup.py
+# ~~~
+# If NRN_PYTHON_DYNAMIC then the following three will be determined from the
+# actual pyexe that runs setup.py
+# ~~~
 set(NRNPYTHON_EXEC ${PYTHON_EXECUTABLE})
 set(NRNPYTHON_PYVER ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
 set(npy_pyver10 "")
 
 # reset since no " allowed
 set(PACKAGE_VERSION ${PROJECT_VERSION})
-set(NRN_LIBDIR ${nrn_dest_sharedlibs})
+set(NRN_LIBDIR ${NRN_INSTALL_SHARE_LIB_DIR})
 
 # set by IV's cmake module
 set(IV_LIBDIR "${IV_INCLUDE_DIR}/../lib")
@@ -96,7 +98,7 @@ endif()
 # =============================================================================
 if(NRN_ENABLE_RX3D)
   add_library(rxdmath SHARED ${CMAKE_CURRENT_SOURCE_DIR}/rxdmath.c)
-  install(TARGETS rxdmath DESTINATION ${nrn_dest_sharedlibs})
+  install(TARGETS rxdmath DESTINATION ${NRN_INSTALL_SHARE_LIB_DIR})
 endif()
 
 # =============================================================================
@@ -117,28 +119,35 @@ if(NRN_ENABLE_MODULE_INSTALL)
     set(NRN_MODULE_INSTALL_OPTIONS "--home ${install_path}" CACHE INTERNAL "" FORCE)
   endif()
 
-  # to tickle setup.py into actually rebuilding if dependencies change,
-  # need to copy inithoc.cpp in from source to binary dir if any module dependent
-  # changes and make a custom target as well.
-  set(bname ${CMAKE_CURRENT_BINARY_DIR}/inithoc.cpp)
-  set(sname ${CMAKE_CURRENT_SOURCE_DIR}/inithoc.cpp)
+  # ~~~
+  # To tickle setup.py into actually rebuilding if dependencies change,
+  # need to copy inithoc.cpp in from source to binary dir if any module
+  # dependent changes and make a custom target as well.
+  # ~~~
+  set(binary_dir_filename ${CMAKE_CURRENT_BINARY_DIR}/inithoc.cpp)
+  set(source_dir_filename ${CMAKE_CURRENT_SOURCE_DIR}/inithoc.cpp)
   set(inithoc_hdeps
       ${CMAKE_CURRENT_SOURCE_DIR}/../oc/nrnmpi.h
       ${CMAKE_CURRENT_BINARY_DIR}/../oc/nrnmpiuse.h
       ${CMAKE_CURRENT_BINARY_DIR}/../oc/nrnpthread.h
       ${CMAKE_CURRENT_BINARY_DIR}/nrnpython_config.h)
 
-  add_custom_command(OUTPUT ${bname}
-                     COMMAND cp ${sname} ${bname}
+  add_custom_command(OUTPUT ${binary_dir_filename}
+                     COMMAND cp ${source_dir_filename} ${binary_dir_filename}
                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                     DEPENDS ${sname} ${CMAKE_CURRENT_BINARY_DIR}/setup.py ${inithoc_hdeps})
+                     DEPENDS ${source_dir_filename} ${CMAKE_CURRENT_BINARY_DIR}/setup.py
+                             ${inithoc_hdeps})
 
-  add_custom_target(hoc_module ALL WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} DEPENDS ${bname})
+  add_custom_target(hoc_module ALL
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                    DEPENDS ${binary_dir_filename})
 
+  # ~~~
   # For DYNAMIC python, inithoc module name convention is different for
   # autotools version and cmake. So nrnpy_hoc.cpp and inithoc.cpp need
   # to know whether they are compiled via the cmake or autotools build system.
   # (note: see also for inithoc.cpp via setup.py)
+  # ~~~
   set_property(SOURCE ${PROJECT_SOURCE_DIR}/src/nrnpython/nrnpy_hoc.cpp
                APPEND
                PROPERTY COMPILE_DEFINITIONS NRNCMAKE)
@@ -171,7 +180,7 @@ if(NRN_ENABLE_MODULE_INSTALL)
         target_include_directories(nrnpython${pyver} BEFORE PUBLIC ${pyinc} ${INCLUDE_DIRS})
         target_link_libraries(nrnpython${pyver} nrniv_lib ${pylib} ${Readline_LIBRARY})
         add_dependencies(nrnpython${pyver} nrniv_lib)
-        install(TARGETS nrnpython${pyver} DESTINATION ${nrn_dest_sharedlibs})
+        install(TARGETS nrnpython${pyver} DESTINATION ${NRN_INSTALL_SHARE_LIB_DIR})
       endforeach()
     else()
       # build python2 library and install it
@@ -179,7 +188,7 @@ if(NRN_ENABLE_MODULE_INSTALL)
         add_library(nrnpython2 SHARED ${NRN_NRNPYTHON_SRC_FILES})
         target_include_directories(nrnpython2 BEFORE PUBLIC ${NRNPYTHON_INCLUDE2} ${INCLUDE_DIRS})
         add_dependencies(nrnpython2 nrniv_lib)
-        install(TARGETS nrnpython2 DESTINATION ${nrn_dest_sharedlibs})
+        install(TARGETS nrnpython2 DESTINATION ${NRN_INSTALL_SHARE_LIB_DIR})
       endif()
 
       # build python3 library and install it
@@ -187,7 +196,7 @@ if(NRN_ENABLE_MODULE_INSTALL)
         add_library(nrnpython3 SHARED ${NRN_NRNPYTHON_SRC_FILES})
         add_dependencies(nrnpython3 nrniv_lib)
         target_include_directories(nrnpython3 BEFORE PUBLIC ${NRNPYTHON_INCLUDE3} ${INCLUDE_DIRS})
-        install(TARGETS nrnpython3 DESTINATION ${nrn_dest_sharedlibs})
+        install(TARGETS nrnpython3 DESTINATION ${NRN_INSTALL_SHARE_LIB_DIR})
       endif()
     endif()
   endif()


### PR DESCRIPTION
 - use `cmake-format` fence `~~~` to avoid comment block formatting
 - only modules directory not formated properly. One can do now:
```
   cmake .. -DNEURON_CMAKE_FORMAT=ON
   make cmake-format
   git checkout ../cmake/modules/    # undo formatting of cmake modules
```

This assumes `cmake-format` is installed:

```
pip2 install cmake-format==0.4.5
```