### PR TITLE
Disable MPICH test on Azure OSX CI for now

### DIFF
--- a/packaging/python/test_wheels.sh
+++ b/packaging/python/test_wheels.sh
@@ -86,9 +86,14 @@ run_parallel_test() {
     # this is for MacOS system
     if [[ "$OSTYPE" == "darwin"* ]]; then
       # assume both MPIs are installed via brew.
+
       brew unlink openmpi
       brew link mpich
-      run_mpi_test "/usr/local/opt/mpich/bin/mpirun" "MPICH" ""
+
+      # TODO : latest mpich has issuee on Azure OSX
+      if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+          run_mpi_test "/usr/local/opt/mpich/bin/mpirun" "MPICH" ""
+      fi
 
       brew unlink mpich
       brew link openmpi


### PR DESCRIPTION
As MPICH has issues on Azure CI, disable tests for now.
See https://github.com/neuronsimulator/nrn/issues/654 for details