### PR TITLE
nrniv -python windows gui event loop not started

### DIFF
--- a/share/lib/python/neuron/gui.py
+++ b/share/lib/python/neuron/gui.py
@@ -79,7 +79,7 @@ class LoopTimer(threading.Thread) :
       self.fun()
       time.sleep(self.interval)
 
-if h.nrnversion(9) == '2' or h.nrnversion(8).find('mingw') > 0:
+if h.nrnversion(9) == '2' or h.nrnversion(8).find('mingw') > 0 or h.nrnversion(8).find('Windows'):
   timer = LoopTimer(0.1, process_events)
   timer.start()
   while not timer.started:


### PR DESCRIPTION
For autotools build nrnversion(8) returns x86_64-w64-mingw but
cmake build returns AMD64-Windows.

Closes #814