### PR TITLE
Windows anaconda3 2020 without path. Figure out the python path.

### DIFF
--- a/bin/nrnpyenv.sh
+++ b/bin/nrnpyenv.sh
@@ -58,7 +58,7 @@ function trypy {
   a=`ls "$1" |grep "$2"`
   if test "$a" != "" ; then
     b=`cygpath -U "$1/$a/$3"`
-    c=`nrnbinstr "$4" "$b"`
+    c=`nrnbinstr "$4" "$b" 2> /dev/null`
     if test "$c" != "" ; then
       c=`cygpath -U "$c"`
       c=`dirname "$c"`
@@ -95,6 +95,10 @@ else
     if test "$PYTHON" = "" ; then
       trypy "$smenu" Anaconda "Anaconda Prompt.lnk" activate.bat
     fi
+    if test "$PYTHON" = "" ; then
+      trypy "$smenu" "Anaconda3 (64-bit)" "Anaconda Prompt (anaconda3).lnk" activate.bat
+    fi
+
     if test "$PYTHON" = "" ; then #brittle but try Enthought
       a=`cygpath -U "$APPDATA/../local/enthought/canopy/edm/envs/user"`
       if test -d "$a" ; then
@@ -433,7 +437,7 @@ foo = [i for i in foo if s not in i]
 print ("# in neither location " + str(foo))
 print ("# " + spname + " = " + sp)
 print ("# site-3 = " + s)
-	
+
 if "darwin" in sys.platform or "linux" in sys.platform or "win" in sys.platform:
   # What, if anything, did python prepend to PATH
   path=""

--- a/bin/nrnpyenv.sh
+++ b/bin/nrnpyenv.sh
@@ -132,6 +132,8 @@ if test "$PYTHON" = "" ; then
           # first item added in trypy
           a="`echo $PATH | sed 's/:.*//'`"
           export PATH="$PATH:$a/Library/mingw-w64/bin:$a/Library/usr/bin:$a/Library/bin:$a/Scripts:$a/bin:$a/condabin"
+          # Actually get this PATH when scripts do a -- eval "`nrnpyenv.sh`"
+          echo "export PATH=\"$PATH\""
         fi
       fi
     fi

--- a/bin/nrnpyenv.sh
+++ b/bin/nrnpyenv.sh
@@ -105,12 +105,17 @@ while true ; do
     if $PYTHON -c 'quit()' >& /dev/null ; then #working
       break
     else # remove from PATH
+      oldpath="$PATH"
       a="`$WHICH $PYTHON`"
       b="`dirname \"$a\"`"
       PATH="`echo \"$PATH\" | sed \"s,:$b:,:,\"`" #remove b from path if internal
       PATH="`echo \"$PATH\" | sed \"s,^$b:,,\"`" #remove b from path if begin
       PATH="`echo \"$PATH\" | sed \"s,:$b\$,\",`" #remove b from path if end
       export PATH
+      if test "$oldpath" = "$PATH" ; then
+        echo "\"$b\", that contained a failing Python, did not get removed from PATH=\"$PATH\"" 1>&2
+        exit 1
+      fi
     fi
   fi
 done

--- a/bin/nrnpyenv.sh
+++ b/bin/nrnpyenv.sh
@@ -88,15 +88,25 @@ else
   # Often people install Anaconda on Windows without adding it to PATH
   if test "$OS" = "Windows_NT" -a "$APPDATA" != "" ; then
     smenu="$APPDATA/Microsoft/Windows/Start Menu/Programs"
-    trypy "$smenu" Anaconda3 "Anaconda Prompt.lnk" activate.bat
+    if test "$PYTHON" = "" ; then
+      trypy "$smenu" "Anaconda3 (64-bit)" "Anaconda Prompt (anaconda3).lnk" activate.bat
+      # Anaconda3 2020 may need more PATH for numpy to work.
+      if test "$PYTHON" != "" ; then
+        if ! $PYTHON -c 'import numpy' >& /dev/null ; then
+          # first item added in trypy
+          a="`echo $PATH | sed 's/:.*//'`"
+          export PATH="$PATH:$a/Library/mingw-w64/bin:$a/Library/usr/bin:$a/Library/bin:$a/Scripts:$a/bin:$a/condabin"
+        fi
+      fi
+    fi
+    if test "$PYTHON" = "" ; then
+      trypy "$smenu" Anaconda3 "Anaconda Prompt.lnk" activate.bat
+    fi
     if test "$PYTHON" = "" ; then
       trypy "$smenu" Anaconda2 "Anaconda Prompt.lnk" activate.bat
     fi
     if test "$PYTHON" = "" ; then
       trypy "$smenu" Anaconda "Anaconda Prompt.lnk" activate.bat
-    fi
-    if test "$PYTHON" = "" ; then
-      trypy "$smenu" "Anaconda3 (64-bit)" "Anaconda Prompt (anaconda3).lnk" activate.bat
     fi
 
     if test "$PYTHON" = "" ; then #brittle but try Enthought


### PR DESCRIPTION
Closes #823 

It remains to augment the PATH further to allow numpy to work properly.
It remains to deal with the /cygdrive/c/Users/ted/AppData/Local/Microsoft/WindowsApps/python3 issue.