### PR TITLE
docs-only check for PRs exclusively

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,10 +99,8 @@ os:
 #=============================================================================
 before_install:
   - |
-    if "${TRAVIS_PULL_REQUEST}" != "false"
-    then
-      if ! git diff --name-only ${TRAVIS_COMMIT_RANGE} | grep -qvE '(\.md)$|^(Copyright)$|^(docs/)'
-      then
+    if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+      if ! git diff --name-only ${TRAVIS_COMMIT_RANGE} | grep -qvE '(\.md)$|^(Copyright)$|^(docs/)' ; then
         echo "Skipping CI build since we have docs-only changes for ${TRAVIS_COMMIT_RANGE} :"
         git diff --name-only ${TRAVIS_COMMIT_RANGE}
         exit

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,11 +99,14 @@ os:
 #=============================================================================
 before_install:
   - |
-    if ! git diff --name-only ${TRAVIS_COMMIT_RANGE} | grep -qvE '(\.md)$|^(Copyright)$|^(docs/)'
+    if "${TRAVIS_PULL_REQUEST}" != "false"
     then
-      echo "Skipping CI build since we have docs-only changes for ${TRAVIS_COMMIT_RANGE} :"
-      git diff --name-only ${TRAVIS_COMMIT_RANGE}
-      exit
+      if ! git diff --name-only ${TRAVIS_COMMIT_RANGE} | grep -qvE '(\.md)$|^(Copyright)$|^(docs/)'
+      then
+        echo "Skipping CI build since we have docs-only changes for ${TRAVIS_COMMIT_RANGE} :"
+        git diff --name-only ${TRAVIS_COMMIT_RANGE}
+        exit
+      fi
     fi
   - echo $LANG
   - echo $LC_ALL


### PR DESCRIPTION
The check we do for docs-only shall be done only for PRs.
Otherwise it gets tricky to manage outside of PRs and might fail in certain conditions (like rebase).

Tested here for non-PR:
* https://travis-ci.com/github/neuronsimulator/nrn/builds/175832701

after failing here: 
* https://travis-ci.com/github/neuronsimulator/nrn/builds/175825847