### PR TITLE
Travis CI early return for jobs if docs-only PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,13 @@ os:
 # Setup environment and Install dependencies
 #=============================================================================
 before_install:
+  - |
+    if ! git diff --name-only ${TRAVIS_COMMIT_RANGE} | grep -qvE '(\.md)$|^(Copyright)$|^(docs/)'
+    then
+      echo "Skipping CI build since we have docs-only changes for ${TRAVIS_COMMIT_RANGE} :"
+      git diff --name-only ${TRAVIS_COMMIT_RANGE}
+      exit
+    fi
   - echo $LANG
   - echo $LC_ALL
   - $CXX -v


### PR DESCRIPTION
Docs-only includes: 
- `*.md`files
- `Copyright` file
- `docs/*` anything in the docs