### PR TITLE
PYTHONPATH generally not required when launch nrniv.

### DIFF
--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -143,24 +143,46 @@ version = h.nrnversion(5)
 __version__ = version
 _original_hoc_file = None
 if not hasattr(hoc, "__file__"):
-  import platform
-  import os
-  p = h.nrnversion(6)
-  if "--prefix=" in p:
-    p = p[p.find('--prefix=') + 9:]
-    p = p[:p.find("'")]
+  # first try is to derive from neuron.__file__
+  p = None
+  if sys.version_info[0] == 2:
+    # python 2 seems to have hoc.__file__ already filled in so never get here.
+    try:
+      import imp
+      mspec = imp.find_module("neuron")
+      p = mspec[1]
+    except:
+      pass
   else:
-    p = "/usr/local/nrn"
-  if sys.version_info >= (3, 0):
+    import importlib
+    mspec = importlib.util.find_spec("neuron")
+    if mspec:
+      p = mspec.origin
+  if p is not None:
     import sysconfig
-    phoc = p + "/lib/python/neuron/hoc%s" % sysconfig.get_config_var('SO')
+    phoc = p.rstrip("__init__.py") + "hoc" + sysconfig.get_config_var('SO')
+    setattr(hoc, "__file__", phoc)
   else:
-    phoc = p + "/lib/python/neuron/hoc.so"
-  if not os.path.isfile(phoc):
-    phoc = p + "/%s/lib/libnrnpython%d.so" % (platform.machine(), sys.version_info[0])
-  if not os.path.isfile(phoc):
-    phoc = p + "/%s/lib/libnrnpython.so" % platform.machine()
-  setattr(hoc, "__file__", phoc)
+    # if the above is robust, maybe all this can be removed.
+    # next try is to derive from nrnversion(6) (only works for autotools build)
+    import platform
+    import os
+    p = h.nrnversion(6)
+    if "--prefix=" in p:
+      p = p[p.find('--prefix=') + 9:]
+      p = p[:p.find("'")]
+    else:
+      p = "/usr/local/nrn"
+    if sys.version_info >= (3, 0):
+      import sysconfig
+      phoc = p + "/lib/python/neuron/hoc%s" % sysconfig.get_config_var('SO')
+    else:
+      phoc = p + "/lib/python/neuron/hoc.so"
+    if not os.path.isfile(phoc):
+      phoc = p + "/%s/lib/libnrnpython%d.so" % (platform.machine(), sys.version_info[0])
+    if not os.path.isfile(phoc):
+      phoc = p + "/%s/lib/libnrnpython.so" % platform.machine()
+    setattr(hoc, "__file__", phoc)
 else:
   _original_hoc_file = hoc.__file__
 # As a workaround to importing doc at neuron import time

--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -144,24 +144,24 @@ __version__ = version
 _original_hoc_file = None
 if not hasattr(hoc, "__file__"):
   # first try is to derive from neuron.__file__
-  p = None
+  origin = None # path to neuron/__init__.py
   if sys.version_info[0] == 2:
     # python 2 seems to have hoc.__file__ already filled in so never get here.
     try:
       import imp
       mspec = imp.find_module("neuron")
-      p = mspec[1]
+      origin = mspec[1]
     except:
       pass
   else:
     from importlib import util
     mspec = util.find_spec("neuron")
     if mspec:
-      p = mspec.origin
-  if p is not None:
+      origin = mspec.origin
+  if origin is not None:
     import sysconfig
-    phoc = p.rstrip("__init__.py") + "hoc" + sysconfig.get_config_var('SO')
-    setattr(hoc, "__file__", phoc)
+    hoc_path = origin.rstrip("__init__.py") + "hoc" + sysconfig.get_config_var('SO')
+    setattr(hoc, "__file__", hoc_path)
   else:
     # if the above is robust, maybe all this can be removed.
     # next try is to derive from nrnversion(6) (only works for autotools build)
@@ -175,14 +175,14 @@ if not hasattr(hoc, "__file__"):
       p = "/usr/local/nrn"
     if sys.version_info >= (3, 0):
       import sysconfig
-      phoc = p + "/lib/python/neuron/hoc%s" % sysconfig.get_config_var('SO')
+      hoc_path = p + "/lib/python/neuron/hoc%s" % sysconfig.get_config_var('SO')
     else:
-      phoc = p + "/lib/python/neuron/hoc.so"
-    if not os.path.isfile(phoc):
-      phoc = p + "/%s/lib/libnrnpython%d.so" % (platform.machine(), sys.version_info[0])
-    if not os.path.isfile(phoc):
-      phoc = p + "/%s/lib/libnrnpython.so" % platform.machine()
-    setattr(hoc, "__file__", phoc)
+      hoc_path = p + "/lib/python/neuron/hoc.so"
+    if not os.path.isfile(hoc_path):
+      hoc_path = p + "/%s/lib/libnrnpython%d.so" % (platform.machine(), sys.version_info[0])
+    if not os.path.isfile(hoc_path):
+      hoc_path = p + "/%s/lib/libnrnpython.so" % platform.machine()
+    setattr(hoc, "__file__", hoc_path)
 else:
   _original_hoc_file = hoc.__file__
 # As a workaround to importing doc at neuron import time

