### PR TITLE
Revert "finitialize could fail if pc.set_maxstep had not been called"

### DIFF
--- a/src/nrniv/netpar.cpp
+++ b/src/nrniv/netpar.cpp
@@ -461,10 +461,8 @@ void nrn_spike_exchange_init() {
     return;
 #endif
 //printf("nrn_spike_exchange_init\n");
-#if NRNMPI
-	if (nrnmpi_use) { active_ = 1; } // in case set_mindelay has not yet been called
-#endif
 	if (!nrn_need_npe()) { return; }
+//	if (!active_ && !nrn_use_selfqueue_) { return; }
 	alloc_space();
 //printf("nrnmpi_use=%d active=%d\n", nrnmpi_use, active_);
 	calc_actual_mindelay();	


### PR DESCRIPTION
This reverts commit d9605cb44c7a6094301927d39a8d8e106a35a011.
That commit broke ExperimentalMechComplex.
Proper use of parallel mpi and threads requires a call to pc.maxstep(maxstep) and every rank must
participate due to the use of MPI collectives to determine the minimum interprocessor NetCon delay.
However it is not convenient to do this automatically because, e.g., ExperimentalMechComplex relies
on pc.maxstep NOT being called as each rank needs to work independently and if maxstep synchronization takes place during this, not all ranks participate in the MPI collective and deadlock results.