### PR TITLE
Stopped caching constants in rxd and moved calls to constants.NA into functions.

### DIFF
--- a/share/lib/python/neuron/rxd/constants.py
+++ b/share/lib/python/neuron/rxd/constants.py
@@ -10,3 +10,8 @@ def NA():
     val = NA_modern
   return val
 
+def molecules_per_mM_um3():
+    # converting from mM um^3 to molecules
+    # = 6.02214129e23 * 1000. / 1.e18 / 1000
+    # = avogadro * (L / m^3) * (m^3 / um^3) * (mM / M)
+    return NA() / 1e18

--- a/share/lib/python/neuron/rxd/generalizedReaction.py
+++ b/share/lib/python/neuron/rxd/generalizedReaction.py
@@ -10,11 +10,6 @@ _weakref_ref = weakref.ref
 _itertools_chain = itertools.chain
 _numpy_array = numpy.array
 
-# converting from mM um^3 to molecules
-# = 6.02214129e23 * 1000. / 1.e18 / 1000
-# = avogadro * (L / m^3) * (m^3 / um^3) * (mM / M)
-molecules_per_mM_um3 = constants.NA() / 1e18
-
 def ref_list_with_mult(obj):
     result = []
     for i, p in zip(list(obj.keys()), list(obj.values())):
@@ -228,6 +223,8 @@ class GeneralizedReaction(object):
         #self._mult = [list(-1. / volumes[sources_indices]) + list(1. / volumes[dests_indices])]
         if self._trans_membrane and active_regions:
             # note that this assumes (as is currently enforced) that if trans-membrane then only one region
+
+            molecules_per_mM_um3 = constants.molecules_per_mM_um3()
 
             # TODO: verify the areas and volumes are in the same order!
             areas = _numpy_array(list(_itertools_chain.from_iterable([list(self._regions[0]._geometry.volumes1d(sec)) for sec in active_secs_list])))

--- a/share/lib/python/neuron/rxd/multiCompartmentReaction.py
+++ b/share/lib/python/neuron/rxd/multiCompartmentReaction.py
@@ -1,12 +1,11 @@
 import weakref
 from . import rxdmath, rxd, node, species, region, initializer
 import numpy
-from .generalizedReaction import GeneralizedReaction, molecules_per_mM_um3, get_scheme_rate1_rate2_regions_custom_dynamics_mass_action
+from .generalizedReaction import GeneralizedReaction, get_scheme_rate1_rate2_regions_custom_dynamics_mass_action
+from .constants import molecules_per_mM_um3
 from neuron import h
 import itertools
 from .rxdException import RxDException
-
-FARADAY = h.FARADAY
 
 def _ref_list_with_mult(obj):
     result = []
@@ -233,7 +232,7 @@ class MultiCompartmentReaction(GeneralizedReaction):
         area_ratios = areas / neuron_areas
         
         # still needs to be multiplied by the valence of each molecule
-        self._memb_scales = -area_ratios * FARADAY / (10000 * molecules_per_mM_um3)
+        self._memb_scales = -area_ratios * h.FARADAY / (10000 * molecules_per_mM_um3())
         
         # since self._memb_scales is only used to compute currents as seen by the rest of NEURON,
         # we only use NEURON's areas 

--- a/share/lib/python/neuron/rxd/node.py
+++ b/share/lib/python/neuron/rxd/node.py
@@ -30,8 +30,6 @@ _point_indices = {}
 _concentration_node = 0
 _molecule_node = 1
 
-molecules_per_mM_um3 = constants.NA() / 1e18
-
 def _get_data():
     return (_volumes, _surface_area, _diffs)
 
@@ -275,7 +273,7 @@ class Node(object):
         # once this is done, we need to divide by volume to get mM
         # TODO: is division still slower than multiplication? Switch to mult.
         if units == 'molecule/ms':
-            scale = molecules_per_mM_um3
+            scale = constants.molecules_per_mM_um3()
         elif units == 'mol/ms':
             # You have: mol
             # You want: (millimol/L) * um^3

--- a/share/lib/python/neuron/rxd/rxd.py
+++ b/share/lib/python/neuron/rxd/rxd.py
@@ -19,7 +19,6 @@ from numpy.ctypeslib import ndpointer
 import re
 import platform
 from warnings import warn
-molecules_per_mM_um3 = constants.NA() / 1e18
 
 # aliases to avoid repeatedly doing multiple hash-table lookups
 _numpy_array = numpy.array
@@ -223,9 +222,6 @@ def byeworld():
     _windows_remove_dlls()
     
 atexit.register(byeworld)
