### PR TITLE
In some circumstances hoc object unreferencing was deferred too long.

### DIFF
--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -61,6 +61,7 @@ extern int hoc_stack_type();
 extern void hoc_call();
 extern Objectdata* hoc_top_level_data;
 extern void hoc_tobj_unref(Object**);
+extern void hoc_unref_defer();
 extern void sec_access_push();
 extern PyObject* nrnpy_pushsec(PyObject*);
 extern bool hoc_valid_stmt(const char*, Object*);
@@ -756,6 +757,7 @@ static PyObject* hocobj_call(PyHocObject* self, PyObject* args,
     } else {
       result = (PyObject*)fcall((void*)self, (void*)args);
     }
+    hoc_unref_defer();
   } else {
     PyErr_SetString(PyExc_TypeError, "object is not callable");
     curargs_ = prevargs_;


### PR DESCRIPTION
hoc_unref_defer() is now called every time python finishes a function
or method call. An example that now destroys the Graph window when g
is unreferenced is:

from neuron import h, gui
g = h.Graph()
g.addexpr('t')
g = None