### PR TITLE
Updated nrnunits.lib.in and rxd.constants to 2019 SI values when --enable-LegacyFR=no 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -575,9 +575,9 @@ fi
 echo "NRNOC_X11 = $NRNOC_X11"
 AC_DEFINE_UNQUOTED(NRNOC_X11,$NRNOC_X11, if nrnoc can use X11)
 
-dnl Use legacy values for FARADAY and R, or 2017 NIST values?
+dnl Use legacy values for FARADAY and R, or 2019 NIST values?
 AC_ARG_ENABLE([LegacyFR],
-	AC_HELP_STRING([--enable-LegacyFR], [Use legacy instead of NIST (as of 2017) values for FARADAY and gas constant R. (default is legacy enabled)]),[
+	AC_HELP_STRING([--enable-LegacyFR], [Use legacy instead of NIST (as of 2019) values for FARADAY and gas constant R. (default is legacy enabled)]),[
 	if test "$enable_LegacyFR" != "yes" ; then
 		enable_LegacyFR="no"
 	fi
@@ -587,14 +587,20 @@ AC_ARG_ENABLE([LegacyFR],
 if test "$enable_LegacyFR" = "yes" ; then
 	LegacyY=""
 	LegacyN="/"
+	LegacyNPy="#"
+	LegacyYPy=""
 	LegacyFR=1
-	AC_DEFINE_UNQUOTED(LegacyFR,1,[1 for legacy, undef for NIST (as of 2017), for FARADAY and R])
+	AC_DEFINE_UNQUOTED(LegacyFR,1,[1 for legacy, undef for NIST (as of 2019), for FARADAY and R])
 else
 	LegacyY="/"
 	LegacyN=""
+	LegacyNPy=""
+	LegacyYPy="#"
 fi
 AC_SUBST(LegacyY)
 AC_SUBST(LegacyN)
+AC_SUBST(LegacyYPy)
+AC_SUBST(LegacyNPy)
 
 dnl This list specifies what files configure actually makes.
 AC_CONFIG_FILES([
@@ -679,7 +685,8 @@ AC_CONFIG_FILES([
 	share/demo/sync/Makefile
 	share/lib/python/neuron/Makefile
 	share/lib/python/neuron/rxd/Makefile
-    share/lib/python/neuron/crxd/Makefile
+	share/lib/python/neuron/crxd/Makefile
+	share/lib/python/neuron/rxd/constants.py
 	])
 fi
 

--- a/share/lib/nrnunits.lib.in
+++ b/share/lib/nrnunits.lib.in
@@ -68,9 +68,9 @@ c			2.99792458+8 m/sec fuzz
 g			9.80665 m/sec2
 au			1.49597871+11 m fuzz
 @LegacyY@mole			6.022169+23 fuzz
-@LegacyN@mole			6.022140857+23 fuzz
+@LegacyN@mole			6.02214076+23 fuzz
 @LegacyY@e			1.6021917-19 coul fuzz
-@LegacyN@e			1.6021766208-19 coul fuzz
+@LegacyN@e			1.602176634-19 coul fuzz
 energy			c2
 force			g
 mercury			1.33322+5 kg/m2-sec2
@@ -394,7 +394,7 @@ ev			e-volt
 / faraday  from  host: physics.nist.gov
 /          	 path: /PhysRefData/fundconst/html/keywords.html
 @LegacyY@faraday			9.6485309+4 coul
-@LegacyN@faraday			96485.33289 coul
+@LegacyN@faraday			96485.3321233100184 coul
 fathom			6 ft
 fermi			1-15 m
 fifth			4|5 qt
@@ -569,9 +569,9 @@ englishell		45 inch
 scottishell		37.2 inch
 flemishell		27 inch
 @LegacyY@planck			6.626-34 joule-sec
-@LegacyN@planck			6.626070040-34 joule-sec
+@LegacyN@planck			6.62607015-34 joule-sec
 @LegacyY@hbar			1.055-34 joule-sec
-@LegacyN@hbar			1.054571800-34 joule-sec
+@LegacyN@hbar			1.0545718176461565-34 joule-sec
 electronmass		9.1095-31 kg
 protonmass		1.6726-27 kg
 neutronmass		1.6606-27 kg

--- a/share/lib/python/neuron/rxd/constants.py
+++ b/share/lib/python/neuron/rxd/constants.py
@@ -1,2 +1,0 @@
-# Avagadro's number (approximation before 2019 redefinition)
-NA = 6.02214129e23 

--- a/share/lib/python/neuron/rxd/constants.py.in
+++ b/share/lib/python/neuron/rxd/constants.py.in
@@ -1,0 +1,4 @@
+# Avogadro's number (approximation before 2019 redefinition)
+@LegacyYPy@NA = 6.02214129e23
+@LegacyNPy@NA = 6.02214076e23
+


### PR DESCRIPTION
This was originally merged in CMake branch with #323. To minimize change in CMake branch, I am creating this PR to master branch.
