### PR TITLE
nrnpyenv.sh determines PYTHONHOME more robustly.

### DIFF
--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -9,6 +9,9 @@
 #include "nrnpy_utils.h"
 #include "../nrniv/shapeplt.h"
 #include <vector>
+#if defined(HAVE_DLFCN_H)
+#include <dlfcn.h>
+#endif
 
 #if defined(NRNPYTHON_DYNAMICLOAD) && NRNPYTHON_DYNAMICLOAD > 0
 // when compiled with different Python.h, force correct value
@@ -2671,6 +2674,25 @@ static PyObject* hocpickle_setstate(PyObject* self, PyObject* args) {
   return Py_None;
 }
 
+static PyObject* libpython_path(PyObject* self, PyObject* args) {
+#if defined(HAVE_DLFCN_H)
+  Dl_info info;
+  int rval = dladdr((const void*)Py_Initialize, &info);
+  if (!rval) {
+    PyErr_SetString(PyExc_Exception, "dladdr: Py_Initialize could not be matched to a shared object");
+    return NULL;
+  }
+  if (!info.dli_fname) {
+    PyErr_SetString(PyExc_Exception, "dladdr: No symbol matching Py_Initialize could be found.");
+    return NULL;
+  }
+  return Py_BuildValue("s", info.dli_fname);
+#else
+  Py_INCREF(Py_None);
+  return Py_None;
+#endif
+}
+
 // available for every HocObject
 static PyMethodDef hocobj_methods[] = {
     {"baseattr", hocobj_baseattr, METH_VARARGS,
@@ -2695,6 +2717,8 @@ static PyMethodDef toplevel_methods[] = {
      "Return a new Section"},
     {"setpointer", setpointer, METH_VARARGS,
      "Assign hoc variable address to NMODL POINTER"},
+    {"libpython_path", libpython_path, METH_NOARGS,
+     "Return full path to file that contains Py_Initialize()"},
     {NULL, NULL, 0, NULL}};
 
 static void add2topdict(PyObject* dict) {


### PR DESCRIPTION
Uses sys.base_prefix whenever possible

Print the provenance of NRN_PYLIB.

On Linux, try to figure out the NRN_PYLIB using sysconfig LIBDIR but
search only in LIBDIR.
Additional method using h.libpython_path()

This only partially is an alternative to #560 and partially responds to #564.
Note that on my desktop, when using the system python3 I now (still) see:
```
$ nrnpyenv.sh /usr/bin/python3
...
#NRN_PYLIB provenance: search based on os.__file__, found one with version in name

# if launch nrniv, then likely need:
export PYTHONHOME="/usr"
export NRN_PYLIB="/usr/lib/python3.6/config-3.6m-x86_64-linux-gnu/libpython3.6m.so"
```
Selected interesting sysconfig variables are from:
```
from distutils import sysconfig as s
z = s.get_config_vars()
for i in z.items():
  if 'lib' in str(i[1]):
    print (i)
```
```
('BINLIBDEST', '/usr/lib/python3.6')
('DESTDIRS', '/usr /usr/lib /usr/lib/python3.6 /usr/lib/python3.6/lib-dynload')
('DESTLIB', '/usr/lib/python3.6')
('DESTSHARED', '/usr/lib/python3.6/lib-dynload')
('DYNLOADFILE', 'dynload_shlib.o')
('INSTSONAME', 'libpython3.6m.so.1.0')
('LDLIBRARY', 'libpython3.6m.so')
('LIBDEST', '/usr/lib/python3.6')
('LIBDIR', '/usr/lib')
('LIBPC', '/usr/lib/x86_64-linux-gnu/pkgconfig')
('LIBPL', '/usr/lib/python3.6/config-3.6m-x86_64-linux-gnu')
('LIBRARY', 'libpython3.6m.a')
```
So perhaps the folder search can be usefully elaborated beyond LIBDIR since in this situation we are falling back finally to a full 'find' starting from os.__file__/../.. which is LIBDIR

For now I have left in the h.libpython_path() stuff for linux and mac, though it has been giving disappointing results. (it seems that a lot of python installations have libpython statically linked to the executable).