### PR TITLE
Skip stub libraries from OSX

### DIFF
--- a/cmake/CMakeListsNrnMech.cmake
+++ b/cmake/CMakeListsNrnMech.cmake
@@ -23,7 +23,8 @@ list(REMOVE_ITEM NRN_LINK_LIBS "interviews")
 # CMake does some magic to transform sys libs to -l<libname>. We replicate it
 foreach(link_lib ${NRN_LINK_LIBS})
   # skip static readline library as it will be linked to nrniv (e.g. with wheel)
-  if ("${link_lib}" MATCHES "libreadline.a")
+  # also stub libraries from OSX can be skipped
+  if ("${link_lib}" MATCHES "(libreadline.a|/*.tbd)")
     continue()
   endif()
 


### PR DESCRIPTION
fixes #669