### PR TITLE
Remove non-static member initialization in class Grid_node

### DIFF
--- a/src/nrnpython/grids.h
+++ b/src/nrnpython/grids.h
@@ -161,7 +161,7 @@ class Grid_node {
     int ics_num_segs;
 
     int insert(int grid_list_index);
-    int node_flux_count = 0;
+    int node_flux_count;
     long * node_flux_idx;
     double * node_flux_scale;
     PyObject ** node_flux_src;


### PR DESCRIPTION
  - as C++11 is not enabled, remove non-static member initialization
  - this is ok as ECS_make_Grid() already takes care of all member
    initialization

fixes #386

I was thinking to add constructor in Grid_node class to initialise node_flux_count to 0 but looking at [ECS_make_Grid function here](https://github.com/neuronsimulator/nrn/blob/b5e55fea3d02bc750be331e13ecc2af942c2df45/src/nrnpython/grids.cpp#L144) I see that all members are already being initialised.