### PR TITLE
Dynamic number of extracellular layers.

### DIFF
--- a/src/nrncvode/nrndaspk.cpp
+++ b/src/nrncvode/nrndaspk.cpp
@@ -544,17 +544,18 @@ for (i=0; i < z.nvsize_; ++i) {
 			double* cd = ml->data[i];
 			Node* nd = ml->nodelist[i];
 			int j = nd->eqn_index_;
+#if EXTRACELLULAR
 #if I_MEMBRANE
 			// i_membrane = sav_rhs --- even for zero area nodes
 			cd[1+3*nlayer] = cd[3+3*nlayer];
-#endif
-#if EXTRACELLULAR == 1
+#endif /*I_MEMBRANE*/
+		    if (nlayer == 1) {
 			// only works for one layer
 			// otherwise loop over layer,
 			// xc is (pd + 2*(nlayer))[layer]
 			// and deal with yprime[i+layer]-yprime[i+layer+1]
 			delta[j] -= 1e-3 * cd[2] * yprime[j];
-#else
+		    }else{
 			int k, jj;
 			double x;
 			k = nlayer-1;
@@ -569,7 +570,8 @@ for (i=0; i < z.nvsize_; ++i) {
 				delta[jj+1] += x; // last one in iteration is nlayer-1
 			}
 			
-#endif
+		    }
+#endif /*EXTRACELLULAR*/
 		}
 	}
 

--- a/src/nrniv/cxprop.cpp
+++ b/src/nrniv/cxprop.cpp
@@ -21,6 +21,7 @@ extern void nrn_mk_prop_pools(int);
 extern void nrn_cache_prop_realloc();
 extern int nrn_is_ion(int);
 void nrn_update_ion_pointer(Symbol* sion, Datum* dp, int id, int ip);
+void nrn_delete_prop_pool(int type);
 #if EXTRACELLULAR
 void nrn_extcell_update_param();
 #endif
@@ -250,6 +251,17 @@ static void mk_prop_pools(int n) {
 		datumpools_ = p2;
 		npools_ = n;
 	}
