### PR TITLE
Build modlunit and nocmodl with debug flags.

### DIFF
--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -26,14 +26,16 @@ set_property(
   PROPERTY COMPILE_DEFINITIONS NRNUNIT=1)
 
 add_executable(modlunit ${NRN_MODLUNIT_SRC_FILES})
-
 # as modlunit and nocmodl are typically executed on front-end node,
 # in order to avoid runtime
 # issues from platform specific optimisations, build modlunit and nocmodl
 # with debug flags as performance is not a concern (for checking units or
 # translating mod to c)
-separate_arguments(NMODL_C_FLAGS UNIX_COMMAND "${CMAKE_C_FLAGS_DEBUG}")
-target_compile_options(modlunit PRIVATE ${NMODL_C_FLAGS})
+# Do not do this for MINGW to avoid undefined reference to `__stack_chk_fail'
+if (NOT MINGW)
+  separate_arguments(NMODL_C_FLAGS UNIX_COMMAND "${CMAKE_C_FLAGS_DEBUG}")
+  target_compile_options(modlunit PRIVATE ${NMODL_C_FLAGS})
+endif()
 
 # =============================================================================
 # Build nocmodl : source-to-source compiler for NMODL
@@ -53,7 +55,9 @@ set_property(
     NRN_DYNAMIC_UNITS=1)
 
 add_executable(nocmodl ${NRN_NMODL_SRC_FILES})
-target_compile_options(nocmodl PRIVATE ${NMODL_C_FLAGS})
+if (NOT MINGW)
+  target_compile_options(nocmodl PRIVATE ${NMODL_C_FLAGS})
+endif()
 
 # =============================================================================
 # Translate all MOD files to C and mark them generated

--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -27,6 +27,14 @@ set_property(
 
 add_executable(modlunit ${NRN_MODLUNIT_SRC_FILES})
 
+# as modlunit and nocmodl are typically executed on front-end node,
+# in order to avoid runtime
+# issues from platform specific optimisations, build modlunit and nocmodl
+# with debug flags as performance is not a concern (for checking units or
+# translating mod to c)
+separate_arguments(NMODL_C_FLAGS UNIX_COMMAND "${CMAKE_C_FLAGS_DEBUG}")
+target_compile_options(modlunit PRIVATE ${NMODL_C_FLAGS})
+
 # =============================================================================
 # Build nocmodl : source-to-source compiler for NMODL
 # =============================================================================
@@ -45,6 +53,7 @@ set_property(
     NRN_DYNAMIC_UNITS=1)
 
 add_executable(nocmodl ${NRN_NMODL_SRC_FILES})
+target_compile_options(nocmodl PRIVATE ${NMODL_C_FLAGS})
 
 # =============================================================================
 # Translate all MOD files to C and mark them generated


### PR DESCRIPTION
- Resolves same issue as BlueBrain/mod2c#54

Note that this fix, with 
```
cmake .. -DCMAKE_INSTALL_PREFIX=install
```
generates compile lines for nocmodl and modlunit sources that have the tokens
```
-g -O2 -g -O0
```