### PR TITLE
sysconfig provenance requires major.minor in libpython name.

### DIFF
--- a/bin/nrnpyenv.sh
+++ b/bin/nrnpyenv.sh
@@ -320,8 +320,9 @@ def nrnpylib_linux():
   libdir=sysconfig.get_config_var("LIBDIR")
   try:
     from os.path import isfile, join
+    ver = "%d.%d"%(sys.version_info[0], sys.version_info[1])
     for f in os.listdir(libdir):
-      if 'libpython' in f and '.so' in f:
+      if 'libpython' in f and '.so' in f and ver in f:
         nrn_pylib = join(libdir, f)
         nrnpylib_provenance='sysconfig LIBDIR'
         return nrn_pylib


### PR DESCRIPTION
On Centos7, it so happens that libpython2.7.so and libpython3.7.so are in the same folder and, as the former is alphabetically earlier than the latter, 'nrnpyenv python3' wrongly computed the former as the value for NRN_PYENV.
This fixes Issue #743 