### PR TITLE
Build fixes to compile with PGI

### DIFF
--- a/cmake/CompilerHelper.cmake
+++ b/cmake/CompilerHelper.cmake
@@ -16,3 +16,11 @@ else()
   set(USING_PGI_COMPILER_TRUE "#")
   set(USING_PGI_COMPILER_FALSE "")
 endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "PGI")
+  # CMake adds strict standard complaint PGI flag "-A" which breaks
+  # compilation of old codes (e.g. python2 files, spdlog, fmt)
+  set(CMAKE_CXX98_STANDARD_COMPILE_OPTION "")
+  set(CMAKE_CXX11_STANDARD_COMPILE_OPTION --c++11)
+  set(CMAKE_CXX14_STANDARD_COMPILE_OPTION --c++14)
+endif()


### PR DESCRIPTION
  - PGI adds -A flag which adds strict language compliance that
    breaks codes
  - after discussing with PGI support, solution was to remove -A