### PR TITLE
autotools: -with-paranrn: CXX loses the -std=c++11 flag.

### DIFF
--- a/m4/withmpi.m4
+++ b/m4/withmpi.m4
@@ -26,6 +26,10 @@ dnl AC_SUBST(LIBTOOL)
 		    if test "$nrnmpi_dynamic" = "no" ; then
 			CC=$MPICC
 			CXX=$MPICXX
+			dnl above line loses the earlier -std=c++11 flag
+                        dnl so re-evaluate CXX and copy to MPICXX
+			AX_CXX_COMPILE_STDCXX(11, noext, mandatory)
+			MPICXX="$CXX"
 		    fi
 			MPICCnrnmpi=$MPICC
 			LIBTOOLTAG='--tag=CC'


### PR DESCRIPTION
This was a compile error problem on centos7 with mpich compiled with
gcc4.8.

Closes #776 
