### PR TITLE
from neuron import coreneuron specifies CoreNEURON run properties

### DIFF
--- a/share/lib/python/neuron/coreneuron.py
+++ b/share/lib/python/neuron/coreneuron.py
@@ -1,4 +1,3 @@
-from neuron import h
 
 # Properties settable by user
 enable = False     # Use CoreNEURON when calling ParallelContext.psolve(tstop).
@@ -14,11 +13,17 @@ def property_check(tstop):
   '''
   Check type and value in range for the user properties.
   '''
-  assert(type(tstop) is float)
-  assert(type(enable) is bool)
-  assert(type(gpu) is bool)
-  assert(type(cell_permute) is int and cell_permute in range(3))
+  global enable, gpu, cell_permute, warp_balance, verbose, prcellstate
+  tstop = float(tstop) # error if can't be a float
+  enable = bool(enable)
+  gpu = bool(gpu)
+  cell_permute = int(cell_permute)
+  assert(cell_permute in range(3))
   assert(cell_permute in (range(3) if gpu else range(2)))
+  warp_balance = int(warp_balance)
+  assert(warp_balance >= 0)
+  verbose = int(verbose)
+  prcellstate = int(prcellstate)
 
 def nrncore_arg(tstop):
   """
@@ -27,6 +32,7 @@ def nrncore_arg(tstop):
   :param tstop: Simulation time (ms)
 
   """
+  from neuron import h
   arg = ''
   property_check(tstop)
   if not enable:

--- a/share/lib/python/neuron/coreneuron.py
+++ b/share/lib/python/neuron/coreneuron.py
@@ -1,0 +1,76 @@
+from neuron import h
+
+# Properties settable by user
+enable = False     # Use CoreNEURON when calling ParallelContext.psolve(tstop).
+gpu = False        # Activate GPU computation.
+cell_permute = 1   # 0 no permutation; 1 optimize node adjacency
+                   # 2 optimize parent node adjacency (only for gpu = True)
+warp_balance = 0   # Number of warps to balance. (0 no balance)
+verbose = 0        # 0 quiet
+prcellstate = -1   # Output prcellstate information for the gid at t=0
+                   # and at tstop. -1 means no output
+
+def property_check(tstop):
+  '''
+  Check type and value in range for the user properties.
+  '''
+  assert(type(tstop) is float)
+  assert(type(enable) is bool)
+  assert(type(gpu) is bool)
+  assert(type(cell_permute) is int and cell_permute in range(3))
+  assert(cell_permute in (range(3) if gpu else range(2)))
+
+def nrncore_arg(tstop):
+  """
+  Return str that can be used for pc.nrncore_run(str)
+  based on user properties and current NEURON settings.
+  :param tstop: Simulation time (ms)
+
+  """
+  arg = ''
+  property_check(tstop)
+  if not enable:
+    return arg
+
+  # args derived from user properties
+  arg += ' --gpu' if gpu else ''
+  arg += ' --tstop %g' % tstop
+  arg += (' --cell-permute %d' % cell_permute) if cell_permute > 0 else ''
+  arg += (' --nwarp %d' % warp_balance) if warp_balance > 0 else ''
+  arg += (' --prcellgid %d' % prcellstate) if prcellstate >= 0 else ''
+  arg += (' --verbose %d' % verbose) if verbose > 0 else ''
+
+  # args derived from current NEURON settings.
+  pc = h.ParallelContext()
+  cvode = h.CVode()
+  arg += ' --mpi' if pc.nhost() > 1 else ''
+  arg += ' --voltage 1000.'
+  binqueue = cvode.queue_mode() & 1
+  arg += ' --binqueue' if binqueue else ''
+  spkcompress = int(pc.spike_compress(-1))
+  arg += (' --spkcompress %g' % spkcompress) if spkcompress else ''
+
+  # since multisend is undocumented in NEURON, perhaps it would be best
+  # to make the next three arg set from user properties here
+  multisend = int(pc.send_time(8))
+  if (multisend & 1) == 1:
+    arg += ' --multisend'
+    interval = (multisend & 2)/2 + 1
+    arg += (' --ms_subinterval %d' % interval) if interval != 2 else ''
+    phases = (multisend & 4)/4 + 1
+    arg += (' --ms_phases %d' % phases)  if phases != 2 else ''
+
+  return arg
+
+
+if __name__ == '__main__':
+  enable = True
+  print(nrncore_arg(5.0))
+  gpu=True
+  cell_permute=2
+  warp_balance=32
+  prcellstate = 7
+  pc = h.ParallelContext()
+  # multisend cannot be used with cmake build
+  #pc.spike_compress(0, 0, 1)
+  print(nrncore_arg(10.0))

