### PR TITLE
rxd : avoid error because of relative dlopen of shared library

### DIFF
--- a/share/lib/python/neuron/rxd/rxd.py
+++ b/share/lib/python/neuron/rxd/rxd.py
@@ -505,7 +505,7 @@ def _c_compile(formula):
         os.system(gcc_cmd)
     #TODO: Find a better way of letting the system locate librxdmath.so.0
     rxdmath_dll = ctypes.cdll[_find_librxdmath()]
-    dll = ctypes.cdll['./%s.so' % filename]
+    dll = ctypes.cdll['%s.so' % os.path.abspath(filename)]
     reaction = dll.reaction
     reaction.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)] 
     reaction.restype = ctypes.c_double


### PR DESCRIPTION
 - newer python versions can give "system relative paths not allowed in hardened programs "
 - this is because of Apple's SIP and Hardened Runtime, see https://github.com/neuronsimulator/nrn/pull/468#issuecomment-619437268

@ramcdougal @adamjhn : I am not sure I am covering all scenarios here but this at least fixes the error that I get with newer pythons (see above link):

```
test_rxd (neuron.tests.test_rxd.RxDTestCase) ... Warning: no DISPLAY environment variable.
--No graphics will be displayed.
dlopen failed - 
dlopen(x86_64/.libs/libnrnmech.so, 2): no suitable image found.  Did find:
	file system relative paths not allowed in hardened programs
--> /Users/runner/runners/2.166.4/work/1/s/nrn_test_venv_37/lib/python3.7/site-packages/neuron/.data/share/nrn/../../x86_64
--> /Users/runner/runners/2.166.4/work/1/s/nrn_test_venv_37/lib/python3.7/site-packages/neuron/.data/share/nrn/../../lib/librxdmath
--> /Users/runner/runners/2.166.4/work/1/s/nrn_test_venv_37/lib/python3.7/site-packages/neuron/.data/share/nrn/../../lib/librxdmath.dylib
--> /Users/runner/runners/2.166.4/work/1/s/nrn_test_venv_37/lib/python3.7/site-packages/neuron/.data/share/nrn/../../x86_64
--> /Users/runner/runners/2.166.4/work/1/s/nrn_test_venv_37/lib/python3.7/site-packages/neuron/.data/share/nrn/../../lib/librxdmath
--> /Users/runner/runners/2.166.4/work/1/s/nrn_test_venv_37/lib/python3.7/site-packages/neuron/.data/share/nrn/../../lib/librxdmath.dylib
Traceback (most recent call last):
  File "/Users/runner/runners/2.166.4/work/1/s/nrn_test_venv_37/lib/python3.7/site-packages/neuron/rxd/rxd.py", line 1540, in _init
    initializer._do_init()
  File "/Users/runner/runners/2.166.4/work/1/s/nrn_test_venv_37/lib/python3.7/site-packages/neuron/rxd/initializer.py", line 52, in _do_init
    rxd._init()
  File "/Users/runner/runners/2.166.4/work/1/s/nrn_test_venv_37/lib/python3.7/site-packages/neuron/rxd/rxd.py", line 1557, in _init
    _compile_reactions()
  File "/Users/runner/runners/2.166.4/work/1/s/nrn_test_venv_37/lib/python3.7/site-packages/neuron/rxd/rxd.py", line 1321, in _compile_reactions
    _c_compile(fxn_string))
  File "/Users/runner/runners/2.166.4/work/1/s/nrn_test_venv_37/lib/python3.7/site-packages/neuron/rxd/rxd.py", line 511, in _c_compile
    dll = ctypes.cdll['./%s.so' % filename]
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/ctypes/__init__.py", line 439, in __getitem__
    return getattr(self, name)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/ctypes/__init__.py", line 434, in __getattr__
    dll = self._dlltype(name)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/ctypes/__init__.py", line 364, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: dlopen(./rxddll636a42a8-92af-11ea-adda-005056a7f861.so, 6): no suitable image found.  Did find:
	file system relative paths not allowed in hardened programs
```