### PR TITLE
Used == when = was needed. No effect on computation.

### DIFF
--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -1711,7 +1711,7 @@ static PyObject* iternext_sl(PyHocObject* po, hoc_Item* ql) {
       // will go to 0, thus invalidating po->iteritem_->element.sec->prop
       po->iteritem_ = next_valid_secitem((hoc_Item*)(po->iteritem_), ql);
       if (po->iteritem_ == ql) {
-        po->u.its_ == PyHoc::Last;
+        po->u.its_ = PyHoc::Last;
         po->iteritem_ = NULL;
         return NULL;
       }else{


### PR DESCRIPTION
Eliminates "warning: equality comparison result unused"

Leaving the statement there for clarity that the state of the iteration is PyHoc::Last but in this circumstance the return value is NULL
which terminates the iteration.