### PR TITLE
Clean up rxd compiler warnings.

### DIFF
--- a/share/lib/python/neuron/rxd/species.py
+++ b/share/lib/python/neuron/rxd/species.py
@@ -40,9 +40,6 @@ ICS_insert_inhom.argtypes = ICS_insert.argtypes = [
     ctypes.c_long,
     numpy.ctypeslib.ndpointer(dtype=int),
     numpy.ctypeslib.ndpointer(dtype=int),
-    numpy.ctypeslib.ndpointer(dtype=int),
-    numpy.ctypeslib.ndpointer(dtype=int),
-    numpy.ctypeslib.ndpointer(dtype=int),
     ctypes.c_long,
     numpy.ctypeslib.ndpointer(dtype=int),
     ctypes.c_long,
@@ -76,7 +73,7 @@ _set_grid_currents = nrn_dll_sym('set_grid_currents')
 _set_grid_currents.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.py_object, ctypes.py_object, ctypes.py_object]
 
 _ics_set_grid_currents = nrn_dll_sym('ics_set_grid_currents')
-_ics_set_grid_currents.argtypes = [ctypes.c_int, ctypes.c_int, numpy.ctypeslib.ndpointer(dtype=numpy.int64), numpy.ctypeslib.ndpointer(dtype=numpy.int64), ctypes.py_object, numpy.ctypeslib.ndpointer(dtype=numpy.float_)]
+_ics_set_grid_currents.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.py_object, numpy.ctypeslib.ndpointer(dtype=numpy.float_)]
 
 
 _delete_by_id = nrn_dll_sym('delete_by_id')
@@ -553,13 +550,10 @@ class _IntracellularSpecies(_SpeciesMathable):
 
         if hasattr(self,'_dgrid'):
             self._grid_id = ICS_insert_inhom(0, self._states._ref_x[0], len(self.states), self.neighbors,
-                                             self._ordered_x_nodes, self._ordered_y_nodes, self._ordered_z_nodes,
-                                             self._x_line_defs, len(self._x_line_defs), self._y_line_defs, 
                                              len(self._y_line_defs), self._z_line_defs, len(self._z_line_defs),
                                              self._dgrid, self._dx, is_diffusable, self._atolscale, self._alphas)
         else:
             self._grid_id = ICS_insert(0, self._states._ref_x[0], len(self.states), self.neighbors,
-                                       self._ordered_x_nodes, self._ordered_y_nodes, self._ordered_z_nodes,
                                        self._x_line_defs, len(self._x_line_defs), self._y_line_defs, 
                                        len(self._y_line_defs), self._z_line_defs, len(self._z_line_defs),
                                        self._d, self._dx, is_diffusable, self._atolscale, self._alphas)
@@ -723,7 +717,7 @@ class _IntracellularSpecies(_SpeciesMathable):
                     scale = sum(node_area)/geom_area
                     scale_factors = [sign * area * scale * scale_factor for area in node_area]
                     self._scale_factors = numpy.asarray(scale_factors, dtype=numpy.float_)
-                    _ics_set_grid_currents(grid_list_start, self._grid_id, self._surface_nodes_per_seg, self._surface_nodes_per_seg_start_indices, self._current_neuron_pointers, self._scale_factors)
+                    _ics_set_grid_currents(grid_list_start, self._grid_id, self._current_neuron_pointers, self._scale_factors)
 
 
     def _semi_compile(self, region, instruction):

--- a/share/lib/python/neuron/rxd/species.py
+++ b/share/lib/python/neuron/rxd/species.py
@@ -550,6 +550,7 @@ class _IntracellularSpecies(_SpeciesMathable):
 
         if hasattr(self,'_dgrid'):
             self._grid_id = ICS_insert_inhom(0, self._states._ref_x[0], len(self.states), self.neighbors,
+                                             self._x_line_defs, len(self._x_line_defs), self._y_line_defs, 
                                              len(self._y_line_defs), self._z_line_defs, len(self._z_line_defs),
                                              self._dgrid, self._dx, is_diffusable, self._atolscale, self._alphas)
         else:

