### PR TITLE
The after_quad callback for fit_praxis not getting minimum args.

### DIFF
--- a/src/nrnoc/hocprax.c
+++ b/src/nrnoc/hocprax.c
@@ -221,6 +221,7 @@ void fit_praxis(void) {
 }
 
 void hoc_after_prax_quad(s) char* s; {
+	efun(minarg, nvar);
 	hoc_obj_run(s, hoc_thisobject);
 }
 


### PR DESCRIPTION
So with the MulRunFitter savepath.fit had arg values that came
from the last praxis call to efun instead of arg values that
generate the minumum error found so far.