### PR TITLE
cmake and autoconf project versions now 8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ project(NEURON C CXX)
 # =============================================================================
 # CMake common project settings
 # =============================================================================
-set(PROJECT_VERSION_MAJOR 7)
-set(PROJECT_VERSION_MINOR 8)
+set(PROJECT_VERSION_MAJOR 8)
+set(PROJECT_VERSION_MINOR 0)
 set(CMAKE_CXX_STANDARD 98)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ dnl distribution file names, banner, nrniv --version, and
 dnl nrnversion(5). If the PACKAGE_VERSION changes then also do a
 dnl git tag -a major.minor.micro consistent with that.
 
-AC_INIT([nrn],[7.8])
+AC_INIT([nrn],[8.0])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR(src/memacs/main.c)
 AM_INIT_AUTOMAKE([foreign])


### PR DESCRIPTION
the 8.0.dev tag was set with ```git tag -a 8.0.dev a37b22f -m 'v8.0.dev'```
of Thu Dec 19 08:06:20 2019

At some point we can have CMake itself call git describe to avoid hardcoding a version.