### PR TITLE
Autotools default NRN_RX3D_OPT_LEVEL=2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -361,6 +361,10 @@ AM_CONDITIONAL(NRNMECH_DLL_STYLE, test x${linux_nrnmech} = xyes)
 AM_CONDITIONAL(NRN_BINARY_SPECIAL, test x${linux_nrnmech} != xyes)
 AM_CONDITIONAL(MAC_DARWIN, test x${macdarwin} = xyes)
 AM_CONDITIONAL(USING_CMAKE, false)
+if test x$NRN_RX3D_OPT_LEVEL = x ; then
+  NRN_RX3D_OPT_LEVEL=2
+fi
+AC_SUBST(NRN_RX3D_OPT_LEVEL)
 
 if test x${addlibdl} = xyes ; then
 	LIBS="$LIBS -ldl"


### PR DESCRIPTION
Cherry pick from 7.8.2 change a9dd7aa0

Without this change, for example,
```
./configure --prefix=`pwd` --without-x --without-paranrn --with-nrnpython=python2 PYTHON_BLD=python2
```
will generate the error message from share/lib/python/neuron/rxd/geometry3d/setup.py durin 'make install'
```
cc1plus: error: argument to ‘-O’ should be a non-negative integer, ‘g’, ‘s’ or ‘fast’
error: command 'gcc' failed with exit status 1
```