### PR TITLE
Fix typo in mac pkg build script.

### DIFF
--- a/src/mac/clean-for-pkg-cmake.sh
+++ b/src/mac/clean-for-pkg-cmake.sh
@@ -5,7 +5,7 @@ if test "$1" = "" ; then
 	exit
 fi
 
-NRN_INSTALL="$1"
+NRN_INST="$1"
 CPU=x86_64
 
 #strip the dylibs


### PR DESCRIPTION
  The typo has been doubling the size of the package and in some
cases removing files in the working repository so that there is a
spurious '+' in the version hash.