### PR TITLE
[Trivial] Fix compilation if git signatures shown by default

### DIFF
--- a/git2nrnversion_h.sh
+++ b/git2nrnversion_h.sh
@@ -11,8 +11,8 @@ if git log > /dev/null && test -d .git ; then
         describe="`git describe --tags`"
         branch="`git rev-parse --abbrev-ref HEAD`" # branch name
         modified="`git status -s -uno --porcelain | sed -n '1s/.*/+/p'`" # + if modified
-        gcs=`git log --format="%h" -n 1` #short commit hash
-        d="`git log --format="%ad" -n 1 --date=short`" # date
+        gcs=`git -c log.showSignature=false log --format="%h" -n 1` #short commit hash
+        d="`git -c log.showSignature=false log --format="%cd" -n 1 --date=short`" # date
         echo "#define GIT_DATE \"$d\""
         echo "#define GIT_BRANCH \"$branch\""
         echo "#define GIT_CHANGESET \"${gcs}${modified}\""


### PR DESCRIPTION
Without this change then the presence of:
```
[log]
  showSignature = True
```
in the local `~/.gitconfig` file breaks compilation of NEURON because the signature information is not escaped properly for inclusion in the generated C++ string literal.

Also change the reported date to be the committer date instead of the
author date. This is likely to better reflect how recent the build is.
CoreNEURON already uses the committer date.

(See also: https://github.com/BlueBrain/CoreNeuron/pull/488)