### PR TITLE
Use --quiet option with setup.py

### DIFF
--- a/src/nrnpython/CMakeLists.txt
+++ b/src/nrnpython/CMakeLists.txt
@@ -160,7 +160,6 @@ if(NRN_ENABLE_MODULE_INSTALL)
   # =============================================================================
   # Copy necessary files to build directory
   # =============================================================================
-
   add_custom_command(
     TARGET hoc_module PRE_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
@@ -174,35 +173,16 @@ if(NRN_ENABLE_MODULE_INSTALL)
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/share/demo
             ${PROJECT_BINARY_DIR}/share/nrn/demo)
 
+  # =============================================================================
+  # Install python module
+  # =============================================================================
   # for each python detected / provided by user, install module at install time
   foreach(pyexe ${NRN_PYTHON_EXE_LIST})
     add_custom_command(
       TARGET hoc_module POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/inithoc.cpp
               ${CMAKE_CURRENT_BINARY_DIR}/inithoc.cpp
-      COMMAND ${pyexe} setup.py install ${NRN_MODULE_INSTALL_OPTIONS}
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-      COMMENT "Building python module with: ${pyexe}")
-  endforeach(pyexe)
-  add_dependencies(hoc_module nrniv_lib)
-
-  # =============================================================================
-  # Copy necessary files to build directory
-  # =============================================================================
-  add_custom_command(
-    TARGET hoc_module PRE_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/share/lib
-            ${PROJECT_BINARY_DIR}/share/nrn/lib
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/share/demo
-            ${PROJECT_BINARY_DIR}/share/nrn/demo)
-
-  # for each python detected / provided by user, install module at install time
-  foreach(pyexe ${NRN_PYTHON_EXE_LIST})
-    add_custom_command(
-      TARGET hoc_module POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/inithoc.cpp
-              ${CMAKE_CURRENT_BINARY_DIR}/inithoc.cpp
-      COMMAND ${pyexe} setup.py install ${NRN_MODULE_INSTALL_OPTIONS}
+      COMMAND ${pyexe} setup.py --quiet install ${NRN_MODULE_INSTALL_OPTIONS}
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       COMMENT "Building python module with: ${pyexe}")
   endforeach(pyexe)


### PR DESCRIPTION
  - --quiet avoid all verbose output, errors are still printed to stdout
  - remove duplicated code for copying files and module installation

fixes #389

@nrnhines : If I am not mistaken, I see duplicated code for module installation [here](https://github.com/neuronsimulator/nrn/blob/b5e55fea3d02bc750be331e13ecc2af942c2df45/src/nrnpython/CMakeLists.txt#L170) and [here](https://github.com/neuronsimulator/nrn/blob/b5e55fea3d02bc750be331e13ecc2af942c2df45/src/nrnpython/CMakeLists.txt#L192). I removed relevant code.