### PR TITLE
Problem when mpi is not installed but distribution expects it.

### DIFF
--- a/src/nrnpython/inithoc.cpp
+++ b/src/nrnpython/inithoc.cpp
@@ -145,9 +145,14 @@ void inithoc() {
   }
   if (libnrnmpi_is_loaded) {
     pmes = nrnmpi_load(1);
-    if (pmes) {
+    if (pmes && env_mpi == NULL) {
+      // common case on MAC distribution is no NEURON_INIT_MPI and
+      // no MPI installed (so nrnmpi_load fails)
+      libnrnmpi_is_loaded = 0;
+    }
+    if (pmes && libnrnmpi_is_loaded) {
       printf(
-        "NEURON_INIT_MPI exists in env but NEURON cannot initialize MPI "
+        "NEURON_INIT_MPI nonzero in env but NEURON cannot initialize MPI "
         "because:\n%s\n",
         pmes);
       exit(1);


### PR DESCRIPTION
Distributions are generally built to load mpi dynamically. However the
following case fails and exits. MPI is not installed. Python is launched.
NEURON_INIT_MPI is not an environment variable (or is not set to 0).

This fix is related to changes introduced because of issue #258
@pramodk @jorblancoa

I left a comment about this mistakenly in pull request #261