### PR TITLE
Fix linking issue with Intel compiler on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,10 +112,10 @@ set(NRN_RX3D_OPT_LEVEL
 # Include cmake modules
 # =============================================================================
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
+include(PlatformHelper)
 include(CompilerHelper)
 include(MacroHelper)
 include(RpathHelper)
-include(PlatformHelper)
 include(ExternalProjectHelper)
 include(FindPythonModule)
 

--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -38,6 +38,9 @@ MAKEFILEDIR="${bindir}"
 if which xcrun; then
     export SDKROOT=`xcrun --sdk macosx --show-sdk-path`
     @USING_CMAKE_TRUE@export MACOSX_DEPLOYMENT_TARGET="@CMAKE_OSX_DEPLOYMENT_TARGET@"
+    if [ -z "${MACOSX_DEPLOYMENT_TARGET}" ]; then
+        unset MACOSX_DEPLOYMENT_TARGET
+    fi
 fi
 
 UserINCFLAGS=""

--- a/cmake/CompilerHelper.cmake
+++ b/cmake/CompilerHelper.cmake
@@ -1,7 +1,7 @@
 # =============================================================================
 # Compiler specific settings
 # =============================================================================
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR NRN_MACOS_BUILD)
   set(UNDEFINED_SYMBOLS_IGNORE_FLAG "-undefined dynamic_lookup")
   string(APPEND CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS " ${UNDEFINED_SYMBOLS_IGNORE_FLAG}")
   string(APPEND CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS " ${UNDEFINED_SYMBOLS_IGNORE_FLAG}")

--- a/src/mac/activate-apps-cmake.sh
+++ b/src/mac/activate-apps-cmake.sh
@@ -28,7 +28,7 @@ ivlibdir=$4
 export CPU
 export NRN_SRC
 NSRC=$NRN_SRC
-export NSRC #needed by nrnversion.sh
+export NSRC # needed by nrnversion.sh
 NRN_VERSION="`sh $NRN_SRC/nrnversion.sh`"
 
 # Equivalent to install from the Makefile.am

--- a/src/mac/activate-apps-cmake.sh
+++ b/src/mac/activate-apps-cmake.sh
@@ -28,7 +28,7 @@ ivlibdir=$4
 export CPU
 export NRN_SRC
 NSRC=$NRN_SRC
-export NSRC # needed by nrnversion.sh
+export NSRC #needed by nrnversion.sh
 NRN_VERSION="`sh $NRN_SRC/nrnversion.sh`"
 
 # Equivalent to install from the Makefile.am


### PR DESCRIPTION
  - `undefined dynamic_lookup` needs to be used on OSX platform
  - include cmake platform helper early to use it in other cmake modules
  - Avoid MACOSX_DEPLOYMENT_TARGET being empty which causes error with Intel compiler on OSX