### PR TITLE
GHA:NEURON:CMake: fix compiler settings + glitch

### DIFF
--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -93,7 +93,7 @@ jobs:
 
           # OS related
           if [ "$RUNNER_OS" == "Linux" ]; then
-            eval "${{ matrix.config.matrix_eval }}";
+            eval $MATRIX_EVAL;
             export TRAVIS_OS_NAME="linux"
             export SHELL="/bin/bash"
           else
@@ -145,10 +145,13 @@ jobs:
               if [ "$NRN_ENABLE_PYTHON_DYNAMIC" == "ON" ]; then
                 export CMAKE_OPTION="-DNRN_ENABLE_PYTHON=ON -DNRN_ENABLE_PYTHON_DYNAMIC=ON -DNRN_PYTHON_DYNAMIC=${PYTHON2};${PYTHON3} -DNRN_ENABLE_CORENEURON=ON";
               else
-                export CMAKE_OPTION="$CMAKE_OPTION -DPYTHON_EXECUTABLE=${PYTHON} -DNRN_ENABLE_CORENEURON=ON";
+                export CMAKE_OPTION="$CMAKE_OPTION -DPYTHON_EXECUTABLE=${PYTHON}";
               fi;
               mkdir build && cd build;
-              cmake $CMAKE_OPTION -DNRN_ENABLE_TESTS=ON -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR ..;
+              echo "Building with: "$CMAKE_OPTION
+              echo "CC="$CC
+              echo "CXX="$CXX
+              cmake $CMAKE_OPTION  -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DNRN_ENABLE_TESTS=ON -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR ..;
               cmake --build . -- -j;
               if [ "$RUNNER_OS" == "macOS" ]; then
                 echo $'[install]\nprefix='>src/nrnpython/setup.cfg;
@@ -216,6 +219,7 @@ jobs:
           NRN_ENABLE_PYTHON_DYNAMIC : ${{ matrix.config.python_dynamic }}
           USE_PYTHON2 : ${{ matrix.config.use_python2 }}
           INSTALL_DIR : ${{ runner.workspace }}/install
+          MATRIX_EVAL: ${{ matrix.config.matrix_eval }}
       
       # This step will set up an SSH connection on tmate.io for live debugging.
       # To trigger it, simply prefix your branch name with `live-debug`


### PR DESCRIPTION
Even though travis code was copied in, additional settings are required for specifying compiler toolchain version.
Also a glitch when specifying CORENEURON OFF , it was turned ON (seems to have worked in travis, no idea why)