### PR TITLE
Helpful error message if Vector.record called without pointer

### DIFF
--- a/src/ivoc/ivocvect.cpp
+++ b/src/ivoc/ivocvect.cpp
@@ -877,6 +877,10 @@ static double v_scantil(void *v) {
 
 
 static Object** v_record(void* v) {
+	if (hoc_is_double_arg(1)) {
+		hoc_execerror("Vector.record:", "A number was provided instead of a pointer.\nDid you forget an _ref_ (Python) or an & (HOC)?");
+		return NULL;
+	}
         Vect* vp = (Vect*)v;
 	nrn_vecsim_add(v, true);
 	return vp->temp_objvar();

--- a/src/ivoc/ivocvect.cpp
+++ b/src/ivoc/ivocvect.cpp
@@ -879,7 +879,6 @@ static double v_scantil(void *v) {
 static Object** v_record(void* v) {
 	if (hoc_is_double_arg(1)) {
 		hoc_execerror("Vector.record:", "A number was provided instead of a pointer.\nDid you forget an _ref_ (Python) or an & (HOC)?");
-		return NULL;
 	}
         Vect* vp = (Vect*)v;
 	nrn_vecsim_add(v, true);


### PR DESCRIPTION
**We now suggest adding an `_ref_` or an &:**

    oc>objref tvec
    oc>tvec = new Vector()
    oc>tvec.record(t)
    /usr/local/nrn/x86_64/bin/nrniv: Vector.record: A number was provided instead of a pointer.
    Did you forget an _ref_ (Python) or an & (HOC)?
     near line 8
     tvec.record(t)
                   ^
            Vector[0].record(0)

Previously said:

    /usr/local/nrn/x86_64/bin/nrniv: bad stack access: expecting (double *); really (double)
    NEURON: interpreter stack type error
     near line 0
     objref hoc_obj_[2]
                       ^
            Vector[0].record(7)

Unfortunately, there is no equivalent fix possible for Vector.play as taking a number
is valid.