### PR TITLE
MPI_Abort if hoc_execerror from python and nhost > 1.

### DIFF
--- a/src/oc/hoc.c
+++ b/src/oc/hoc.c
@@ -700,7 +700,7 @@ void hoc_execerror_mes(const char* s, const char* t, int prnt){	/* recover from 
 	ctp = cbuf;
 	*ctp = '\0';
 
-	if (oc_jump_target_) {
+	if (oc_jump_target_ && nrnmpi_numprocs_world == 1) {
 		hoc_newobj1_err();
 		(*oc_jump_target_)();
 	}


### PR DESCRIPTION
This came up recently again and a brute force solution is implemented here. See #635 for a sense in which this is problematic.
@pramodk Please try in your context to see if this resolves your issue.