### PR TITLE
Look for corenrn_embedded_run instead of corenrn_version for CoreNEURON

### DIFF
--- a/src/nrniv/nrnbbcore_write.cpp
+++ b/src/nrniv/nrnbbcore_write.cpp
@@ -1899,7 +1899,7 @@ extern char* neuron_home;
 /** Check if coreneuron is loaded into memory */
 bool is_coreneuron_loaded() {
     bool is_loaded = false;
-    // check if corenrn_version symbol can be found
+    // check if corenrn_embedded_run symbol can be found
     void * handle = dlopen(NULL, RTLD_NOW | RTLD_GLOBAL);
     if (handle) {
         void* fn = dlsym(handle, "corenrn_embedded_run");

--- a/src/nrniv/nrnbbcore_write.cpp
+++ b/src/nrniv/nrnbbcore_write.cpp
@@ -1902,7 +1902,7 @@ bool is_coreneuron_loaded() {
     // check if corenrn_version symbol can be found
     void * handle = dlopen(NULL, RTLD_NOW | RTLD_GLOBAL);
     if (handle) {
-        void* fn = dlsym(handle, "corenrn_version");
+        void* fn = dlsym(handle, "corenrn_embedded_run");
         is_loaded = fn == NULL ? false : true;
         dlclose(handle);
     }


### PR DESCRIPTION
  - for coreneuron launching we need to run corenrn_embedded_run
    and that's what we should look for in the process's memory space
  - with multiple execution of coreneuron from neuron we have seen
    that corenrn_version exists in memory space but not
    corenrn_embedded_run