### PR TITLE
Fix for pdb and python wheel compatibility

### DIFF
--- a/ci/azure-wheel-test-upload.yml
+++ b/ci/azure-wheel-test-upload.yml
@@ -15,6 +15,11 @@ steps:
       packaging/python/test_wheels.sh $(which python) wheelhouse/*.whl
     displayName: 'Test with System Python'
 
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: '$(Build.SourcesDirectory)/wheelhouse'
+    displayName: 'Publish wheel as build artifact'
+
   - task: TwineAuthenticate@1
     inputs:
       pythonUploadServiceConnection: AzureNeuronPypiNightly

--- a/cmake/CMakeListsNrnMech.cmake
+++ b/cmake/CMakeListsNrnMech.cmake
@@ -22,6 +22,11 @@ list(REMOVE_ITEM NRN_LINK_LIBS "interviews")
 
 # CMake does some magic to transform sys libs to -l<libname>. We replicate it
 foreach(link_lib ${NRN_LINK_LIBS})
+  # skip static readline library as it will be linked to nrniv (e.g. with wheel)
+  if ("${link_lib}" MATCHES "libreadline.a")
+    continue()
+  endif()
+
   get_filename_component(dir_path ${link_lib} DIRECTORY)
   if(NOT dir_path)
     string(APPEND NRN_LINK_DEFS " -l${link_lib}")

--- a/packaging/python/Dockerfile
+++ b/packaging/python/Dockerfile
@@ -44,6 +44,19 @@ RUN curl -L -o openmpi-4.0.3.tar.gz  https://download.open-mpi.org/release/open-
     && ./configure --prefix=/opt/openmpi \
     && make -j install
 
+RUN curl -L -o readline-7.0.tar.gz https://ftp.gnu.org/gnu/readline/readline-7.0.tar.gz \
+    && tar -xvzf readline-7.0.tar.gz \
+    && cd readline-7.0  \
+    && ./configure --prefix=/opt/readline --disable-shared CFLAGS="-fPIC" \
+    && make -j install
+
+# create readline with ncurses
+RUN cd /opt/readline/lib \
+    && ar -x libreadline.a \
+    && ar -x ../../ncurses/lib/libncurses.a \
+    && ar cq libreadline.a *.o \
+    && rm *.o
+
 ENV PATH /opt/openmpi/bin:/opt/cmake/bin:$PATH
 
 RUN yum -y install libX11-devel.x86_64 libXcomposite-devel.x86_64 vim-enhanced.x86_64

--- a/packaging/python/README.md
+++ b/packaging/python/README.md
@@ -76,3 +76,18 @@ As we haven't setup proper policy yet, do not do this step. For testing purpose 
 pip3 install twine
 python3 -m twine upload --repository-url https://test.pypi.org/legacy/ nrn/wheelhouse/NEURON-*
 ```
+
+#### Updating neuron_wheel docker image
+
+If you have changed Dockerfile, you can build the new image as:
+
+```
+docker build -t neuronsimulator/neuron_wheel .
+```
+
+and then push image to hub.docker.com as:
+
+```
+docker login --username=<username>
+docker push neuronsimulator/neuron_wheel
+```

--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -60,7 +60,7 @@ build_wheel_linux() {
     if [ "$2" == "--bare" ]; then
         python setup.py bdist_wheel
     else
-        python setup.py build_ext --cmake-prefix=/opt/ncurses --cmake-defs="NRN_MPI_DYNAMIC=$3" bdist_wheel
+        python setup.py build_ext --cmake-prefix="/opt/ncurses;/opt/readline" --cmake-defs="NRN_MPI_DYNAMIC=$3" bdist_wheel
     fi
 
     if [ "$TRAVIS" = true ] ; then


### PR DESCRIPTION
  - internal readline was built with neuron wheel
  - as internal readline is very old, it cause issue
    with readline library present on target machine.
  - now build newer readline 7.0 with ncurses included
    and link that with neuron
  - also update dockerfile used for wheel building
  - update ci scripts and pipeline to publish wheel as
    artifacts for testing