### PR TITLE
Support for translating mod files to cpp using nrnivmodl

### DIFF
--- a/bin/nrniv_makefile.in
+++ b/bin/nrniv_makefile.in
@@ -41,12 +41,17 @@ CC = @CC@
 CXX = @CXX@
 CFLAGS = @CFLAGS@ $(PTHREAD_CFLAGS)
 CXXFLAGS = @CXXFLAGS@ $(PTHREAD_CFLAGS)
-COMPILE = $(CC) $(DEFS) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
+CCCOMPILE = $(CC) $(DEFS) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
 CXXCOMPILE = $(CXX) $(DEFS) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
 CCLD = $(CC)
 CXXLD = $(CXX)
 
 CXXLINK = $(LIBTOOL) --mode=link $(CXXLD) $(AM_CXXFLAGS) $(CXXFLAGS) $(LDFLAGS)
+
+COMPILE=$(CCCOMPILE)
+ifeq ($(NMODL_C_Ext),cpp)
+   COMPILE = $(CXXCOMPILE)
+endif
 
 @BUILD_NRNMPI_DYNAMIC_TRUE@lnrnmpi =
 @BUILD_NRNMPI_DYNAMIC_FALSE@lnrnmpi = -lnrnmpi
@@ -63,7 +68,7 @@ NRNOCOBJS = $(libobjdir)/ocmain.o $(libobjdir)/nrnnoiv.o $(libobjdir)/ocnoiv.o
 NRNIVOBJS = $(libobjdir)/nrnmain.o $(libobjdir)/ivocmain.o $(libobjdir)/nvkludge.o
 
 .SUFFIXES:
-.SUFFIXES: .c .mod .o
+.SUFFIXES: .$(NMODL_C_Ext) .mod .o
 #
 # How to make a .o file from a .mod file.  Note that we have to delete the
 # .c file, or else make will get confused.  We have to go directly from
@@ -82,17 +87,17 @@ NRNIVOBJS = $(libobjdir)/nrnmain.o $(libobjdir)/ivocmain.o $(libobjdir)/nvkludge
 
 #%.o : %.mod
 
-.mod.c:
-	$(bindir)/nocmodl $*
+.mod.$(NMODL_C_Ext):
+	$(bindir)/nocmodl $* ext=$(NMODL_C_Ext)
 
-.c.o:
-	$(COMPILE) -c $*.c
+.$(NMODL_C_Ext).o:
+	$(COMPILE) -c $*.$(NMODL_C_Ext)
 
 .mod.o:
-	$(bindir)/nocmodl $*
-	$(COMPILE) -c $*.c
+	$(bindir)/nocmodl $* ext=$(NMODL_C_Ext)
+	$(COMPILE) -c $*.$(NMODL_C_Ext)
 
-mod_func.o: mod_func.c
+mod_func.o: mod_func.$(NMODL_C_Ext)
 	$(COMPILE) -c $<
 
 special: $(MODOBJFILES) $(COBJFILES) mod_func.o

--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -67,7 +67,6 @@ NMODL_C_Ext="c"
 if [ "$1" = "-cpp" ] ; then
        NMODL_C_Ext="cpp"
        shift
-       shift
 fi
 
 pwd

--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -63,6 +63,13 @@ if [ ! -d $MODSUBDIR ] ; then
 	mkdir $MODSUBDIR
 fi
 
+NMODL_C_Ext="c"
+if [ "$1" = "-cpp" ] ; then
+       NMODL_C_Ext="cpp"
+       shift
+       shift
+fi
+
 pwd
 
 files=""
@@ -132,38 +139,38 @@ echo '#include <stdio.h>
 #include "hocdec.h"
 extern int nrnmpi_myid;
 extern int nrn_nobanner_;
-' > mod_func.c
+' > mod_func.${NMODL_C_Ext}
 for i in $bfiles ; do
 	echo 'extern void _'$i'_reg(void);'
