### PR TITLE
bugfix: Error when removing a section.

### DIFF
--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -1571,6 +1571,7 @@ static PyObject* iternext_sl(PyHocObject* po, hoc_Item* ql) {
     for (;;) {  // have to watch out for deleted sections.
       hoc_Item* q1 = q->next;
       Section* sec = q->element.sec;
+      if (sec == NULL) return NULL;
       if (!sec->prop) {  // delete from list and go on
         // to the next. If no more return NULL
         hoc_l_delete(q);


### PR DESCRIPTION
The following code produces a segfault because sec == NULL.
It seems to only be a problem for two sections when the second section is set to None.
```
from neuron import h
soma = h.Section(name='soma')
dend = h.Section(name='dend')
for sec in h.allsec():
    print(sec)
dend = None
for sec in h.allsec():
    print(sec)
```
@nrnhines edited to put code into a code format block