### PR TITLE
Follow changes in Homebrew 2.7.0 CLI

### DIFF
--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install homebrew packages
         if: startsWith(matrix.os, 'macOS')
         run: |
-          brew install coreutils doxygen mpich xz autoconf automake libtool && brew unlink mpich && brew install openmpi && brew cask install xquartz
+          brew install coreutils doxygen mpich xz autoconf automake libtool && brew unlink mpich && brew install openmpi && brew install --cask xquartz
         shell: bash
         
       - name: Install apt packages

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,7 +95,7 @@ jobs:
     displayName: 'Install Python from python.org'
 
   - script: |
-      brew cask install xquartz
+      brew install --cask xquartz
       brew install flex bison mpich
       brew unlink mpich && brew install openmpi
       cmake --version


### PR DESCRIPTION
As of this morning the CI in https://github.com/neuronsimulator/nrn-build-ci started to fail on macOS, apparently because the GitHub Actions macOS 10.15 image now includes a newer version of Homebrew.

As explained [here](https://github.com/Homebrew/discussions/discussions/340), the old `brew cask install XXX` syntax has been removed and `brew install --cask XXX` is preferred.