### PR TITLE
Pointer can be dereferenced only if non-NULL.

### DIFF
--- a/src/nrniv/nrnbbcore_write.cpp
+++ b/src/nrniv/nrnbbcore_write.cpp
@@ -780,7 +780,7 @@ int nrn_dblpntr2nrncore(double* pd, NrnThread& nt, int& type, int& index) {
   if (pd >= nt._actual_v && pd < (nt._actual_v + nnode)) {
     type = voltage; // signifies an index into voltage array portion of _data
     index = pd - nt._actual_v;
-  } else if (pd >= nt._nrn_fast_imem->_nrn_sav_rhs && pd < (nt._nrn_fast_imem->_nrn_sav_rhs + nnode)) {
+  } else if (nt._nrn_fast_imem && pd >= nt._nrn_fast_imem->_nrn_sav_rhs && pd < (nt._nrn_fast_imem->_nrn_sav_rhs + nnode)) {
     type = i_membrane_; // signifies an index into i_membrane_ array portion of _data
     index = pd - nt._nrn_fast_imem->_nrn_sav_rhs;
   }else{


### PR DESCRIPTION
Fast imembrane_ may not be in use.

Segmentation error occurred with testnetstimdirect.hoc of http://github.com/nrnhines/testcorenrn