### PR TITLE
Remove hardcoded name of curses library

### DIFF
--- a/src/readline/CMakeLists.txt
+++ b/src/readline/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(Curses REQUIRED QUIET)
 # readline library
 # =============================================================================
 add_library(readline STATIC ${READLINE_SOURCE_FILES})
-target_link_libraries(readline curses)
+target_link_libraries(readline ${CURSES_LIBRARIES})
 set_property(TARGET readline PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # =============================================================================


### PR DESCRIPTION
  - use CMake variable ${CURSES_LIBRARIES} instead of curses

fixes #374