### PR TITLE
Root point not a soma requires special handling.

### DIFF
--- a/share/lib/hoc/import3d/read_swc.hoc
+++ b/share/lib/hoc/import3d/read_swc.hoc
@@ -321,7 +321,8 @@ printf("\nNotice: %s:\nThe first two points have different types (%d and %d) but
 //i noncontiguous with parent and
 // if parent is not soma and parent of parent is soma
 // then i appended to connect2prox
-if (p > 1) if (type.x[p] != 1 && type.x[pix2ix(p)] == 1) {
+if (p > 1) {
+    if (type.x[p] != 1 && type.x[pix2ix(p)] == 1) {
 	connect2prox.x[i] = 1
 	$o1.x[p] = 1 // p not treated as a 1pt section
 	err = 1
@@ -329,6 +330,12 @@ if (p > 1) if (type.x[p] != 1 && type.x[pix2ix(p)] == 1) {
 printf("\nNotice: %s:\n %d parent is %d which is the proximal point of a section\n  connected by a wire to the soma.\n  The dendrite is being connected to\n  the proximal end of the parent dendrite.\n  If this is an incorrect guess, then change the file.\n"\
 , file.getname, id.x[i], id.x[p])
 	}
+    }
+} else if (p == 0) { // parent is root point.
+    if (type.x[p] != 1) { // and parent is not a soma point.
+	connect2prox.x[i] = 1
+	$o1.x[p] = 1
+    }
 }
 				
 			}

--- a/test/pynrn/test_swc.py
+++ b/test/pynrn/test_swc.py
@@ -167,6 +167,14 @@ tst_data = ['''
 4  3 20  0 0 1  3
 5  3 10  1 0 1  2
 6  3 10 20 0 1  5
+''','''
+# no soma 2 dendrites with root connection.
+#n,type,x,y,z,radius,parent
+1  3 0  0  0 3 -1
+2  3 2  0 0 1  1
+3  3 10  0 0 1  2
+4  3 -2  0 0 1  1
+5  3 -10  0 0 1  4
 ''']
 
 def mkswc(swc_contents):
@@ -459,6 +467,15 @@ dend[2] L=20  parent dend[0](1)
  0   10 0 0 2
  1   10 1 0 2
  2   10 20 0 2
+''','''
+dend[0] L=10  
+ 0   0 0 0 6
+ 1   2 0 0 2
+ 2   10 0 0 2
+dend[1] L=10  parent dend[0](0)
+ 0   0 0 0 6
+ 1   -2 0 0 2
+ 2   -10 0 0 2
 ''']
 
 def test_swc():


### PR DESCRIPTION
If root point is not a soma point then all noncontiguous connections to
that point are connected to the proximal end of the root section.

Fixes a ModelDB regression test issue for 237728 BlossEtAl2018 mentioned in #923.