-done >> mod_func.c
+done >> mod_func.${NMODL_C_Ext}
 echo '
 void modl_reg(){
   if (!nrn_nobanner_) if (nrnmpi_myid < 1) {
     fprintf(stderr, "Additional mechanisms from files'$newline'");
-' >> mod_func.c
+' >> mod_func.${NMODL_C_Ext}
 
 for i in $files
 do
 	echo '    fprintf(stderr," '$i'.mod");'
-done >>mod_func.c
+done >>mod_func.${NMODL_C_Ext}
 
 echo '    fprintf(stderr, "'$newline'");
-  }' >>mod_func.c
+  }' >>mod_func.${NMODL_C_Ext}
 
 for i in $bfiles; do
 	echo '  _'$i'_reg();'
 	MODOBJS="$MODOBJS $i.o"
-done >> mod_func.c
+done >> mod_func.${NMODL_C_Ext}
 
-echo "}" >> mod_func.c
+echo "}" >> mod_func.${NMODL_C_Ext}
 
 
 if test -n "$cfiles" ; then
-	COBJS=`echo "$cfiles" | sed 's/\.c/.o/g'`
+	COBJS=`echo "$cfiles" | sed "s/\.${NMODL_C_Ext}/.o/g"`
 fi
 
-@NRN_BINARY_SPECIAL_TRUE@@USING_CMAKE_TRUE@make -j 4 -f "${MAKEFILEDIR}/nrnmech_makefile" "ROOT=${prefix}" "MODOBJFILES=$MODOBJS" "COBJFILES=$COBJS" "UserLDFLAGS=$UserLDFLAGS" "UserINCFLAGS=$UserINCFLAGS" special &&
-@NRN_BINARY_SPECIAL_TRUE@@USING_CMAKE_FALSE@make -j 4 -f "${MAKEFILEDIR}/nrniv_makefile" "ROOT=${prefix}" "MODOBJFILES=$MODOBJS" "COBJFILES=$COBJS" "UserLDFLAGS=$UserLDFLAGS" "UserINCFLAGS=$UserINCFLAGS" special &&
+@NRN_BINARY_SPECIAL_TRUE@@USING_CMAKE_TRUE@make -j 4 -f "${MAKEFILEDIR}/nrnmech_makefile" "ROOT=${prefix}" "MODOBJFILES=$MODOBJS" "COBJFILES=$COBJS" "UserLDFLAGS=$UserLDFLAGS" "UserINCFLAGS=$UserINCFLAGS" "NMODL_C_Ext=$NMODL_C_Ext" special &&
+@NRN_BINARY_SPECIAL_TRUE@@USING_CMAKE_FALSE@make -j 4 -f "${MAKEFILEDIR}/nrniv_makefile" "ROOT=${prefix}" "MODOBJFILES=$MODOBJS" "COBJFILES=$COBJS" "UserLDFLAGS=$UserLDFLAGS" "UserINCFLAGS=$UserINCFLAGS" "NMODL_C_Ext=$NMODL_C_Ext" special &&
 @NRN_BINARY_SPECIAL_TRUE@  echo "Successfully created $MODSUBDIR/special"
 
 @NRN_BINARY_SPECIAL_FALSE@MODLO=`echo "$MODOBJS" | sed 's/\.o/.lo/g'`
@@ -171,8 +178,8 @@ fi
 @NRN_BINARY_SPECIAL_FALSE@if test "${mdir}" = "${prefix}/share/nrn/demo/release/powerpc" ; then
 @NRN_BINARY_SPECIAL_FALSE@  mdir='${NRNHOME}'/share/nrn/demo/release/${MODSUBDIR}
 @NRN_BINARY_SPECIAL_FALSE@fi
