### PR TITLE
separate nbconvert target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -211,6 +211,9 @@ after_success:
       echo "------- Build Doxygen Documentation -------";
       pushd $TRAVIS_BUILD_DIR/build;
       make doxygen;
+      echo "------- Prepare Docs for Sphinx -------";
+      pushd $TRAVIS_BUILD_DIR/build;
+      make prepare_docs;
       echo "-------- Build Sphinx documentation --------";
       pushd $TRAVIS_BUILD_DIR/build;
       make sphinx;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,6 @@ if(SPHINX_FOUND)
           WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
           COMMENT "Generating documentation with Sphinx"
   )
-  add_dependencies(sphinx prepare_docs)
 endif()
 
 # =============================================================================

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,14 @@ NEURON consolidated documentation is available at [https://neuronsimulator.githu
 
 #### Local build
 
+It is recommended using a `virtualenv`, for example:
+
+```
+pip3 install virtualenv
+python3 -m virtualenv venv
+source venv/bin/activate
+```
+
 In order to build documentation locally, you need to pip install the [docs_requirements](docs_requirements.txt) :
 ```
 pip3 install --user -r docs/docs_requirements.txt --upgrade
@@ -23,8 +31,11 @@ pip3 install --user -r docs/docs_requirements.txt --upgrade
 Then in your CMake build folder:
 ```
 make doxygen
+make prepare_docs
 make sphinx
 ```  
 That will build everything in the `build/docs` folder and you can then open `index.html` locally.
 
-Sidenote: these actions can be observed in [.travis.yml](../.travis.yml)
+Sidenotes:
+ * these actions can be observed in [.travis.yml](../.travis.yml)
+ * `prepare_docs` converts jupyter notebooks to html


### PR DESCRIPTION
Remove CMake `prepare_docs` dependency for `sphinx`. 
By doing so, `make sphinx` will work faster in case of local re-runs. 