--- a/share/lib/python/neuron/coreneuron.py
+++ b/share/lib/python/neuron/coreneuron.py
@@ -15,7 +15,7 @@ def property_check(tstop):
   '''
   global enable, gpu, cell_permute, warp_balance, verbose, prcellstate
   tstop = float(tstop) # error if can't be a float
-  enable = bool(enable)
+  enable = bool(int(enable))
   gpu = bool(gpu)
   cell_permute = int(cell_permute)
   assert(cell_permute in range(3))

--- a/src/nrniv/netpar.cpp
+++ b/src/nrniv/netpar.cpp
@@ -1217,6 +1217,16 @@ int nrn_set_timeout(int timeout) {
 }
 
 void BBS::netpar_solve(double tstop) {
+	// temporary check to be eventually replaced by verify_structure()
+	extern int tree_changed, v_structure_change, diam_changed;
+	if (tree_changed || v_structure_change) {
+	  hoc_execerror("NEURON model internal structures are out of date",NULL);
+        }
+	if (diam_changed) {
+	  recalc_diam();
+	}
+	// if cvode_active, and anything at all has changed, should call re_init
+
 #if NRNMPI
 	double mt, md;
 	tstopunset;

--- a/src/nrniv/nrnbbcore_write.cpp
+++ b/src/nrniv/nrnbbcore_write.cpp
@@ -1972,8 +1972,18 @@ int nrncore_run(const char* arg) {
   return r(nrn_nthread, have_gap, nrnmpi_use, nrn_use_fast_imem, arg);
 }
 
-char* (*nrnpy_nrncore_arg_p_)(double tstop);
+int (*nrnpy_nrncore_enable_value_p_)();
+/** Return neuron.coreneuron.enable */
+int nrncore_is_enabled() {
+  if (nrnpy_nrncore_enable_value_p_) {
+    int b = (*nrnpy_nrncore_enable_value_p_)();
+    return b;
+  }
+  return 0;
+}
 
+char* (*nrnpy_nrncore_arg_p_)(double tstop);
+/** Run coreneuron with arg string from neuron.coreneuron.nrncore_arg(tstop) */
 int nrncore_psolve(double tstop) {
   if (nrnpy_nrncore_arg_p_) {
     char* arg = (*nrnpy_nrncore_arg_p_)(tstop);
@@ -1989,6 +1999,10 @@ int nrncore_psolve(double tstop) {
 #else // !HAVE_DLFCN_H
 
 int nrncore_run(const char*) {
+  return 0;
+}
+
+int nrncore_is_enabled() {
   return 0;
 }
 

--- a/src/nrniv/nrnbbcore_write.cpp
+++ b/src/nrniv/nrnbbcore_write.cpp
@@ -1983,23 +1983,25 @@ int nrncore_is_enabled() {
 }
 
 char* (*nrnpy_nrncore_arg_p_)(double tstop);
-/** Run coreneuron with arg string from neuron.coreneuron.nrncore_arg(tstop) */
+/** Run coreneuron with arg string from neuron.coreneuron.nrncore_arg(tstop)
+ *  Return 0 on success
+*/
 int nrncore_psolve(double tstop) {
   if (nrnpy_nrncore_arg_p_) {
     char* arg = (*nrnpy_nrncore_arg_p_)(tstop);
     if (arg) {
       nrncore_run(arg);
       free(arg);
-      return 1;
+      return 0;
     }
   }
-  return 0;
+  return -1;
 }
 
 #else // !HAVE_DLFCN_H
 
 int nrncore_run(const char*) {
-  return 0;
+  return -1;
 }
 
 int nrncore_is_enabled() {

--- a/src/nrniv/nrnbbcore_write.cpp
+++ b/src/nrniv/nrnbbcore_write.cpp
@@ -1971,10 +1971,31 @@ int nrncore_run(const char* arg) {
 #endif
   return r(nrn_nthread, have_gap, nrnmpi_use, nrn_use_fast_imem, arg);
 }
-#else
+
+char* (*nrnpy_nrncore_arg_p_)(double tstop);
+
+int nrncore_psolve(double tstop) {
+  if (nrnpy_nrncore_arg_p_) {
+    char* arg = (*nrnpy_nrncore_arg_p_)(tstop);
+    if (arg) {
+      nrncore_run(arg);
+      free(arg);
+      return 1;
+    }
+  }
+  return 0;
+}
+
+#else // !HAVE_DLFCN_H
+
 int nrncore_run(const char*) {
   return 0;
 }
-#endif //HAVE_DLFCN_H
+
+int nrncore_psolve(double tstop) {
+  return 0;
+}
+
+#endif //!HAVE_DLFCN_H
 
 } // end of extern "C"

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -2884,7 +2884,10 @@ static void sectionlist_helper_(void* sl, Object* args) {
   }
 }
 
-/** value of neuron.coreneuron.enable as 0, 1 (-1 if error) */
+/** value of neuron.coreneuron.enable as 0, 1 (-1 if error)
+ *  TODO: seems like this could be generalized so that
+ *  additional cases would require less code.
+*/
 extern int (*nrnpy_nrncore_enable_value_p_)();
 static int nrncore_enable_value() {
   PyObject* modules = PyImport_GetModuleDict();
@@ -2893,10 +2896,10 @@ static int nrncore_enable_value() {
     if (module) {
       PyObject* val = PyObject_GetAttrString(module, "enable");
       if (val) {
-        long b = PyLong_AsLong(val);
+        long enable = PyLong_AsLong(val);
         Py_DECREF(val);
-        if (b != -1) {
-          return b;
+        if (enable != -1) {
+          return enable;
         }
       }
     }

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -2884,6 +2884,35 @@ static void sectionlist_helper_(void* sl, Object* args) {
   }
 }
 
+/** value of neuron.coreneuron.enable as 0, 1 (-1 if error) */
+extern int (*nrnpy_nrncore_enable_value_p_)();
+static int nrncore_enable_value() {
+  PyObject* modules = PyImport_GetModuleDict();
+  if (modules) {
+    PyObject* module = PyDict_GetItemString(modules, "neuron.coreneuron");
+    if (module) {
+      PyObject* val = PyObject_GetAttrString(module, "enable");
+      if (val) {
+        long b = PyLong_AsLong(val);
+        Py_DECREF(val);
+        if (b != -1) {
+          return b;
+        }
+      }
+    }
+  }
+  if (PyErr_Occurred()) {
+    PyErr_Print();
+    return -1;
+  }
+  return 0;
+}
+
+/** Gets the python string returned by  neuron.coreneuron.nrncore_arg(tstop)
+    return a strdup() copy of the string which should be free when the caller
+    finishes with it. Return NULL if error or bool(neuron.coreneuron.enable)
+    is False.
+*/
 extern char* (*nrnpy_nrncore_arg_p_)(double tstop);
 static char* nrncore_arg(double tstop) {
   PyObject* modules = PyImport_GetModuleDict();
@@ -2923,6 +2952,7 @@ myPyMODINIT_FUNC nrnpy_hoc() {
   nrnpy_gui_helper3_ = gui_helper_3_;
   nrnpy_gui_helper3_str_ = gui_helper_3_str_;
   nrnpy_nrncore_arg_p_ = nrncore_arg;
+  nrnpy_nrncore_enable_value_p_ = nrncore_enable_value;
 
   nrnpy_object_to_double_ = object_to_double_;
   PyLockGIL lock;

--- a/src/parallel/ocbbs.cpp
+++ b/src/parallel/ocbbs.cpp
@@ -668,7 +668,7 @@ static double spike_record(void* v) {
 static double psolve(void* v) {
 	OcBBS* bbs = (OcBBS*)v;
 	double tstop = chkarg(1, t, 1e9);
-        int enabled = nrncore_is_enabled();
+	int enabled = nrncore_is_enabled();
 	if (enabled == 1) {
 		nrncore_psolve(tstop);
 	}else if (enabled == 0) {

--- a/src/parallel/ocbbs.cpp
+++ b/src/parallel/ocbbs.cpp
@@ -73,7 +73,7 @@ extern "C" {
 	extern size_t nrnbbcore_register_mapping();
 	extern int nrncore_run(const char*);
 	extern bool nrn_trajectory_request_per_time_step_;
-
+	extern int nrncore_psolve(double tstop);
 }
 
 class OcBBS : public BBS , public Resource {
@@ -666,7 +666,10 @@ static double spike_record(void* v) {
 
 static double psolve(void* v) {
 	OcBBS* bbs = (OcBBS*)v;
-	bbs->netpar_solve(chkarg(1, t, 1e9));
+	double tstop = chkarg(1, t, 1e9);
+	if (!nrncore_psolve(tstop)) {
+		bbs->netpar_solve(tstop);
+	}
 	return 0.;
 }
 

--- a/src/parallel/ocbbs.cpp
+++ b/src/parallel/ocbbs.cpp
@@ -73,6 +73,7 @@ extern "C" {
 	extern size_t nrnbbcore_register_mapping();
 	extern int nrncore_run(const char*);
 	extern bool nrn_trajectory_request_per_time_step_;
+	extern int nrncore_is_enabled();
 	extern int nrncore_psolve(double tstop);
 }
 
@@ -667,10 +668,14 @@ static double spike_record(void* v) {
 static double psolve(void* v) {
 	OcBBS* bbs = (OcBBS*)v;
 	double tstop = chkarg(1, t, 1e9);
-	if (!nrncore_psolve(tstop)) {
+        int enabled = nrncore_is_enabled();
+	if (enabled == 1) {
+		nrncore_psolve(tstop);
+	}else if (enabled == 0) {
+		// Classic case
 		bbs->netpar_solve(tstop);
 	}
-	return 0.;
+	return double(enabled);
 }
 
 static double set_maxstep(void* v) {


### PR DESCRIPTION
coreneuron.nrncore_arg(tstop) returns str that can be used with
pc.nrncore_run(str) based on coreneuron properties and current
NEURON settings. User specifiable properties are enable, gpu,
cell_permute, warp_balance, verbose, and prcellstate. Args derived
from current NEURON settings are --mpi, --binqueue, --spkcompress,
--multisend, --ms_subinterval, and --ms_phases.

Closes #639