-@NRN_BINARY_SPECIAL_FALSE@@USING_CMAKE_FALSE@make -j 4 -f "$MAKEFILEDIR/nrnmech_makefile" "ROOT=${prefix}" "MODOBJFILES=$MODLO" "COBJFILES=$CLO" "UserLDFLAGS=$UserLDFLAGS" "UserINCFLAGS=$UserINCFLAGS" libnrnmech.la
-@NRN_BINARY_SPECIAL_FALSE@@USING_CMAKE_TRUE@make -j 4 -f "$MAKEFILEDIR/nrnmech_makefile" "ROOT=${prefix}" "MODOBJFILES=$MODOBJS" "COBJFILES=$COBJS" "UserLDFLAGS=$UserLDFLAGS" "UserINCFLAGS=$UserINCFLAGS" libnrnmech.la VERBOSE=1
+@NRN_BINARY_SPECIAL_FALSE@@USING_CMAKE_FALSE@make -j 4 -f "$MAKEFILEDIR/nrnmech_makefile" "ROOT=${prefix}" "MODOBJFILES=$MODLO" "COBJFILES=$CLO" "UserLDFLAGS=$UserLDFLAGS" "UserINCFLAGS=$UserINCFLAGS" "NMODL_C_Ext=$NMODL_C_Ext" libnrnmech.la
+@NRN_BINARY_SPECIAL_FALSE@@USING_CMAKE_TRUE@make -j 4 -f "$MAKEFILEDIR/nrnmech_makefile" "ROOT=${prefix}" "MODOBJFILES=$MODOBJS" "COBJFILES=$COBJS" "UserLDFLAGS=$UserLDFLAGS" "UserINCFLAGS=$UserINCFLAGS" "NMODL_C_Ext=$NMODL_C_Ext" libnrnmech.la VERBOSE=1
 @NRN_BINARY_SPECIAL_FALSE@  echo '#!/bin/sh
 @NRN_BINARY_SPECIAL_FALSE@if test "x${NRNHOME}" = "x" ; then
 @NRN_BINARY_SPECIAL_FALSE@    NRNHOME='"\"${prefix}\""'

--- a/bin/nrnivmodl_makefile_cmake.in
+++ b/bin/nrnivmodl_makefile_cmake.in
@@ -33,21 +33,26 @@ CXX ?= @CMAKE_CXX_COMPILER@
 CFLAGS = @BUILD_TYPE_C_FLAGS@ @CMAKE_C_FLAGS@
 CXXFLAGS = @BUILD_TYPE_CXX_FLAGS@ @CMAKE_CXX_FLAGS@ @CXX11_STANDARD_COMPILE_OPTION@
 
-COMPILE = $(CC) $(CFLAGS) @NRN_COMPILE_DEFS@ $(INCLUDES)
+CCCOMPILE = $(CC) $(CFLAGS) @NRN_COMPILE_DEFS@ $(INCLUDES)
 CXXCOMPILE = $(CXX) $(CXXFLAGS) @NRN_COMPILE_DEFS@ $(INCLUDES)
 CXX_LINK_EXE = $(CXX) $(CXXFLAGS) @CMAKE_EXE_LINKER_FLAGS@
 CXX_LINK_SHARED = $(CXX) $(CXXFLAGS) @CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS@ @CMAKE_SHARED_LIBRARY_CXX_FLAGS@ @CMAKE_SHARED_LINKER_FLAGS@
