### PR TITLE
Remove `-lintl` linking returned by `sysconfig.get_config_var('LDFLAGS')`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ install:
       export CYTHON_LIB=$($PIP show cython | grep Location);
       export CYTHON_EXE=$(echo $CYTHON_LIB | awk '{print $2}' | awk -F "lib" '{print$1}')"bin";
       export PATH=$CYTHON_EXE:$PATH;
-      echo $PATH;
+      brew link --overwrite python;
     fi
 
 #=============================================================================

--- a/m4/nrnpython.m4
+++ b/m4/nrnpython.m4
@@ -42,7 +42,7 @@ Examine config.log to see error details. Something wrong with
 	PYLIB=$PYLIB
 or
 	PYLIBDIR=$PYLIBDIR
-or	
+or
 	PYLIBLINK=$PYLIBLINK
 or
 	PYINCDIR=$PYINCDIR
@@ -212,6 +212,12 @@ explicitly specify PYINCDIR])
 				PYLIBDIR="$gcfLIBDIR"
 				PYLIBLINK="-L$PYLIBDIR -l$PYLIB $gcfLIBS $gcfMODLIBS"
 				PYLIB="$PYLIBLINK -R$PYLIBDIR"
+			fi
+			dnl add LDFLAGS for python version >= 3.7
+			if [[ $(bc <<< "$PYVER >= 3.7") -eq 1 ]] ; then
+				AC_NRN_PYCONF(EXTRALDFLAGS, get_config_var('LDFLAGS'),"",$ac_nrn_python)
+				PYLIBLINK="$EXTRALDFLAGS $PYLIBLINK"
+				PYLIB="$EXTRALDFLAGS $PYLIB"
 			fi
 		fi
 

--- a/m4/nrnpython.m4
+++ b/m4/nrnpython.m4
@@ -192,7 +192,7 @@ explicitly specify PYINCDIR])
 			fi
 		fi
 		if test "$EXTRAPYLIBS" = "" ; then
-			AC_NRN_PYCONF(EXTRAPYLIBS,get_config_var('LIBS'),"",$ac_nrn_python)
+			AC_NRN_PYCONF(EXTRAPYLIBS,get_config_var('LIBS').replace('-lintl',''),"",$ac_nrn_python)
 		fi
 		setup_extra_link_args=extra_link_args
 		case "$host_os" in
@@ -205,19 +205,13 @@ explicitly specify PYINCDIR])
 		if test "$PYLIB" = "" ; then
 			AC_NRN_PYCONF(gcfLIBRARY, get_config_var('LIBRARY'),"",$ac_nrn_python)
 			AC_NRN_PYCONF(gcfLIBDIR, get_config_var('LIBDIR'),"",$ac_nrn_python)
-			AC_NRN_PYCONF(gcfLIBS, get_config_var('LIBS'),"",$ac_nrn_python)
+			AC_NRN_PYCONF(gcfLIBS, get_config_var('LIBS').replace('-lintl',''),"",$ac_nrn_python)
 			AC_NRN_PYCONF(gcfMODLIBS, get_config_var('MODLIBS'),"",$ac_nrn_python)
 			PYLIB=`echo $gcfLIBRARY|sed 's/lib\(.*\)\.a/\1/'`
 			if test "$PYLIB" != "" ; then
 				PYLIBDIR="$gcfLIBDIR"
 				PYLIBLINK="-L$PYLIBDIR -l$PYLIB $gcfLIBS $gcfMODLIBS"
 				PYLIB="$PYLIBLINK -R$PYLIBDIR"
-			fi
-			dnl add LDFLAGS for python version >= 3.7
-			if [[ $(bc <<< "$PYVER >= 3.7") -eq 1 ]] ; then
-				AC_NRN_PYCONF(EXTRALDFLAGS, get_config_var('LDFLAGS'),"",$ac_nrn_python)
-				PYLIBLINK="$EXTRALDFLAGS $PYLIBLINK"
-				PYLIB="$EXTRALDFLAGS $PYLIB"
 			fi
 		fi
 


### PR DESCRIPTION
fixes #454