### PR TITLE
ion style error

### DIFF
--- a/src/nrnoc/eion.c
+++ b/src/nrnoc/eion.c
@@ -238,7 +238,7 @@ double nrn_nernst(ci, co, z) double z, ci, co; {
 }
 
 void nrn_wrote_conc(sym, pe, it) Symbol* sym; double* pe; int it; {
-	if (it & 04) {
+	if (it & 040) {
 		pe[0] = nrn_nernst(pe[1], pe[2], nrn_ion_charge(sym));
 	}
 }


### PR DESCRIPTION
nrn_wrote_conc was using the cinit slot rather than einit slot to
determine whether to re-initialize the reversal potential using the
nernst equation due to a change of concentation in the INITIAL block of
a mechanism that WRITE a concentation. (By default, the cinit and
einit slots have the same value but can differ if the user specified
an explicit ion_style.