### PR TITLE
Enable Python 3.9 manylinux1 wheel in release 7.8.1 (#838)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,8 @@ jobs:
         python.version: '3.7'
       Python38:
         python.version: '3.8'
+      Python39:
+        python.version: '3.9'
   steps:
   - script: |
       docker run --rm \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,6 +75,9 @@ jobs:
       Python38:
         python.version: '3.8'
         python.org.version: '3.8.2'
+      Python39:
+        python.version: '3.9'
+        python.org.version: '3.9.0'
   steps:
 
   - script: |

--- a/bldnrnmacpkgcmake.sh
+++ b/bldnrnmacpkgcmake.sh
@@ -6,14 +6,16 @@ set -ex
 
 args="$*"
 if test "$args" = "" ; then
-  args="python2.7 python3.6 python3.7 python3.8"
+  args="python2.7 python3.6 python3.7 python3.8 python3.9"
 fi
 
 #10.7 possible if one builds with pythons that are consistent with that.
 export MACOSX_DEPLOYMENT_TARGET=10.9
 
 
-NRN_SRC=$HOME/neuron/nrncmake
+if test "$NRN_SRC" == "" ; then
+  NRN_SRC=$HOME/neuron/nrncmake
+fi
 NRN_BLD=$NRN_SRC/build
 NSRC=$NRN_SRC
 export NSRC
@@ -43,6 +45,7 @@ cmake .. -DCMAKE_INSTALL_PREFIX=$NRN_INSTALL \
   -DNRN_PYTHON_DYNAMIC="$pythons" \
   -DIV_ENABLE_X11_DYNAMIC=ON \
   -DNRN_ENABLE_CORENEURON=OFF \
+  -DNRN_ENABLE_INTERNAL_READLINE=ON \
   -DNRN_RX3D_OPT_LEVEL=2 \
   -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
 

--- a/packaging/python/Dockerfile
+++ b/packaging/python/Dockerfile
@@ -32,7 +32,7 @@ RUN wget http://ftpmirror.gnu.org/ncurses/ncurses-5.9.tar.gz \
     && ./configure --prefix=/nrnwheel/ncurses --without-shared CFLAGS="-fPIC" \
     && make -j install
 
-RUN wget http://www.mpich.org/static/downloads/3.3.2/mpich-3.3.2.tar.gz \
+RUN curl -L -o mpich-3.3.2.tar.gz http://www.mpich.org/static/downloads/3.3.2/mpich-3.3.2.tar.gz \
     && tar -xvzf mpich-3.3.2.tar.gz \
     && cd mpich-3.3.2 \
     && ./configure --prefix=/nrnwheel/mpich \

--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -38,9 +38,11 @@ setup_venv() {
     "$py_bin" -m venv "$venv_dir"
     . "$venv_dir/bin/activate"
 
-    if ! pip install -U pip setuptools wheel; then
+    # pep425tags are not available anymore from 0.35
+    # temporary workaround until we get smtg stable
+    if ! pip install -U pip setuptools "wheel<0.35"; then
         curl https://bootstrap.pypa.io/get-pip.py | python
-        pip install -U setuptools wheel
+        pip install -U setuptools "wheel<0.35"
     fi
 }
 


### PR DESCRIPTION
Cherry-picked from master into release/7.8.1. branch:
  - manylinux1 docker image is rebuilt and pushed
  - azure CI updated to build 3.9 wheel
  - This will be released as pypi wheel 7.8.1.2

Related to #815