### PR TITLE
Cherry-pick important fixes from master to release/7.8 (after version 7.8.2)

### DIFF
--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install homebrew packages
         if: startsWith(matrix.os, 'macOS')
         run: |
-          brew install coreutils doxygen mpich xz autoconf automake libtool && brew unlink mpich && brew install openmpi && brew cask install xquartz
+          brew install coreutils doxygen mpich xz autoconf automake libtool && brew unlink mpich && brew install openmpi && brew install --cask xquartz
         shell: bash
         
       - name: Install apt packages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ Currently we have enabled CMake code formatting using [cmake-format](https://git
 * Make sure to install cmake-format utility with Python version you are using:
 
 ```
-pip3.7 install cmake-format==0.6.0 --user
+pip3.7 install cmake-format==0.6.0 pyyaml --user
 ```
 Now you should have `cmake-format` command available.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ jobs:
     displayName: 'Install Python from python.org'
 
   - script: |
-      brew cask install xquartz
+      brew install --cask xquartz
       brew install flex bison mpich
       brew unlink mpich && brew install openmpi
     displayName: 'Install OSX System Depdendencies'

--- a/bin/nrnivmodl_makefile_cmake.in
+++ b/bin/nrnivmodl_makefile_cmake.in
@@ -37,8 +37,11 @@ _cm =,
 INCLUDES = -I. $(INCFLAGS) $(UserINCFLAGS) -I$(incdir)
 INCLUDES += $(if @MPI_C_INCLUDE_PATH@, -I$(subst ;, -I,@MPI_C_INCLUDE_PATH@),)
 
-CC ?= @CMAKE_C_COMPILER@
-CXX ?= @CMAKE_CXX_COMPILER@
+# CC/CXX are always defined. If the definition comes from default change it
+ifeq ($(origin CC), default)
+    CC = @CMAKE_C_COMPILER@
+    CXX = @CMAKE_CXX_COMPILER@
+endif
 CFLAGS = @BUILD_TYPE_C_FLAGS@ @CMAKE_C_FLAGS@
 CXXFLAGS = @BUILD_TYPE_CXX_FLAGS@ @CMAKE_CXX_FLAGS@ @CXX11_STANDARD_COMPILE_OPTION@
 

--- a/git2nrnversion_h.sh
+++ b/git2nrnversion_h.sh
@@ -20,10 +20,9 @@ if git log > /dev/null && test -d .git ; then
 elif test -f src/nrnoc/nrnversion.h ; then
         sed -n '1,$p' src/nrnoc/nrnversion.h
 else
-        echo "#define GIT_DATE \"1999-12-31\""
-        echo "#define GIT_BRANCH \"?\""
-        echo "#define GIT_CHANGESET \"?\""
-        echo "#define GIT_DESCRIBE \"?\""
-        exit 1
+        echo "#define GIT_DATE \"Build Time: $(date "+%Y-%m-%d-%H:%M:%S")\""
+        echo "#define GIT_BRANCH \"unknown branch\""
+        echo "#define GIT_CHANGESET \"unknown commit id\""
+        echo "#define GIT_DESCRIBE \"${PROJECT_VERSION}.dev0\""
 fi
 

--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -40,11 +40,9 @@ setup_venv() {
     "$py_bin" -m venv "$venv_dir"
     . "$venv_dir/bin/activate"
 
-    # pep425tags are not available anymore from 0.35
-    # temporary workaround until we get smtg stable
-    if ! pip install -U pip setuptools "wheel<0.35"; then
-        curl https://bootstrap.pypa.io/get-pip.py | python
-        pip install -U setuptools "wheel<0.35"
+    if ! pip install -U pip setuptools wheel; then
+        curl https://raw.githubusercontent.com/pypa/get-pip/20.3.4/get-pip.py | python
+        pip install -U setuptools wheel
     fi
 }
 

--- a/setup.py
+++ b/setup.py
@@ -352,7 +352,7 @@ def mac_osx_setenv():
     except ImportError:
         from setuptools.dist import Distribution
         Distribution().fetch_build_eggs(["wheel"])
-    from wheel import pep425tags
+    from wheel.macosx_libfile import extract_macosx_min_system_version
 
     sdk_root = subprocess.check_output(['xcrun', '--sdk', 'macosx', '--show-sdk-path']
                                        ).decode().strip()
@@ -360,7 +360,7 @@ def mac_osx_setenv():
     os.environ['SDKROOT'] = sdk_root
 
     # Match Python OSX framework
-    py_osx_framework = pep425tags.extract_macosx_min_system_version(sys.executable)
+    py_osx_framework = extract_macosx_min_system_version(sys.executable)
     if py_osx_framework is None:
         py_osx_framework=[10, 9]
     if py_osx_framework[1] > 9:

--- a/src/ivoc/ivocvect.cpp
+++ b/src/ivoc/ivocvect.cpp
@@ -67,7 +67,26 @@ extern "C" {
 #define FRead(arg1,arg2,arg3,arg4) if (fread(arg1,arg2,arg3,arg4) != arg3) {}
 #endif
 
-static double dmaxint_;
+/**
+ * As all parameters are passed from hoc as double, we need
+ * to calculate max integer that can fit into double variable.
+ *
+ * With IEEE 64-bit double has 52 bits of mantissa, so it's 2^53.
+ * calculating it with approach `while (dbl + 1 != dbl) dbl++;`
+ * has issues with SSE and other 32 bits platform. So we are using
+ * direct value here.
+ *
+ * The maximum mantissa 0xFFFFFFFFFFFFF which is 52 bits all 1.
+ * In Python it's:
+ *
+ *  >>> (2.**53).hex()
+ *   '0x1.0000000000000p+53'
+ *  >>> (2.**53)
+ *   9007199254740992.0
+ *
+ * See https://stackoverflow.com/questions/1848700/biggest-integer-that-can-be-stored-in-a-double
+ */
+static double dmaxint_ = 9007199254740992;
 
 // Definitions allow machine independent write and read
 // note that must include BYTEHEADER at head of routine
@@ -3776,20 +3795,7 @@ static void steer_x(void* v) {
 }
 
 void Vector_reg() {
-	dmaxint_ = 1073741824.;
-	for(;;) {
-		if (dmaxint_*2. == double(int(dmaxint_*2.))) {
-			dmaxint_ *= 2.;
-		}else{
-			if (dmaxint_*2. - 1. == double(int(dmaxint_*2. - 1.))) {
-				dmaxint_ = 2.*dmaxint_ - 1.;
-			}
-			break;
-		}
-	}		
-	//printf("dmaxint=%30.20g   %d\n", dmaxint_, (long)dmaxint_);
-        class2oc("Vector", v_cons, v_destruct, v_members, NULL, v_retobj_members,
-        	v_retstr_members);
+	class2oc("Vector", v_cons, v_destruct, v_members, NULL, v_retobj_members, v_retstr_members);
 	svec_ = hoc_lookup("Vector");
 	// now make the x variable an actual double
 	Symbol* sv = hoc_lookup("Vector");

--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -139,7 +139,8 @@ set(NRN_INCLUDE_DIRS
 # is different from the contents of nrnversion.h
 # ~~~
 add_custom_target(
-  nrnversion_h ${PROJECT_SOURCE_DIR}/git2nrnversion_h.sh ${PROJECT_SOURCE_DIR} > nrnversion.h.tmp
+  nrnversion_h
+  COMMAND ${CMAKE_COMMAND} -E env PROJECT_VERSION=${PROJECT_VERSION} $ENV{SHELL} ${PROJECT_SOURCE_DIR}/git2nrnversion_h.sh ${PROJECT_SOURCE_DIR} > nrnversion.h.tmp
   COMMAND ${CMAKE_COMMAND} -E copy_if_different nrnversion.h.tmp ${NRN_NRNOC_SRC_DIR}/nrnversion.h
   DEPENDS ${PROJECT_SOURCE_DIR}/git2nrnversion_h.sh)
 


### PR DESCRIPTION
***NOTE*** :  We should `rebase and merge` these 4 commits **instead** of squash. 

* Fix for CMake failure when tarball doesn't contain `./git` sub-directory
* Fix for deadlock when compiled with AVX-512 (#900) 
* nrnivmodl was using default system C/C++ compiler instead of
   what CMake detects at configure time (#609)
* Follow changes in Homebrew 2.7.0 CLI. (#916)