### PR TITLE
py shim: xcrun must bring all original args

### DIFF
--- a/share/lib/python/scripts/_binwrapper.py
+++ b/share/lib/python/scripts/_binwrapper.py
@@ -7,13 +7,17 @@ import os
 import sys
 from pkg_resources import working_set
 from distutils.ccompiler import new_compiler
-from distutils.sysconfig import customize_compiler
+from distutils.sysconfig import customize_compiler, get_config_var
 
 
 def _set_default_compiler():
     """Set (dont overwrite) CC/CXX so that apps dont use the build-time ones"""
     ccompiler = new_compiler()
     customize_compiler(ccompiler)
+    # xcrun wrapper must bring all args
+    if ccompiler.compiler[0] == 'xcrun':
+        ccompiler.compiler[0] = get_config_var("CC")
+        ccompiler.compiler_cxx[0] = get_config_var("CXX")
     os.environ.setdefault("CC", ccompiler.compiler[0])
     os.environ.setdefault("CXX", ccompiler.compiler_cxx[0])
 


### PR DESCRIPTION
## The problem
nrnivmodl fails in new MAC OS
```
 -> Compiling mod_func.c
xcrun -O2   -I. -I..   -I/Users/joao/Library/Python/3.7/lib/python/site-packages/neuron/.data/include  -I/usr/local/Cellar/open-mpi/4.0.3/include -fPIC -c mod_func.c -o mod_func.o
xcrun: error: unrecognized option: -O2
Usage: xcrun [options] <tool name> ... arguments ...
[...]
```

The error is due to the way MAC shipped python was compiled:
```
>>> from distutils.sysconfig import get_config_var
>>> print (get_config_var('CC'))
xcrun -sdk macosx clang  -arch x86_64

>>> from distutils.ccompiler import new_compiler
>>> from distutils.sysconfig import customize_compiler
>>> ccompiler = new_compiler()
>>> customize_compiler(ccompiler)
>>> print("CC: ", ccompiler.compiler[0])
CC: xcrun
```

Investigating, distutils takes the first text from get_config_var to look for the executable and, in case it exists, assumes that's the compiler and it's good to use

However, xcrun is a shim which has a mandatory argument: `clang`. Without it xcrun doesn't compile anything

## This PR
This seems a pretty nasty bug which, according to some local experimentation, will even prevent extensions from being compiled. Before Apple or Python.org make a fix, we patch for this specific case. However it can potentially happen with other wrappers that require args.

The quick fix check if the "detected compiler" is xcrun. If that's the case then one sets the compiler to the original CC/CXX config var.