### PR TITLE
Support for using file transfer mode via coreneuron embedded module

### DIFF
--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install apt packages
         if: startsWith(matrix.os, 'ubuntu')
         run: |
-          sudo apt-get install  build-essential doxygen autoconf automake libtool autotools-dev libopenmpi-dev libmpich-dev libx11-dev libxcomposite-dev mpich openmpi-bin patchelf python-pip python-tk python-numpy python3-numpy python3-pip g++-5 g++-6 g++-8 g++-9  
+          sudo apt-get install build-essential doxygen autoconf automake libtool autotools-dev libopenmpi-dev libx11-dev libxcomposite-dev openmpi-bin patchelf python-pip python-tk python-numpy python3-numpy python3-pip g++-5 g++-6 g++-8 g++-9
         shell: bash
 
       - name: Set up Python2

--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install apt packages
         if: startsWith(matrix.os, 'ubuntu')
         run: |
-          sudo apt-get install build-essential doxygen autoconf automake libtool autotools-dev libopenmpi-dev libx11-dev libxcomposite-dev openmpi-bin patchelf python-pip python-tk python-numpy python3-numpy python3-pip g++-5 g++-6 g++-8 g++-9
+          sudo apt-get install  build-essential doxygen autoconf automake libtool autotools-dev libopenmpi-dev libmpich-dev libx11-dev libxcomposite-dev mpich openmpi-bin patchelf python-pip python-tk python-numpy python3-numpy python3-pip g++-5 g++-6 g++-8 g++-9  
         shell: bash
 
       - name: Set up Python2

--- a/share/lib/python/neuron/coreneuron.py
+++ b/share/lib/python/neuron/coreneuron.py
@@ -2,6 +2,7 @@
 # Properties settable by user
 enable = False     # Use CoreNEURON when calling ParallelContext.psolve(tstop).
 gpu = False        # Activate GPU computation.
+file_mode = False  # Run via file transfer mode instead of in-memory transfer
 cell_permute = 1   # 0 no permutation; 1 optimize node adjacency
                    # 2 optimize parent node adjacency (only for gpu = True)
 warp_balance = 0   # Number of warps to balance. (0 no balance)
@@ -38,8 +39,12 @@ def nrncore_arg(tstop):
   if not enable:
     return arg
 
+  # note that this name is also used in C++ file nrncore_write.cpp
+  CORENRN_DATA_DIR = "corenrn_data"
+
   # args derived from user properties
   arg += ' --gpu' if gpu else ''
+  arg += ' --datpath %s' % CORENRN_DATA_DIR if file_mode else ''
   arg += ' --tstop %g' % tstop
   arg += (' --cell-permute %d' % cell_permute) if cell_permute > 0 else ''
   arg += (' --nwarp %d' % warp_balance) if warp_balance > 0 else ''

--- a/src/nrniv/nrncore_write.h
+++ b/src/nrniv/nrncore_write.h
@@ -11,7 +11,7 @@ extern void nrncore_netpar_cellgroups_helper(CellGroup*);
 
 int nrncore_run(const char* arg);
 int nrncore_is_enabled();
-int nrncore_psolve(double tstop);
+int nrncore_psolve(double tstop, int file_mode);
 
 #if defined(__cplusplus)
 }

--- a/src/nrniv/nrncore_write/io/nrncore_io.cpp
+++ b/src/nrniv/nrncore_write/io/nrncore_io.cpp
@@ -26,20 +26,26 @@ extern void (*nrnthread_v_transfer_)(NrnThread*);
 int chkpnt;
 const char *bbcore_write_version = "1.4"; // Generalize *_gap.dat to allow transfer of any range variable
 
+/// create directory with given path
+void create_dir_path(const std::string& path) {
+    // only one rank needs to create directory
+    if (nrnmpi_myid == 0) {
+        if (!isDirExist(path)) {
+            if (!makePath(path)) {
+                hoc_execerror(path.c_str(), "directory did not exist and makePath for it failed");
+            }
+        }
+    }
+    // rest of the ranks should wait before continue simulation
+#ifdef NRNMPI
+    nrnmpi_barrier();
+#endif
+}
+
 std::string get_write_path(){
     std::string path("."); // default path
     if (ifarg(1)) {
         path = hoc_gargstr(1);
-        if (nrnmpi_myid == 0) {
-            if (!isDirExist(path)) {
-                if (!makePath(path)) {
-                    hoc_execerror(path.c_str(), "directory did not exist and makePath for it failed");
-                }
-            }
-        }
-        #ifdef NRNMPI
-        nrnmpi_barrier();
-        #endif
     }
     return path;
 }

