### PR TITLE
Added CoreNEURON documentation in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Please refer to [docs/cmake_doc/options.rst](docs/cmake_doc/options.rst) for mor
 
 #### Optimized CPU and GPU Support using CoreNEURON
 
-NEURON now integrates [CoreNEURON library](https://github.com/BlueBrain/CoreNeuron/) for improved simulation performance on modern CPU and GPU architectures. CoreNEURON is designed as a library within the NEURON simulator and can transparently handle all spiking network simulations including gap junction coupling with the fixed time step method. You can find detailed [build instructions here](https://github.com/BlueBrain/CoreNeuron/#installation).
+NEURON now integrates [CoreNEURON library](https://github.com/BlueBrain/CoreNeuron/) for improved simulation performance on modern CPU and GPU architectures. CoreNEURON is designed as a library within the NEURON simulator and can transparently handle all spiking network simulations including gap junction coupling with the fixed time step method. You can find detailed instructions [here](docs/coreneuron/how-to/coreneuron.md) and [here](https://github.com/BlueBrain/CoreNeuron/#installation).
 
 <a name="build-autotools"></a>
 ### Build using Autotools

--- a/docs/coreneuron/how-to/coreneuron.md
+++ b/docs/coreneuron/how-to/coreneuron.md
@@ -2,12 +2,12 @@
 
 **CoreNEURON** is a compute engine for the **NEURON** simulator optimised for both memory usage and computational speed. Its goal is to simulate large cell networks with minimal memory footprint and optimal performance.
 
-If you are a new user and would like to use **CoreNEURON**, this tutorial will be a good starting point to understand complete workflow of using **CoreNEURON** with **NEURON**.
+If you are a new user and would like to use **CoreNEURON**, this tutorial will be a good starting point to understand the complete workflow of using **CoreNEURON** with **NEURON**.
 
 
 # How to install CoreNEURON
 
-**CoreNEURON** is a submodule of the NEURON repository and can be installed with NEURON by enabling the flag **NRN_ENABLE_CORENEURON** in the CMake command you are using to install NEURON.
+**CoreNEURON** is a submodule of the **NEURON** repository and can be installed with **NEURON** by enabling the flag **NRN_ENABLE_CORENEURON** in the CMake command used to install **NEURON**.
 For example:
 
     cmake .. \
@@ -19,71 +19,61 @@ For example:
 ## Notes
 
 ### Performance
-**CoreNEURON** is by itself an optimized compute engine of **NEURON**, however to unlock the full performance from your system we suggested using either an **Intel Compiler** or the **NMODL ISPC Backend** which we're going to discuss below. Those compilers are able to vectorize better the code than **GCC** achieving the best performance gains possible.
+**CoreNEURON** is by itself an optimized compute engine of **NEURON**, however to unlock better performance from the used CPUs it's suggested using either an **Intel Compiler** or the **NMODL ISPC Backend** which is described below. Those compilers are able to vectorize better the code than **GCC** achieving the best performance gains possible.
+
+### GPU execution
+**CoreNEURON** supports also GPU execution based on an **OpenACC** backend. To be able to use it it's needed to install **NEURON** and **CoreNEURON** with a compiler that supports **OpenACC**. Currently the best supported compiler for the **OpenACC** backend is **PGI** and this is the recommended one for compilation.
+To enable the GPU backend specify the following *CMake* variables:
+
+    -DNRN_ENABLE_CORENEURON=ON
+    -DCORENRN_ENABLE_GPU=ON
 
 ### NMODL
 The **NMODL** Framework is a code generation engine for the **N**EURON **MOD**eling **L**anguage. 
-**NMODL** is a part of **CoreNEURON** and can be used to generate optimized code for modern compute architectures including CPUs, GPUs.
+**NMODL** is a part of **CoreNEURON** and can be used to generate optimized code for modern compute architectures including CPUs and GPUs.
 **NMODL** can also generate code using a backend for the **ISPC** compiler, which can vectorize greatly the generated code running on CPU and accelerate further the simulation.
 
-> Disclaimer: To use the ISPC compiler backend you need to have ISPC compiler preinstalled in your system
+> Disclaimer: To use the ISPC compiler backend ISPC compiler must be preinstalled in your system. More information on how to install ISPC can be found [here](https://ispc.github.io/downloads.html). 
 
 #### How to use NMODL
-You can enable the **NMODL** code generation in **CoreNEURON** using the following *CMake* command:
+To enable the **NMODL** code generation in **CoreNEURON** specify the following *CMake* variables:
 
-       cmake .. \
-         -DNRN_ENABLE_INTERVIEWS=OFF \
-         -DNRN_ENABLE_MPI=OFF \
-         -DNRN_ENABLE_RX3D=OFF \
-         -DNRN_ENABLE_CORENEURON=ON \
-         -DCORENRN_ENABLE_NMODL=ON
-To use the **ISPC** backed you can add the following flags:
+    -DNRN_ENABLE_CORENEURON=ON
+    -DCORENRN_ENABLE_NMODL=ON
+
+To use the **ISPC** backend add the following flags:
 
     -DCORENRN_ENABLE_ISPC=ON
     -DCMAKE_ISPC_COMPILER=<path-to-ISPC-compiler-installation> # Only if the ispc executable is not in the PATH environment variable
+
 > Disclaimer: NMODL is currently under development and some mod files could be unsupported. Please feel free to try using NMODL with your mod files and report any issues on the [NMODL repository](https://github.com/BlueBrain/nmodl)
+
 # How to use CoreNEURON
 ## Python API
-To use **CoreNEURON** directly from **NEURON** using the in-memory mode you can add the following in your python script before calling the *psolve* function to run the simulation:
+To use **CoreNEURON** directly from **NEURON** using the in-memory mode add the following in your python script before calling the *psolve* function to run the simulation:
 
     from neuron import coreneuron
     coreneuron.enable = True
+    coreneuron.gpu = True # Only for GPU execution
 
-> To run a simulation with coreneuron h.cvode.cache_efficient(1) must be set
+> To run a simulation with CoreNEURON h.cvode.cache_efficient(1) must also be set
 
 You can find an example of the in-memory mode usage of **CoreNEURON** [here](https://github.com/neuronsimulator/nrn/blob/master/test/coreneuron/test_direct.py)
+
 ## HOC API
 To use the **CoreNEURON** in-memory mode using a HOC script you need to add the following before calling the *psolve* function to run the simulation:
 
     po = new PythonObject()
     po.coreneuron.enable = 1
     po.coreneuron.nrncore_arg(tstop)
+
+> To run a simulation with CoreNEURON h.cvode.cache_efficient(1) must also be set
+
 You can find an example of the in-memory mode usage of **CoreNEURON** [here](https://github.com/neuronsimulator/nrn/blob/master/test/coreneuron/test_direct.hoc)
+
 ## How to handle extra mod files
-In case you want to compile and use extra mod files with **NEURON** or **CoreNEURON**, before using your script you need to run on the same folder **nrnivmodl** as usual and then **nrnivmodl-core**, which is the equivalent of **nrnivmodl** for **CoreNEURON** and takes care of compiling and linking the extra mechanisms' mod files into **CoreNEURON**.
+In case you want to compile and use extra mod files with **NEURON** or **CoreNEURON** you need to execute **nrnivmodl** and pass as argument the folder of the mod files you want to compile. To create the libraries and executables needed to run the **CoreNEURON** simulation it's also needed to add the *-coreneuron* flag and then you can execute your **special** and your script that uses **CoreNEURON** as before.
 For example:
 
-    nrnivmodl mod
-    nrnivmodl-core mod
+    nrnivmodl -coreneuron mod
     ./x86_64/special -python init.py
-
-# CoreNEURON on GPUs
-**CoreNEURON** can be also configured to run on GPUs. To do so, you need to specify an extra flag in your *CMake* command:
-
-    -DCORENRN_ENABLE_GPU=ON
-Due to technical issues it's not yet possible to run **NEURON** with **CoreNEURON** with the in-memory mode.
-To run your simulation on GPUs you need to:
-
- 1. Run **nrnivmodl** and **nrnivmodl-core** as before
- 2. Repalce *pc.psolve()* with **pc.nrnbbcore_write('coredat')** and run your script as before
-This call is going to generate an intermediate model inside the *coredat* folder which is then going to be used as input to **CoreNEURON**.
-3. Run **CoreNEURON** using the **special-core** executable which was created in the **x86_64** folder and specify the **--datpath coredat**. You can find the rest of the options of **special-core**  [here](https://github.com/BlueBrain/CoreNeuron)
-
-An example bash script for running **CoreNEURON** on GPUs is the following:
-
-    nrnivmodl mod
-    nrnivmodl-core mod
-    ./x86_64/special -python init.py
-    ./x86_64/special-core --gpu --datpath coredat -e 10
-
-

--- a/docs/coreneuron/how-to/coreneuron.md
+++ b/docs/coreneuron/how-to/coreneuron.md
@@ -1,0 +1,89 @@
+# NEURON - CoreNEURON Integration
+
+**CoreNEURON** is a compute engine for the **NEURON** simulator optimised for both memory usage and computational speed. Its goal is to simulate large cell networks with minimal memory footprint and optimal performance.
+
+If you are a new user and would like to use **CoreNEURON**, this tutorial will be a good starting point to understand complete workflow of using **CoreNEURON** with **NEURON**.
+
+
+# How to install CoreNEURON
+
+**CoreNEURON** is a submodule of the NEURON repository and can be installed with NEURON by enabling the flag **NRN_ENABLE_CORENEURON** in the CMake command you are using to install NEURON.
+For example:
+
+    cmake .. \
+         -DNRN_ENABLE_INTERVIEWS=OFF \
+         -DNRN_ENABLE_MPI=OFF \
+         -DNRN_ENABLE_RX3D=OFF \
+         -DNRN_ENABLE_CORENEURON=ON
+
+## Notes
+
+### Performance
+**CoreNEURON** is by itself an optimized compute engine of **NEURON**, however to unlock the full performance from your system we suggested using either an **Intel Compiler** or the **NMODL ISPC Backend** which we're going to discuss below. Those compilers are able to vectorize better the code than **GCC** achieving the best performance gains possible.
+
+### NMODL
+The **NMODL** Framework is a code generation engine for the **N**EURON **MOD**eling **L**anguage. 
+**NMODL** is a part of **CoreNEURON** and can be used to generate optimized code for modern compute architectures including CPUs, GPUs.
+**NMODL** can also generate code using a backend for the **ISPC** compiler, which can vectorize greatly the generated code running on CPU and accelerate further the simulation.
+
+> Disclaimer: To use the ISPC compiler backend you need to have ISPC compiler preinstalled in your system
+
+#### How to use NMODL
+You can enable the **NMODL** code generation in **CoreNEURON** using the following *CMake* command:
+
+       cmake .. \
+         -DNRN_ENABLE_INTERVIEWS=OFF \
+         -DNRN_ENABLE_MPI=OFF \
+         -DNRN_ENABLE_RX3D=OFF \
+         -DNRN_ENABLE_CORENEURON=ON \
+         -DCORENRN_ENABLE_NMODL=ON
+To use the **ISPC** backed you can add the following flags:
+
+    -DCORENRN_ENABLE_ISPC=ON
+    -DCMAKE_ISPC_COMPILER=<path-to-ISPC-compiler-installation> # Only if the ispc executable is not in the PATH environment variable
+> Disclaimer: NMODL is currently under development and some mod files could be unsupported. Please feel free to try using NMODL with your mod files and report any issues on the [NMODL repository](https://github.com/BlueBrain/nmodl)
+# How to use CoreNEURON
+## Python API
+To use **CoreNEURON** directly from **NEURON** using the in-memory mode you can add the following in your python script before calling the *psolve* function to run the simulation:
+
+    from neuron import coreneuron
+    coreneuron.enable = True
+
+> To run a simulation with coreneuron h.cvode.cache_efficient(1) must be set
+
+You can find an example of the in-memory mode usage of **CoreNEURON** [here](https://github.com/neuronsimulator/nrn/blob/master/test/coreneuron/test_direct.py)
+## HOC API
+To use the **CoreNEURON** in-memory mode using a HOC script you need to add the following before calling the *psolve* function to run the simulation:
+
+    po = new PythonObject()
+    po.coreneuron.enable = 1
+    po.coreneuron.nrncore_arg(tstop)
+You can find an example of the in-memory mode usage of **CoreNEURON** [here](https://github.com/neuronsimulator/nrn/blob/master/test/coreneuron/test_direct.hoc)
+## How to handle extra mod files
+In case you want to compile and use extra mod files with **NEURON** or **CoreNEURON**, before using your script you need to run on the same folder **nrnivmodl** as usual and then **nrnivmodl-core**, which is the equivalent of **nrnivmodl** for **CoreNEURON** and takes care of compiling and linking the extra mechanisms' mod files into **CoreNEURON**.
+For example:
+
+    nrnivmodl mod
+    nrnivmodl-core mod
+    ./x86_64/special -python init.py
+
+# CoreNEURON on GPUs
+**CoreNEURON** can be also configured to run on GPUs. To do so, you need to specify an extra flag in your *CMake* command:
+
+    -DCORENRN_ENABLE_GPU=ON
+Due to technical issues it's not yet possible to run **NEURON** with **CoreNEURON** with the in-memory mode.
+To run your simulation on GPUs you need to:
+
+ 1. Run **nrnivmodl** and **nrnivmodl-core** as before
+ 2. Repalce *pc.psolve()* with **pc.nrnbbcore_write('coredat')** and run your script as before
+This call is going to generate an intermediate model inside the *coredat* folder which is then going to be used as input to **CoreNEURON**.
+3. Run **CoreNEURON** using the **special-core** executable which was created in the **x86_64** folder and specify the **--datpath coredat**. You can find the rest of the options of **special-core**  [here](https://github.com/BlueBrain/CoreNeuron)
+
+An example bash script for running **CoreNEURON** on GPUs is the following:
+
+    nrnivmodl mod
+    nrnivmodl-core mod
+    ./x86_64/special -python init.py
+    ./x86_64/special-core --gpu --datpath coredat -e 10
+
+

--- a/docs/coreneuron/how-to/coreneuron.md
+++ b/docs/coreneuron/how-to/coreneuron.md
@@ -19,7 +19,7 @@ For example:
 ## Notes
 
 ### Performance
-**CoreNEURON** is by itself an optimized compute engine of **NEURON**, however to unlock better performance from the used CPUs it's suggested using either an **Intel Compiler** or the **NMODL ISPC Backend** which is described below. Those compilers are able to vectorize better the code than **GCC** achieving the best performance gains possible.
+**CoreNEURON** is by itself an optimized compute engine of **NEURON**, however to unlock better CPU performance it's recommended to use either an **Intel Compiler** or the **NMODL ISPC Backend** (described described below). Those compilers are able to vectorize the code better than **GCC**, achieving the best possible performance gains.
 
 ### GPU execution
 **CoreNEURON** supports also GPU execution based on an **OpenACC** backend. To be able to use it it's needed to install **NEURON** and **CoreNEURON** with a compiler that supports **OpenACC**. Currently the best supported compiler for the **OpenACC** backend is **PGI** and this is the recommended one for compilation.
@@ -56,7 +56,7 @@ To use **CoreNEURON** directly from **NEURON** using the in-memory mode add the 
     coreneuron.enable = True
     coreneuron.gpu = True # Only for GPU execution
 
-> To run a simulation with CoreNEURON h.cvode.cache_efficient(1) must also be set
+> NOTE: In order to run a simulation with CoreNEURON, h.cvode.cache_efficient(1) must also be set
 
 You can find an example of the in-memory mode usage of **CoreNEURON** [here](https://github.com/neuronsimulator/nrn/blob/master/test/coreneuron/test_direct.py)
 
@@ -71,7 +71,7 @@ To use the **CoreNEURON** in-memory mode using a HOC script you need to add the 
     po = new PythonObject()
     po.coreneuron.enable = 1
 
-> To run a simulation with CoreNEURON h.cvode.cache_efficient(1) must also be set
+> NOTE: In order to run a simulation with CoreNEURON, h.cvode.cache_efficient(1) must also be set
 
 You can find an example of the in-memory mode usage of **CoreNEURON** [here](https://github.com/neuronsimulator/nrn/blob/master/test/coreneuron/test_direct.hoc)
 

--- a/docs/coreneuron/how-to/coreneuron.md
+++ b/docs/coreneuron/how-to/coreneuron.md
@@ -63,9 +63,13 @@ You can find an example of the in-memory mode usage of **CoreNEURON** [here](htt
 ## HOC API
 To use the **CoreNEURON** in-memory mode using a HOC script you need to add the following before calling the *psolve* function to run the simulation:
 
+    if (!nrnpython("from neuron import coreneuron")) {
+        printf("Python not available\n")
+        return
+    }
+
     po = new PythonObject()
     po.coreneuron.enable = 1
-    po.coreneuron.nrncore_arg(tstop)
 
 > To run a simulation with CoreNEURON h.cvode.cache_efficient(1) must also be set
 

--- a/docs/coreneuron/how-to/coreneuron.md
+++ b/docs/coreneuron/how-to/coreneuron.md
@@ -1,8 +1,8 @@
 # NEURON - CoreNEURON Integration
 
-**CoreNEURON** is a compute engine for the **NEURON** simulator optimised for both memory usage and computational speed. Its goal is to simulate large cell networks with minimal memory footprint and optimal performance.
+**CoreNEURON** is a compute engine for the **NEURON** simulator optimised for both memory usage and computational speed using modern CPU/GPU architetcures. Its goal is to simulate large cell networks with minimal memory footprint and optimal performance.
 
-If you are a new user and would like to use **CoreNEURON**, this tutorial will be a good starting point to understand the complete workflow of using **CoreNEURON** with **NEURON**.
+If you are a new user and would like to use **CoreNEURON**, this tutorial will be a good starting point to understand the complete workflow of using **CoreNEURON** with **NEURON**. We would be grateful for any feedback about your use cases or issues you encounter using the CoreNEURON. Please [report any issue here](https://github.com/neuronsimulator/nrn/issues) and we will be happy to help.
 
 
 # How to install CoreNEURON
@@ -19,21 +19,24 @@ For example:
 ## Notes
 
 ### Performance
-**CoreNEURON** is by itself an optimized compute engine of **NEURON**, however to unlock better CPU performance it's recommended to use either an **Intel Compiler** or the **NMODL ISPC Backend** (described described below). Those compilers are able to vectorize the code better than **GCC**, achieving the best possible performance gains.
+**CoreNEURON** is by itself an optimized compute engine of **NEURON**, however to unlock better CPU performance it's recommended to use compilers like **Intel / PGI / Cray  Compiler** or the **ISPC Backend** using the new [NMODL Compiler Framework](https://github.com/BlueBrain/nmodl) (described described below). These compilers are able to vectorize the code better than **GCC** or **Clang**, achieving the best possible performance gains. Note that Intel compiler can be installed by downloading [oneAPI HPC Toolkit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/hpc-toolkit.html).
 
 ### GPU execution
-**CoreNEURON** supports also GPU execution based on an **OpenACC** backend. To be able to use it it's needed to install **NEURON** and **CoreNEURON** with a compiler that supports **OpenACC**. Currently the best supported compiler for the **OpenACC** backend is **PGI** and this is the recommended one for compilation.
+**CoreNEURON** supports also GPU execution based on an **OpenACC** backend. To be able to use it it's needed to install **NEURON** and **CoreNEURON** with a compiler that supports **OpenACC**. Currently the best supported compiler for the **OpenACC** backend is **PGI** (available via [NVIDIA-HPC-SDK](https://developer.nvidia.com/hpc-sdk)) and this is the recommended one for compilation.
 To enable the GPU backend specify the following *CMake* variables:
 
     -DNRN_ENABLE_CORENEURON=ON
     -DCORENRN_ENABLE_GPU=ON
 
+Make sure to set the compilers via CMake flags `-DCMAKE_C_COMPILER=<C_Compiler>` and `-DCMAKE_CXX_COMPILER=<CXX_Compiler>`.
+
 ### NMODL
+
 The **NMODL** Framework is a code generation engine for the **N**EURON **MOD**eling **L**anguage. 
 **NMODL** is a part of **CoreNEURON** and can be used to generate optimized code for modern compute architectures including CPUs and GPUs.
 **NMODL** can also generate code using a backend for the **ISPC** compiler, which can vectorize greatly the generated code running on CPU and accelerate further the simulation.
 
-> Disclaimer: To use the ISPC compiler backend ISPC compiler must be preinstalled in your system. More information on how to install ISPC can be found [here](https://ispc.github.io/downloads.html). 
+**NOTE**: To use the ISPC compiler backend ISPC compiler must be preinstalled in your system. More information on how to install ISPC can be found [here](https://ispc.github.io/downloads.html).
 
 #### How to use NMODL
 To enable the **NMODL** code generation in **CoreNEURON** specify the following *CMake* variables:
@@ -46,9 +49,10 @@ To use the **ISPC** backend add the following flags:
     -DCORENRN_ENABLE_ISPC=ON
     -DCMAKE_ISPC_COMPILER=<path-to-ISPC-compiler-installation> # Only if the ispc executable is not in the PATH environment variable
 
-> Disclaimer: NMODL is currently under development and some mod files could be unsupported. Please feel free to try using NMODL with your mod files and report any issues on the [NMODL repository](https://github.com/BlueBrain/nmodl)
+**NOTE** : NMODL is currently under active development and some mod files could be unsupported. Please feel free to try using NMODL with your mod files and report any issues on the [NMODL repository](https://github.com/BlueBrain/nmodl)
 
 # How to use CoreNEURON
+
 ## Python API
 To use **CoreNEURON** directly from **NEURON** using the in-memory mode add the following in your python script before calling the *psolve* function to run the simulation:
 
@@ -56,9 +60,9 @@ To use **CoreNEURON** directly from **NEURON** using the in-memory mode add the 
     coreneuron.enable = True
     coreneuron.gpu = True # Only for GPU execution
 
-> NOTE: In order to run a simulation with CoreNEURON, h.cvode.cache_efficient(1) must also be set
+**NOTE**: In order to run a simulation with CoreNEURON, `h.cvode.cache_efficient(1)` must also be set.
 
-You can find an example of the in-memory mode usage of **CoreNEURON** [here](https://github.com/neuronsimulator/nrn/blob/master/test/coreneuron/test_direct.py)
+You can find an example of the in-memory mode usage of **CoreNEURON** [here](https://github.com/neuronsimulator/nrn/blob/master/test/coreneuron/test_direct.py).
 
 ## HOC API
 To use the **CoreNEURON** in-memory mode using a HOC script you need to add the following before calling the *psolve* function to run the simulation:
@@ -71,13 +75,17 @@ To use the **CoreNEURON** in-memory mode using a HOC script you need to add the 
     po = new PythonObject()
     po.coreneuron.enable = 1
 
-> NOTE: In order to run a simulation with CoreNEURON, h.cvode.cache_efficient(1) must also be set
+**NOTE**: In order to run a simulation with CoreNEURON, h.cvode.cache_efficient(1) must also be set
 
 You can find an example of the in-memory mode usage of **CoreNEURON** [here](https://github.com/neuronsimulator/nrn/blob/master/test/coreneuron/test_direct.hoc)
 
-## How to handle extra mod files
-In case you want to compile and use extra mod files with **NEURON** or **CoreNEURON** you need to execute **nrnivmodl** and pass as argument the folder of the mod files you want to compile. To create the libraries and executables needed to run the **CoreNEURON** simulation it's also needed to add the *-coreneuron* flag and then you can execute your **special** and your script that uses **CoreNEURON** as before.
+See more informaiton in CoreNEURON [README documentation](https://github.com/BlueBrain/CoreNeuron#dependencies).
+
+## Compiling MOD files
+
+In order to use mod files with **NEURON** or **CoreNEURON** you need to execute **nrnivmodl** and pass as argument the folder of the mod files you want to compile. To run the simulation using **CoreNEURON**, you have to use *-coreneuron* flag and then you can execute your **special** binary to run the model.
 For example:
 
-    nrnivmodl -coreneuron mod
+    nrnivmodl -coreneuron mod_folder
     ./x86_64/special -python init.py
+

--- a/docs/coreneuron/index.rst
+++ b/docs/coreneuron/index.rst
@@ -1,0 +1,9 @@
+How to use CoreNEURON
+=====================
+
+.. toctree::
+   :maxdepth: 4
+
+   ./how-to/coreneuron.md
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Welcome to NEURON's documentation!
    new_doc/index
    tutorials/index
    rxd-tutorials/index
+   coreneuron/index
 
 .. toctree::
    :maxdepth: 2

--- a/share/lib/python/neuron/rxd/geometry3d/FullJoinMorph.py
+++ b/share/lib/python/neuron/rxd/geometry3d/FullJoinMorph.py
@@ -67,8 +67,8 @@ def fullmorph(source, dx, soma_step=100, mesh_grid=None, relevant_pts=None):
         arcs += [sec.arc3d(i + 1) - sec.arc3d(i) for i in rng[:-1]]
 
     # TODO: include segment boundaries when checking cone lengths
-    # warning on minimum size of dx
-    check = min(min(diams)/math.sqrt(3), min(arcs)/math.sqrt(3))
+    # warning on minimum size of dx, only considering positive lengths
+    check = min(min(d for d in diams if d > 0)/math.sqrt(3), min(a for a in arcs if a > 0)/math.sqrt(3))
     if (dx > check):
         warnings.warn("Resolution may be too low. To guarantee accurate voxelization, use a dx <= {}.".format(check))
     


### PR DESCRIPTION
Added documentation about:
- How to install NEURON with CoreNEURON using CMake
- How to install important CoreNEURON components (GPU, NMODL, ISPC)
- How to enable CoreNEURON sim in python and HOC scripts
- How to compile mod files for CoreNEURON