### PR TITLE
h.Section(name='name', cell=cell) arg order is now name, cell.

### DIFF
--- a/share/lib/python/neuron/tests/test_neuron.py
+++ b/share/lib/python/neuron/tests/test_neuron.py
@@ -98,6 +98,11 @@ class NeuronTestCase(unittest.TestCase):
         sections[0](0.5).na_ion.ena = 40.0 # issue #651
         assert(sections[0](0.5).na_ion.ena == 40.0)
 
+    def testSectionArgOrder(self):
+        """ First optional arg for Section is name (but name="name" is recommended)"""
+        soma = h.Section('soma')
+        assert soma.name() == 'soma'
+
     def testSectionListIterator(self):
         """As of v8.0, iteration over a SectionList does not change the cas"""
         # See issue 509. SectionList iterator bug requires change to

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -264,7 +264,7 @@ static void NPyVarOfMechIter_dealloc(NPyVarOfMechIter* self) {
 
 static int NPySecObj_init(NPySecObj* self, PyObject* args, PyObject* kwds) {
   // printf("NPySecObj_init %p %p\n", self, self->sec_);
-  static const char* kwlist[] = {"cell", "name", NULL};
+  static const char* kwlist[] = {"name", "cell", NULL};
   if (self != NULL && !self->sec_) {
     if (self->name_) {
       delete[] self->name_;
@@ -275,8 +275,8 @@ static int NPySecObj_init(NPySecObj* self, PyObject* args, PyObject* kwds) {
     PyObject* cell = 0;
     // avoid "warning: deprecated conversion from string constant to char*"
     // someday eliminate the (char**) when python changes their prototype
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|Os", (char**)kwlist,
-                                     &self->cell_, &name)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|sO", (char**)kwlist,
+                                     &name, &self->cell_)) {
       return -1;
     }
     // note that we are NOT referencing the cell


### PR DESCRIPTION
Fixes #895

Need to verify proper error recovery if name is not a string or cell is invalid is some way.

If name is not a string, proper error recovery occurs. The cell is supposed to be a container for the section and section does not reference the cell.  Normally, cell destruction is assumed to destroy the section. If this does not occur, section.cell() will likely result in a segfault. As this is an issue beyond the scope of this pr, a separate issue #898 has been created.