### PR TITLE
Valgrinderr

### DIFF
--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -2750,7 +2750,7 @@ myPyMODINIT_FUNC nrnpy_hoc() {
 #if PY_MAJOR_VERSION >= 3
   err = PyDict_SetItemString(modules, "hoc", m);
   assert(err == 0);
-  Py_DECREF(m);
+//  Py_DECREF(m);
   return m;
 fail:
   return NULL;

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -1611,7 +1611,6 @@ static PyObject* var_of_mech_next(NPyVarOfMechIter* self) {
   Symbol* sym = self->msym_->u.ppsym[self->i_];
   self->i_++;
   NPyRangeVar* r = (NPyRangeVar*)PyObject_New(NPyRangeVar, range_type);
-  Py_INCREF(r);
   r->pymech_ = self->pymech_;
   Py_INCREF(r->pymech_);
   r->sym_ = sym;


### PR DESCRIPTION
Fix valgrind invalid read error during finalize that could cause segmentation violations and
a memory leak when iterating over variables of a mechanism.
