### PR TITLE
Add compatibility workaround for Spack's Python

### DIFF
--- a/src/nrnpython/setup.py.in
+++ b/src/nrnpython/setup.py.in
@@ -68,15 +68,20 @@ else:
 ldefs = extern_defines.split('-D')
 
 # if using MPI then at least for linking need special paths and libraries
-mpicc_bin = get_escaped_path("@CC@")
-mpicxx_bin = get_escaped_path("@CXX@")
 import os
+c_compiler_path = get_escaped_path("@CC@")
+cxx_compiler_path = get_escaped_path("@CXX@")
+# With some Python versions (BB5 2020/12 archive 3.7.X at least) then setup.py
+# tries to compile C++ code with the C compiler. At least with PGI this fails.
+# With the 2021/01 BB5 configuration this is not needed.
+os.environ['CC'] = cxx_compiler_path if using_pgi else c_compiler_path
+os.environ["CXX"] = cxx_compiler_path
 if using_pgi:
-  os.environ["CC"]=mpicxx_bin
-else:
-  os.environ["CC"]=mpicc_bin
-
-os.environ["CXX"]=mpicxx_bin
+  # With the 2021/01 BB5 Python, which includes patches from Spack, this is
+  # needed to ensure the PGI/NVIDIA linker is used as well as the compiler.
+  # Otherwise GCC is used and it chokes on PGI/NVIDIA-specific compiler flags.
+  os.environ["LDSHARED"] = os.environ['CC'] + " -shared"
+  os.environ["LDCXXSHARED"] = os.environ["CXX"] + " -shared"
 
 # apparently we do not need the following
 #################################

--- a/src/nrnpython/setup.py.in
+++ b/src/nrnpython/setup.py.in
@@ -71,15 +71,18 @@ ldefs = extern_defines.split('-D')
 import os
 c_compiler_path = get_escaped_path("@CC@")
 cxx_compiler_path = get_escaped_path("@CXX@")
-# With some Python versions (BB5 2020/12 archive 3.7.X at least) then setup.py
-# tries to compile C++ code with the C compiler. At least with PGI this fails.
-# With the 2021/01 BB5 configuration this is not needed.
+
+# setup.py tries to compile C++ code with the C compiler. This works with
+# gcc and intel but fails with at least PGI compiler. Hence, use C++ compiler
+# if PGI compiler is used.
 os.environ['CC'] = cxx_compiler_path if using_pgi else c_compiler_path
 os.environ["CXX"] = cxx_compiler_path
+
 if using_pgi:
-  # With the 2021/01 BB5 Python, which includes patches from Spack, this is
-  # needed to ensure the PGI/NVIDIA linker is used as well as the compiler.
-  # Otherwise GCC is used and it chokes on PGI/NVIDIA-specific compiler flags.
+  # Spack installed Python includes patches that require setting LDSHARED
+  # and LDCXXSHARED environmental variables to ensure the PGI/NVIDIA linker
+  # is used as well as the compiler. Otherwise GCC is used and it chokes on
+  # PGI/NVIDIA-specific compiler flags.
   os.environ["LDSHARED"] = os.environ['CC'] + " -shared"
   os.environ["LDCXXSHARED"] = os.environ["CXX"] + " -shared"
 


### PR DESCRIPTION
https://github.com/spack/spack/pull/16856 (merged 06/2020) includes patches to Python that cause behaviour inconsistent with the upstream version. The patches also introduce a new `LDCXXSHARED` environment variable that addresses a long-standing upstream issue (https://bugs.python.org/issue1222585).

This change explicitly specifies that the PGI linker should be used when the PGI compiler is used. This has to be specified separately for C++ and C for compatibility with the Spack patches that introduce the `LDCXXSHARED` environment variable.

This avoids compilation errors due to passing PGI commandline options to gcc, which was used as the default linker. Without the Spack patches to Python this change was not needed, and the linker seemed to be derived from the CC and CXX variables.