### PR TITLE
Fix double quotes for sed command on windows/msys2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,6 +311,8 @@ else()
   set(GLOBAL_VAR_TOGGLE_COMMAND "'s/ RANGE minf/ GLOBAL minf/'")
   set(TABLE_VAR_TOGGLE_COMMAND "'s/ :TABLE minf/ TABLE minf/'")
 endif()
+separate_arguments(GLOBAL_VAR_TOGGLE_COMMAND UNIX_COMMAND "${GLOBAL_VAR_TOGGLE_COMMAND}")
+separate_arguments(TABLE_VAR_TOGGLE_COMMAND UNIX_COMMAND "${TABLE_VAR_TOGGLE_COMMAND}")
 add_custom_target(
   hh_update
   COMMAND sed ${GLOBAL_VAR_TOGGLE_COMMAND} ${CMAKE_SOURCE_DIR}/src/nrnoc/hh.mod >
@@ -320,7 +322,8 @@ add_custom_target(
   COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/hh.mod.2
           ${CMAKE_SOURCE_DIR}/src/nrnoc/hh.mod
   COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_BINARY_DIR}/hh.mod.1 ${CMAKE_BINARY_DIR}/hh.mod.2
-  COMMENT "Update hh.mod for CoreNEURON compatibility")
+  COMMENT "Update hh.mod for CoreNEURON compatibility"
+  VERBATIM)
 add_dependencies(nrniv hh_update)
 
 # =============================================================================


### PR DESCRIPTION
 - use VERBATIM with add_custom_target otherwise the cross-platform
   behavior is undefined and you could get surprises with quoted
   strings.
 - use separate_arguments to avoid double quotes with single quotes

fixes #393

Refereces:

* [Here is detailed discussion](https://stackoverflow.com/questions/35847655/when-should-i-quote-variables/35853080) about quoting variables.
* [This is about separate_arguments](https://stackoverflow.com/questions/27650807/avoid-quotes-when-using-cmake-to-pass-a-process-output-as-compile-options-for-sp) command.
