### PR TITLE
On hoc error, avoid oc_restore_code tobj_count... messages.

### DIFF
--- a/src/oc/hoc_oop.c
+++ b/src/oc/hoc_oop.c
@@ -989,7 +989,27 @@ hoc_execerror("[...](...) syntax only allowed for array range variables:", sym0-
 	}
 	
 	obp = hoc_obj_look_inside_stack(nindex);
+
+  /* This function is handling the name of obp.name... and when there is no
+     error obp is popped below via one of many hoc_pop_defer. The problem occurs
+     when name is a method call and an error occurs which which requires
+     recovery from an arbitrary number of stack frames. In particular,
+     if the stack item for obp is a OBJECTTMP, it needs to be unreffed and
+     the count of OBJECTTMP decremented. As this is done when iterating
+     over the stack frames in initcode and oc_restore_code, it is necessary
+     for push_frame (or any place that implements the equivalent, e.g.
+     hoc_call) to store sufficient information in the frame in order to
+     properly handle this eventuality. A bool should suffice but for
+     consistency testing we store the stack index holding obp. Unfortunately,
+     it is a long way from here to the push_frame and more often than not
+     push_frame will occur without having passed by here. So some care must
+     be taken to make sure that the stack index set here really is associated
+     with a push_frame resulting from this invocation and for any other
+     push_frame, the absolute index info is -1.
+   */
+
 	if (obp) {
+		nrn_obtmp_stk_index_on_err(nindex); /* relative to current stack pointer */
 #if USE_PYTHON
 		if (obp->template->sym == nrnpy_pyobj_sym_) {
 			if (isfunc & 2) {
@@ -1229,6 +1249,7 @@ hoc_execerror(sym->name, ":ITERATOR can only be used in a for statement");
 	}
 	hoc_objectdata = hoc_objectdata_restore(psav);
 	hoc_thisobject = obsav;
+	nrn_obtmp_stk_index_on_err(-1);
 }
 
 void hoc_object_eval(void) {

--- a/src/oc/oc_ansi.h
+++ b/src/oc/oc_ansi.h
@@ -213,6 +213,7 @@ extern void hoc_install_object_data_index(Symbol*);
 extern void hoc_template_notify(Object*, int);
 extern void hoc_construct_point(Object*, int);
 extern void hoc_call_ob_proc(Object* ob, Symbol* sym, int narg);
+extern void nrn_obtmp_stk_index_on_err(int);
 extern void hoc_push_frame(Symbol*, int);
 extern void hoc_pop_frame(void);
 extern int hoc_argindex(void);


### PR DESCRIPTION
These imply memory leaks of OBJECTTMP objects on the stack.
Also was leaking localobj objects on hoc errors.

Fixes #513

Simplest example:
```
>>> from neuron import h
>>> h.Vector(1).plot(1)
bad stack access: expecting (Object **); really (double)
NEURON: interpreter stack type error
 near line 0
 objref hoc_obj_[2]
                   ^
        Vector[0].plot(1)
oc_restore_code tobj_count=1 should be 0
```

This fixes most but not all practical sources of this error. This commit
provides a pattern to follow to provide sufficient information for the
factored out src/oc/code.c static void frame_clean_on_err(Frame* f) to
make sure that on a hoc_execerror all OBJECTTMP resources are unreffed.
In testing it is observed that in hoc calling into python that there are
many places in the python code that error handling on the python side
needs review to avoid extra python exceptions with a first line of
'The above exception was the direct cause of the following exception'.
Fixing those is deferred to a later changeset in order to be able to
highlight the major change to error handling in hoc that this represents.