+}
+
+void nrn_delete_prop_pool(int type) {
+  assert(type < npools_);
+  if (dblpools_[type]) {
+    if (dblpools_[type]->nget() > 0) {
+      hoc_execerror(memb_func[type].sym->name, "prop pool in use");
+    }
+    delete dblpools_[type];
+    dblpools_[type] = NULL;
+  }
 }
 
 void nrn_mk_prop_pools(int n) {

--- a/src/nrnoc/cprop.c
+++ b/src/nrnoc/cprop.c
@@ -12,6 +12,7 @@ greater cache efficiency
 
 void nrn_mk_prop_pools(int n) {}
 void nrn_cache_prop_realloc() {}
+void nrn_delete_prop_pool(int type) {}
 int nrn_is_valid_section_ptr(void* v) { return 0; }
 
 double* nrn_prop_data_alloc(int type, int count, Prop* p) {
@@ -38,4 +39,3 @@ Section* nrn_section_alloc() {
 void nrn_section_free(Section* s) {
 	free(s);
 }
-

--- a/src/nrnoc/extcelln.c
+++ b/src/nrnoc/extcelln.c
@@ -10,6 +10,7 @@
 
 extern int cvode_active_;
 extern int nrn_use_daspk_;
+extern void nrn_delete_prop_pool(int type);
 
 #if EXTRACELLULAR
 
@@ -261,6 +262,7 @@ void nlayer_extracellular() {
     if (nlayer == old) { return; }
 
     check_if_extracellular_in_use();
+    nrn_delete_prop_pool(EXTRACELL);
     update_extracellular_reg(old);
     update_existing_extnode(old);
   }

--- a/src/nrnoc/extcelln.c
+++ b/src/nrnoc/extcelln.c
@@ -151,10 +151,13 @@ i_membrane = sav_g * (NODERHS(nd)) + sav_rhs;
 #endif
 }
 
-static int nparm() {
+static int nparm() { /* number of doubles for property data */
+  /* 3 are the nlayer size arrays xg, xc, xraxial */
 #if I_MEMBRANE
+  /* 4 is for e_extracellular, i_membrane, sav_g, and sav_rhs */
   return 3*(nlayer) + 4;
 #else
+  /* 1 is for e_extracellular */
   return 3*(nlayer) + 1;
 #endif
 }
@@ -229,7 +232,14 @@ static void check_if_extracellular_in_use() {
 }
 
 static void update_existing_extnode(int old_nlayer) {
-  /* there aren't any because of check_if_extracellular_in_use() */
+  /*
+    This is a placeholder for a later extension to allow change
+    of nlayer even if the extracellular mechanism has been instantiated
+    in some sections. It is deferred for later because it is not clear
+    that handling pointer updates to vext is straightforward.
+    Hence the check_if_extracellular_in_use() function, which will
+    be eliminated when this is filled in.
+  */
 }
 
 static void update_extracellular_reg(int old_nlayer) {
@@ -257,12 +267,14 @@ static void update_extracellular_reg(int old_nlayer) {
 
 void nlayer_extracellular() {
   if (ifarg(1)) {
+    /* Note in section.h: #define  nlayer (nrn_nlayer_extracellular) */
     int old = nlayer;
     nrn_nlayer_extracellular = (int)chkarg(1, 1., 1000.);
-    if (nlayer == old) { return; }
+    if (nrn_nlayer_extracellular == old) { return; }
 
     check_if_extracellular_in_use();
     nrn_delete_prop_pool(EXTRACELL);
+    /*global nlayer is the new value. Following needs to know the previous */
     update_extracellular_reg(old);
     update_existing_extnode(old);
   }

--- a/src/nrnoc/extcelln.c
+++ b/src/nrnoc/extcelln.c
@@ -258,7 +258,7 @@ static void update_extracellular_reg(int old_nlayer) {
 void nlayer_extracellular() {
   if (ifarg(1)) {
     int old = nlayer;
-    nrn_nlayer_extracellular = (int)chkarg(1, 0., 1000.);
+    nrn_nlayer_extracellular = (int)chkarg(1, 1., 1000.);
     if (nlayer == old) { return; }
 
     check_if_extracellular_in_use();

--- a/src/nrnoc/neuron.h
+++ b/src/nrnoc/neuron.h
@@ -39,6 +39,10 @@ extern void fit_praxis(), attr_praxis(), pval_praxis(), stop_praxis();
 extern void keep_nseg_parm();
 #endif
 
+#if EXTRACELLULAR
+extern void nlayer_extracellular();
+#endif
+
 extern void nrnallsectionmenu(), nrnallpointmenu(), nrnsecmenu();
 extern void nrnglobalmechmenu(), nrnmechmenu(), nrnpointmenu();
 

--- a/src/nrnoc/options.h
+++ b/src/nrnoc/options.h
@@ -16,11 +16,7 @@ in one section is set but no others. But only the first time through treeset.
 
 #define I_MEMBRANE	1	/* compute i_cap and i_membrane on fadvance */
 
-#if _CRAY
-#define EXTRACELLULAR	0  /* this form of gaussian elimination is vectorized*/
-#else
-#define EXTRACELLULAR	2	/* number of extracellular layers */
-#endif
+#define EXTRACELLULAR	2	/* default number of extracellular layers */
 
 #define DIAMLIST	1	/* section contains diameter info */
 #define EXTRAEQN	0	/* ionic concentrations calculated via

--- a/src/nrnoc/section.h
+++ b/src/nrnoc/section.h
@@ -186,26 +186,24 @@ typedef struct Node {
 
 #if EXTRACELLULAR
 /* pruned to only work with sparse13 */
-#define  nlayer (EXTRACELLULAR)	/* first (0) layer is extracellular next to membrane */
-/*
-changing nlayer here means you have to change the explicit numbers
-nlayer-1 in the mechanism structure in extcell.c
-*/
+extern int nrn_nlayer_extracellular;
+#define  nlayer (nrn_nlayer_extracellular) /* first (0) layer is extracellular next to membrane */
 typedef struct Extnode {
 	double	*param;	/* points to extracellular parameter vector */
 	/* v is membrane potential. so v internal = Node.v + Node.vext[0] */
 	/* However, the Node equation is for v internal. */
 	/* This is reconciled during update. */
 	
-	double	v[nlayer]; /* v external. */
-	double	_a[nlayer];
-	double	_b[nlayer];
-	double* _d[nlayer];
-	double* _rhs[nlayer]; /* d, rhs, a, and b are analogous to those in node */
-	double* _a_matelm[nlayer];
-	double* _b_matelm[nlayer];
-	double* _x12[nlayer]; /* effect of v[layer] on eqn layer-1 (or internal)*/
-	double* _x21[nlayer]; /* effect of v[layer-1 or internal] on eqn layer*/
+	/* Following all have allocated size of nlayer */
+	double	*v; /* v external. */
+	double	*_a;
+	double	*_b;
+	double* *_d;
+	double* *_rhs; /* d, rhs, a, and b are analogous to those in node */
+	double* *_a_matelm;
+	double* *_b_matelm;
+	double* *_x12; /* effect of v[layer] on eqn layer-1 (or internal)*/
+	double* *_x21; /* effect of v[layer-1 or internal] on eqn layer*/
 } Extnode;
 #endif
 

--- a/test/pynrn/test_nlayer.py
+++ b/test/pynrn/test_nlayer.py
@@ -1,0 +1,58 @@
+from neuron import h, gui
+
+class Model:
+  def __init__(self):
+    nlayer = int(h.nlayer_extracellular())
+
+    cable = [h.Section("cable%d"%i) for i in range(4)]
+    cable[1].connect(cable[0](1))
+    cable[2].connect(cable[1](1))
+    cable[3].connect(cable[0](0))
+
+    for sec in cable:
+      sec.nseg = 3
+      sec.L = 100
+      sec.diam = 1
+      sec.insert('hh')
+      sec.insert('extracellular') # default, virtually wire to ground
+      for i in range(nlayer):
+        sec.xg[i] = 1e7       # Gaussian elimination roundoff errors in 10 ms
+        sec.xraxial[i] = 1e14 # accumulate if left at default 1e9
+      sec.xg[nlayer-1] = .001 # all voltage drop in last layer
+
+    cable[3](1).e_extracellular = -20 # stimulate extracellularly
+
+    self.cable = cable
+
+  def run(self):
+    h.tstop = 10
+    h.run()
+    res = [h.Vector(), h.Vector()]
+    for sec in self.cable:
+      for seg in sec.allseg():
+        res[0].append(seg.v)
+        res[1].append(seg.vext[0])
+    return res
+
+def test_nlayer():
+  res = []
+  for nlayer in [1, 2, 3]:
+    h.nlayer_extracellular(nlayer)
+    assert (nlayer == int(h.nlayer_extracellular()))
+    m = Model()
+    res.append(m.run())
+    del m
+  for r in res[1:]:
+    for i in range(2):
+     x = r[i].c().sub(res[0][i]).abs().sum()
+     print (x)
+     assert(x < 0.006) # At 10ms. At 5ms would be 2e-5
+  return res
+
+if __name__ == "__main__":
+  res = test_nlayer()
+  for i in range(len(res[0][0])):
+    for j in range(2):
+      for k in range(3):
+        print("%g" % res[k][j].x[i], end=" ")
+    print()

--- a/test/pynrn/test_nlayer.py
+++ b/test/pynrn/test_nlayer.py
@@ -46,7 +46,7 @@ def test_nlayer():
     for i in range(2):
      x = r[i].c().sub(res[0][i]).abs().sum()
      print (x)
-     assert(x < 0.006) # At 10ms. At 5ms would be 2e-5
+     assert(x < 0.01) # At 10ms. At 5ms would be 2e-5
   return res
 
 if __name__ == "__main__":


### PR DESCRIPTION
Responds to #918 
At present, just the computational framework for a dynamically resizeable Extnode. The global variable for nlayer is ```nrn_nlayer_extracellular``` and has a default of 2. Produces same results as master for fixed step method and IDA.

The interpreter function, ```nlayer = nlayer_extracellular([nlayer])``` dynamically changes the value of ```nrn_nlayer_extracellular``` and updates all interface aspects that depend on nlayer. Nlayer can only be changed if no extracellular mechanism instance is currently in use. Without an arg, ```nlayer_extracellular()``` returns the present value of nlayer.

The user should not expect identical results with different numbers of layers and default values for xg and xraxial as gaussian elimination has different round off errors in these cases.