### PR TITLE
Replace help(h.xpanel) with doc.get_docstring('xpanel', '')

### DIFF
--- a/share/lib/python/neuron/tests/test_neuron.py
+++ b/share/lib/python/neuron/tests/test_neuron.py
@@ -134,13 +134,14 @@ class NeuronTestCase(unittest.TestCase):
                    error = 1
         assert(error == 0)
         return 0
-    
+
     def testHelp(self):
         error = False
         try:
-            help(h.xpanel)
+            from neuron import doc
+            print (doc.get_docstring('xpanel', ''))
         except:
-            print("'help(h.xpanel)' failed")
+            print("'doc.get_docstring('xpanel', '')' failed")
             error = True
         self.assertFalse(error)
         return 0


### PR DESCRIPTION
Avoid need of explicit closing help dialog with `q` when running interactive.