### PR TITLE
Fix some ctest errors.

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -39,6 +39,9 @@ nrn_configure_file(nrnivmodl bin)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nrnivmodl_makefile_cmake.in
                ${PROJECT_BINARY_DIR}/bin/nrnmech_makefile @ONLY)
 
+# if running from the build folder (e.g. make test) may need this.
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/nrnpyenv.sh DESTINATION ${PROJECT_BINARY_DIR}/bin)
+
 # =============================================================================
 # Install targets
 # =============================================================================

--- a/test/pynrn/test_basic.py
+++ b/test/pynrn/test_basic.py
@@ -83,13 +83,13 @@ def test_nrntest_test_2():
     assert str(h.dend[1].name()) == "dend[1]"
 
     def e(stmt):
+        err = 0
         try:
-            exec(stmt)
+            exec(stmt, globals(), locals())
         except Exception:
-            assert (
-                str(sys.exc_info()[0]) + ': ' + str(sys.exc_info()[1])
-                == "<class 'TypeError'>: not assignable"
-            )
+            assert ('not assignable' in str(sys.exc_info()[1]))
+            err = 1
+        assert(err == 1)
 
     e('h.axon = 1')
     e('h.dend[1] = 1')


### PR DESCRIPTION
When -DNRN_ENABLE_PYTHON_DYNAMIC=ON ctest may run nrniv from
CMAKE_PROJECT_BUILD/bin and that may need a copy of nrnpyenv.sh
there as well.

ctest can exhibit the error:
SyntaxError: unqualified exec is not allowed in function 'e' because it
is a nested function (test_basic.py, line 87)
