### PR TITLE
Trigger Azure CI scheduled build always

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,7 @@ schedules:
   branches:
     include:
     - master
+  always: true
 
 # Auto cancel old PR builds
 pr:


### PR DESCRIPTION

      - Azure CI is supposed to be run nightly for wheel upload.
      - If we use default option always=false then it doesn't
        trigger build as master branch is already build when
        PR is merged.