### PR TITLE
Fix/newobj error

### DIFF
--- a/share/lib/python/neuron/tests/test_neuron.py
+++ b/share/lib/python/neuron/tests/test_neuron.py
@@ -172,40 +172,41 @@ class NeuronTestCase(unittest.TestCase):
         '''Test deletion of incompletely constructed objects'''
         h.load_file("stdlib.hoc")
         h('''
+begintemplate Foo
+endtemplate Foo
+
 begintemplate NewObj
-objref this, ob
+objref this, ob, foo1, foo2
 proc init() {localobj s
-  print this, $1, $2
+  foo1 = new Foo()
   if ($1 == 0) {
     execerror("generate an error")
   } else if ($1 == $2) {
-    print "calling execute1"
     s = new String()
     sprint(s.s, "ob = new NewObj(%d, %d)", $1-1, $2)
     execute1(s.s, this)
-    print "return from execute1"
   } else {
-    print "else before ", this, ob, $1, $2
     ob = new NewObj($1-1, $2)
-    print "else after ", this, ob, $1, $2
   }
+  foo2 = new Foo()
 }
 endtemplate NewObj
 ''')
         args = (4, 2)
         a = h.NewObj(*args)
         b = h.List("NewObj")
-        print("#NewObj in existence", b.count())
-        for i in range(b.count()):
-          print(b.o(i), b.o(i).ob)
-        assert(b.count() == args[0] - args[1] + 1)
+        c = h.List("Foo")
+        print("#NewObj and #Foo in existence", b.count(), c.count())
+        z = args[0] - args[1] + 1
+        assert(b.count() == z)
+        assert(c.count() == 2*z)
 
         del a
         del b
+        del c
         b = h.List("NewObj")
-        print("after del a #NewObj in existence", b.count())
-        for i in range(b.count()):
-          print(b.o(i), b.o(i).ob)
+        c = h.List("Foo")
+        print("after del a #NewObj and #Foo in existence", b.count(), c.count())
         assert(b.count() == 0)
 
         return 1

--- a/share/lib/python/neuron/tests/test_neuron.py
+++ b/share/lib/python/neuron/tests/test_neuron.py
@@ -208,6 +208,7 @@ endtemplate NewObj
         c = h.List("Foo")
         print("after del a #NewObj and #Foo in existence", b.count(), c.count())
         assert(b.count() == 0)
+        assert(c.count() == 0)
 
         return 1
 