-
-# Faraday's constant (store to reduce number of lookups)
-FARADAY = h.FARADAY
 
 _cvode_object = h.CVode()
 
@@ -1244,6 +1240,7 @@ def _compile_reactions():
                           _c_compile(fxn_string))
 
     #Setup intracellular 3D reactions
+    molecules_per_mM_um3 = constants.molecules_per_mM_um3()
     if regions_inv_3d:
         for reg in regions_inv_3d:
             ics_grid_ids = []

--- a/share/lib/python/neuron/rxd/section1d.py
+++ b/share/lib/python/neuron/rxd/section1d.py
@@ -233,7 +233,7 @@ class Section1D(rxdsection.RxDSection):
                 sign = 1
             else:
                 raise RxDException('bad nrn_region for setting up currents (should never get here)')
-            scales.append(sign * surface_area[self.indices] * 10000. / (self.species.charge * rxd.FARADAY * volumes[self.indices]))
+            scales.append(sign * surface_area[self.indices] * 10000. / (self.species.charge * h.FARADAY * volumes[self.indices]))
             for i in range(self.nseg):
                 seg = self._sec((i + 0.5) / self.nseg)
                 cur_map[self.species.name + self.nrn_region][seg] = len(ptrs)

--- a/share/lib/python/neuron/rxd/species.py
+++ b/share/lib/python/neuron/rxd/species.py
@@ -1690,7 +1690,7 @@ class Species(_SpeciesMathable):
                 charge = self.charge
                 namei = self._name + 'i'
                 nameo = self._name + 'o'
-                tenthousand_over_charge_faraday = 10000. / (charge * rxd.FARADAY)
+                tenthousand_over_charge_faraday = 10000. / (charge * h.FARADAY)
                 for i, nodeobj in enumerate(self._nodes):
                     if surface_area[i]:
                         r = nodeobj.region

--- a/share/lib/python/neuron/rxd/species.py
+++ b/share/lib/python/neuron/rxd/species.py
@@ -806,7 +806,7 @@ class _IntracellularSpecies(_SpeciesMathable):
                 return(len(sig.parameters))
             else:
                 sig = inspect.getargspec(fun)
-                if sig.args != None or sig.keywords != None:
+                if sig.varargs != None or sig.keywords != None:
                     raise RxDException("Intracellular diffusion coefficient function may not include *args or *kwargs")
                 return len(sig.args)
         dc = None

--- a/share/lib/python/neuron/rxdtests/do_test.py
+++ b/share/lib/python/neuron/rxdtests/do_test.py
@@ -22,7 +22,7 @@ def do_test(test_to_run, results_location, num_record=10):
     
     import itertools
     
-
+    h.nrnunit_use_legacy(True)
     data = {'record_count': 0, 'data': []}
     do_test.data=data
     record_count = 0

--- a/test/rxd/conftest.py
+++ b/test/rxd/conftest.py
@@ -25,7 +25,6 @@ def neuron_import(request):
 
     neuron.load_mechanisms(osp.abspath(osp.dirname(__file__)))
     from neuron import h, rxd
-
     return h, rxd, save_path
 
 @pytest.fixture
@@ -39,6 +38,8 @@ def neuron_instance(neuron_import):
     h, rxd, save_path = neuron_import
     data = {'record_count': 0, 'data': []}
     h.load_file('stdrun.hoc')
+
+    h.nrnunit_use_legacy(True) 
     
     # pytest fixtures at the function scope that require neuron_instance will go    # out of scope after neuron_instance. So species, sections, etc. will go 
     # out of scope after neuron_instance is torn down. 

--- a/test/rxd/test_currents.py
+++ b/test/rxd/test_currents.py
@@ -36,7 +36,10 @@ def test_currents(model_pump):
 
     neuron_instance, model = model_pump
     h, rxd, data = neuron_instance
+    # check changing the units after initialization
+    h.nrnunit_use_legacy(False)
     h.finitialize(-65)
+    h.nrnunit_use_legacy(True)
     h.continuerun(10)
     max_err = compare_data(data)
     assert max_err < tol
@@ -46,8 +49,11 @@ def test_currents_cvode(model_pump):
 
     neuron_instance, model = model_pump
     h, rxd, data = neuron_instance
+    # check changing the units after initialization
     h.CVode().active(True)
+    h.nrnunit_use_legacy(False)
     h.finitialize(-65)
+    h.nrnunit_use_legacy(True)
     h.continuerun(10)
     max_err = compare_data(data)
     assert max_err < tol


### PR DESCRIPTION
This avoids storing constants on import which will be inconsistent if you then switch to using the legacy values.