### PR TITLE
GHA: Manual workflow to create releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: NEURON Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      rel_branch:
+        description: 'Release branch/commit'
+        default: 'release/x.y'
+        required: true
+      rel_tag:
+        description: 'Release version (tag name)'
+        default: 'x.y.z'
+        required: true
+
+env:
+  GH_REPO: ${{ github.server_url }}/${{ github.repository }}
+  REL_TAG: ${{ github.event.inputs.rel_tag }}
+  REL_BRANCH: ${{ github.event.inputs.rel_branch }}
+
+jobs:
+  tag-n-release:
+    runs-on: ubuntu-18.04
+    name: tag-n-release ${{ github.event.inputs.rel_tag }} (${{ github.event.inputs.rel_branch }})
+    outputs:
+      release_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout branch ${{ env.REL_BRANCH }}
+        with:
+            ref: ${{ env.REL_BRANCH }}
+      
+      - name: Create and upload tag ${{ env.REL_TAG }}
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git tag -a $REL_TAG -m "${REL_TAG}"
+          git push origin $REL_TAG
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: ${{runner.workspace}}/nrn
+                
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.REL_TAG }}
+          release_name: Release ${{ env.REL_TAG }}
+          prerelease: true
+                 
+  full-src-package:
+    runs-on: ubuntu-18.04
+    needs: tag-n-release
+    steps:    
+    - name: Checkout feature-rich code
+      run: |
+        git clone --depth=1 --shallow-submodules --recurse-submodules $GH_REPO $REL_TAG
+        mv ${REL_TAG} neuron
+        cd neuron
+        git log --oneline
+        
+    - name: Make nrnversion.h
+      run: |   
+        mkdir build && cd build
+        cmake -DNRN_ENABLE_PYTHON=OFF -DNRN_ENABLE_RX3D=OFF -DNRN_ENABLE_MPI=OFF -DNRN_ENABLE_INTERVIEWS=OFF ../neuron
+        make nrnversion_h VERBOSE=1 
+    
+    - name: Create full-src-package
+      id: tar
+      run: |   
+        tar -czvf ${REL_TAG}.tar.gz neuron
+        echo ::set-output name=asset_file::${REL_TAG}.tar.gz
+        
+    - name: Upload full-src-package to release
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ needs.tag-n-release.outputs.release_url }}
+        asset_name: ${{ github.job }}-${{ steps.tar.outputs.asset_file }}
+        asset_content_type: application/gzip
+        asset_path: ${{ steps.tar.outputs.asset_file }}
+      env: 
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This sets up a manual workflow that creates a new  NEURON release in GitHub + uploads feature-rich source code package (#843) together with proper version file. 

Inputs: 
* release branch
* release version (tag name)

Workflow actions: 
* git annotated tag & push
* create release on GitHub
* package full source code (submodules + external) and uploads that to release