--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -154,8 +154,8 @@ if not hasattr(hoc, "__file__"):
     except:
       pass
   else:
-    import importlib
-    mspec = importlib.util.find_spec("neuron")
+    from importlib import util
+    mspec = util.find_spec("neuron")
     if mspec:
       p = mspec.origin
   if p is not None:

--- a/src/ivoc/ivocmain.cpp
+++ b/src/ivoc/ivocmain.cpp
@@ -227,7 +227,7 @@ extern "C" {
 linux that dlopen needs a full path to the file. A path to the binary
 is not necessarily sufficent as one may launch python or nrniv on the
 target machine and the lib folder cannot be derived from the location of
-the python executable.This seems to be robust if this file is inside a
+the python executable.This seems to be robust if nrn_version is inside a
 shared library.
 The return value ends with a '/' and if the prefix cannot be determined
 the return value is "".
@@ -236,7 +236,7 @@ const char* path_prefix_to_libnrniv() {
   static char* path_prefix_to_libnrniv_ = NULL;
   if (!path_prefix_to_libnrniv_) {
     Dl_info info;
-    int rval = dladdr((void*)path_prefix_to_libnrniv, &info);
+    int rval = dladdr((void*)nrn_version, &info);
     std::string name;
     if (rval) {
       if (info.dli_fname) {

--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -184,7 +184,9 @@ set_property(
   PROPERTY COMPILE_DEFINITIONS CABLE=1)
 
 set_property(
-  SOURCE ${PROJECT_SOURCE_DIR}/src/nrniv/nrnpy.cpp ${PROJECT_SOURCE_DIR}/src/nrnmpi/nrnmpi_dynam.c
+  SOURCE ${PROJECT_SOURCE_DIR}/src/nrniv/nrnpy.cpp
+         ${PROJECT_SOURCE_DIR}/src/nrnmpi/nrnmpi_dynam.c
+         ${PROJECT_SOURCE_DIR}/src/nrnpython/nrnpython.cpp
   APPEND
   PROPERTY COMPILE_DEFINITIONS NRNCMAKE)
 

--- a/src/nrnpython/CMakeLists.txt
+++ b/src/nrnpython/CMakeLists.txt
@@ -209,6 +209,7 @@ if(NRN_ENABLE_MODULE_INSTALL)
   # ~~~
   set_property(
     SOURCE ${PROJECT_SOURCE_DIR}/src/nrnpython/nrnpy_hoc.cpp
+           ${PROJECT_SOURCE_DIR}/src/nrnpython/nrnpython.cpp
     APPEND
     PROPERTY COMPILE_DEFINITIONS NRNCMAKE)
 

--- a/src/nrnpython/nrnpython.cpp
+++ b/src/nrnpython/nrnpython.cpp
@@ -57,8 +57,13 @@ void nrnpy_augment_path() {
 #if defined(__linux__) || defined(DARWIN)
     // If /where/installed/lib/python/neuron exists, then append to sys.path
     std::string lib = std::string(path_prefix_to_libnrniv());
+    // For an autotools build, it ends with x86_64/lib/
+    size_t pos = lib.find("x86_64/lib/", lib.length() - 11);
+    if (pos != std::string::npos) {
+      lib.replace(pos, std::string::npos, "lib/");
+    }
 #else
-    std::string lib = std::string(neuronhome_forward()) + std::string("/lib");
+    std::string lib = std::string(neuronhome_forward()) + std::string("/lib/");
 #endif
     if (isDirExist(lib + std::string("python/neuron"))) {
       std::string cmd = std::string("sys.path.append('") + lib + std::string("python')");

--- a/src/nrnpython/nrnpython.cpp
+++ b/src/nrnpython/nrnpython.cpp
@@ -66,7 +66,7 @@ void nrnpy_augment_path() {
     std::string lib = std::string(neuronhome_forward()) + std::string("/lib/");
 #endif
     if (isDirExist(lib + std::string("python/neuron"))) {
-      std::string cmd = std::string("sys.path.append('") + lib + std::string("python')");
+      std::string cmd = std::string("sys.path.append('") + lib + "python')";
       err = PyRun_SimpleString(cmd.c_str());
       assert(err == 0);
     }

--- a/src/nrnpython/nrnpython.cpp
+++ b/src/nrnpython/nrnpython.cpp
@@ -57,8 +57,8 @@ void nrnpy_augment_path() {
 #if defined(__linux__) || defined(DARWIN)
     // If /where/installed/lib/python/neuron exists, then append to sys.path
     std::string lib = std::string(path_prefix_to_libnrniv());
-    // For an autotools build, it ends with x86_64/lib/
-    size_t pos = lib.find("x86_64/lib/", lib.length() - 11);
+    // For an autotools build on an x86_64, it ends with x86_64/lib/
+    size_t pos = lib.find(NRNHOSTCPU "/lib/", lib.length() - (5+strlen(NRNHOSTCPU)));
     if (pos != std::string::npos) {
       lib.replace(pos, std::string::npos, "lib/");
     }

--- a/src/nrnpython/nrnpython.cpp
+++ b/src/nrnpython/nrnpython.cpp
@@ -8,6 +8,8 @@
 #include <nrnoc2iv.h>
 #include <nrnpy_reg.h>
 #include <hoccontext.h>
+#include <string>
+#include <ocfile.h> // bool isDirExist(const std::string& path);
 
 extern "C" {
 #include <hocstr.h>
@@ -21,6 +23,9 @@ extern char* hoc_ctp;
 extern FILE* hoc_fin;
 extern const char* hoc_promptstr;
 extern char* neuronhome_forward();
+#if DARWIN || defined(__linux__)
+extern const char* path_prefix_to_libnrniv();
+#endif
 // extern char*(*PyOS_ReadlineFunctionPointer)(FILE*, FILE*, char*);
 #if (PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 4)
 static char* nrnpython_getline(FILE*, FILE*, const char*);
@@ -45,16 +50,21 @@ int nrnpy_site_problem;
 
 void nrnpy_augment_path() {
   static int augmented = 0;
-  char buf[1024];
   if (!augmented && strlen(neuronhome_forward()) > 0) {
-    // printf("augment_path\n");
     augmented = 1;
-    sprintf(buf, "sys.path.append('%s/lib/python')", neuronhome_forward());
     int err = PyRun_SimpleString("import sys");
     assert(err == 0);
-    err = PyRun_SimpleString(buf);
-    assert(err == 0);
-    sprintf(buf, "sys.path.prepend('')");
+#if defined(__linux__) || defined(DARWIN)
+    // If /where/installed/lib/python/neuron exists, then append to sys.path
+    std::string lib = std::string(path_prefix_to_libnrniv());
+#else
+    std::string lib = std::string(neuronhome_forward()) + std::string("/lib");
+#endif
+    if (isDirExist(lib + std::string("python/neuron"))) {
+      std::string cmd = std::string("sys.path.append('") + lib + std::string("python')");
+      err = PyRun_SimpleString(cmd.c_str());
+      assert(err == 0);
+    }
     err = PyRun_SimpleString("sys.path.insert(0, '')");
     assert(err == 0);
   }

--- a/src/nrnpython/nrnpython.cpp
+++ b/src/nrnpython/nrnpython.cpp
@@ -60,10 +60,13 @@ void nrnpy_augment_path() {
 #if !defined(NRNCMAKE)
     // For an autotools build on an x86_64, it ends with x86_64/lib/
     const char* lastpart = NRNHOSTCPU "/lib/";
-    assert(lib.length() > strlen(lastpart));
-    size_t pos = lib.length() - strlen(lastpart);
-    assert(lib.find(lastpart, pos) != std::string::npos);
-    lib.replace(pos, std::string::npos, "lib/");
+    if (lib.length() > strlen(lastpart)) {
+      size_t pos = lib.length() - strlen(lastpart);
+      pos = lib.find(lastpart, pos);
+      if (pos != std::string::npos) {
+        lib.replace(pos, std::string::npos, "lib/");
+      }
+    }
 #endif //!NRNCMAKE
 #else // not defined(__linux__) || defined(DARWIN)
     std::string lib = std::string(neuronhome_forward()) + std::string("/lib/");

--- a/src/nrnpython/nrnpython.cpp
+++ b/src/nrnpython/nrnpython.cpp
@@ -57,14 +57,17 @@ void nrnpy_augment_path() {
 #if defined(__linux__) || defined(DARWIN)
     // If /where/installed/lib/python/neuron exists, then append to sys.path
     std::string lib = std::string(path_prefix_to_libnrniv());
+#if !defined(NRNCMAKE)
     // For an autotools build on an x86_64, it ends with x86_64/lib/
-    size_t pos = lib.find(NRNHOSTCPU "/lib/", lib.length() - (5+strlen(NRNHOSTCPU)));
-    if (pos != std::string::npos) {
-      lib.replace(pos, std::string::npos, "lib/");
-    }
-#else
+    const char* lastpart = NRNHOSTCPU "/lib/";
+    assert(lib.length() > strlen(lastpart));
+    size_t pos = lib.length() - strlen(lastpart);
+    assert(lib.find(lastpart, pos) != std::string::npos);
+    lib.replace(pos, std::string::npos, "lib/");
+#endif //!NRNCMAKE
+#else // not defined(__linux__) || defined(DARWIN)
     std::string lib = std::string(neuronhome_forward()) + std::string("/lib/");
-#endif
+#endif //not defined(__linux__) || defined(DARWIN)
     if (isDirExist(lib + std::string("python/neuron"))) {
       std::string cmd = std::string("sys.path.append('") + lib + "python')";
       err = PyRun_SimpleString(cmd.c_str());


### PR DESCRIPTION
If the default location of the neuron module exists, it will be
automatically appended to sys.path .
Note that the default location is /where/installed/nrn/lib/python/neuron
PYTHONPATH of course is not required if the neuron module is installed
in site-packages or any place that is already in sys.path.

This fixes #629 