### PR TITLE
Use early numpy wheel for each neuron wheel.

### DIFF
--- a/ci/win_install_deps.cmd
+++ b/ci/win_install_deps.cmd
@@ -23,10 +23,10 @@ pwsh -command "(Get-Content C:\Python38\Lib\distutils\cygwinccompiler.py) -repla
 pwsh -command "(Get-Content C:\Python27\Lib\distutils\cygwinccompiler.py) -replace 'msvcr90', 'msvcrt' | Out-File C:\Python27\Lib\distutils\cygwinccompiler.py"
 
 :: install numpy
-C:\Python35\python.exe -m pip install numpy || goto :error
-C:\Python36\python.exe -m pip install numpy || goto :error
-C:\Python37\python.exe -m pip install numpy || goto :error
-C:\Python38\python.exe -m pip install numpy || goto :error
+C:\Python35\python.exe -m pip install numpy==1.10.4 || goto :error
+C:\Python36\python.exe -m pip install numpy==1.12.1 || goto :error
+C:\Python37\python.exe -m pip install numpy==1.14.6 || goto :error
+C:\Python38\python.exe -m pip install numpy==1.17.5 || goto :error
 C:\Python27\python.exe -m pip install numpy || goto :error
 
 :: install nsis

--- a/packaging/python/build_requirements.txt
+++ b/packaging/python/build_requirements.txt
@@ -1,3 +1,2 @@
 cython
-numpy
 

--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -53,10 +53,10 @@ pip_numpy_install() {
     # numpy is special as we want the minimum wheel version
     numpy_ver="numpy"
     case "$py_ver" in
-      35) numpy_ver="numpy==1.10.1" ;;
+      35) numpy_ver="numpy==1.10.4" ;;
       36) numpy_ver="numpy==1.12.1" ;;
-      37) numpy_ver="numpy==1.15.1" ;;
-      38) numpy_ver="numpy==1.17.4" ;;
+      37) numpy_ver="numpy==1.14.6" ;;
+      38) numpy_ver="numpy==1.17.5" ;;
       39) numpy_ver="numpy==1.19.3" ;;
       *) numpy_ver="numpy";;
     esac

--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -23,9 +23,11 @@ if [ ! -f setup.py ]; then
     exit 1
 fi
 
+py_ver=""
+
 setup_venv() {
     local py_bin="$1"
-    local py_ver=$("$py_bin" -c "import sys; print('%d%d' % tuple(sys.version_info)[:2])")
+    py_ver=$("$py_bin" -c "import sys; print('%d%d' % tuple(sys.version_info)[:2])")
     local venv_dir="nrn_build_venv$py_ver"
 
     if [ "$py_ver" -lt 35 ]; then
@@ -47,6 +49,21 @@ setup_venv() {
 }
 
 
+pip_numpy_install() {
+    # numpy is special as we want the minimum wheel version
+    numpy_ver="numpy"
+    case "$py_ver" in
+      35) numpy_ver="numpy==1.10.1" ;;
+      36) numpy_ver="numpy==1.12.1" ;;
+      37) numpy_ver="numpy==1.15.1" ;;
+      38) numpy_ver="numpy==1.17.4" ;;
+      39) numpy_ver="numpy==1.19.3" ;;
+      *) numpy_ver="numpy";;
+    esac
+    echo " - pip install $numpy_ver"
+    pip install $numpy_ver
+}
+
 build_wheel_linux() {
     echo "[BUILD WHEEL] Building with interpreter $1"
     local skip=
@@ -56,6 +73,7 @@ build_wheel_linux() {
     echo " - Installing build requirements"
     pip install git+https://github.com/ferdonline/auditwheel@fix/rpath_append
     pip install -r packaging/python/build_requirements.txt
+    pip_numpy_install
 
     echo " - Building..."
     rm -rf dist build
@@ -85,6 +103,7 @@ build_wheel_osx() {
 
     echo " - Installing build requirements"
     pip install -U delocate -r packaging/python/build_requirements.txt
+    pip_numpy_install
 
     echo " - Building..."
     rm -rf dist build


### PR DESCRIPTION
  Later numpy version on user machine should work.

Experimental attempt for each neuron wheel to be built against an early wheel numpy version.
Closes #510