### PR TITLE
Pyiter3

### DIFF
--- a/share/lib/python/neuron/tests/test_neuron.py
+++ b/share/lib/python/neuron/tests/test_neuron.py
@@ -71,6 +71,26 @@ class NeuronTestCase(unittest.TestCase):
         v.x[0] = 5
         assert v.x[0] == 5
 
+    def testIterators(self):
+        """Test section, segment, mechanism, rangevar iterators."""
+        # setup model
+        sections = [h.Section(name='s%d'%i) for i in range(3)]
+        iclamps = [h.IClamp(sec(.5)) for sec in sections]
+        for i, sec in enumerate(sections):
+            sec.nseg = 3
+            sec.insert('pas')
+            sec.insert('hh')
+        #iterate
+        import hashlib
+        sha = hashlib.sha256()
+        for sec in h.allsec():
+            for seg in sec:
+                for mech in seg:
+                    for var in mech:
+                        sha.update(("%s(%g).%s.%s=%g" % (sec.name(), seg.x, mech.name(), var.name(), var[0])).encode('utf-8'))
+        d = sha.hexdigest()
+        assert d == 'ac49344c054bc9e56e165fa75423d8bcb7cce96c4527f259362b527ee05103d8'
+
     @classmethod
     def ExtendedSection(cls):
         """test prsection (modified print statement)"""

--- a/src/nrnoc/cabcode.c
+++ b/src/nrnoc/cabcode.c
@@ -314,8 +314,22 @@ void delete_section(void) {
 	Symbol* sym;
 	int i;
 	sec = chk_access();
+	if (!sec->prop) { /* already deleted */
+		hoc_retpushx(0.0);
+		return;
+	}
+	if (sec->prop->dparam[PROP_PY_INDEX]._pvoid) { /* Python Section */
+		/* the Python Section will be a zombie section with a pointer
+		   to an invalid Section*.
+		*/
+		sec->prop->dparam[PROP_PY_INDEX]._pvoid = NULL;
+		section_ref(sec);
+		sec_free(sec->prop->dparam[8].itm);
+		hoc_retpushx(0.0);
+		return;
+	}
 	if (!sec->prop->dparam[0].sym) {
-		hoc_execerror("Cannot delete an unnamed section", (char*)0);
+		hoc_execerror("Cannot delete an unnamed hoc section", (char*)0);
 	}
 	sym = sec->prop->dparam[0].sym;
 	ob = sec->prop->dparam[6].obj;
@@ -327,7 +341,7 @@ void delete_section(void) {
 	}
 	sec_free(*pitm);
 	*pitm = 0;
-	hoc_retpushx(0.);
+	hoc_retpushx(1.);
 }
 
 /*

--- a/src/nrnoc/secref.c
+++ b/src/nrnoc/secref.c
@@ -67,6 +67,10 @@ static double s_unname(void* v) {
 	hoc_Item** pitm;
 	Section* sec;
 	sec = (Section*)v;
+	/* Python Sections cannot be unnamed, return 0.0 */
+	if (sec->prop && sec->prop->dparam[PROP_PY_INDEX]._pvoid) {
+		return 0.0;
+	}
 	pitm = sec2pitm(sec);
 	*pitm = (hoc_Item*)0;
 	sec->prop->dparam[0].sym = (Symbol*)0;
