### PR TITLE
Better support for CoreNEURON launching and refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,16 @@ if(NRN_ENABLE_CORENEURON)
 endif()
 
 # =============================================================================
+# Set library type
+# =============================================================================
+if(NRN_ENABLE_SHARED)
+    set(NRN_LIBRARY_TYPE "SHARED")
+else()
+    set(NRN_LIBRARY_TYPE "STATIC")
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
+
+# =============================================================================
 # Add helpder CMake modules AFTER setting options
 # =============================================================================
 include(NeuronFileLists)

--- a/packaging/python/test_wheels.sh
+++ b/packaging/python/test_wheels.sh
@@ -86,9 +86,14 @@ run_parallel_test() {
     # this is for MacOS system
     if [[ "$OSTYPE" == "darwin"* ]]; then
       # assume both MPIs are installed via brew.
+
       brew unlink openmpi
       brew link mpich
-      run_mpi_test "/usr/local/opt/mpich/bin/mpirun" "MPICH" ""
+
+      # TODO : latest mpich has issuee on Azure OSX
+      if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+          run_mpi_test "/usr/local/opt/mpich/bin/mpirun" "MPICH" ""
+      fi
 
       brew unlink mpich
       brew link openmpi

--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -251,7 +251,7 @@ endif()
 # =============================================================================
 # All source directories to include
 # =============================================================================
-add_library(nrniv_lib SHARED ${NRN_NRNIV_LIB_SRC_FILES})
+add_library(nrniv_lib ${NRN_LIRARY_TYPE} ${NRN_NRNIV_LIB_SRC_FILES})
 if(NRN_WINDOWS_BUILD)
   target_link_libraries(nrniv_lib ${TERMCAP_LIBRARIES} ${Readline_LIBRARY})
 else()

--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -251,7 +251,7 @@ endif()
 # =============================================================================
 # All source directories to include
 # =============================================================================
-add_library(nrniv_lib ${NRN_LIRARY_TYPE} ${NRN_NRNIV_LIB_SRC_FILES})
+add_library(nrniv_lib ${NRN_LIBRARY_TYPE} ${NRN_NRNIV_LIB_SRC_FILES})
 if(NRN_WINDOWS_BUILD)
   target_link_libraries(nrniv_lib ${TERMCAP_LIBRARIES} ${Readline_LIBRARY})
 else()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,10 +22,10 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/share/lib
           ${PROJECT_BINARY_DIR}/share/nrn/lib)
 
