### PR TITLE
rxd: .concentration for SpeciesOnExtracellular

### DIFF
--- a/share/lib/python/neuron/rxd/species.py
+++ b/share/lib/python/neuron/rxd/species.py
@@ -255,6 +255,18 @@ class SpeciesOnExtracellular(_SpeciesMathable):
 
     def __str__(self):
         return '%s[%s]' % (self._species()._short_repr(), self._extracellular()._region._short_repr())
+    
+    @property
+    def concentration(self):
+        """An iterable of the current concentrations."""
+        return self.nodes.concentration
+    
+    @concentration.setter
+    def concentration(self, value):
+        """Sets all Node objects in the restriction to the specified concentration value.
+        
+        This is equivalent to s.nodes.concentration = value"""
+        self.nodes.concentration = value
 
     @property
     def states3d(self):


### PR DESCRIPTION
To get or set the concentrations for an intracellular species on a region, we have long been able to use, e.g.:

    ca[cyt].concentration

This was shorthand for ca[cyt].nodes.concentration. No such shorthand was allowed for extracellular; e.g. ca[ecs].nodes.concentration... this commit adds support for ca[ecs].concentration.