### PR TITLE
Create x86_64 (or arch) folder under install prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,6 +398,13 @@ if(MINGW)
 endif()
 
 # =============================================================================
+# Installation steps for backward compatibility
+# =============================================================================
+# create arch folder under prefix with symlink to bin and lib
+nrn_install_dir_symlink(${CMAKE_INSTALL_PREFIX}/bin ${CMAKE_INSTALL_PREFIX}/${CMAKE_HOST_SYSTEM_PROCESSOR}/bin)
+nrn_install_dir_symlink(${CMAKE_INSTALL_PREFIX}/lib ${CMAKE_INSTALL_PREFIX}/${CMAKE_HOST_SYSTEM_PROCESSOR}/lib)
+
+# =============================================================================
 # Print build status
 # =============================================================================
 

--- a/cmake/MacroHelper.cmake
+++ b/cmake/MacroHelper.cmake
@@ -248,3 +248,14 @@ macro(nocmodl_mod_to_c modfile_basename)
     DEPENDS ${PROJECT_BINARY_DIR}/bin/nocmodl ${modfile_basename}.mod
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src/nrniv)
 endmacro()
+
+# =============================================================================
+# Create symbolic links
+# =============================================================================
+macro(nrn_install_dir_symlink source_dir symlink_dir)
+    # make sure to have directory path exist upto parent dir
+    get_filename_component(parent_symlink_dir ${symlink_dir} DIRECTORY)
+    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${parent_symlink_dir})")
+    # create symbolic link
+    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${source_dir} ${symlink_dir})")
+endmacro(nrn_install_dir_symlink)


### PR DESCRIPTION
 fixes  #463

@nrnhines : I don't remember this precisely - I assume make install on windows is executed under mingw / linux environment, right? Asking because `cmake -E create_symlink` is supported on unix environment.

With this PR, on install we see:

```
$ ll /gpfs/bbp.cscs.ch/home/kumbhar/tmp/nrn/build/install/x86_64/
total 4
drwxr-xr-x 2 kumbhar bbp 4096 Mar 29 21:31 ./
drwxr-xr-x 7 kumbhar bbp 4096 Mar 29 21:31 ../
lrwxrwxrwx 1 kumbhar bbp   56 Mar 29 21:31 bin -> /gpfs/bbp.cscs.ch/home/kumbhar/tmp/nrn/build/install/bin/
lrwxrwxrwx 1 kumbhar bbp   56 Mar 29 21:31 lib -> /gpfs/bbp.cscs.ch/home/kumbhar/tmp/nrn/build/install/lib/
```