--- a/src/nrnpython/rxd.cpp
+++ b/src/nrnpython/rxd.cpp
@@ -14,7 +14,7 @@ extern "C" {
 #include <nrnwrap_Python.h>
 #include <nrnpython.h>
 
-static void ode_solve(double, double, double*, double*);
+static void ode_solve(double, double*, double*);
 extern PyTypeObject* hocobject_type;
 extern int structure_change_cnt;
 extern int states_cvode_offset;
@@ -64,7 +64,7 @@ SpeciesIndexList* species_indices = NULL;
 
 /*intracellular reactions*/
 double* states;
-int num_states=0;
+unsigned int num_states=0;
 int _num_reactions = 0;
 int* _num_species = NULL;
 int _max_species_per_location = 0;
@@ -208,8 +208,7 @@ extern "C" void free_conc_ptrs()
 
 
 extern "C" void rxd_setup_curr_ptrs(int num_currents, int* curr_index, double* curr_scale,
-						  PyHocObject** curr_ptrs, int conc_count, 
-						  int* conc_index, PyHocObject** conc_ptrs)
+						  PyHocObject** curr_ptrs)
 {
     free_curr_ptrs();
 	/* info for NEURON currents - to update states */
@@ -328,7 +327,6 @@ extern "C" void rxd_include_node_flux3D(int grid_count, int* grid_counts,
 extern "C" void rxd_include_node_flux1D(int n, long* index, double* scales,
                                         PyObject** sources)
 {
-    int i;
     if (_node_flux_count != 0)
     {
         free(_node_flux_idx);
@@ -544,7 +542,7 @@ static void add_currents(double * result)
         }
     }
 }
-static void mul(int nrow, int nnonzero, long* nonzero_i, long* nonzero_j, const double* nonzero_values, const double* v, double* result) {
+static void mul(int nnonzero, long* nonzero_i, long* nonzero_j, const double* nonzero_values, const double* v, double* result) {
     long i, j, k;
     /* now loop through all the nonzero locations */
     /* NOTE: this would be more efficient if not repeatedly doing the result[i] lookup */
@@ -621,9 +619,9 @@ static void nrn_tree_solve(double* a, double* b, double* c, double* dbase, doubl
 
 
 
-static void ode_solve(double t, double dt, double* p1, double* p2)
+static void ode_solve(double dt, double* p1, double* p2)
 {
-    unsigned long i, j;
+    long i, j;
     double* b = p1 + _cvode_offset;
     double* y = p2 + _cvode_offset;
     double* full_b, *full_y;
@@ -723,7 +721,7 @@ extern "C" void setup_currents(int num_currents, int num_fluxes,
         int* num_species, int* node_idxs, double* scales,
         PyHocObject** ptrs, int* mapped, int* mapped_ecs)
 {
-    int i, j, k, id, side, idx;
+    int i, j, k, id, side;
     Current_Triple* c;
     Grid_node* grid;
     
@@ -748,7 +746,7 @@ extern "C" void setup_currents(int num_currents, int num_fluxes,
     memset(_rxd_induced_currents_grid, SPECIES_ABSENT, sizeof(int)*_memb_curr_total);
     _rxd_induced_currents_ecs_idx = (int*)malloc(sizeof(int)*_memb_curr_total);
 
-    for(i = 0, idx = 0, k = 0; i < num_currents; i++)
+    for(i = 0, k = 0; i < num_currents; i++)
     {
         _memb_cur_ptrs[i] = (PyHocObject**)malloc(sizeof(PyHocObject*)*num_species[i]);
         //memcpy(_memb_cur_ptrs[i], &ptrs[k], sizeof(PyHocObject*)*num_species[i]);
@@ -848,7 +846,7 @@ static void _currents(double* rhs)
 }
 
 
-extern "C" int rxd_nonvint_block(int method, int size, double* p1, double* p2, int thread_id) {
+extern "C" int rxd_nonvint_block(int method, int size, double* p1, double* p2, int) {
         if(method > 0 && initialized && structure_change_cnt != prev_structure_change_cnt)
         {
             /*TODO: Exclude irrelevant (non-rxd) structural changes*/
@@ -885,11 +883,11 @@ extern "C" int rxd_nonvint_block(int method, int size, double* p1, double* p2, i
             break;
         case 7:
             /* ode_fun(t, y, ydot); from t and y determine ydot */
-            _rhs_variable_step(*t_ptr, p1, p2);
-            _rhs_variable_step_ecs(*t_ptr, p1, p2, _cvode_offset);
+            _rhs_variable_step(p1, p2);
+            _rhs_variable_step_ecs(p1, p2);
             break;
         case 8:
-            ode_solve(*t_ptr, *dt_ptr, p1, p2); /*solve mx=b replace b with x */
+            ode_solve(*dt_ptr, p1, p2); /*solve mx=b replace b with x */
             /* TODO: we can probably reuse the dgadi code here... for now, we do nothing, which implicitly approximates the Jacobian as the identity matrix */
             //y= p1 = states and b = p2 = RHS for x direction
             ics_ode_solve(*dt_ptr, p1, p2);
@@ -1205,18 +1203,6 @@ extern "C" void species_atolscale(int id, double scale, int len, int* idx)
     list->length = len;
     list->atolscale = scale;
     list->next = NULL;
-}
-
-static void free_SpeciesIndexList()
-{
-    SpeciesIndexList* list;
-    while(species_indices != NULL)
-    {
-        list = species_indices;
-        free(list->indices);
-        species_indices = list->next;
-        free(list);
-    }
 }
 
 extern "C" void remove_species_atolscale(int id)
@@ -1543,7 +1529,7 @@ extern "C" void set_reaction_indices( int num_locations, int* regions, int* num_
 
 void _fadvance(void) {
 	double dt = *dt_ptr;
-	int i;
+	long i;
 	/*variables for diffusion*/
 	double *rhs; 
 	long* zvi = _rxd_zero_volume_indices;
@@ -1551,7 +1537,7 @@ void _fadvance(void) {
     rhs = (double*)calloc(num_states,sizeof(double));
     /*diffusion*/
     if(diffusion)
-	    mul(_rxd_euler_nrow, _rxd_euler_nnonzero, _rxd_euler_nonzero_i, _rxd_euler_nonzero_j, _rxd_euler_nonzero_values, states, rhs);
+	    mul(_rxd_euler_nnonzero, _rxd_euler_nonzero_i, _rxd_euler_nonzero_j, _rxd_euler_nonzero_values, states, rhs);
 
     add_currents(rhs);
 
@@ -1608,7 +1594,7 @@ void _ode_reinit(double* y)
 }
 
 
-void _rhs_variable_step(const double t, const double* p1, double* p2) 
+void _rhs_variable_step(const double* p1, double* p2) 
 {
     Grid_node *grid;
 	long i, j, p, c;
@@ -1667,7 +1653,7 @@ void _rhs_variable_step(const double t, const double* p1, double* p2)
     rhs = (double*)calloc(num_states,sizeof(double));
 	
     if(diffusion)
-        mul(_rxd_euler_nrow, _rxd_euler_nnonzero, _rxd_euler_nonzero_i, _rxd_euler_nonzero_j, _rxd_euler_nonzero_values, states, rhs);
+        mul(_rxd_euler_nnonzero, _rxd_euler_nonzero_i, _rxd_euler_nonzero_j, _rxd_euler_nonzero_values, states, rhs);
 
     /*reactions*/
     MEM_ZERO(&ydot[num_states - _rxd_num_zvi], sizeof(double)*_ecs_count);
@@ -1818,7 +1804,9 @@ void get_reaction_rates(ICSReactions* react, double* states, double* rates, doub
         }
 
         if(react->vptrs != NULL)
+        {
             v = *(react->vptrs[segment]);
+        }
 
 	    react->reaction(states_for_reaction, params_for_reaction, result_array, mc_mult, ecs_states_for_reaction, ecs_params_for_reaction, ecs_result, flux, v);
         
@@ -1901,15 +1889,15 @@ void solve_reaction(ICSReactions* react, double* states, double *bval, double* c
     double** params_for_reaction = (double**)malloc(react->num_params*sizeof(double*));
     double** result_array = (double**)malloc(react->num_species*sizeof(double*));
     double** result_array_dx = (double**)malloc(react->num_species*sizeof(double*));
-    double* mc_mult;
+    double* mc_mult = NULL;
     if(react->num_mult > 0)
         mc_mult = (double*)malloc(react->num_mult*sizeof(double));
 
-    double* ecs_states_for_reaction;
-    double* ecs_states_for_reaction_dx;
-    double* ecs_params_for_reaction;
-    double* ecs_result;
-    double* ecs_result_dx;
+    double* ecs_states_for_reaction = NULL;
+    double* ecs_states_for_reaction_dx = NULL;
+    double* ecs_params_for_reaction = NULL;
+    double* ecs_result = NULL;
+    double* ecs_result_dx = NULL;
     double v = 0;
     if(react->num_ecs_species > 0)
     {

--- a/src/nrnpython/rxd.h
+++ b/src/nrnpython/rxd.h
@@ -145,7 +145,7 @@ void ics_dg_adi_y_inhom(ICS_Grid_node* g, int, int, int, double, double*, double
 void ics_dg_adi_z_inhom(ICS_Grid_node* g, int, int, int, double, double*, double*, double*, double*, double*, double*);
 
 /*Variable step function declarations*/
-void _rhs_variable_step(const double, const double*, double*);
+void _rhs_variable_step(const double*, double*);
 
 void _ode_reinit(double*);
 
@@ -163,16 +163,15 @@ void _ics_rhs_variable_step_helper(ICS_Grid_node*, double const* const, double*)
 void _rhs_variable_step_helper(Grid_node*, double const * const, double*);
 
 void ics_ode_solve(double, double*, const double*);
-void ics_ode_solve_helper(ICS_Grid_node*, double, const double*, double*);
+void ics_ode_solve_helper(ICS_Grid_node*, double, double*);
 
 void _rhs_variable_step_helper_tort(Grid_node*, double const * const, double*);
 
 void _rhs_variable_step_helper_vol(Grid_node*, double const * const, double*);
 
-static void ecs_refresh_reactions(int);
 void set_num_threads_3D(int n);
 
-void _rhs_variable_step_ecs(const double, const double*, double*, const int);
+void _rhs_variable_step_ecs(const double*, double*);
 
 void clear_rates_ecs();
 void do_ics_reactions(double*, double*, double*, double*);

--- a/src/nrnpython/rxd_intracellular.cpp
+++ b/src/nrnpython/rxd_intracellular.cpp
@@ -76,48 +76,6 @@ extern "C" void set_hybrid_data(int64_t* num_1d_indices_per_grid, int64_t* num_3
     } 
 }
 
-/* solve_dd_clhs_tridiag uses Thomas Algorithm to solves a 
- * diagonally dominant tridiagonal matrix (Ax=b), where the
- * triple (lower, diagonal and upper) are repeated to form A. 
- * N        -   length of the matrix
- * l_diag   -   lower diagonal 
- * diag     -   diagonal
- * u_diag   -   upper diagonal
- * b        -   pointer to the RHS  (length N)
- * lbc_diag -   the lower boundary diagonal (the first diagonal element)
- * lbc_u_diag - the lower boundary upper diagonal (the first upper 
- *              diagonal element)
- * ubc_l_diag - the upper boundary lower diagonal (the last lower
- *              diagonal element)
- * ubc_diag -   the upper boundary diagonal (the last diagonal element)
- * The solution (x) is stored in b.
- * c          - scratchpad array, N - 1 doubles long
- */
-static int solve_dd_clhs_tridiag(const int N, const double l_diag, const double diag, 
-    const double u_diag, const double lbc_diag, const double lbc_u_diag,
-    const double ubc_l_diag, const double ubc_diag, double* const b, double* const c) 
-{
-    int i;
-    
-    
-    c[0] = lbc_u_diag/lbc_diag;
-    b[0] = b[0]/lbc_diag;
-
-    for(i=1;i<N-1;i++)
-    {
-        c[i] = u_diag/(diag-l_diag*c[i-1]);
-        b[i] = (b[i]-l_diag*b[i-1])/(diag-l_diag*c[i-1]);
-    }
-    b[N-1] = (b[N-1]-ubc_l_diag*b[N-2])/(ubc_diag-ubc_l_diag*c[N-2]);
-
-    /*back substitution*/
-    for(i=N-2;i>=0;i--)
-    {
-        b[i]=b[i]-c[i]*b[i+1];  
-    }
-    return 0;
-}
-
 /* solve Ax=b where A is a diagonally dominant tridiagonal matrix
  * N	-	length of the matrix
  * l_diag	-	pointer to the lower diagonal (length N-1)
@@ -163,7 +121,6 @@ void ics_find_deltas(long start, long stop, long node_start, double* delta, long
     double prev_alpha;
     double current_alpha;
     double next_alpha;
-    double dt = *dt_ptr;
     for(int i = start; i < stop - 1; i += 2)
     {   
         long line_start = ordered_nodes[ordered_index]; 
@@ -215,7 +172,6 @@ void ics_find_deltas(long start, long stop, long node_start, double* delta, long
     double prev_alpha;
     double current_alpha;
     double next_alpha;
-    double dt = *dt_ptr;
     for(int i = start; i < stop - 1; i += 2)
     {   
         long line_start = ordered_nodes[ordered_index]; 
@@ -264,7 +220,6 @@ static void* do_ics_deltas(void* dataptr){
     int line_stop = data->line_stop;
     int node_start = data->ordered_start;
     double* states = g->states;
-    double dt = *dt_ptr;
     double* deltas = ics_adi_dir->deltas;
     long* line_defs = ics_adi_dir->ordered_line_defs;
     long* ordered_nodes = ics_adi_dir->ordered_nodes;
@@ -299,7 +254,7 @@ void run_threaded_deltas(ICS_Grid_node* g, ICSAdiDirection* ics_adi_dir){
 }
 
 //Inhomogeneous diffusion coefficient 
-void ics_dg_adi_x_inhom(ICS_Grid_node* g, int line_start, int line_stop, int node_start, double r, double* states, double* RHS, double* scratchpad, double* u_diag, double* diag, double* l_diag){
+void ics_dg_adi_x_inhom(ICS_Grid_node* g, int line_start, int line_stop, int node_start, double, double* states, double* RHS, double* scratchpad, double* u_diag, double* diag, double* l_diag){
     double* delta_x = g->ics_adi_dir_x->deltas;
     double* delta_y = g->ics_adi_dir_y->deltas;
     double* delta_z = g->ics_adi_dir_z->deltas;
@@ -320,7 +275,6 @@ void ics_dg_adi_x_inhom(ICS_Grid_node* g, int line_start, int line_stop, int nod
 
     long current_index;
     long ordered_index = node_start;
-    long N = 0;
     for(int i = line_start; i < line_stop - 1; i += 2)
     {
         long N = x_lines[i+1];
@@ -372,7 +326,7 @@ void ics_dg_adi_x_inhom(ICS_Grid_node* g, int line_start, int line_stop, int nod
     }
 }
 
-void ics_dg_adi_y_inhom(ICS_Grid_node* g, int line_start, int line_stop, int node_start, double r, double* states, double* RHS, double* scratchpad, double* u_diag, double* diag, double* l_diag){
+void ics_dg_adi_y_inhom(ICS_Grid_node* g, int line_start, int line_stop, int node_start, double, double* states, double* RHS, double* scratchpad, double* u_diag, double* diag, double* l_diag){
     double* delta = g->ics_adi_dir_y->deltas;
     long* lines = g->ics_adi_dir_y->ordered_line_defs;
     double* alphas = g->_ics_alphas;
@@ -387,7 +341,6 @@ void ics_dg_adi_y_inhom(ICS_Grid_node* g, int line_start, int line_stop, int nod
     long current_index;
     long* ordered_y_nodes = g->ics_adi_dir_y->ordered_nodes;
     long ordered_index = node_start;
-    long N = 0;
 
     for(int i = line_start; i < line_stop - 1; i += 2)
     {
@@ -436,7 +389,7 @@ void ics_dg_adi_y_inhom(ICS_Grid_node* g, int line_start, int line_stop, int nod
     }
 
 }
-void ics_dg_adi_z_inhom(ICS_Grid_node* g, int line_start, int line_stop, int node_start, double r, double* states, double* RHS, double* scratchpad, double* u_diag, double* diag, double* l_diag){
+void ics_dg_adi_z_inhom(ICS_Grid_node* g, int line_start, int line_stop, int node_start, double, double* states, double* RHS, double* scratchpad, double* u_diag, double* diag, double* l_diag){
     double* delta = g->ics_adi_dir_z->deltas;
     long* lines = g->ics_adi_dir_z->ordered_line_defs;
     long* ordered_z_nodes = g->ics_adi_dir_z->ordered_nodes;
@@ -451,7 +404,6 @@ void ics_dg_adi_z_inhom(ICS_Grid_node* g, int line_start, int line_stop, int nod
     
     long current_index;
     long ordered_index = node_start;
-    long N = 0;
     for(int i = line_start; i< line_stop - 1; i+=2)
     {
         long N = lines[i+1];
@@ -499,7 +451,7 @@ void ics_dg_adi_z_inhom(ICS_Grid_node* g, int line_start, int line_stop, int nod
 }
 
 //Homogeneous diffusion coefficient 
-void ics_dg_adi_x(ICS_Grid_node* g, int line_start, int line_stop, int node_start, double r, double* states, double* RHS, double* scratchpad, double* u_diag, double* diag, double* l_diag){
+void ics_dg_adi_x(ICS_Grid_node* g, int line_start, int line_stop, int node_start, double, double* states, double* RHS, double* scratchpad, double* u_diag, double* diag, double* l_diag){
     double* delta_x = g->ics_adi_dir_x->deltas;
     double* delta_y = g->ics_adi_dir_y->deltas;
     double* delta_z = g->ics_adi_dir_z->deltas;
@@ -520,7 +472,6 @@ void ics_dg_adi_x(ICS_Grid_node* g, int line_start, int line_stop, int node_star
 
     long current_index;
     long ordered_index = node_start;
-    long N = 0;
     for(int i = line_start; i < line_stop - 1; i += 2)
     {
         long N = x_lines[i+1];
@@ -568,7 +519,7 @@ void ics_dg_adi_x(ICS_Grid_node* g, int line_start, int line_stop, int node_star
     }
 }
 
-void ics_dg_adi_y(ICS_Grid_node* g, int line_start, int line_stop, int node_start, double r, double* states, double* RHS, double* scratchpad, double* u_diag, double* diag, double* l_diag){
+void ics_dg_adi_y(ICS_Grid_node* g, int line_start, int line_stop, int node_start, double, double* states, double* RHS, double* scratchpad, double* u_diag, double* diag, double* l_diag){
     double* delta = g->ics_adi_dir_y->deltas;
     long* lines = g->ics_adi_dir_y->ordered_line_defs;
     double* alphas = g->_ics_alphas;
@@ -583,7 +534,6 @@ void ics_dg_adi_y(ICS_Grid_node* g, int line_start, int line_stop, int node_star
     long current_index;
     long* ordered_y_nodes = g->ics_adi_dir_y->ordered_nodes;
     long ordered_index = node_start;
-    long N = 0;
 
     for(int i = line_start; i < line_stop - 1; i += 2)
     {
@@ -632,7 +582,7 @@ void ics_dg_adi_y(ICS_Grid_node* g, int line_start, int line_stop, int node_star
     }
 
 }
-void ics_dg_adi_z(ICS_Grid_node* g, int line_start, int line_stop, int node_start, double r, double* states, double* RHS, double* scratchpad, double* u_diag, double* diag, double* l_diag){
+void ics_dg_adi_z(ICS_Grid_node* g, int line_start, int line_stop, int node_start, double, double* states, double* RHS, double* scratchpad, double* u_diag, double* diag, double* l_diag){
     double* delta = g->ics_adi_dir_z->deltas;
     long* lines = g->ics_adi_dir_z->ordered_line_defs;
     long* ordered_z_nodes = g->ics_adi_dir_z->ordered_nodes;
@@ -647,7 +597,6 @@ void ics_dg_adi_z(ICS_Grid_node* g, int line_start, int line_stop, int node_star
     
     long current_index;
     long ordered_index = node_start;
-    long N = 0;
     for(int i = line_start; i< line_stop - 1; i+=2)
     {
         long N = lines[i+1];
@@ -807,7 +756,7 @@ static void variable_step_delta(long start, long stop, long node_start,
     double prev_alpha;
     double current_alpha;
     double next_alpha;
-    double prev_dc, current_dc, next_dc;
+    double current_dc, next_dc;
     for(int i = start; i < stop - 1; i += 2)
     {   
         long line_start = ordered_nodes[ordered_index]; 
@@ -837,7 +786,6 @@ static void variable_step_delta(long start, long stop, long node_start,
                 prev_alpha = current_alpha;
                 current_alpha = next_alpha;
                 next_alpha = alphas[next_index];
-                prev_dc = current_dc;
                 current_dc = next_dc;
                 next_dc = dcs[next_index];
                 ydot[current_index] += (r / current_alpha) * ( current_dc * flux(prev_alpha, current_alpha, prev_state, current_state) + 
@@ -1329,7 +1277,7 @@ static void variable_step_z(ICS_Grid_node* g, int line_start, int line_stop, int
     }
 }
 
-void ics_ode_solve_helper(ICS_Grid_node* g, double dt, const double* CVode_states, double* CVodeRHS)
+void ics_ode_solve_helper(ICS_Grid_node* g, double dt, double* CVodeRHS)
 {
     int num_states = g->_num_nodes;
 

--- a/src/nrnpython/rxd_vol.cpp
+++ b/src/nrnpython/rxd_vol.cpp
@@ -132,7 +132,7 @@ static void ecs_dg_adi_vol_x(ECS_Grid_node* g, const double dt, const int y, con
             if(g->size_z > 1)
                 RHS[0] += (Fxz(zp,zpd,z) - Fxz(z,zmd,zm))/div_z;
             RHS[0] *= (dt/ALPHA(0,y,z));
-            RHS[0] += g->states[IDX(0,y,z)] + g->states_cur[IDX(0,y,z)];
+            RHS[0] += state[IDX(0,y,z)] + g->states_cur[IDX(0,y,z)];
         }
         return;
     }
@@ -166,14 +166,14 @@ static void ecs_dg_adi_vol_x(ECS_Grid_node* g, const double dt, const int y, con
 	    l_diag[g->size_x-2] = -dt*prev/SQ(g->dx);
 
 	    x=0;
-	    RHS[x] = g->states[IDX(x,y,z)] + (dt/ALPHA(x,y,z))*
+	    RHS[x] = state[IDX(x,y,z)] + (dt/ALPHA(x,y,z))*
 					((Fxx(x+1,x)/SQ(g->dx)) 
 				+    (Fxy(yp,ypd,y) - Fxy(y,ymd,ym))/div_y 
 				+ 	 (Fxz(zp,zpd,z) - Fxz(z,zmd,zm))/div_z)
                 + g->states_cur[IDX(x,y,z)];
 
         x = g->size_x-1;
-        RHS[x]  = g->states[IDX(x,y,z)] + (dt/ALPHA(x,y,z))*
+        RHS[x]  = state[IDX(x,y,z)] + (dt/ALPHA(x,y,z))*
 				((Fxx(x-1,x))/SQ(g->dx) 
 			+    (Fxy(yp,ypd,y) - Fxy(y,ymd,ym))/div_y 
 			+ 	 (Fxz(zp,zpd,z) - Fxz(z,zmd,zm))/div_z)
@@ -192,13 +192,13 @@ static void ecs_dg_adi_vol_x(ECS_Grid_node* g, const double dt, const int y, con
 	for(x=1;x<g->size_x-1;x++)
 	{
 #ifndef __PGI
-        __builtin_prefetch(&(g->states[IDX(x+PREFETCH,y,z)]), 0, 1);
-        __builtin_prefetch(&(g->states[IDX(x+PREFETCH,yp,z)]), 0, 0);
-        __builtin_prefetch(&(g->states[IDX(x+PREFETCH,ym,z)]), 0, 0);
-        __builtin_prefetch(&(g->states[IDX(x+PREFETCH,ypd,z)]), 0, 0);
-        __builtin_prefetch(&(g->states[IDX(x+PREFETCH,ymd,z)]), 0, 0);
+        __builtin_prefetch(&(state[IDX(x+PREFETCH,y,z)]), 0, 1);
+        __builtin_prefetch(&(state[IDX(x+PREFETCH,yp,z)]), 0, 0);
+        __builtin_prefetch(&(state[IDX(x+PREFETCH,ym,z)]), 0, 0);
+        __builtin_prefetch(&(state[IDX(x+PREFETCH,ypd,z)]), 0, 0);
+        __builtin_prefetch(&(state[IDX(x+PREFETCH,ymd,z)]), 0, 0);
 #endif
-		RHS[x] =  g->states[IDX(x,y,z)] + (dt/ALPHA(x,y,z))*
+		RHS[x] =  state[IDX(x,y,z)] + (dt/ALPHA(x,y,z))*
 				((Fxx(x+1,x) - Fxx(x,x-1))/SQ(g->dx) 
 			+    (Fxy(yp,ypd,y) - Fxy(y,ymd,ym))/div_y 
 			+ 	 (Fxz(zp,zpd,z) - Fxz(z,zmd,zm))/div_z)
@@ -484,11 +484,11 @@ static void ecs_dg_adi_tort_x(ECS_Grid_node* g, const double dt, const int y, co
         {
             RHS[0] = 0;
             if(g->size_y > 1)
-                RHS[0] += (DcY(0,ypd,z)*g->states[IDX(0,yp,z)] - (DcY(0,ypd,z)+DcY(0,ymd,z))*g->states[IDX(0,y,z)] + DcY(0,ymd,z)*g->states[IDX(0,ym,z)])/(div_y*SQ(g->dy));
+                RHS[0] += (DcY(0,ypd,z)*state[IDX(0,yp,z)] - (DcY(0,ypd,z)+DcY(0,ymd,z))*state[IDX(0,y,z)] + DcY(0,ymd,z)*state[IDX(0,ym,z)])/(div_y*SQ(g->dy));
             if(g->size_z > 1)
-                RHS[0] += (DcZ(0,y,zpd)*g->states[IDX(0,y,zp)] - (DcZ(0,y,zpd)+DcZ(0,y,zmd))*g->states[IDX(0,y,z)] + DcZ(0,y,zmd)*g->states[IDX(0,y,zm)])/(div_z*SQ(g->dz));
+                RHS[0] += (DcZ(0,y,zpd)*state[IDX(0,y,zp)] - (DcZ(0,y,zpd)+DcZ(0,y,zmd))*state[IDX(0,y,z)] + DcZ(0,y,zmd)*state[IDX(0,y,zm)])/(div_z*SQ(g->dz));
             RHS[0] *= dt;
-            RHS[0] += g->states[IDX(0,y,z)] + g->states_cur[IDX(0,y,z)];
+            RHS[0] += state[IDX(0,y,z)] + g->states_cur[IDX(0,y,z)];
         }
         return;
     }
@@ -513,16 +513,16 @@ static void ecs_dg_adi_tort_x(ECS_Grid_node* g, const double dt, const int y, co
 	    l_diag[g->size_x-2] = -0.5*dt*DcX(g->size_x-1,y,z)/SQ(g->dx);
         
 
-	    RHS[0] =  g->states[IDX(0,y,z)]
-			    + dt*((DcX(1,y,z)*g->states[IDX(1,y,z)] - DcX(1,y,z)*g->states[IDX(0,y,z)])/(2.*SQ(g->dx))
-			    +	  (DcY(0,ypd,z)*g->states[IDX(0,yp,z)] - (DcY(0,ypd,z)+DcY(0,ymd,z))*g->states[IDX(0,y,z)] + DcY(0,ymd,z)*g->states[IDX(0,ym,z)])/(div_y*SQ(g->dy))
-			    +	  (DcZ(0,y,zpd)*g->states[IDX(0,y,zp)] - (DcZ(0,y,zpd)+DcZ(0,y,zmd))*g->states[IDX(0,y,z)] + DcZ(0,y,zmd)*g->states[IDX(0,y,zm)])/(div_z*SQ(g->dz)))
+	    RHS[0] =  state[IDX(0,y,z)]
+			    + dt*((DcX(1,y,z)*state[IDX(1,y,z)] - DcX(1,y,z)*state[IDX(0,y,z)])/(2.*SQ(g->dx))
+			    +	  (DcY(0,ypd,z)*state[IDX(0,yp,z)] - (DcY(0,ypd,z)+DcY(0,ymd,z))*state[IDX(0,y,z)] + DcY(0,ymd,z)*state[IDX(0,ym,z)])/(div_y*SQ(g->dy))
+			    +	  (DcZ(0,y,zpd)*state[IDX(0,y,zp)] - (DcZ(0,y,zpd)+DcZ(0,y,zmd))*state[IDX(0,y,z)] + DcZ(0,y,zmd)*state[IDX(0,y,zm)])/(div_z*SQ(g->dz)))
                 + g->states_cur[IDX(0,y,z)];
         x = g->size_x-1;
-        RHS[x] =  g->states[IDX(x,y,z)]
-				+ dt*((DcX(x,y,z)*g->states[IDX(x-1,y,z)] - DcX(x,y,z)*g->states[IDX(x,y,z)])/(2.*SQ(g->dx))
-				+	  (DcY(x,ypd,z)*g->states[IDX(x,yp,z)] - (DcY(x,ypd,z)+DcY(x,ymd,z))*g->states[IDX(x,y,z)] + DcY(x,ymd,z)*g->states[IDX(x,ym,z)])/(div_y*SQ(g->dy))
-				+	  (DcZ(x,y,zpd)*g->states[IDX(x,y,zp)] - (DcZ(x,y,zpd)+DcZ(x,y,zmd))*g->states[IDX(x,y,z)] + DcZ(x,y,zmd)*g->states[IDX(x,y,zm)])/(div_z*SQ(g->dz)))
+        RHS[x] =  state[IDX(x,y,z)]
+				+ dt*((DcX(x,y,z)*state[IDX(x-1,y,z)] - DcX(x,y,z)*state[IDX(x,y,z)])/(2.*SQ(g->dx))
+				+	  (DcY(x,ypd,z)*state[IDX(x,yp,z)] - (DcY(x,ypd,z)+DcY(x,ymd,z))*state[IDX(x,y,z)] + DcY(x,ymd,z)*state[IDX(x,ym,z)])/(div_y*SQ(g->dy))
+				+	  (DcZ(x,y,zpd)*state[IDX(x,y,zp)] - (DcZ(x,y,zpd)+DcZ(x,y,zmd))*state[IDX(x,y,z)] + DcZ(x,y,zmd)*state[IDX(x,y,zm)])/(div_z*SQ(g->dz)))
                 + g->states_cur[IDX(x,y,z)];
 
     }
@@ -539,15 +539,15 @@ static void ecs_dg_adi_tort_x(ECS_Grid_node* g, const double dt, const int y, co
 	for(x=1;x<g->size_x-1;x++)
 	{
 #ifndef __PGI
-        __builtin_prefetch(&(g->states[IDX(x+PREFETCH,y,z)]), 0, 1);
-        __builtin_prefetch(&(g->states[IDX(x+PREFETCH,yp,z)]), 0, 0);
-        __builtin_prefetch(&(g->states[IDX(x+PREFETCH,ym,z)]), 0, 0);
+        __builtin_prefetch(&(state[IDX(x+PREFETCH,y,z)]), 0, 1);
+        __builtin_prefetch(&(state[IDX(x+PREFETCH,yp,z)]), 0, 0);
+        __builtin_prefetch(&(state[IDX(x+PREFETCH,ym,z)]), 0, 0);
 #endif
  
-		RHS[x] =  g->states[IDX(x,y,z)]
-			+ dt*((DcX(x+1,y,z)*g->states[IDX(x+1,y,z)] - (DcX(x+1,y,z)+DcX(x,y,z))*g->states[IDX(x,y,z)] + DcX(x,y,z)*g->states[IDX(x-1,y,z)])/(2.*SQ(g->dx))
-            + (DcY(x,ypd,z)*g->states[IDX(x,yp,z)] - (DcY(x,ypd,z)+DcY(x,ymd,z))*g->states[IDX(x,y,z)] + DcY(x,ymd,z)*g->states[IDX(x,ym,z)])/(div_y*SQ(g->dy))
-            + (DcZ(x,y,zpd)*g->states[IDX(x,y,zp)] - (DcZ(x,y,zpd)+DcZ(x,y,zmd))*g->states[IDX(x,y,z)] + DcZ(x,y,zmd)*g->states[IDX(x,y,zm)])/(div_z*SQ(g->dz)))
+		RHS[x] =  state[IDX(x,y,z)]
+			+ dt*((DcX(x+1,y,z)*state[IDX(x+1,y,z)] - (DcX(x+1,y,z)+DcX(x,y,z))*state[IDX(x,y,z)] + DcX(x,y,z)*state[IDX(x-1,y,z)])/(2.*SQ(g->dx))
+            + (DcY(x,ypd,z)*state[IDX(x,yp,z)] - (DcY(x,ypd,z)+DcY(x,ymd,z))*state[IDX(x,y,z)] + DcY(x,ymd,z)*state[IDX(x,ym,z)])/(div_y*SQ(g->dy))
+            + (DcZ(x,y,zpd)*state[IDX(x,y,zp)] - (DcZ(x,y,zpd)+DcZ(x,y,zmd))*state[IDX(x,y,z)] + DcZ(x,y,zmd)*state[IDX(x,y,zm)])/(div_z*SQ(g->dz)))
             + g->states_cur[IDX(x,y,z)];
 	}
 	
@@ -557,6 +557,7 @@ static void ecs_dg_adi_tort_x(ECS_Grid_node* g, const double dt, const int y, co
 	free(l_diag);
 	free(u_diag);
 }
+
 
 /* dg_adi_tort_y performs the second of 3 steps in DG-ADI
  * g    -   the parameters and state of the grid
@@ -826,7 +827,7 @@ void _rhs_variable_step_helper_tort(Grid_node* g, double const * const states, d
         }
     }
     else {
-        for (i = 0, index = 0, next_i = num_states_y*num_states_z; 
+        for (i = 0, index = 0, prev_i = 0, next_i = num_states_y*num_states_z; 
              i < num_states_x; i++) {
             for(j = 0, prev_j = index - num_states_z, next_j = index + num_states_z; j < num_states_y; j++) {
                 
@@ -938,7 +939,7 @@ void _rhs_variable_step_helper_vol(Grid_node* g, double const * const states, do
         }
     }
     else {
-        for (i = 0, index = 0, next_i = num_states_y*num_states_z; 
+        for (i = 0, index = 0, prev_i = 0, next_i = num_states_y*num_states_z; 
              i < num_states_x; i++) {
             for(j = 0, prev_j = index - num_states_z, next_j = index + num_states_z; j < num_states_y; j++) {
                 


### PR DESCRIPTION
Several unused functions, unused parameters, signed/unsigned comparisons and non-virtual destructor warnings.