--- a/share/lib/python/neuron/tests/test_neuron.py
+++ b/share/lib/python/neuron/tests/test_neuron.py
@@ -192,12 +192,13 @@ proc init() {localobj s
 }
 endtemplate NewObj
 ''')
-        a = h.NewObj(4, 2)
+        args = (4, 2)
+        a = h.NewObj(*args)
         b = h.List("NewObj")
         print("#NewObj in existence", b.count())
         for i in range(b.count()):
           print(b.o(i), b.o(i).ob)
-        assert(b.count() == 3)
+        assert(b.count() == args[0] - args[1] + 1)
 
         del a
         del b

--- a/share/lib/python/neuron/tests/test_neuron.py
+++ b/share/lib/python/neuron/tests/test_neuron.py
@@ -168,6 +168,46 @@ class NeuronTestCase(unittest.TestCase):
         assert(p.exitcode == 0)
         return 0
 
+    def test_newobj_err(self):
+        '''Test deletion of incompletely constructed objects'''
+        h.load_file("stdlib.hoc")
+        h('''
+begintemplate NewObj
+objref this, ob
+proc init() {localobj s
+  print this, $1, $2
+  if ($1 == 0) {
+    execerror("generate an error")
+  } else if ($1 == $2) {
+    print "calling execute1"
+    s = new String()
+    sprint(s.s, "ob = new NewObj(%d, %d)", $1-1, $2)
+    execute1(s.s, this)
+    print "return from execute1"
+  } else {
+    print "else before ", this, ob, $1, $2
+    ob = new NewObj($1-1, $2)
+    print "else after ", this, ob, $1, $2
+  }
+}
+endtemplate NewObj
+''')
+        a = h.NewObj(4, 2)
+        b = h.List("NewObj")
+        print("#NewObj in existence", b.count())
+        for i in range(b.count()):
+          print(b.o(i), b.o(i).ob)
+        assert(b.count() == 3)
+
+        del a
+        del b
+        b = h.List("NewObj")
+        print("after del a #NewObj in existence", b.count())
+        for i in range(b.count()):
+          print(b.o(i), b.o(i).ob)
+        assert(b.count() == 0)
+
+        return 1
 
 def basicRxD3D():
     from neuron import h, rxd

--- a/src/ivoc/ocjump.cpp
+++ b/src/ivoc/ocjump.cpp
@@ -21,6 +21,7 @@ extern Object* hoc_thisobject;
 extern void hoc_execute1();
 extern bool hoc_valid_stmt(const char* stmt, Object* ob);
 extern int hoc_execerror_messages;
+void* nrn_get_oji();
 }
 
 static bool valid_stmt1(const char* stmt, Object* ob) {
@@ -76,11 +77,11 @@ therefore hoc_execerror looks at a function pointer and if it's non-NULL
 here and can do an explicit longjump using the begin_ */
 	static void ljmptarget();
 	void ljmp();
+	static OcJumpImpl* oji_;
 private:
 	void begin();
 	void restore();
 	void finish();
-	static OcJumpImpl* oji_;
 private:
 	OcJumpImpl* prev_;
 	jmp_buf begin_;
@@ -118,6 +119,10 @@ private:
 	int cc2;
 #endif
 };
+
+void* nrn_get_oji() {
+  return (void*)OcJumpImpl::oji_;
+}
 
 //------------------------------------------------------------------
 

--- a/src/ivoc/ocjump.cpp
+++ b/src/ivoc/ocjump.cpp
@@ -120,6 +120,9 @@ private:
 #endif
 };
 
+/** Return handle for the current longjump buffer info.
+ *  Valid until finish is called on the oji_ instance.
+**/
 void* nrn_get_oji() {
   return (void*)OcJumpImpl::oji_;
 }

--- a/src/oc/hoc.c
+++ b/src/oc/hoc.c
@@ -673,7 +673,7 @@ void (*oc_jump_target_)();	/* see ivoc/SRC/ocjump.c */
 
 int yystart;
 
-extern void hoc_newobj1_err();
+extern void hoc_newobj1_err(void* jmp);
 
 void hoc_execerror_mes(const char* s, const char* t, int prnt){	/* recover from run-time error */
 	hoc_in_yyparse = 0;
@@ -705,7 +705,7 @@ void hoc_execerror_mes(const char* s, const char* t, int prnt){	/* recover from 
 	*ctp = '\0';
 
 	if (oc_jump_target_ && nrnmpi_numprocs_world == 1) {
-		hoc_newobj1_err();
+		hoc_newobj1_err(oc_jump_target_);
 		(*oc_jump_target_)();
 	}
 #if NRNMPI
@@ -721,10 +721,10 @@ void hoc_execerror_mes(const char* s, const char* t, int prnt){	/* recover from 
 		hoc_win_normal_cursor();
 #endif
 	if (hoc_oc_jmpbuf) {
-		hoc_newobj1_err();
+		hoc_newobj1_err((void(*)())2);
 		longjmp(hoc_oc_begin, 1);
 	}
-	hoc_newobj1_err();
+	hoc_newobj1_err((void(*)())1);
 	longjmp(begin, 1);
 }
 

--- a/src/oc/hoc.c
+++ b/src/oc/hoc.c
@@ -674,7 +674,7 @@ void (*oc_jump_target_)();	/* see ivoc/SRC/ocjump.c */
 int yystart;
 
 /* what to do about partially constructed objects at hoc_execerror */
-extern void hoc_newobj1_err(void* jmp);
+extern void hoc_newobj1_err();
 
 /** If one of the two jmp_buf is controlling the longjmp
  *  hoc_newobj1_err needs handle to know how much to unwrap the newobj1 stack.
@@ -714,7 +714,7 @@ void hoc_execerror_mes(const char* s, const char* t, int prnt){	/* recover from 
 	*ctp = '\0';
 
 	if (oc_jump_target_ && nrnmpi_numprocs_world == 1) {
-		hoc_newobj1_err(oc_jump_target_); /* arg used just to distinguish between the other two cases below */
+		hoc_newobj1_err();
 		(*oc_jump_target_)();
 	}
 #if NRNMPI
@@ -730,10 +730,10 @@ void hoc_execerror_mes(const char* s, const char* t, int prnt){	/* recover from 
 		hoc_win_normal_cursor();
 #endif
 	if (hoc_oc_jmpbuf) {
-		hoc_newobj1_err((void*)2);
+		hoc_newobj1_err();
 		longjmp(hoc_oc_begin, 1);
 	}
-	hoc_newobj1_err((void*)1);
+	hoc_newobj1_err();
 	longjmp(begin, 1);
 }
 

--- a/src/oc/hoc.c
+++ b/src/oc/hoc.c
@@ -721,10 +721,10 @@ void hoc_execerror_mes(const char* s, const char* t, int prnt){	/* recover from 
 		hoc_win_normal_cursor();
 #endif
 	if (hoc_oc_jmpbuf) {
-		hoc_newobj1_err((void(*)())2);
+		hoc_newobj1_err((void*)2);
 		longjmp(hoc_oc_begin, 1);
 	}
-	hoc_newobj1_err((void(*)())1);
+	hoc_newobj1_err((void*)1);
 	longjmp(begin, 1);
 }
 

--- a/src/oc/hoc.c
+++ b/src/oc/hoc.c
@@ -673,6 +673,7 @@ void (*oc_jump_target_)();	/* see ivoc/SRC/ocjump.c */
 
 int yystart;
 
+/* what to do about partially constructed objects at hoc_execerror */
 extern void hoc_newobj1_err(void* jmp);
 
 void hoc_execerror_mes(const char* s, const char* t, int prnt){	/* recover from run-time error */
@@ -705,7 +706,7 @@ void hoc_execerror_mes(const char* s, const char* t, int prnt){	/* recover from 
 	*ctp = '\0';
 
 	if (oc_jump_target_ && nrnmpi_numprocs_world == 1) {
-		hoc_newobj1_err(oc_jump_target_);
+		hoc_newobj1_err(oc_jump_target_); /* arg used just to distinguish between the other two cases below */
 		(*oc_jump_target_)();
 	}
 #if NRNMPI

--- a/src/oc/hoc.c
+++ b/src/oc/hoc.c
@@ -676,6 +676,14 @@ int yystart;
 /* what to do about partially constructed objects at hoc_execerror */
 extern void hoc_newobj1_err(void* jmp);
 
+/** If one of the two jmp_buf is controlling the longjmp
+ *  hoc_newobj1_err needs handle to know how much to unwrap the newobj1 stack.
+**/
+void* nrn_get_hoc_jmp() {
+  void* jmp = hoc_oc_jmpbuf ? (void*)hoc_oc_begin : (void*)begin;
+  return jmp;
+}
+
 void hoc_execerror_mes(const char* s, const char* t, int prnt){	/* recover from run-time error */
 	hoc_in_yyparse = 0;
 	yystart = 1;

--- a/src/oc/hoc_oop.c
+++ b/src/oc/hoc_oop.c
@@ -550,20 +550,13 @@ void pop_newobj1_err() {
 }
 
 /** unref partially constructed objects controlled by current longjump handle **/
-void hoc_newobj1_err(void* jmp) { /* called from hoc_execerror */
+void hoc_newobj1_err() { /* called from hoc_execerror */
   if (newobj1_err_index_ > 0) {
     int i;
     /* Note: for the case of pure hoc, there may not be an oc_jump_target_
        in which case jmp will get set to the hoc.c controlling jmp_buf
     */
-    void* oji = (jmp == (void*)oc_jump_target_) ? nrn_get_oji() : nrn_get_hoc_jmp();
-#if 0 /* useful for debugging */
-    printf("newobj1_err    jmp=%p  current oji=%p\n", jmp, oji);
-    for (i = 0; i < newobj1_err_index_; ++i) {
-      newobj1_err_t* ne = newobj1_err_ + i;
-      printf("newobj1_err[%d] with oji=%p ob=%p %s\n", i, ne->oji, ne->ob, hoc_object_name(ne->ob));
-    }
-#endif
+    void* oji = oc_jump_target_ ? nrn_get_oji() : nrn_get_hoc_jmp();
     while (newobj1_err_index_ > 0) {
       newobj1_err_t* ne = newobj1_err_ + (newobj1_err_index_ - 1);
       if (ne->oji == oji) {

--- a/src/oc/hoc_oop.c
+++ b/src/oc/hoc_oop.c
@@ -506,19 +506,31 @@ Object** hoc_temp_objvar(Symbol* symtemp, void* v){
   object.
 **/
 
-#define NEWOBJ1_ERR_SIZE 100
+#define NEWOBJ1_ERR_SIZE 32
 typedef struct {
   Object* ob;
   void* oji;
 } newobj1_err_t;
 	
 extern void* nrn_get_oji();
-void (*oc_jump_target_)();
+extern void (*oc_jump_target_)();
 static int newobj1_err_index_;
-static newobj1_err_t newobj1_err_[NEWOBJ1_ERR_SIZE];
+static int newobj1_err_size_;
+static newobj1_err_t* newobj1_err_;
 
 void push_newobj1_err(Object* ob) {
-  assert(newobj1_err_index_ < NEWOBJ1_ERR_SIZE);
+  if (newobj1_err_index_ >= newobj1_err_size_) {
+    if (newobj1_err_size_ == 0) {
+      newobj1_err_size_ = NEWOBJ1_ERR_SIZE;
+      newobj1_err_ = (newobj1_err_t*)calloc(newobj1_err_size_, sizeof(newobj1_err_t));
+      assert(newobj1_err_);
+    }else{
+      newobj1_err_size_ *= 2;
+      newobj1_err_ = (newobj1_err_t*)realloc(newobj1_err_, newobj1_err_size_*sizeof(newobj1_err_t));
+      assert(newobj1_err_);
+    }
+  }
+
   newobj1_err_t* ne = newobj1_err_ + newobj1_err_index_++;
   ne->ob = ob;
   ne->oji = oc_jump_target_ ? nrn_get_oji() : (void*)oc_jump_target_;

--- a/src/oc/hoc_oop.c
+++ b/src/oc/hoc_oop.c
@@ -518,6 +518,7 @@ typedef struct {
 } newobj1_err_t;
 	
 extern void* nrn_get_oji();
+extern void* nrn_get_hoc_jmp();
 extern void (*oc_jump_target_)();
 static int newobj1_err_index_; /* stack index */
 static int newobj1_err_size_;
@@ -539,7 +540,7 @@ static void push_newobj1_err(Object* ob) {
 
   newobj1_err_t* ne = newobj1_err_ + newobj1_err_index_++;
   ne->ob = ob;
-  ne->oji = oc_jump_target_ ? nrn_get_oji() : (void*)oc_jump_target_;
+  ne->oji = oc_jump_target_ ? nrn_get_oji() : nrn_get_hoc_jmp();
 }
 
 /** pop the now fully constructed object **/
@@ -553,16 +554,14 @@ void hoc_newobj1_err(void* jmp) { /* called from hoc_execerror */
   if (newobj1_err_index_ > 0) {
     int i;
     /* Note: for the case of pure hoc, there may not be an oc_jump_target_
-       in which case jmp will never equal the oc_jump_target_ and none of
-       the partially constructed objects will be unreffed. I.e. just like
-       before the attempt to handle this issue.
+       in which case jmp will get set to the hoc.c controlling jmp_buf
     */
-    void* oji = (jmp == (void*)oc_jump_target_) ? nrn_get_oji() : jmp;
+    void* oji = (jmp == (void*)oc_jump_target_) ? nrn_get_oji() : nrn_get_hoc_jmp();
 #if 0 /* useful for debugging */
-    printf("newobj1_err    current oji=%p\n", oji);
+    printf("newobj1_err    jmp=%p  current oji=%p\n", jmp, oji);
     for (i = 0; i < newobj1_err_index_; ++i) {
       newobj1_err_t* ne = newobj1_err_ + i;
-printf("newobj1_err[%d] with oji=%p ob=%p %s\n", i, ne->oji, ne->ob, hoc_object_name(ne->ob));
+      printf("newobj1_err[%d] with oji=%p ob=%p %s\n", i, ne->oji, ne->ob, hoc_object_name(ne->ob));
     }
 #endif
     while (newobj1_err_index_ > 0) {

--- a/src/oc/ocnoiv.c
+++ b/src/oc/ocnoiv.c
@@ -105,6 +105,7 @@ Object* ivoc_list_item(Object* list, int item) {
 }
 int ivoc_list_count(list) Object* list; { return 0; }
 void bbs_done(void){}
+void* nrn_get_oji(){return NULL;}
 
 Symbol* ivoc_alias_lookup(const char* name, Object* ob) {return (Symbol*)0;}
 void ivoc_free_alias(Object* ob){}


### PR DESCRIPTION
Fixes #828 
PR #762 breaks most models that use LinearCircuit GUI. For ModelDB test this means the following models now work again which otherwise segfault at
``` 
       SectionRef[0].has_loc()
      SectionRef[0].init()
    InsideCell[0].default(Vector[37], NULLobject)
  ElementBase[5].init(..., 8)
```
```
112086 giuglianoEtAl2007
3676 ephaptic
136176 Katona_et_al
230888 ChandlerHodgkin1965
124394 nevian
118662 dm1_pn_model
```
The problem was that  ```execute1(stmt,obj)``` properly returns even if stmt ultimately causes a ```hoc_execerror```.
In the above, this happened during construction of a new object, and meant that a deleted object could continue in use.
A test has been added. 