@@ -91,6 +95,10 @@ static double s_rename(void* v) {
 	sec = (Section*)v;
 	if (!sec->prop) {
 		Printf("SectionRef[???].sec is a deleted section\n");
+		return 0.;
+	}
+	/* Python Sections cannot be renamed, return 0.0 */
+	if (sec->prop->dparam[PROP_PY_INDEX]._pvoid) {
 		return 0.;
 	}
 	qsec = sec->prop->dparam[8].itm;
@@ -204,7 +212,7 @@ static double s_rename(void* v) {
 	}
 #endif
 	hoc_objectdata = obdsav;
-	return 1;
+	return 1.0;
 }
 
 int nrn_secref_nchild(Section* sec) {

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -294,21 +294,6 @@ static int NPyAllSegOfSecIter_init(NPyAllSegOfSecIter* self, PyObject* args,
   return 0;
 }
 
-static int NPySegOfSecIter_init(NPySegOfSecIter* self, PyObject* args,
-                              PyObject* kwds) {
-  NPySecObj* pysec;
-  // printf("NPySegOfSecIter_init %p %p\n", self, self->sec_);
-  if (self != NULL && !self->pysec_) {
-    if (!PyArg_ParseTuple(args, "O!", psection_type, &pysec)) {
-      return -1;
-    }
-    self->seg_iter_ = 0;
-    self->pysec_ = pysec;
-    Py_INCREF(pysec);
-  }
-  return 0;
-}
-
 PyObject* NPySecObj_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
   NPySecObj* self;
   self = (NPySecObj*)type->tp_alloc(type, 0);
@@ -329,20 +314,6 @@ PyObject* NPyAllSegOfSecIter_new(PyTypeObject* type, PyObject* args,
   // printf("NPyAllSegOfSecIter_new %p\n", self);
   if (self != NULL) {
     if (NPyAllSegOfSecIter_init(self, args, kwds) != 0) {
-      Py_DECREF(self);
-      return NULL;
-    }
-  }
-  return (PyObject*)self;
-}
-
-PyObject* NPySegOfSecIter_new(PyTypeObject* type, PyObject* args,
-                            PyObject* kwds) {
-  NPySegOfSecIter* self;
-  self = (NPySegOfSecIter*)type->tp_alloc(type, 0);
-  // printf("NPySegOfSecIter_new %p\n", self);
-  if (self != NULL) {
-    if (NPySegOfSecIter_init(self, args, kwds) != 0) {
       Py_DECREF(self);
       return NULL;
     }
@@ -388,23 +359,6 @@ static PyObject* NPyMechObj_new(PyTypeObject* type, PyObject* args,
   NPyMechObj* self;
   self = (NPyMechObj*)type->tp_alloc(type, 0);
   // printf("NPyMechObj_new %p %s\n", self,
-  // ((PyObject*)self)->ob_type->tp_name);
-  if (self != NULL) {
-    self->pyseg_ = pyseg;
-    Py_INCREF(self->pyseg_);
-  }
-  return (PyObject*)self;
-}
-
-static PyObject* NPyMechOfSegIter_new(PyTypeObject* type, PyObject* args,
-                                PyObject* kwds) {
-  NPySegObj* pyseg;
-  if (!PyArg_ParseTuple(args, "O!", psegment_type, &pyseg)) {
-    return NULL;
-  }
-  NPyMechOfSegIter* self;
-  self = (NPyMechOfSegIter*)type->tp_alloc(type, 0);
-  // printf("NPyMechOfSegIter_new %p %s\n", self,
   // ((PyObject*)self)->ob_type->tp_name);
   if (self != NULL) {
     self->pyseg_ = pyseg;
@@ -487,19 +441,6 @@ static void o2loc(Object* o, Section** psec, double* px) {
 
 static int NPyMechObj_init(NPyMechObj* self, PyObject* args, PyObject* kwds) {
   // printf("NPyMechObj_init %p %p %s\n", self, self->pyseg_,
-  // ((PyObject*)self)->ob_type->tp_name);
-  NPySegObj* pyseg;
-  if (!PyArg_ParseTuple(args, "O!", psegment_type, &pyseg)) {
-    return -1;
-  }
-  Py_INCREF(pyseg);
-  Py_XDECREF(self->pyseg_);
-  self->pyseg_ = pyseg;
-  return 0;
-}
-
-static int NPyMechOfSegIter_init(NPyMechOfSegIter* self, PyObject* args, PyObject* kwds) {
-  // printf("NPyMechOfSegIter_init %p %p %s\n", self, self->pyseg_,
   // ((PyObject*)self)->ob_type->tp_name);
   NPySegObj* pyseg;
   if (!PyArg_ParseTuple(args, "O!", psegment_type, &pyseg)) {
@@ -1201,13 +1142,6 @@ static PyObject* allseg_of_sec_iter(NPyAllSegOfSecIter* self) {
   return (PyObject*)self;
 }
 
-static PyObject* seg_of_sec_iter(NPySegOfSecIter* self) {
-  //printf("seg_of_sec_iter\n");
-  Py_INCREF(self);
-  self->seg_iter_ = 0;
-  return (PyObject*)self;
-}
-
 static PyObject* allseg_of_sec_next(NPyAllSegOfSecIter* self) {
   NPySegObj* seg;
   int n1 = self->pysec_->sec_->nnode - 1;
@@ -1609,15 +1543,6 @@ static int section_setattro(NPySecObj* self, PyObject* pyname,
   }
   Py_DECREF(pyname);
   return err;
-}
-
-static PyObject* mech_of_seg_iter(NPyMechOfSegIter* self) {
-  //printf("mech_of_seg_iter\n");
-  Py_INCREF(self);
-  Node* nd = node_exact(self->pyseg_->pysec_->sec_, self->pyseg_->x_);
-  Prop* p = mech_of_segment_prop(nd->prop);
-  self->prop_ = p;
-  return (PyObject*)self;
 }
 
 static PyObject* mech_of_seg_next(NPyMechOfSegIter* self) {

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -771,7 +771,6 @@ NPySecObj* newpysechelp(Section* sec) {
   if (!sec || !sec->prop) {
     return NULL;
   }
-  section_ref(sec);
   NPySecObj* pysec = NULL;
   if (sec->prop->dparam[PROP_PY_INDEX]._pvoid) {
     pysec = (NPySecObj*)sec->prop->dparam[PROP_PY_INDEX]._pvoid;
@@ -780,6 +779,7 @@ NPySecObj* newpysechelp(Section* sec) {
   } else {
     pysec = (NPySecObj*)psection_type->tp_alloc(psection_type, 0);
     pysec->sec_ = sec;
+    section_ref(sec);
     pysec->name_ = 0;
     pysec->cell_ = 0;
   }

--- a/src/nrnpython/nrnpy_nrn_2.h
+++ b/src/nrnpython/nrnpy_nrn_2.h
@@ -243,7 +243,7 @@ static PyTypeObject nrnpy_SegOfSecIterType = {
     0,                                        /* tp_clear */
     0,                                        /* tp_richcompare */
     0,                                        /* tp_weaklistoffset */
-    (getiterfunc)seg_of_sec_iter,             /* tp_iter */
+    (getiterfunc)PyObject_SelfIter,           /* tp_iter */
     (iternextfunc)seg_of_sec_next,            /* tp_iternext */
     0,                                        /* tp_methods */
     0,                                        /* tp_members */
@@ -253,9 +253,9 @@ static PyTypeObject nrnpy_SegOfSecIterType = {
     0,                                        /* tp_descr_get */
     0,                                        /* tp_descr_set */
     0,                                        /* tp_dictoffset */
-    (initproc)NPySegOfSecIter_init,           /* tp_init */
+    0,                                        /* tp_init */
     0,                                        /* tp_alloc */
-    NPySegOfSecIter_new,                      /* tp_new */
+    0,                                        /* tp_new */
 };
 
 static PyTypeObject nrnpy_MechOfSegIterType = {
@@ -284,7 +284,7 @@ static PyTypeObject nrnpy_MechOfSegIterType = {
     0,                                        /* tp_clear */
     0,                                        /* tp_richcompare */
     0,                                        /* tp_weaklistoffset */
-    (getiterfunc)mech_of_seg_iter,            /* tp_iter */
+    (getiterfunc)PyObject_SelfIter,           /* tp_iter */
     (iternextfunc)mech_of_seg_next,           /* tp_iternext */
     0,                                        /* tp_methods */
     0,                                        /* tp_members */
@@ -294,9 +294,9 @@ static PyTypeObject nrnpy_MechOfSegIterType = {
     0,                                        /* tp_descr_get */
     0,                                        /* tp_descr_set */
     0,                                        /* tp_dictoffset */
-    (initproc)NPyMechOfSegIter_init,          /* tp_init */
+    0,                                        /* tp_init */
     0,                                        /* tp_alloc */
-    NPyMechOfSegIter_new,                     /* tp_new */
+    0,                                        /* tp_new */
 };
 
 

--- a/src/nrnpython/nrnpy_nrn_2.h
+++ b/src/nrnpython/nrnpy_nrn_2.h
@@ -32,7 +32,7 @@ static PyTypeObject nrnpy_SectionType = {
     0,                                        /* tp_clear */
     (richcmpfunc)pysec_richcmp,               /* tp_richcompare */
     0,                                        /* tp_weaklistoffset */
-    (getiterfunc)section_iter,                /* tp_iter */
+    (getiterfunc)seg_of_section_iter,         /* tp_iter */
     0,                                        /* tp_iternext */
     NPySecObj_methods,                        /* tp_methods */
     0,                                        /* tp_members */
@@ -47,12 +47,12 @@ static PyTypeObject nrnpy_SectionType = {
     NPySecObj_new,                            /* tp_new */
 };
 
-static PyTypeObject nrnpy_AllsegIterType = {
+static PyTypeObject nrnpy_AllSegOfSecIterType = {
     PyObject_HEAD_INIT(NULL)0,                /*ob_size*/
-    ccast "nrn.AllsegIter",                   /*tp_name*/
-    sizeof(NPyAllsegIter),                    /*tp_basicsize*/
+    ccast "nrn.AllSegOfSecIter",              /*tp_name*/
+    sizeof(NPyAllSegOfSecIter),               /*tp_basicsize*/
     0,                                        /*tp_itemsize*/
-    (destructor)NPyAllsegIter_dealloc,        /*tp_dealloc*/
+    (destructor)NPyAllSegOfSecIter_dealloc,   /*tp_dealloc*/
     0,                                        /*tp_print*/
     0,                                        /*tp_getattr*/
     0,                                        /*tp_setattr*/
@@ -70,23 +70,23 @@ static PyTypeObject nrnpy_AllsegIterType = {
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
     ccast
     "Iterate over all Segments of a Section, including x=0 and 1", /* tp_doc */
-    0,                            /* tp_traverse */
-    0,                            /* tp_clear */
-    0,                            /* tp_richcompare */
-    0,                            /* tp_weaklistoffset */
-    (getiterfunc)allseg_iter,     /* tp_iter */
-    (iternextfunc)allseg_next,    /* tp_iternext */
-    0,                            /* tp_methods */
-    0,                            /* tp_members */
-    0,                            /* tp_getset */
-    0,                            /* tp_base */
-    0,                            /* tp_dict */
-    0,                            /* tp_descr_get */
-    0,                            /* tp_descr_set */
-    0,                            /* tp_dictoffset */
-    (initproc)NPyAllsegIter_init, /* tp_init */
-    0,                            /* tp_alloc */
-    NPyAllsegIter_new,            /* tp_new */
+    0,                                        /* tp_traverse */
+    0,                                        /* tp_clear */
+    0,                                        /* tp_richcompare */
+    0,                                        /* tp_weaklistoffset */
+    (getiterfunc)allseg_of_sec_iter,          /* tp_iter */
+    (iternextfunc)allseg_of_sec_next,         /* tp_iternext */
+    0,                                        /* tp_methods */
+    0,                                        /* tp_members */
+    0,                                        /* tp_getset */
+    0,                                        /* tp_base */
+    0,                                        /* tp_dict */
+    0,                                        /* tp_descr_get */
+    0,                                        /* tp_descr_set */
+    0,                                        /* tp_dictoffset */
+    (initproc)NPyAllSegOfSecIter_init,        /* tp_init */
+    0,                                        /* tp_alloc */
+    NPyAllSegOfSecIter_new,                   /* tp_new */
 };
 
 static PyTypeObject nrnpy_SegmentType = {
@@ -115,8 +115,8 @@ static PyTypeObject nrnpy_SegmentType = {
     0,                                        /* tp_clear */
     (richcmpfunc)pyseg_richcmp,               /* tp_richcompare */
     0,                                        /* tp_weaklistoffset */
-    (getiterfunc)segment_iter,                /* tp_iter */
-    (iternextfunc)segment_next,               /* tp_iternext */
+    (getiterfunc)mech_of_segment_iter,        /* tp_iter */
+    0,                                        /* tp_iternext */
     NPySegObj_methods,                        /* tp_methods */
     NPySegObj_members,                        /* tp_members */
     0,                                        /* tp_getset */
@@ -203,7 +203,7 @@ static PyTypeObject nrnpy_MechanismType = {
     0,                                        /* tp_richcompare */
     0,                                        /* tp_weaklistoffset */
     0,                                        /* tp_iter */
-    (iternextfunc)mech_next,                  /* tp_iternext */
+    0,                                        /* tp_iternext */
     NPyMechObj_methods,                       /* tp_methods */
     NPyMechObj_members,                       /* tp_members */
     0,                                        /* tp_getset */
@@ -216,3 +216,87 @@ static PyTypeObject nrnpy_MechanismType = {
     0,                                        /* tp_alloc */
     NPyMechObj_new,                           /* tp_new */
 };
+
+static PyTypeObject nrnpy_SegOfSecIterType = {
+    PyObject_HEAD_INIT(NULL)0,                /*ob_size*/
+    ccast "nrn.SegOfSecIter",                 /*tp_name*/
+    sizeof(NPySegOfSecIter),                 /*tp_basicsize*/
+    0,                                        /*tp_itemsize*/
+    (destructor)NPySegOfSecIter_dealloc,      /*tp_dealloc*/
+    0,                                        /*tp_print*/
+    0,                                        /*tp_getattr*/
+    0,                                        /*tp_setattr*/
+    0,                                        /*tp_compare*/
+    0,                                        /*tp_repr*/
+    0,                                        /*tp_as_number*/
+    0,                                        /*tp_as_sequence*/
+    0,                                        /*tp_as_mapping*/
+    0,                                        /*tp_hash*/
+    0,                                        /*tp_call*/
+    0,                                        /*tp_str*/
+    0,                                        /*tp_getattro*/
+    0,                                        /*tp_setattro*/
+    0,                                        /*tp_as_buffer*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+    ccast "Iterate over nonzero area Segments of a Section (does not include x=0 or 1)", /* tp_doc */
+    0,                                        /* tp_traverse */
+    0,                                        /* tp_clear */
+    0,                                        /* tp_richcompare */
+    0,                                        /* tp_weaklistoffset */
+    (getiterfunc)seg_of_sec_iter,             /* tp_iter */
+    (iternextfunc)seg_of_sec_next,            /* tp_iternext */
+    0,                                        /* tp_methods */
+    0,                                        /* tp_members */
+    0,                                        /* tp_getset */
+    0,                                        /* tp_base */
+    0,                                        /* tp_dict */
+    0,                                        /* tp_descr_get */
+    0,                                        /* tp_descr_set */
+    0,                                        /* tp_dictoffset */
+    (initproc)NPySegOfSecIter_init,           /* tp_init */
+    0,                                        /* tp_alloc */
+    NPySegOfSecIter_new,                      /* tp_new */
+};
+
+static PyTypeObject nrnpy_MechOfSegIterType = {
+    PyObject_HEAD_INIT(NULL)0,                /*ob_size*/
+    ccast "nrn.MechOfSegIter",                /*tp_name*/
+    sizeof(NPyMechOfSegIter),                /*tp_basicsize*/
+    0,                                        /*tp_itemsize*/
+    (destructor)NPyMechOfSegIter_dealloc,     /*tp_dealloc*/
+    0,                                        /*tp_print*/
+    0,                                        /*tp_getattr*/
+    0,                                        /*tp_setattr*/
+    0,                                        /*tp_compare*/
+    0,                                        /*tp_repr*/
+    0,                                        /*tp_as_number*/
+    0,                                        /*tp_as_sequence*/
+    0,                                        /*tp_as_mapping*/
+    0,                                        /*tp_hash*/
+    0,                                        /*tp_call*/
+    0,                                        /*tp_str*/
+    0,                                        /*tp_getattro*/
+    0,                                        /*tp_setattro*/
+    0,                                        /*tp_as_buffer*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+    ccast "Iterate over Mechanisms in a Segment of a Section", /* tp_doc */
+    0,                                        /* tp_traverse */
+    0,                                        /* tp_clear */
+    0,                                        /* tp_richcompare */
+    0,                                        /* tp_weaklistoffset */
+    (getiterfunc)mech_of_seg_iter,            /* tp_iter */
+    (iternextfunc)mech_of_seg_next,           /* tp_iternext */
+    0,                                        /* tp_methods */
+    0,                                        /* tp_members */
+    0,                                        /* tp_getset */
+    0,                                        /* tp_base */
+    0,                                        /* tp_dict */
+    0,                                        /* tp_descr_get */
+    0,                                        /* tp_descr_set */
+    0,                                        /* tp_dictoffset */
+    (initproc)NPyMechOfSegIter_init,          /* tp_init */
+    0,                                        /* tp_alloc */
+    NPyMechOfSegIter_new,                     /* tp_new */
+};
+
+

--- a/src/nrnpython/nrnpy_nrn_2.h
+++ b/src/nrnpython/nrnpy_nrn_2.h
@@ -202,7 +202,7 @@ static PyTypeObject nrnpy_MechanismType = {
     0,                                        /* tp_clear */
     0,                                        /* tp_richcompare */
     0,                                        /* tp_weaklistoffset */
-    0,                                        /* tp_iter */
+    (getiterfunc)var_of_mech_iter,            /* tp_iter */
     0,                                        /* tp_iternext */
     NPyMechObj_methods,                       /* tp_methods */
     NPyMechObj_members,                       /* tp_members */
@@ -220,7 +220,7 @@ static PyTypeObject nrnpy_MechanismType = {
 static PyTypeObject nrnpy_SegOfSecIterType = {
     PyObject_HEAD_INIT(NULL)0,                /*ob_size*/
     ccast "nrn.SegOfSecIter",                 /*tp_name*/
-    sizeof(NPySegOfSecIter),                 /*tp_basicsize*/
+    sizeof(NPySegOfSecIter),                  /*tp_basicsize*/
     0,                                        /*tp_itemsize*/
     (destructor)NPySegOfSecIter_dealloc,      /*tp_dealloc*/
     0,                                        /*tp_print*/
@@ -261,7 +261,7 @@ static PyTypeObject nrnpy_SegOfSecIterType = {
 static PyTypeObject nrnpy_MechOfSegIterType = {
     PyObject_HEAD_INIT(NULL)0,                /*ob_size*/
     ccast "nrn.MechOfSegIter",                /*tp_name*/
-    sizeof(NPyMechOfSegIter),                /*tp_basicsize*/
+    sizeof(NPyMechOfSegIter),                 /*tp_basicsize*/
     0,                                        /*tp_itemsize*/
     (destructor)NPyMechOfSegIter_dealloc,     /*tp_dealloc*/
     0,                                        /*tp_print*/
@@ -286,6 +286,47 @@ static PyTypeObject nrnpy_MechOfSegIterType = {
     0,                                        /* tp_weaklistoffset */
     (getiterfunc)PyObject_SelfIter,           /* tp_iter */
     (iternextfunc)mech_of_seg_next,           /* tp_iternext */
+    0,                                        /* tp_methods */
+    0,                                        /* tp_members */
+    0,                                        /* tp_getset */
+    0,                                        /* tp_base */
+    0,                                        /* tp_dict */
+    0,                                        /* tp_descr_get */
+    0,                                        /* tp_descr_set */
+    0,                                        /* tp_dictoffset */
+    0,                                        /* tp_init */
+    0,                                        /* tp_alloc */
+    0,                                        /* tp_new */
+};
+
+static PyTypeObject nrnpy_VarOfMechIterType = {
+    PyObject_HEAD_INIT(NULL)0,                /*ob_size*/
+    ccast "nrn.VarOfMechIter",                /*tp_name*/
+    sizeof(NPyVarOfMechIter),                 /*tp_basicsize*/
+    0,                                        /*tp_itemsize*/
+    (destructor)NPyVarOfMechIter_dealloc,     /*tp_dealloc*/
+    0,                                        /*tp_print*/
+    0,                                        /*tp_getattr*/
+    0,                                        /*tp_setattr*/
+    0,                                        /*tp_compare*/
+    0,                                        /*tp_repr*/
+    0,                                        /*tp_as_number*/
+    0,                                        /*tp_as_sequence*/
+    0,                                        /*tp_as_mapping*/
+    0,                                        /*tp_hash*/
+    0,                                        /*tp_call*/
+    0,                                        /*tp_str*/
+    0,                                        /*tp_getattro*/
+    0,                                        /*tp_setattro*/
+    0,                                        /*tp_as_buffer*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+    ccast "Iterate over Mechanisms in a Segment of a Section", /* tp_doc */
+    0,                                        /* tp_traverse */
+    0,                                        /* tp_clear */
+    0,                                        /* tp_richcompare */
+    0,                                        /* tp_weaklistoffset */
+    (getiterfunc)PyObject_SelfIter,           /* tp_iter */
+    (iternextfunc)var_of_mech_next,           /* tp_iternext */
     0,                                        /* tp_methods */
     0,                                        /* tp_members */
     0,                                        /* tp_getset */

--- a/src/nrnpython/nrnpy_nrn_3.h
+++ b/src/nrnpython/nrnpy_nrn_3.h
@@ -6,7 +6,7 @@ static PyType_Slot nrnpy_SectionType_slots[] = {
     {Py_tp_getattro, (void*)section_getattro},
     {Py_tp_setattro, (void*)section_setattro},
     {Py_tp_richcompare, (void*)pysec_richcmp},
-    {Py_tp_iter, (void*)section_iter},
+    {Py_tp_iter, (void*)seg_of_section_iter},
     {Py_tp_methods, (void*)NPySecObj_methods},
     {Py_tp_init, (void*)NPySecObj_init},
     {Py_tp_new, (void*)NPySecObj_new},
@@ -22,23 +22,39 @@ static PyType_Spec nrnpy_SectionType_spec = {
 };
 
 
-static PyType_Slot nrnpy_AllsegIterType_slots[] = {
-    {Py_tp_dealloc, (void*)NPyAllsegIter_dealloc},
-    {Py_tp_iter, (void*)allseg_iter},
-    {Py_tp_iternext, (void*)allseg_next},
-    {Py_tp_init, (void*)NPyAllsegIter_init},
-    {Py_tp_new, (void*)NPyAllsegIter_new},
+static PyType_Slot nrnpy_AllSegOfSecIterType_slots[] = {
+    {Py_tp_dealloc, (void*)NPyAllSegOfSecIter_dealloc},
+    {Py_tp_iter, (void*)allseg_of_sec_iter},
+    {Py_tp_iternext, (void*)allseg_of_sec_next},
+    {Py_tp_init, (void*)NPyAllSegOfSecIter_init},
+    {Py_tp_new, (void*)NPyAllSegOfSecIter_new},
     {Py_tp_doc, (void*)"Iterate over all Segments of a Section, including x=0 and 1"},
     {0, 0},
 };
-static PyType_Spec nrnpy_AllsegIterType_spec = {
+static PyType_Spec nrnpy_AllSegOfSecIterType_spec = {
     "nrn.AllsegIter",
-    sizeof(NPyAllsegIter),
+    sizeof(NPyAllSegOfSecIter),
     0,
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-    nrnpy_AllsegIterType_slots,
+    nrnpy_AllSegOfSecIterType_slots,
 };
 
+static PyType_Slot nrnpy_SegOfSecIterType_slots[] = {
+    {Py_tp_dealloc, (void*)NPySegOfSecIter_dealloc},
+    {Py_tp_iter, (void*)seg_of_sec_iter},
+    {Py_tp_iternext, (void*)seg_of_sec_next},
+    {Py_tp_init, (void*)NPySegOfSecIter_init},
+    {Py_tp_new, (void*)NPySegOfSecIter_new},
+    {Py_tp_doc, (void*)"Iterate over nonzero area Segments of a Section (does not include x=0 and 1)"},
+    {0, 0},
+};
+static PyType_Spec nrnpy_SegOfSecIterType_spec = {
+    "nrn.SegOfSecIter",
+    sizeof(NPySegOfSecIter),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    nrnpy_SegOfSecIterType_slots,
+};
 
 static PyType_Slot nrnpy_SegmentType_slots[] = {
     {Py_tp_dealloc, (void*)NPySegObj_dealloc},
@@ -47,8 +63,7 @@ static PyType_Slot nrnpy_SegmentType_slots[] = {
     {Py_tp_getattro, (void*)segment_getattro},
     {Py_tp_setattro, (void*)segment_setattro},
     {Py_tp_richcompare, (void*)pyseg_richcmp},
-    {Py_tp_iter, (void*)segment_iter},
-    {Py_tp_iternext, (void*)segment_next},
+    {Py_tp_iter, (void*)mech_of_segment_iter},
     {Py_tp_methods, (void*)NPySegObj_methods},
     {Py_tp_members, (void*)NPySegObj_members},
     {Py_tp_init, (void*)NPySegObj_init},
@@ -64,6 +79,42 @@ static PyType_Spec nrnpy_SegmentType_spec = {
     nrnpy_SegmentType_slots,
 };
 
+static PyType_Slot nrnpy_MechOfSegIterType_slots[] = {
+    {Py_tp_dealloc, (void*)NPyMechOfSegIter_dealloc},
+    {Py_tp_iter, (void*)mech_of_seg_iter},
+    {Py_tp_iternext, (void*)mech_of_seg_next},
+    {Py_tp_init, (void*)NPyMechOfSegIter_init},
+    {Py_tp_new, (void*)NPyMechOfSegIter_new},
+    {Py_tp_doc, (void*)"Iterate over Mechanisms in a Segment of a Section"},
+    {0, 0},
+};
+static PyType_Spec nrnpy_MechOfSegIterType_spec = {
+    "nrn.MechanismIter",
+    sizeof(NPyMechOfSegIter),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    nrnpy_MechOfSegIterType_slots,
+};
+
+static PyType_Slot nrnpy_MechanismType_slots[] = {
+    {Py_tp_dealloc, (void*)NPyMechObj_dealloc},
+    {Py_tp_repr, (void*)pymech_repr},
+    {Py_tp_getattro, (void*)mech_getattro},
+    {Py_tp_setattro, (void*)mech_setattro},
+    {Py_tp_methods, (void*)NPyMechObj_methods},
+    {Py_tp_members, (void*)NPyMechObj_members},
+    {Py_tp_init, (void*)NPyMechObj_init},
+    {Py_tp_new, (void*)NPyMechObj_new},
+    {Py_tp_doc, (void*)"Mechanism objects"},
+    {0, 0},
+};
+static PyType_Spec nrnpy_MechanismType_spec = {
+    "nrn.Mechanism",
+    sizeof(NPyMechObj),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    nrnpy_MechanismType_slots,
+};
 
 static PyType_Slot nrnpy_RangeType_slots[] = {
     {Py_tp_dealloc, (void*)NPyRangeVar_dealloc},
@@ -83,29 +134,6 @@ static PyType_Spec nrnpy_RangeType_spec = {
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
     nrnpy_RangeType_slots,
 };
-
-
-static PyType_Slot nrnpy_MechanismType_slots[] = {
-    {Py_tp_dealloc, (void*)NPyMechObj_dealloc},
-    {Py_tp_repr, (void*)pymech_repr},
-    {Py_tp_getattro, (void*)mech_getattro},
-    {Py_tp_setattro, (void*)mech_setattro},
-    {Py_tp_iternext, (void*)mech_next},
-    {Py_tp_methods, (void*)NPyMechObj_methods},
-    {Py_tp_members, (void*)NPyMechObj_members},
-    {Py_tp_init, (void*)NPyMechObj_init},
-    {Py_tp_new, (void*)NPyMechObj_new},
-    {Py_tp_doc, (void*)"Mechanism objects"},
-    {0, 0},
-};
-static PyType_Spec nrnpy_MechanismType_spec = {
-    "nrn.Mechanism",
-    sizeof(NPyMechObj),
-    0,
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-    nrnpy_MechanismType_slots,
-};
-
 
 static struct PyModuleDef nrnmodule = {PyModuleDef_HEAD_INIT, "nrn",
                                        "NEURON interaction with Python", -1,

--- a/src/nrnpython/nrnpy_nrn_3.h
+++ b/src/nrnpython/nrnpy_nrn_3.h
@@ -41,10 +41,8 @@ static PyType_Spec nrnpy_AllSegOfSecIterType_spec = {
 
 static PyType_Slot nrnpy_SegOfSecIterType_slots[] = {
     {Py_tp_dealloc, (void*)NPySegOfSecIter_dealloc},
-    {Py_tp_iter, (void*)seg_of_sec_iter},
+    {Py_tp_iter, (void*)PyObject_SelfIter},
     {Py_tp_iternext, (void*)seg_of_sec_next},
-    {Py_tp_init, (void*)NPySegOfSecIter_init},
-    {Py_tp_new, (void*)NPySegOfSecIter_new},
     {Py_tp_doc, (void*)"Iterate over nonzero area Segments of a Section (does not include x=0 and 1)"},
     {0, 0},
 };
@@ -81,10 +79,8 @@ static PyType_Spec nrnpy_SegmentType_spec = {
 
 static PyType_Slot nrnpy_MechOfSegIterType_slots[] = {
     {Py_tp_dealloc, (void*)NPyMechOfSegIter_dealloc},
-    {Py_tp_iter, (void*)mech_of_seg_iter},
+    {Py_tp_iter, (void*)PyObject_SelfIter},
     {Py_tp_iternext, (void*)mech_of_seg_next},
-    {Py_tp_init, (void*)NPyMechOfSegIter_init},
-    {Py_tp_new, (void*)NPyMechOfSegIter_new},
     {Py_tp_doc, (void*)"Iterate over Mechanisms in a Segment of a Section"},
     {0, 0},
 };

--- a/src/nrnpython/nrnpy_nrn_3.h
+++ b/src/nrnpython/nrnpy_nrn_3.h
@@ -85,7 +85,7 @@ static PyType_Slot nrnpy_MechOfSegIterType_slots[] = {
     {0, 0},
 };
 static PyType_Spec nrnpy_MechOfSegIterType_spec = {
-    "nrn.MechanismIter",
+    "nrn.MechOfSegIter",
     sizeof(NPyMechOfSegIter),
     0,
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
@@ -97,6 +97,7 @@ static PyType_Slot nrnpy_MechanismType_slots[] = {
     {Py_tp_repr, (void*)pymech_repr},
     {Py_tp_getattro, (void*)mech_getattro},
     {Py_tp_setattro, (void*)mech_setattro},
+    {Py_tp_iter, (void*)var_of_mech_iter},
     {Py_tp_methods, (void*)NPyMechObj_methods},
     {Py_tp_members, (void*)NPyMechObj_members},
     {Py_tp_init, (void*)NPyMechObj_init},
@@ -110,6 +111,21 @@ static PyType_Spec nrnpy_MechanismType_spec = {
     0,
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
     nrnpy_MechanismType_slots,
+};
+
+static PyType_Slot nrnpy_VarOfMechIterType_slots[] = {
+    {Py_tp_dealloc, (void*)NPyVarOfMechIter_dealloc},
+    {Py_tp_iter, (void*)PyObject_SelfIter},
+    {Py_tp_iternext, (void*)var_of_mech_next},
+    {Py_tp_doc, (void*)"Iterate over variables  in a Mechanism"},
+    {0, 0},
+};
+static PyType_Spec nrnpy_VarOfMechIterType_spec = {
+    "nrn.VarOfMechIter",
+    sizeof(NPyVarOfMechIter),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    nrnpy_VarOfMechIterType_slots,
 };
 
 static PyType_Slot nrnpy_RangeType_slots[] = {

--- a/test/rxd/3d/test_pure_diffusion_3d.py
+++ b/test/rxd/3d/test_pure_diffusion_3d.py
@@ -65,7 +65,7 @@ def test_pure_diffusion_3d_inhom(ics_pure_diffusion):
     dend, r, ca = model
     h.dt *= 50
     for nd in ca.nodes:
-        if nd.x > 0.5:
+        if nd.x >= 0.5:
             nd.d = 0
     h.finitialize(-65)
     loss = -(numpy.array(ca.nodes.concentration) * numpy.array(ca.nodes.volume)).sum()
@@ -85,7 +85,7 @@ def test_pure_diffusion_3d_inhom_cvode(ics_pure_diffusion):
     dend, r, ca = model
     h.CVode().active(True)
     for nd in ca.nodes:
-        if nd.x > 0.5:
+        if nd.x >= 0.5:
             nd.d = 0
     h.finitialize(-65)
     loss = -(numpy.array(ca.nodes.concentration) * numpy.array(ca.nodes.volume)).sum()


### PR DESCRIPTION
Replaces Pull Request Pyiter #422  which has been languishing a few months and was full of
irrelevant commits already in the master. This pull request displays a reasonable sequence of the
change commits. In addition to its primary introduction of Pythonic iterators, it fixes a memory leak, allows h.delete_section of a python section, and prevents use of freed memory when h.delete_section is used within a section iterator.

Resolves #352 Pythonic iterators for Section, Segment, Mechanism, RangeVar
Test added.
```
s = h.Section(name='s')
s.nseg=3
s.insert('pas')

for sec in h.allsec():
  for seg in sec:
    for mech in seg:
      for var in mech:
        print ('%s(%g).%s = %g' % (sec.name(), seg.x, var.name(), var[0]))
```