### PR TITLE
Do not copy libivx11dynam if iv is a submodule (IV_LIB_DIR not set).

### DIFF
--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -281,7 +281,9 @@ if(IV_ENABLE_X11_DYNAMIC)
            ${PROJECT_SOURCE_DIR}/src/ivoc/xdep.cpp ${PROJECT_SOURCE_DIR}/src/oc/x.c
     APPEND
     PROPERTY COMPILE_DEFINITIONS IVX11_DYNAM)
-  if(NOT IV_ENABLE_SHARED)
+  if((NOT IV_ENABLE_SHARED) AND IV_LIB_DIR)
+    # IV_LIB_DIR is not set when IV is a submodule and not yet installed
+    # but libivx11dynam is already in its proper place at POST_BUILD.
     # When IV_ENABLE_SHARED=ON, libivx11dynam is found in IV_LIB_DIR (the location of
     # libinterviews). When OFF, libivx11dynam needs to be copied to the location of libnrniv.  The
     # goal is that if libnrniv is loaded, the system can find libivx11dynam independent of


### PR DESCRIPTION
When nrn is built with iv as a submodule, libivx11dynam does not have to be copied to ${PROJECT_BINARY_DIR}/lib at POST_BUILD because it was already built at that location.