### PR TITLE
Build issue fix for GCC v9 : std namespace missing after #358

### DIFF
--- a/src/parallel/bbsclimpi.cpp
+++ b/src/parallel/bbsclimpi.cpp
@@ -37,7 +37,7 @@ struct ltint {
 	}
 };
 
-class KeepArgs : public map<int, bbsmpibuf*, ltint>{};
+class KeepArgs : public std::map<int, bbsmpibuf*, ltint>{};
 
 #endif
 
@@ -274,7 +274,7 @@ void BBSClient::save_args(int userid) {
 #if defined(HAVE_STL)
 	nrnmpi_ref(sendbuf_);
 	keepargs_->insert(
-		pair<const int, bbsmpibuf* >(userid, sendbuf_)
+		std::pair<const int, bbsmpibuf* >(userid, sendbuf_)
 	);
 	
 #endif

--- a/src/parallel/bbsdirectmpi.cpp
+++ b/src/parallel/bbsdirectmpi.cpp
@@ -32,7 +32,7 @@ struct ltint {
 	}
 };
 
-class KeepArgs : public map<int, bbsmpibuf*, ltint>{};
+class KeepArgs : public std::map<int, bbsmpibuf*, ltint>{};
 
 #endif
 
@@ -267,7 +267,7 @@ void BBSDirect::save_args(int userid) {
 #if defined(HAVE_STL)
 	nrnmpi_ref(sendbuf_);
 	keepargs_->insert(
-		pair<const int, bbsmpibuf*>(userid, sendbuf_)
+		std::pair<const int, bbsmpibuf*>(userid, sendbuf_)
 	);
 	
 #endif

--- a/src/parallel/bbssrv2mpi.cpp
+++ b/src/parallel/bbssrv2mpi.cpp
@@ -104,12 +104,12 @@ printf("todo_less_than %d < %d return %d\n", this->id_, w->id_, w1->id_ < w2->id
 	return w1->id_ < w2->id_;
 }
 
-class MessageList : public multimap <const char*, bbsmpibuf*, ltstr>{};
-class PendingList : public multimap <const char*, const int, ltstr>{};
-class WorkList : public map <int, const WorkItem*, ltint>{};
-class LookingToDoList : public set <int, ltint>{};
-class ReadyList : public set<const WorkItem*, ltWorkItem>{};
-class ResultList: public multimap<int, const WorkItem*, ltint>{};
+class MessageList : public std::multimap <const char*, bbsmpibuf*, ltstr>{};
+class PendingList : public std::multimap <const char*, const int, ltstr>{};
+class WorkList : public std::map <int, const WorkItem*, ltint>{};
+class LookingToDoList : public std::set <int, ltint>{};
+class ReadyList : public std::set<const WorkItem*, ltWorkItem>{};
+class ResultList: public std::multimap<int, const WorkItem*, ltint>{};
 #else
 class MessageList {};
 class PendingList {};
@@ -201,7 +201,7 @@ void BBSDirectServer::put_pending(const char* key, int cid) {
 printf("put_pending |%s| %d\n", key, cid);
 #endif
 	char* s = newstr(key);
-	pending_->insert(pair<const char* const, const int>(s, cid));
+	pending_->insert(std::pair<const char* const, const int>(s, cid));
 #endif
 }
 
@@ -233,7 +233,7 @@ void BBSDirectServer::post(const char* key, bbsmpibuf* send) {
 		nrnmpi_bbssend(cid, TAKE, send);
 	}else{
 		MessageList::iterator m = messages_->insert(
-		  pair<const char* const, bbsmpibuf*>(newstr(key), send)
+		  std::pair<const char* const, bbsmpibuf*>(newstr(key), send)
 		);
 		nrnmpi_ref(send);
 	}
@@ -257,7 +257,7 @@ printf("BBSDirectServer::post_todo pid=%d cid=%d send=%p\n", pid, cid, send);
 	if (p != work_->end()) {
 		w->parent_ = (WorkItem*)((*p).second);
 	}
-	work_->insert(pair<const int, const WorkItem*>(w->id_, w));
+	work_->insert(std::pair<const int, const WorkItem*>(w->id_, w));
 #if debug
 printf("work insert %d\n", w->id_);
 #endif
@@ -356,7 +356,7 @@ printf("DirectServer::post_result id=%d send=%p\n", id, send);
 	nrnmpi_ref(send);
 	nrnmpi_unref(w->buf_);
 	w->buf_ = send;
-	results_->insert(pair<const int, const WorkItem*>(w->parent_ ? w->parent_->id_ : 0, w));
+	results_->insert(std::pair<const int, const WorkItem*>(w->parent_ ? w->parent_->id_ : 0, w));
 #endif
 }
 


### PR DESCRIPTION
  - some of the stl containers in bbs* files missing std:: namespace
  - not sure why this issue appears with gcc v9 and not with previous
    versions of compiler

fixes #365

@nrnhines : this fixes #365. I didnt look into details of why after #358 we didnt see this issue with older gcc compilers.