+# Note that DYLD_LIBRARY_PATH is not required and interfere with dlopen
 set(TEST_ENV
     NEURONHOME=${PROJECT_BINARY_DIR}/share/nrn NRNHOME=${PROJECT_BINARY_DIR}
-    LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}
-    DYLD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/lib:$ENV{DYLD_LIBRARY_PATH})
+    LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH})
 if(NRN_ENABLE_PYTHON)
   list(
     APPEND
@@ -106,9 +106,23 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
   endif()
 
   if(NRN_ENABLE_CORENEURON)
-    add_test(NAME coreneuron_direct COMMAND ${PYTHON_EXECUTABLE} -m pytest
-                                            ${PROJECT_SOURCE_DIR}/test/coreneuron)
-    list(APPEND TESTS coreneuron_direct)
+    file(COPY ${PROJECT_SOURCE_DIR}/test/coreneuron/mod DESTINATION ${PROJECT_BINARY_DIR}/test/)
+    add_custom_target(
+      coreneuron_mod ALL
+      COMMAND
+        ${CMAKE_COMMAND} -E env ${TEST_ENV} $ENV{SHELL} ${CMAKE_BINARY_DIR}/bin/nrnivmodl .
+      COMMAND
+        ${CMAKE_COMMAND} -E env ${TEST_ENV} $ENV{SHELL} ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core .
+       WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
+    add_dependencies(coreneuron_mod nrniv nrniv-core)
+
+    add_test(NAME coreneuron_direct_py COMMAND ${PYTHON_EXECUTABLE}
+                                            ${PROJECT_SOURCE_DIR}/test/coreneuron/test_direct.py
+                                    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
+    add_test(NAME coreneuron_direct_hoc COMMAND ${CMAKE_BINARY_DIR}/bin/nrniv
+                                            ${PROJECT_SOURCE_DIR}/test/coreneuron/test_direct.hoc
+                                    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
+    list(APPEND TESTS coreneuron_direct_py coreneuron_direct_hoc)
   endif()
 endif()
 set_tests_properties(${TESTS} PROPERTIES ENVIRONMENT "${TEST_ENV}")

--- a/test/coreneuron/mod/sample.mod
+++ b/test/coreneuron/mod/sample.mod
@@ -1,0 +1,5 @@
+NEURON	{
+	SUFFIX Sample
+	RANGE decay, gamma
+}
+

--- a/test/coreneuron/test_direct.hoc
+++ b/test/coreneuron/test_direct.hoc
@@ -1,0 +1,69 @@
+// Launch:
+// nrnivmodl mod
+// nrnivmodl-core mod
+// nrniv tst_direct.hoc
+//   success if prints 3 lines of 1 at the end
+
+{load_file("stdrun.hoc")}
+
+create soma
+
+proc test_direct_memory_transfer() { localobj po, pc, ic, tv, vvec, i_mem, tvstd, vstd, i_memstd
+    soma {
+        L=5.6419
+        diam=5.6419
+        insert hh
+        ic = new IClamp(.5)
+    }
+    ic.del = .5
+    ic.dur = 0.1
+    ic.amp = 0.3
+
+    // for testing external mod file
+    soma { insert Sample }
+
+    cvode.use_fast_imem(1)
+    cvode.cache_efficient(1)
+
+    // record results of a run
+    vvec = new Vector()
+    soma {vvec.record(&v(.5))}
+    i_mem = new Vector()
+    soma {i_mem.record(&i_membrane_(.5))}
+    tv = new Vector()
+    soma {tv.record(&t)}
+
+    // normal NEURON run
+    run()
+
+    // store results for later comparison
+    vstd = vvec.cl()
+    tvstd = tv.cl()
+    i_memstd = i_mem.cl()
+
+    // resize so no chance of comparing equal if psolve does nothing
+    vvec.resize(0)
+    tv.resize(0)
+    i_mem.resize(0)
+
+    if (!nrnpython("from neuron import coreneuron")) {
+        printf("Python not available\n")
+        return
+    }
+
+    po = new PythonObject()
+    po.coreneuron.enable = 1
+    printf("nrncore_arg: |%s|\n", po.coreneuron.nrncore_arg(tstop))
+
+    pc = new ParallelContext()
+    pc.set_maxstep(10)
+    stdinit()
+    pc.psolve(tstop)
+
+    // compare results
+    print (tv.eq(tvstd))
+    print (vvec.cl().sub(vstd).abs().max() < 1e-10)
+    print (i_mem.cl().sub(i_memstd).abs().max() < 1e-10)
+}
+
+test_direct_memory_transfer()

--- a/test/coreneuron/test_direct.py
+++ b/test/coreneuron/test_direct.py
@@ -13,6 +13,9 @@ def test_direct_memory_transfer():
     ic.dur = 0.1
     ic.amp = 0.3
 
+    #for testing external mod file
+    h.soma.insert("Sample")
+
     h.cvode.use_fast_imem(1)
     h.cvode.cache_efficient(1)
 
@@ -27,10 +30,16 @@ def test_direct_memory_transfer():
     tvstd = tv.cl()
     i_memstd = i_mem.cl()
 
+    from neuron import coreneuron
+    coreneuron.enable = True
+
     pc = h.ParallelContext()
     h.stdinit()
-    pc.nrncore_run("-e %g"%h.tstop, 0)
+    pc.psolve(h.tstop)
 
     assert(tv.eq(tvstd))
     assert(v.cl().sub(vstd).abs().max() < 1e-10)
     assert(i_mem.cl().sub(i_memstd).abs().max() < 1e-10)
+
+if __name__ == "__main__":
+    test_direct_memory_transfer()


### PR DESCRIPTION
  * Until now shared library of coreneuron was loaded automatically
    from <arch>/libcorenrnmech.so
  * To support statically build CoreNEURON for GPU, one can link
   coreneuron library as:
      nrnivmodl-core mod
      nrnivmodl -loadflags "-Lx86_64/ -lcorenrnmech" mod
  * If CoreNEURON is already loaded, don't do anything
  * Better error handling
  * Code refactoring with modular function
  * Updae CoreNEURON submodule
  * Use full path for loading mech library (OSX security settings)
  * Set PIC for nrniv STATIC library
  * Set correct build type for nrniv library
  * Update direct memory test for CoreNEURON

Same as #646 but need to create separate PR as I push forced changes on a close PR.