### PR TITLE
callback for returning spikes from CORENEURON

### DIFF
--- a/src/nrniv/netpar.cpp
+++ b/src/nrniv/netpar.cpp
@@ -74,7 +74,7 @@ extern double nrnmpi_step_wait_; // barrier at beginning of spike exchange.
  *
  * @param spiketvec - vector of spikes
  * @param spikegidvec - vector of gids
- * @return true if we copy incoming vectors' data
+ * @return 1 if CORENEURON shall drop writing `out.dat`; 0 otherwise
  */
 int nrnthread_all_spike_vectors_return(std::vector<double>& spiketvec, std::vector<int>& spikegidvec);
 
@@ -1108,12 +1108,12 @@ void BBS::outputcell(int gid) {
 void BBS::spike_record(int gid, IvocVect* spikevec, IvocVect* gidvec) {
 	PreSyn* ps;
     if (gid >= 0) {
+        all_spiketvec = NULL, all_spikegidvec = NULL; // invalidate global spike vectors
         nrn_assert(gid2out_->find(gid, ps));
         assert(ps);
         ps->record(spikevec, gidvec, gid);
-    }else{ // record all output spikes
-        all_spiketvec = spikevec;
-        all_spikegidvec = gidvec;
+    }else{ // record all output spikes.
+        all_spiketvec = spikevec, all_spikegidvec = gidvec; // track global spike vectors (optimisation)
         NrnHashIterate(Gid2PreSyn, gid2out_, PreSyn*, ps) {
             if (ps->output_index_ >= 0) {
                 ps->record(all_spiketvec, all_spikegidvec, ps->output_index_);
@@ -1124,6 +1124,7 @@ void BBS::spike_record(int gid, IvocVect* spikevec, IvocVect* gidvec) {
 
 void BBS::spike_record(IvocVect* gids, IvocVect* spikevec, IvocVect* gidvec) {
 	int sz = vector_capacity(gids);
+    all_spiketvec = NULL, all_spikegidvec = NULL; // invalidate global spike vectors
 	double* pd = vector_vec(gids);
 	for (int i = 0; i < sz; ++i) {
 		PreSyn* ps;
@@ -1301,23 +1302,31 @@ void BBS::netpar_solve(double tstop) {
 }
 
 int nrnthread_all_spike_vectors_return(std::vector<double>& spiketvec, std::vector<int>& spikegidvec){
-    /*
-     * if all_spiketvec and all_spikegidvec are set (pc.spike_record with gid=-1 was called) 
-     * and they are still reference counted (obj_->refcount), then copy over incoming vectors
-     */
-    if(all_spiketvec != NULL && all_spiketvec->obj_ != NULL  && all_spiketvec->obj_->refcount > 0 &&
-        all_spikegidvec != NULL && all_spikegidvec->obj_ != NULL && all_spikegidvec->obj_->refcount > 0) {
-        
-        all_spiketvec->resize(spiketvec.size());
-        all_spikegidvec->resize(spikegidvec.size());
-        assert(all_spiketvec->capacity() == all_spikegidvec->capacity());
-        for(int i = 0; i < all_spiketvec->capacity(); ++i ) {
-            all_spiketvec->elem(i) = spiketvec[i];
-            all_spikegidvec->elem(i) = spikegidvec[i];
+    assert(spiketvec.size() == spikegidvec.size());
+    if( spiketvec.size() ) {
+        /* Optimisation:
+         *  if all_spiketvec and all_spikegidvec are set (pc.spike_record with gid=-1 was called)
+         *  and they are still reference counted (obj_->refcount), then copy over incoming vectors.
+         */
+        if (all_spiketvec != NULL && all_spiketvec->obj_ != NULL  && all_spiketvec->obj_->refcount > 0 &&
+            all_spikegidvec != NULL && all_spikegidvec->obj_ != NULL && all_spikegidvec->obj_->refcount > 0) {
+
+            all_spiketvec->resize(spiketvec.size());
+            all_spikegidvec->resize(spikegidvec.size());
+            for (int i = 0; i < all_spiketvec->capacity(); ++i) {
+                all_spiketvec->elem(i) = spiketvec[i];
+                all_spikegidvec->elem(i) = spikegidvec[i];
+            }
+        }else{ // different underlying vectors for PreSyns
+            for (int i = 0; i < spikegidvec.size(); ++i ) {
+                PreSyn* ps;
+                if (gid2out_->find(spikegidvec[i], ps)) {
+                    ps->record(spiketvec[i]);
+                }
+            }
         }
-        return 1;
     }
-    return 0;
+    return 1;
 }
 
 

--- a/src/nrniv/nrnbbcore_write.cpp
+++ b/src/nrniv/nrnbbcore_write.cpp
@@ -1869,7 +1869,7 @@ void nrnthread_trajectory_return(int tid, int n_pr, int vecsz, void** vpr, doubl
 }
 
 extern "C" {
-extern void nrnthread_all_spike_vectors_return(std::vector<double>& spiketvec, std::vector<int>& spikegidvec);
+extern int nrnthread_all_spike_vectors_return(std::vector<double>& spiketvec, std::vector<int>& spikegidvec);
 }
 
 static core2nrn_callback_t cnbs[]  = {

--- a/src/nrniv/nrnbbcore_write.cpp
+++ b/src/nrniv/nrnbbcore_write.cpp
@@ -1868,6 +1868,10 @@ void nrnthread_trajectory_values(int tid, int n_pr, void** vpr, double t);
 void nrnthread_trajectory_return(int tid, int n_pr, int vecsz, void** vpr, double t);
 }
 
+extern "C" {
+extern void nrnthread_all_spike_vectors_return(std::vector<double>& spiketvec, std::vector<int>& spikegidvec);
+}
+
 static core2nrn_callback_t cnbs[]  = {
   {"nrn2core_group_ids_", (CNB)nrnthread_group_ids},
   {"nrn2core_mkmech_info_", (CNB)write_memb_mech_types_direct},
@@ -1888,6 +1892,8 @@ static core2nrn_callback_t cnbs[]  = {
   {"nrn2core_get_trajectory_requests_", (CNB)nrnthread_get_trajectory_requests},
   {"nrn2core_trajectory_values_", (CNB)nrnthread_trajectory_values},
   {"nrn2core_trajectory_return_", (CNB)nrnthread_trajectory_return},
+
+  {"nrn2core_all_spike_vectors_return_", (CNB)nrnthread_all_spike_vectors_return},
   {NULL, NULL}
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -122,7 +122,17 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
     add_test(NAME coreneuron_direct_hoc COMMAND ${CMAKE_BINARY_DIR}/bin/nrniv
                                             ${PROJECT_SOURCE_DIR}/test/coreneuron/test_direct.hoc
                                     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
-    list(APPEND TESTS coreneuron_direct_py coreneuron_direct_hoc)
+    add_test(NAME coreneuron_spikes_py COMMAND ${PYTHON_EXECUTABLE}
+                                            ${PROJECT_SOURCE_DIR}/test/coreneuron/test_spikes.py
+                                    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
+    list(APPEND TESTS coreneuron_direct_py coreneuron_direct_hoc coreneuron_spikes_py)
+    if(NRN_ENABLE_MPI)
+      add_test(
+              NAME coreneuron_mpi_spikes_py
+              COMMAND
+              ${MPIEXEC} -np 2 ${CMAKE_BINARY_DIR}/bin/nrniv -python ${PROJECT_SOURCE_DIR}/test/coreneuron/test_spikes.py)
+      list(APPEND TESTS coreneuron_mpi_spikes_py)
+    endif()
   endif()
 endif()
 set_tests_properties(${TESTS} PROPERTIES ENVIRONMENT "${TEST_ENV}")

--- a/test/coreneuron/test_spikes.py
+++ b/test/coreneuron/test_spikes.py
@@ -1,0 +1,79 @@
+import pytest
+import sys
+
+from neuron import h, gui
+
+def test_spikes():
+    h('''create soma''')
+    h.soma.L=5.6419
+    h.soma.diam=5.6419
+    h.soma.insert("hh")
+    h.soma.nseg = 3
+    ic = h.IClamp(h.soma(.25))
+    ic.delay = .1
+    ic.dur = 0.1
+    ic.amp = 0.3
+
+    ic2 = h.IClamp(h.soma(.75))
+    ic2.delay = 5.5
+    ic2.dur = 1
+    ic2.amp = 0.3
+
+    h.tstop = 10
+    h.cvode.use_fast_imem(1)
+    h.cvode.cache_efficient(1)
+
+    pc = h.ParallelContext()
+  
+    pc.set_gid2node(pc.id()+1, pc.id())
+    myobj = h.NetCon(h.soma(0.5)._ref_v, None, sec=h.soma)
+    pc.cell(pc.id()+1, myobj)
+
+
+    # NEURON spikes run
+    nrn_spike_t = h.Vector()
+    nrn_spike_gids = h.Vector()
+    pc.spike_record(-1, nrn_spike_t, nrn_spike_gids)
+
+    h.run()
+   
+    nrn_spike_t = nrn_spike_t.to_python()
+    nrn_spike_gids = nrn_spike_gids.to_python()
+
+    # CORENEURON spike_record(-1):
+    from neuron import coreneuron
+    coreneuron.enable = True
+    h.stdinit()
+    corenrn_all_spike_t = h.Vector()
+    corenrn_all_spike_gids = h.Vector()
+    
+    pc.spike_record(-1, corenrn_all_spike_t, corenrn_all_spike_gids)
+    pc.psolve(h.tstop)
+
+    corenrn_all_spike_t = corenrn_all_spike_t.to_python()
+    corenrn_all_spike_gids = corenrn_all_spike_gids.to_python()
+
+
+    # CORENEURON spike_record(gidlist):
+    h.stdinit()
+    corenrn_gidlist_spike_t = h.Vector()
+    corenrn_gidlist_spike_gids = h.Vector()
+    pc.spike_record((pc.id()+1), corenrn_gidlist_spike_t, corenrn_gidlist_spike_gids)
+    pc.psolve(h.tstop)  
+
+    corenrn_gidlist_spike_t = corenrn_gidlist_spike_t.to_python()
+    corenrn_gidlist_spike_gids = corenrn_gidlist_spike_gids.to_python()
+
+    # check spikes match
+    assert(len(nrn_spike_t)) # check we've actually got spikes
+    assert(len(nrn_spike_t) == len(nrn_spike_gids)); # matching no. of gids
+    assert(nrn_spike_t == corenrn_all_spike_t)
+    assert(nrn_spike_gids == corenrn_all_spike_gids)
+    assert(corenrn_gidlist_spike_t == corenrn_all_spike_t)
+    assert(corenrn_gidlist_spike_gids == corenrn_all_spike_gids)
+
+    h.quit()
+  
+
+if __name__ == "__main__":
+    test_spikes()


### PR DESCRIPTION
NEURON facing callback: when we record all or some output spikes (i.e `pc.spike_record( -1)` or `pc.spike_record(gidlist)`) provide a callback so that CORENEURON can returnspike vectors. 

In link with : https://github.com/BlueBrain/CoreNeuron/pull/354 