### PR TITLE
ontology_id type fix for ions

### DIFF
--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -1178,7 +1178,7 @@ class DensityMechanism:
         except:
           # older versions of the NMODL library didn't support .ontology_id
           pass
-        result[name] = {'read': read, 'write': write, 'charge': valence, 'ontology_id': ontology_id}
+        result[name] = {'read': read, 'write': write, 'charge': valence, 'ontology_id': nmodl.to_nmodl(ontology_id)}
       self.__ions = result
     # return a copy
     return dict(self.__ions)


### PR DESCRIPTION
Previously

h.hh.ions['k']['ontology_id']

returned a nmodl._nmodl.ast.String (which displays as invisible); now it returns a string.