### PR TITLE
Fix pip bootstrapping with Python 3.5

### DIFF
--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -43,7 +43,7 @@ setup_venv() {
     # pep425tags are not available anymore from 0.35
     # temporary workaround until we get smtg stable
     if ! pip install -U pip setuptools "wheel<0.35"; then
-        curl https://bootstrap.pypa.io/get-pip.py | python
+        curl https://raw.githubusercontent.com/pypa/get-pip/20.3.4/get-pip.py | python
         pip install -U setuptools "wheel<0.35"
     fi
 }

--- a/packaging/python/test_wheels.sh
+++ b/packaging/python/test_wheels.sh
@@ -164,7 +164,7 @@ fi
 # on osx we need to install pip from source
 if [[ "$OSTYPE" == "darwin"* ]] && [[ "$python_ver" == "35" ]]; then
   echo "Updating pip for OSX with Python 3.5"
-  curl https://bootstrap.pypa.io/get-pip.py | python
+  curl https://raw.githubusercontent.com/pypa/get-pip/20.3.4/get-pip.py | python
 fi
 
 # install neuron and neuron


### PR DESCRIPTION
  - with latest 20.1 release, get-pip.py not compatible with Python 3.5
  - see pypa/get-pip/issues/83 for details
  - use last working release 20.3.4

(Python 3.5 has reached end-of-life and it's usage is very minimal anyway. So after 8.0 we can see if it's necessary to maintain 3.5 series) 

cc: @ferdonline 