### PR TITLE
Update coreneuron with nmodl and improve sub-modules cloning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,8 @@ set(Python_ADDITIONAL_VERSIONS 3 3.9 3.8 3.7 3.6 3.5 3.4 3.3 3.2 3.1 3.0 2.8 2.7
 # =============================================================================
 # Include cmake modules
 # =============================================================================
+# sub-directorty containing project submodules
+set(THIRD_PARTY_DIRECTORY "${PROJECT_SOURCE_DIR}/external")
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 include(PlatformHelper)
 include(CompilerHelper)

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ with CoreNEURON
 
 Please refer to [docs/cmake_doc/options.rst](docs/cmake_doc/options.rst) for more information on the CMake options.
 
+#### Optimized CPU and GPU Support using CoreNEURON
+
+NEURON now integrates [CoreNEURON library](https://github.com/BlueBrain/CoreNeuron/) for improved simulation performance on modern CPU and GPU architectures. CoreNEURON is designed as a library within the NEURON simulator and can transparently handle all spiking network simulations including gap junction coupling with the fixed time step method. You can find detailed [build instructions here](https://github.com/BlueBrain/CoreNeuron/#installation).
+
 <a name="build-autotools"></a>
 ### Build using Autotools
 

--- a/cmake/ExternalProjectHelper.cmake
+++ b/cmake/ExternalProjectHelper.cmake
@@ -16,11 +16,15 @@ function(initialize_submodule path)
     message(
       FATAL_ERROR "git not found and ${path} sub-module not cloned (use git clone --recursive)")
   endif()
-  message(STATUS "Sub-module : missing ${path} : running git submodule update --init --recursive")
+  message(STATUS "Sub-module : missing ${path} : running git submodule update --init")
   execute_process(
     COMMAND
-      ${GIT_EXECUTABLE}  submodule update --init --recursive -- ${path}
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+      ${GIT_EXECUTABLE}  submodule update --init -- ${path}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    RESULT_VARIABLE ret)
+  if(ret EQUAL "1")
+      message( FATAL_ERROR "git submodule init failed")
+  endif()
 endfunction()
 
 # check for external project and initialize submodule if it is missing
@@ -28,14 +32,21 @@ function(add_external_project name)
   find_path(
     ${name}_PATH
     NAMES CMakeLists.txt
-    PATHS "${PROJECT_SOURCE_DIR}/external/${name}")
+    PATHS "${THIRD_PARTY_DIRECTORY}/${name}")
   if(NOT EXISTS ${${name}_PATH})
     if(NOT_A_GIT_REPO)
       message(FATAL_ERROR "Looks like you are building from source. Git needed for ${name} feature.")
     endif()
-    initialize_submodule(external/${name})
+    initialize_submodule("${THIRD_PARTY_DIRECTORY}/${name}")
   else()
-    message(STATUS "Sub-project : using ${name} from from external/${name}")
+    message(STATUS "Sub-project : using ${name} from from ${THIRD_PARTY_DIRECTORY}/${name}")
   endif()
-  add_subdirectory(external/${name})
+  # if second argument is passed and if it's OFF then skip add_subdirectory
+  if(${ARGC} GREATER 1)
+    if(${ARGV2})
+      add_subdirectory("${THIRD_PARTY_DIRECTORY}/${name}")
+    endif()
+  else()
+    add_subdirectory("${THIRD_PARTY_DIRECTORY}/${name}")
+  endif()
 endfunction()


### PR DESCRIPTION
* CoreNEURON and nmodl are updated to latest master
* External project helper module is improved
  - avoid hardcoding third project directory as same cmake module
    can be used by internal projects like coreneuron and nmodl
  - error if git submodule update is failed
  - avoid recursive cloning as each project initialize necessary
    submodules