### PR TITLE
Fix deadlock when compiling with AVX-512

### DIFF
--- a/src/ivoc/ivocvect.cpp
+++ b/src/ivoc/ivocvect.cpp
@@ -68,7 +68,7 @@ extern "C" {
 #endif
 
 /**
- * As all parameters are passed to hoc as double, we need
+ * As all parameters are passed from hoc as double, we need
  * to calculate max integer that can fit into double variable.
  *
  * With IEEE 64-bit double has 52 bits of mantissa, so it's 2^53.

--- a/src/ivoc/ivocvect.cpp
+++ b/src/ivoc/ivocvect.cpp
@@ -67,7 +67,24 @@ extern "C" {
 #define FRead(arg1,arg2,arg3,arg4) if (fread(arg1,arg2,arg3,arg4) != arg3) {}
 #endif
 
-static double dmaxint_;
+/**
+ * As all parameters are passed to hoc as double, we need
+ * to calculate max integer that can fit into double variable.
+ *
+ * With IEEE 64-bit double has 52 bits of mantissa, so it's 2^53.
+ * calculating it with approach `while (dbl + 1 != dbl) dbl++;`
+ * has issues with SSE and other 32 bits platform. So we are using
+ * direct value here.
+ *
+ * The maximum mantissa 0xFFFFFFFFFFFFF which is 52 bits all 1.
+ * In Python it's:
+ *
+ *  >>> (2.**53).hex()
+ *   '0x1.0000000000000p+53'
+ *
+ * See https://stackoverflow.com/questions/1848700/biggest-integer-that-can-be-stored-in-a-double
+ */
+static double dmaxint_ = 0x1.0000000000000p+53;
 
 // Definitions allow machine independent write and read
 // note that must include BYTEHEADER at head of routine
@@ -3776,20 +3793,7 @@ static void steer_x(void* v) {
 }
 
 void Vector_reg() {
-	dmaxint_ = 1073741824.;
-	for(;;) {
-		if (dmaxint_*2. == double(int(dmaxint_*2.))) {
-			dmaxint_ *= 2.;
-		}else{
-			if (dmaxint_*2. - 1. == double(int(dmaxint_*2. - 1.))) {
-				dmaxint_ = 2.*dmaxint_ - 1.;
-			}
-			break;
-		}
-	}		
-	//printf("dmaxint=%30.20g   %d\n", dmaxint_, (long)dmaxint_);
-        class2oc("Vector", v_cons, v_destruct, v_members, NULL, v_retobj_members,
-        	v_retstr_members);
+	class2oc("Vector", v_cons, v_destruct, v_members, NULL, v_retobj_members, v_retstr_members);
 	svec_ = hoc_lookup("Vector");
 	// now make the x variable an actual double
 	Symbol* sv = hoc_lookup("Vector");

--- a/src/ivoc/ivocvect.cpp
+++ b/src/ivoc/ivocvect.cpp
@@ -81,10 +81,12 @@ extern "C" {
  *
  *  >>> (2.**53).hex()
  *   '0x1.0000000000000p+53'
+ *  >>> (2.**53)
+ *   9007199254740992.0
  *
  * See https://stackoverflow.com/questions/1848700/biggest-integer-that-can-be-stored-in-a-double
  */
-static double dmaxint_ = 0x1.0000000000000p+53;
+static double dmaxint_ = 9007199254740992;
 
 // Definitions allow machine independent write and read
 // note that must include BYTEHEADER at head of routine


### PR DESCRIPTION
 - max integer that can fit into double was calculated
   explicitly and that results into infinite loop.
 - instead of using explicit loop (which can fail with
   sse/avx512 or on 32bit platform), use explicit value
   as IEEE-754 double is always 64 bit.

fixes #900