### PR TITLE
nrnivmodl fix default to original compiler

### DIFF
--- a/bin/nrnivmodl_makefile_cmake.in
+++ b/bin/nrnivmodl_makefile_cmake.in
@@ -38,8 +38,11 @@ _cm =,
 INCLUDES = -I. $(INCFLAGS) $(UserINCFLAGS) -I$(incdir)
 INCLUDES += $(if @MPI_C_INCLUDE_PATH@, -I$(subst ;, -I,@MPI_C_INCLUDE_PATH@),)
 
-CC ?= @CMAKE_C_COMPILER@
-CXX ?= @CMAKE_CXX_COMPILER@
+# CC and CXX are implicitly defined. We check against cc, which is never (hopefully) user defined
+ifeq ($(CC), cc)
+    CC = @CMAKE_C_COMPILER@
+    CXX = @CMAKE_CXX_COMPILER@
+endif
 CFLAGS = @BUILD_TYPE_C_FLAGS@ @CMAKE_C_FLAGS@
 CXXFLAGS = @BUILD_TYPE_CXX_FLAGS@ @CMAKE_CXX_FLAGS@ @CXX11_STANDARD_COMPILE_OPTION@
 

--- a/bin/nrnivmodl_makefile_cmake.in
+++ b/bin/nrnivmodl_makefile_cmake.in
@@ -38,8 +38,8 @@ _cm =,
 INCLUDES = -I. $(INCFLAGS) $(UserINCFLAGS) -I$(incdir)
 INCLUDES += $(if @MPI_C_INCLUDE_PATH@, -I$(subst ;, -I,@MPI_C_INCLUDE_PATH@),)
 
-# CC and CXX are implicitly defined. We check against cc, which is never (hopefully) user defined
-ifeq ($(CC), cc)
+# CC/CXX are always defined. If the definition comes from default change it
+ifeq ($(origin CC), default)
     CC = @CMAKE_C_COMPILER@
     CXX = @CMAKE_CXX_COMPILER@
 endif


### PR DESCRIPTION
nrnivmodl_core should take @CMAKE_C_COMPILER@ by default. However the `?=` operator was never assigning since CC is implicitly defined.
For special implicitly defined variables we can use `$(origin` to see if the default is being assumed.

Fixes #609