+
+COMPILE=$(CCCOMPILE)
+ifeq ($(NMODL_C_Ext),cpp)
+   COMPILE = $(CXXCOMPILE)
+endif
 
 # File path config (internal)
 MODC_DIR = $(OUTPUT)
 OBJS_DIR = $(OUTPUT)
 mod_files = $(sort $(notdir $(wildcard $(MODS_PATH)/*.mod)))
 mod_names = $(mod_files:.mod=)
-modc_files = $(addprefix $(MODC_DIR)/,$(addsuffix .c,$(mod_names)))
+modc_files = $(addprefix $(MODC_DIR)/,$(addsuffix .$(NMODL_C_Ext),$(mod_names)))
 mod_objs   = $(addprefix $(OBJS_DIR)/,$(addsuffix .o,$(mod_names)))
 
 mod_func_o = $(OBJS_DIR)/mod_func.o
-mod_func_c = $(MODC_DIR)/mod_func.c
+mod_func_c = $(MODC_DIR)/mod_func.$(NMODL_C_Ext)
 
 special  = $(OUTPUT)/special
 LIB_SUFFIX_ = $(if $(MECH_NAME),_$(MECH_NAME),)
@@ -96,21 +101,21 @@ mech_lib_static: mod_func.o $(mod_objs) build_always
 	@printf " => $(C_GREEN)LINKING$(C_RESET) static library $(mech_lib) Mod files: $(mod_files)\n"
 	(cd .. ; ar cq ${mech_lib} $(mod_func_o) $(mod_objs);)
 
-mod_func.o: mod_func.c
+mod_func.o: mod_func.$(NMODL_C_Ext)
 	@printf " -> $(C_GREEN)Compiling$(C_RESET) $<\n"
 	$(COMPILE) @CMAKE_CXX_COMPILE_OPTIONS_PIC@ -c $< -o $@
 
 # Generic build c->o. Need PIC for shared lib
-$(OBJS_DIR)/%.o: $(MODC_DIR)/%.c | $(OBJS_DIR)
+$(OBJS_DIR)/%.o: $(MODC_DIR)/%.$(NMODL_C_Ext) | $(OBJS_DIR)
 	@printf " -> $(C_GREEN)Compiling$(C_RESET) $<\n"
 	(cd .. ; $(COMPILE) @CMAKE_CXX_COMPILE_OPTIONS_PIC@ -c $< -o $@)
 
 
 # Build c files with nocmodl
-$(MODC_DIR)/%.c: $(MODS_PATH)/%.mod | $(MODC_DIR)
-	@printf " -> $(C_GREEN)NMODL$(C_RESET) $<\n"
+$(MODC_DIR)/%.$(NMODL_C_Ext): $(MODS_PATH)/%.mod | $(MODC_DIR)
+	@printf " -> $(C_GREEN)MOD2C$(C_RESET) $<\n"
 	MODLUNIT=$(datadir_lib)/nrnunits.lib \
-	  $(bindir)/nocmodl $<
+	  $(bindir)/nocmodl $< ext=$(NMODL_C_Ext)
 
 # If .mod doesnt exist attempt from previously built opt mods in shared/
 $(MODC_DIR)/%.cpp: $(datadir_lib)/%.cpp | $(MODC_DIR)

--- a/bin/nrnmech_makefile.in
+++ b/bin/nrnmech_makefile.in
@@ -27,12 +27,23 @@ NJ_LIBS = @NRNJAVA_LIBS@
 PY_LIBS =
 NRNNI_LIBS = @NRNNI_LIBS@
 
-INCLUDES = -I. -I.. -I"$(pkgincludedir)" -I"$(libdir)" $(UserINCFLAGS) 
+INCLUDES = -I. -I.. -I"$(pkgincludedir)" -I"$(libdir)" $(UserINCFLAGS)
 
 LIBTOOL = "$(pkgdatadir)/libtool" @LIBTOOLTAG@
 CC = @CC@
+CXX = @CXX@
 CFLAGS = @CFLAGS@
+CXXFLAGS = @CXXFLAGS@
 
+ifeq ($(NMODL_C_Ext),cpp)
+COMPILE = $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
+        $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
+LTCOMPILE = $(LIBTOOL) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) \
+        $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
+CCLD = $(CXX)
+LINK = $(LIBTOOL) --mode=link $(CCLD) -module $(AM_CXXFLAGS) $(CXXFLAGS) \
+        $(AM_LDFLAGS) $(LDFLAGS) -o $@
+else
 COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
         $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
 LTCOMPILE = $(LIBTOOL) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) \
@@ -40,6 +51,7 @@ LTCOMPILE = $(LIBTOOL) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) \
 CCLD = $(CC)
 LINK = $(LIBTOOL) --mode=link $(CCLD) -module $(AM_CFLAGS) $(CFLAGS) \
         $(AM_LDFLAGS) $(LDFLAGS) -o $@
+endif
 
 @BUILD_NRNMPI_DYNAMIC_TRUE@lnrnmpi =
 @BUILD_NRNMPI_DYNAMIC_FALSE@lnrnmpi = -lnrnmpi
@@ -55,14 +67,14 @@ NRNIVOBJS = "$(libobjdir)/nrnmain.o" "$(libobjdir)/ivocmain.o" "$(libobjdir)/nvk
 
 .SUFFIXES:
 
-.SUFFIXES: .c .mod .lo
+.SUFFIXES: .$(NMODL_C_Ext) .mod .lo
 #
 # How to make a .o file from a .mod file.  Note that we have to delete the
 # .c file, or else make will get confused.  We have to go directly from
 # a .mod to a .o file because otherwise GNU make will try to use a rule
 # involving m2c.  Argh!!  Why did they have to build in so many implicit
 # rules?
-# 
+#
 #.mod.o:
 #	$(bindir)/nocmodl $* || (rm -f $*.c; exit 1)
 #	$(COMPILE) -c $*.c
@@ -74,18 +86,18 @@ NRNIVOBJS = "$(libobjdir)/nrnmain.o" "$(libobjdir)/ivocmain.o" "$(libobjdir)/nvk
 
 #%.o : %.mod
 
-.mod.c:
-	"$(bindir)/nocmodl" $*
-	
-.c.lo:
+.mod.$(NMODL_C_Ext):
+	"$(bindir)/nocmodl" $* ext=$(NMODL_C_Ext)
+
+.$(NMODL_C_Ext).lo:
 	$(LTCOMPILE) -c -o $@ `test -f '$<' || echo '$(srcdir)/'`$<
 
 .mod.lo:
-	"$(bindir)/nocmodl" $*
-	$(LTCOMPILE) -c -o $@ $*.c
+	"$(bindir)/nocmodl" $* ext=$(NMODL_C_Ext)
+	$(LTCOMPILE) -c -o $@ $*.$(NMODL_C_Ext)
 
-mod_func.lo: mod_func.c
-	$(LTCOMPILE) -c -o $@ $*.c
+mod_func.lo: mod_func.$(NMODL_C_Ext)
+	$(LTCOMPILE) -c -o $@ $*.$(NMODL_C_Ext)
 
 libnrnmech_la_OBJECTS = $(MODOBJFILES) mod_func.lo $(COBJFILES)
 libnrnmech_la_LIBADD = $(NRNOCLIBS) $(NRNIVLIBS)

--- a/bin/nrnoc_makefile.in
+++ b/bin/nrnoc_makefile.in
@@ -36,9 +36,18 @@ INCLUDES = -I. -I$(pkgincludedir) -I$(libdir)
 LIBTOOL = $(pkgdatadir)/libtool
 CC = @CC@
 CFLAGS = @CFLAGS@
+CXX = @CXX@
+CXXFLAGS = @CXXFLAGS@
+
+ifeq ($(NMODL_C_Ext),cpp)
+COMPILE = $(CXX) $(DEFS) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
+CCLD = $(CXX)
+LINK = $(LIBTOOL) --mode=link $(CCLD) $(AM_CXXFLAGS) $(CXXFLAGS) $(LDFLAGS)
+else
 COMPILE = $(CC) $(DEFS) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
 CCLD = $(CC)
 LINK = $(LIBTOOL) --mode=link $(CCLD) $(AM_CFLAGS) $(CFLAGS) $(LDFLAGS)
+endif
 
 NRNOCLIBS = -L$(libdir) $(libdir)/libnrnoc.la -loc @MEMACSLIB@ \
 	-lscopmath -lsparse13 @READLINE_LIBS@ \
@@ -47,14 +56,14 @@ NRNOCLIBS = -L$(libdir) $(libdir)/libnrnoc.la -loc @MEMACSLIB@ \
 NRNOCOBJS = $(libobjdir)/ocmain.o $(libobjdir)/nrnnoiv.o $(libobjdir)/ocnoiv.o
 
 .SUFFIXES:
-.SUFFIXES: .c .mod .o
+.SUFFIXES: .$(NMODL_C_Ext) .mod .o
 #
 # How to make a .o file from a .mod file.  Note that we have to delete the
 # .c file, or else make will get confused.  We have to go directly from
 # a .mod to a .o file because otherwise GNU make will try to use a rule
 # involving m2c.  Argh!!  Why did they have to build in so many implicit
 # rules?
-# 
+#
 #.mod.o:
 #	$(bindir)/nocmodl $* || (rm -f $*.c; exit 1)
 #	$(COMPILE) -c $*.c
@@ -66,15 +75,15 @@ NRNOCOBJS = $(libobjdir)/ocmain.o $(libobjdir)/nrnnoiv.o $(libobjdir)/ocnoiv.o
 
 #%.o : %.mod
 
-.mod.c:
-	$(bindir)/nocmodl $*
-	
-.c.o:
-	$(COMPILE) -c $*.c
+.mod.$(NMODL_C_Ext):
+	$(bindir)/nocmodl $* ext=${NMODL_C_Ext}
+
+.$(NMODL_C_Ext).o:
+	$(COMPILE) -c $*.$(NMODL_C_Ext)
 
 .mod.o:
-	$(bindir)/nocmodl $*
-	$(COMPILE) -c $*.c
+	$(bindir)/nocmodl $* ext=${NMODL_C_Ext}
+	$(COMPILE) -c $*.$(NMODL_C_Ext)
 
 mod_func.o: mod_func.c
 	$(COMPILE) -c $<

--- a/src/nmodl/modl.c
+++ b/src/nmodl/modl.c
@@ -78,6 +78,7 @@ static char pgm_name[] =	"nmodl";
 extern char *RCS_version;
 extern char *RCS_date;
 static void openfiles();
+static char *translator_extension;
 
 int main(argc, argv)
 	int             argc;
@@ -102,8 +103,7 @@ int main(argc, argv)
 	Fprintf(stderr, "%s   %s   %s\n",
 		pgm_name, RCS_version, RCS_date);
 #endif
-#endif	
-							
+#endif
 	modprefix = prefix_;
 	init();			/* keywords into symbol table, initialize
 				 * lists, etc. */
@@ -127,12 +127,12 @@ int main(argc, argv)
 
 	openfiles(argc, argv);	/* .mrg else .mod,  .var, .c */
 #if NMODL || HMODL
-	Fprintf(stderr, "Translating %s into %s.c\n", finname,
-		modprefix);
+	Fprintf(stderr, "Translating %s into %s.%s\n", finname,
+		modprefix, translator_extension);
 #else
 #if !SIMSYS
-	Fprintf(stderr, "Translating %s into %s.c and %s.var\n", finname,
-		modprefix, modprefix);
+	Fprintf(stderr, "Translating %s into %s.%s and %s.var\n", finname,
+		modprefix, translator_extension, modprefix);
 #endif
 #endif
 	IGNORE(yyparse());
@@ -288,7 +288,15 @@ static void openfiles(argc, argv)
 		diag("Can't create variable file: ", s);
 	}
 #endif
-	Sprintf(s, "%s.c", modprefix);
+    // if last command line argument is 'ext=cpp' then use
+    // .cpp as extension for translated c code otherwise
+    // use .c as extension.
+    if (strcmp(argv[argc-1], "ext=cpp") == 0) {
+        translator_extension = "cpp";
+    } else {
+        translator_extension = "c";
+    }
+	Sprintf(s, "%s.%s", modprefix, translator_extension);
 	if ((fcout = fopen(s, "w")) == (FILE *) 0) {
 		diag("Can't create C file: ", s);
 	}


### PR DESCRIPTION
Based on discussion in #384 I was playing with nrnivmodl and relevant files to support C++ code generation. Current implementation allows to choose C++ or C output after installation which will be helpful for debugging/developing. Once we verify that all models work without any issue with C++, we can remove current logic and make out C++ only.

Idea of this PR is to :

* keep old behaviour or existing workflow i.e. `nrnivmodl`
* add command line option in nrnivmodl so that user can choose to translate mod files to C++

Here is summary of changes:

  - nrnivmodl accept extra option **-cpp** by which all mod files
    are translated to .cpp instead of .c (i.e. `nrnivmodl -cpp .`
  - all files are then compiled with CXX and relevant compiler
    flags to build special
  - keep everything backward compatible i.e. if **-cpp** flag is not
    provided then keep old behaviour
  - nocmodl accepts extra comamnd line argument **ext=cpp** (last argument)
    by which .mod file is translated to .cpp
  - nrnivmodl and relevant makefiles are updated to accept **-cpp** flag

For example,

* Default behaviour (C code)

```
$ /Users/kumbhar/workarena/repos/bbp/nn/build/install/bin/nrnivmodl .
Creating x86_64 directory for .o files.

/Users/kumbhar/workarena/repos/bbp/ringtest/mod
ls: ./*.inc: No such file or directory
./halfgap.mod
halfgap.mod
mkdir -p x86_64
 -> Compiling mod_func.c
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -g  -O0    -I. -I..   -I/Users/kumbhar/workarena/repos/bbp/nn/build/install/include   -fPIC -c mod_func.c -o mod_func.o
 -> MOD2C halfgap.mod
MODLUNIT=/Users/kumbhar/workarena/repos/bbp/nn/build/install/share/nrn/lib/nrnunits.lib \
	  /Users/kumbhar/workarena/repos/bbp/nn/build/install/bin/nocmodl halfgap.mod ext=c
Translating halfgap.mod into halfgap.c
Thread Safe
 -> Compiling x86_64/halfgap.c
(cd .. ; /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -g  -O0    -I. -I..   -I/Users/kumbhar/workarena/repos/bbp/nn/build/install/include   -fPIC -c x86_64/halfgap.c -o x86_64/halfgap.o)
 => LINKING library x86_64/libnrnmech.0.0.dylib Mod files: halfgap.mod
(cd .. ; /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -g  -O0   -std=c++11 -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -fPIC -L/usr/local/opt/ruby/lib -I /Users/kumbhar/workarena/repos/bbp/nn/build/install/include -o x86_64/libnrnmech.0.0.dylib -Wl,-install_name,@rpath/libnrnmech.0.0.dylib \
	  x86_64/mod_func.o x86_64/halfgap.o -L/Users/kumbhar/workarena/repos/bbp/nn/build/install/lib -lnrniv -Wl,-rpath,/Users/kumbhar/workarena/repos/bbp/nn/build/install/lib    -lreadline /Library/Frameworks/Python.framework/Versions/3.6/lib/libpython3.6m.dylib)
(cd .. ; rm -f x86_64/.libs/libnrnmech.so ; mkdir -p x86_64/.libs ; ln -s ../../x86_64/libnrnmech.0.0.dylib x86_64/.libs/libnrnmech.so)
Successfully created x86_64/special
```

* New option (CPP code):


```
$ /Users/kumbhar/workarena/repos/bbp/nn/build/install/bin/nrnivmodl -cpp .
Creating x86_64 directory for .o files.

/Users/kumbhar/workarena/repos/bbp/ringtest/mod
halfgap.mod
halfgap.mod
mkdir -p x86_64
 -> Compiling mod_func.cpp
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -g  -O0   -std=c++11  -I. -I..   -I/Users/kumbhar/workarena/repos/bbp/nn/build/install/include   -fPIC -c mod_func.cpp -o mod_func.o
 -> MOD2C halfgap.mod
MODLUNIT=/Users/kumbhar/workarena/repos/bbp/nn/build/install/share/nrn/lib/nrnunits.lib \
	  /Users/kumbhar/workarena/repos/bbp/nn/build/install/bin/nocmodl halfgap.mod ext=cpp
Translating halfgap.mod into halfgap.cpp
Thread Safe
 -> Compiling x86_64/halfgap.cpp
(cd .. ; /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -g  -O0   -std=c++11  -I. -I..   -I/Users/kumbhar/workarena/repos/bbp/nn/build/install/include   -fPIC -c x86_64/halfgap.cpp -o x86_64/halfgap.o)
In file included from x86_64/halfgap.cpp:12:
/Users/kumbhar/workarena/repos/bbp/nn/build/install/include/nrniv_mf.h:77:12: error:
      conflicting types for 'derivimplicit_thread'
extern int derivimplicit_thread(int, int*, int*, double*, int(*)(double*, union D...
           ^
/Users/kumbhar/workarena/repos/bbp/nn/build/install/include/scoplib_ansi.h:72:5: note:
      previous declaration is here
int derivimplicit_thread();
    ^
x86_64/halfgap.cpp:88:31: error: unknown type name '_ho'
 static void* _hoc_create_pnt(_ho) Object* _ho; { void* create_point_process();
```

As shown above, compilation is failing. I now remember some fixes we did in MOD2C as well with generated code to compiler with CXX. I think it won't take much efforts to fix compilation issues / generated code (e.g. mismatch with function prototypes/definitions, K&R function declarations).

fixes #384