--- a/src/nrniv/nrncore_write/io/nrncore_io.h
+++ b/src/nrniv/nrncore_write/io/nrncore_io.h
@@ -9,6 +9,7 @@ class NrnThread;
 union Datum;
 class NrnMappingInfo;
 
+void create_dir_path(const std::string& path);
 std::string get_write_path();
 std::string get_filename(const std::string &path, std::string file_name);
 

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -2939,17 +2939,25 @@ static void sectionlist_helper_(void* sl, Object* args) {
   }
 }
 
-/** value of neuron.coreneuron.enable as 0, 1 (-1 if error)
- *  TODO: seems like this could be generalized so that
- *  additional cases would require less code.
-*/
+/// value of neuron.coreneuron.enable as 0, 1 (-1 if error)
 extern int (*nrnpy_nrncore_enable_value_p_)();
-static int nrncore_enable_value() {
+
+/// value of neuron.coreneuron.file_mode as 0, 1 (-1 if error)
+extern int (*nrnpy_nrncore_file_mode_value_p_)();
+
+/*
+ * Helper function to inspect value of int/boolean option
+ * under coreneuron module.
+ *
+ * \todo : seems like this could be generalized so that
+ *  additional cases would require less code.
+ */
+static int get_nrncore_opt_value(const char* option) {
   PyObject* modules = PyImport_GetModuleDict();
   if (modules) {
     PyObject* module = PyDict_GetItemString(modules, "neuron.coreneuron");
     if (module) {
-      PyObject* val = PyObject_GetAttrString(module, "enable");
+      PyObject* val = PyObject_GetAttrString(module, option);
       if (val) {
         long enable = PyLong_AsLong(val);
         Py_DECREF(val);
@@ -2964,6 +2972,16 @@ static int nrncore_enable_value() {
     return -1;
   }
   return 0;
+}
+
+/// return value of neuron.coreneuron.enable
+static int nrncore_enable_value() {
+    return get_nrncore_opt_value("enable");
+}
+
+/// return value of neuron.coreneuron.file_mode
+static int nrncore_file_mode_value() {
+    return get_nrncore_opt_value("file_mode");
 }
 
 /** Gets the python string returned by  neuron.coreneuron.nrncore_arg(tstop)
@@ -3013,6 +3031,7 @@ myPyMODINIT_FUNC nrnpy_hoc() {
   nrnpy_decref = nrnpy_decref_;
   nrnpy_nrncore_arg_p_ = nrncore_arg;
   nrnpy_nrncore_enable_value_p_ = nrncore_enable_value;
+  nrnpy_nrncore_file_mode_value_p_ = nrncore_file_mode_value;
   nrnpy_object_to_double_ = object_to_double_;
   nrnpy_rvp_rxd_to_callable = rvp_rxd_to_callable_;
   PyLockGIL lock;

--- a/src/parallel/ocbbs.cpp
+++ b/src/parallel/ocbbs.cpp
@@ -74,7 +74,8 @@ extern "C" {
 	extern int nrncore_run(const char*);
 	extern bool nrn_trajectory_request_per_time_step_;
 	extern int nrncore_is_enabled();
-	extern int nrncore_psolve(double tstop);
+	extern int nrncore_is_file_mode();
+	extern int nrncore_psolve(double tstop, int file_mode);
 }
 
 class OcBBS : public BBS , public Resource {
@@ -666,8 +667,9 @@ static double psolve(void* v) {
 	OcBBS* bbs = (OcBBS*)v;
 	double tstop = chkarg(1, t, 1e9);
 	int enabled = nrncore_is_enabled();
+	int file_mode = nrncore_is_file_mode();
 	if (enabled == 1) {
-		nrncore_psolve(tstop);
+		nrncore_psolve(tstop, file_mode);
 	}else if (enabled == 0) {
 		// Classic case
 		bbs->netpar_solve(tstop);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -119,7 +119,7 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
   endif()
   if (NRN_ENABLE_MPI)
     # Launching mpi executable with full path can mangle different python versions and libraries(see issue #894)
-    # Therefore we extract the executable name and create a dedicated target, because add_test($MPIEXEC_NAME) would re-append the full path. 
+    # Therefore we extract the executable name and create a dedicated target, because add_test($MPIEXEC_NAME) would re-append the full path.
     get_filename_component(MPIEXEC_NAME ${MPIEXEC} NAME)
     add_custom_target(test_subworld_mpiexec_name
         COMMAND
@@ -152,6 +152,10 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
     add_test(NAME coreneuron_spikes_py COMMAND ${PYTHON_EXECUTABLE}
                                             ${PROJECT_SOURCE_DIR}/test/coreneuron/test_spikes.py
                                     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
+    add_test(NAME coreneuron_spikes_file_mode_py COMMAND ${PYTHON_EXECUTABLE}
+                                            ${PROJECT_SOURCE_DIR}/test/coreneuron/test_spikes.py
+                                            file_mode
+                                    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
     add_test(NAME coreneuron_fornetcon_py COMMAND ${PYTHON_EXECUTABLE}
                                             ${PROJECT_SOURCE_DIR}/test/coreneuron/test_fornetcon.py
                                     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
@@ -165,18 +169,23 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
                                             ${PROJECT_SOURCE_DIR}/test/gjtests/test_natrans.py
                                     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
     list(APPEND TESTS coreneuron_direct_py coreneuron_direct_hoc
-                      coreneuron_spikes_py coreneuron_fornetcon_py
+                      coreneuron_spikes_py coreneuron_spikes_file_mode_py coreneuron_fornetcon_py
                       coreneuron_datareturn_py coreneuron_test_units_py
                       coreneuron_test_natrans_py)
     if(NRN_ENABLE_MPI)
       find_python_module(mpi4py)
       if(mpi4py_FOUND)
         add_test(
-                NAME coreneuron_mpi_spikes_py  COMMAND ${MPIEXEC} -np 2 ${PYTHON_EXECUTABLE}
+                NAME coreneuron_spikes_mpi_py  COMMAND ${MPIEXEC} -np 2 ${PYTHON_EXECUTABLE}
                                               ${PROJECT_SOURCE_DIR}/test/coreneuron/test_spikes.py mpi4py
                                       WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
-        list(APPEND TESTS coreneuron_mpi_spikes_py)
+        list(APPEND TESTS coreneuron_spikes_mpi_py)
       endif()
+        add_test(
+                NAME coreneuron_spikes_mpi_file_mode_py  COMMAND ${MPIEXEC} -np 2 ${PYTHON_EXECUTABLE}
+                                              ${PROJECT_SOURCE_DIR}/test/coreneuron/test_spikes.py nrnmpi_init file_mode
+                                      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
+        list(APPEND TESTS coreneuron_spikes_mpi_file_mode_py)
     endif()
   endif()
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -182,8 +182,8 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
         list(APPEND TESTS coreneuron_spikes_mpi_py)
       endif()
         add_test(
-                NAME coreneuron_spikes_mpi_file_mode_py  COMMAND ${MPIEXEC} -np 2 ${PYTHON_EXECUTABLE}
-                                              ${PROJECT_SOURCE_DIR}/test/coreneuron/test_spikes.py nrnmpi_init file_mode
+                NAME coreneuron_spikes_mpi_file_mode_py  COMMAND ${MPIEXEC} -np 2 ${CMAKE_HOST_SYSTEM_PROCESSOR}/special
+                                              -python ${PROJECT_SOURCE_DIR}/test/coreneuron/test_spikes.py nrnmpi_init file_mode
                                       WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
         list(APPEND TESTS coreneuron_spikes_mpi_file_mode_py)
     endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -181,9 +181,10 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
                                       WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
         list(APPEND TESTS coreneuron_spikes_mpi_py)
       endif()
+        # using -pyexe to workaround #894
         add_test(
                 NAME coreneuron_spikes_mpi_file_mode_py  COMMAND ${MPIEXEC} -np 2 ${CMAKE_HOST_SYSTEM_PROCESSOR}/special
-                                              -python ${PROJECT_SOURCE_DIR}/test/coreneuron/test_spikes.py nrnmpi_init file_mode
+                                              -python -pyexe ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/coreneuron/test_spikes.py nrnmpi_init file_mode
                                       WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
         list(APPEND TESTS coreneuron_spikes_mpi_file_mode_py)
     endif()

--- a/test/coreneuron/test_spikes.py
+++ b/test/coreneuron/test_spikes.py
@@ -1,11 +1,20 @@
 import pytest
 import sys
 
-from neuron import h, gui
 
-def test_spikes(use_mpi4py=False):
+def test_spikes(use_mpi4py=False, use_nrnmpi_init=False, file_mode=False):
+    # mpi4py needs tp be imported before importing h
     if use_mpi4py:
         from mpi4py import MPI
+        from neuron import h, gui
+    # without mpi4py we need to call nrnmpi_init explicitly
+    elif use_nrnmpi_init:
+        from neuron import h, gui
+        h.nrnmpi_init()
+    # otherwise serial execution
+    else:
+        from neuron import h, gui
+
     h('''create soma''')
     h.soma.L=5.6419
     h.soma.diam=5.6419
@@ -26,38 +35,35 @@ def test_spikes(use_mpi4py=False):
     h.cvode.cache_efficient(1)
 
     pc = h.ParallelContext()
-  
+
     pc.set_gid2node(pc.id()+1, pc.id())
     myobj = h.NetCon(h.soma(0.5)._ref_v, None, sec=h.soma)
     pc.cell(pc.id()+1, myobj)
 
-
-    # NEURON spikes run
+    # NEURON run
     nrn_spike_t = h.Vector()
     nrn_spike_gids = h.Vector()
     pc.spike_record(-1, nrn_spike_t, nrn_spike_gids)
 
     h.run()
-   
+
     nrn_spike_t = nrn_spike_t.to_python()
     nrn_spike_gids = nrn_spike_gids.to_python()
 
-    # CORENEURON spike_record(-1) / spike_record(gidlist):
+    # CORENEURON run
     from neuron import coreneuron
     coreneuron.enable = True
+    coreneuron.file_mode = file_mode
     coreneuron.verbose = 0
     h.stdinit()
     corenrn_all_spike_t = h.Vector()
     corenrn_all_spike_gids = h.Vector()
-    
-    pc.spike_record( -1 if pc.id() == 0 else (pc.id()),
-                     corenrn_all_spike_t,
-                     corenrn_all_spike_gids )
+
+    pc.spike_record(-1, corenrn_all_spike_t, corenrn_all_spike_gids )
     pc.psolve(h.tstop)
 
     corenrn_all_spike_t = corenrn_all_spike_t.to_python()
     corenrn_all_spike_gids = corenrn_all_spike_gids.to_python()
-
 
     # check spikes match
     assert(len(nrn_spike_t)) # check we've actually got spikes
@@ -66,7 +72,12 @@ def test_spikes(use_mpi4py=False):
     assert(nrn_spike_gids == corenrn_all_spike_gids)
 
     h.quit()
-  
+
 
 if __name__ == "__main__":
-    test_spikes('mpi4py' in sys.argv)
+    # simple CLI arguments handling
+    mpi4py_option = 'mpi4py' in sys.argv
+    file_mode_option = 'file_mode' in sys.argv
+    nrnmpi_init_option = 'nrnmpi_init' in sys.argv
+
+    test_spikes(mpi4py_option, nrnmpi_init_option, file_mode_option)


### PR DESCRIPTION
  * add new option coreneuron.file_mode = True / False
  * if file_mode=True, the model is written to folder
    corenrn_data and coreneuron is launched
  * with file transfer mode, only spikes will be
    available
  * bug fix in the test test_spikes.py in MPI mode:
    mpi4py needs to be imported before importing neuron
  * add test for file_mode both in serial as well as
    mpi mode

I see two benefits with this PR:
* Significant  help a lot to test file transfer mode. Currently
   we have to write separate shell scripts to run special and
    special-core.
* For GPU execution we can not use process per core but
   just few processes. But then model building part becomes
   slow. Based on this PR, we can build model with process
    per core and dump to the file. Then on CoreNEURON side
    only few ranks can load the data and utilise GPU using
    multiple OpenMP threads per rank.

cc: @iomaganaris @alexsavulescu 