### PR TITLE
Avoid "NEURON model internal structures are out of date" error while running NEURON

### DIFF
--- a/src/nrniv/netpar.cpp
+++ b/src/nrniv/netpar.cpp
@@ -1235,11 +1235,14 @@ int nrn_set_timeout(int timeout) {
 void BBS::netpar_solve(double tstop) {
 	// temporary check to be eventually replaced by verify_structure()
 	extern int tree_changed, v_structure_change, diam_changed;
-	if (tree_changed || v_structure_change) {
-	  hoc_execerror("NEURON model internal structures are out of date",NULL);
-        }
+    if (tree_changed) {
+        setup_topology();
+    }
+    if (v_structure_change) {
+        v_setup_vectors();
+    }
 	if (diam_changed) {
-	  recalc_diam();
+	     recalc_diam();
 	}
 	// if cvode_active, and anything at all has changed, should call re_init
 


### PR DESCRIPTION
  - In commit 674dbac2390529e240 provision was added to terminate execution
    if model structure is changed
  - But this change was strictly required in case of CoreNEURON
  - In case of NEURON execution, we now allow execution after setting vectors
    and topology.

fixes #745