### PR TITLE
Make help() work (+ test)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -305,16 +305,13 @@ def setup_package():
         version=__version__,
         package_dir={'': NRN_PY_ROOT},
         packages=py_packages,
-        package_data={
-            'neuron': ['help_data.dat']
-        },
+        package_data={'neuron': ['*.dat']},
         ext_modules=extensions,
         scripts=[
             os.path.join(NRN_PY_SCRIPTS, f)
             for f in os.listdir(NRN_PY_SCRIPTS)
             if f[0] != '_'
         ],
-        include_package_data=True,
         cmdclass=dict(build_ext=CMakeAugmentedBuilder, docs=Docs),
         install_requires=['numpy>=1.9.3'],
         tests_require=["flake8", "pytest"],

--- a/setup.py
+++ b/setup.py
@@ -305,6 +305,9 @@ def setup_package():
         version=__version__,
         package_dir={'': NRN_PY_ROOT},
         packages=py_packages,
+        package_data={
+            'neuron': ['help_data.dat']
+        },
         ext_modules=extensions,
         scripts=[
             os.path.join(NRN_PY_SCRIPTS, f)

--- a/setup.py
+++ b/setup.py
@@ -311,6 +311,7 @@ def setup_package():
             for f in os.listdir(NRN_PY_SCRIPTS)
             if f[0] != '_'
         ],
+        include_package_data=True,
         cmdclass=dict(build_ext=CMakeAugmentedBuilder, docs=Docs),
         install_requires=['numpy>=1.9.3'],
         tests_require=["flake8", "pytest"],

--- a/share/lib/python/neuron/tests/test_neuron.py
+++ b/share/lib/python/neuron/tests/test_neuron.py
@@ -134,6 +134,16 @@ class NeuronTestCase(unittest.TestCase):
                    error = 1
         assert(error == 0)
         return 0
+    
+    def testHelp(self):
+        error = False
+        try:
+            help(h.xpanel)
+        except:
+            print("'help(h.xpanel)' failed")
+            error = True
+        self.assertFalse(error)
+        return 0
 
 
     def testRxDexistence(self):


### PR DESCRIPTION
## The Problem
help() wouldn't work

Investigating, python package data files were not being included.

## This PR
Adds a package_data rule to ship all *.dat files under "neuron" (automatically recursive)