### PR TITLE
Remove spaces from mod files' names in nrnivmodl

### DIFF
--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -87,6 +87,9 @@ unhide_spaces() {
 escape_spaces() {
   echo "$1" | sed 's/+++/\\ /g'
 }
+remove_spaces() {
+  echo "$1" | sed 's/ //g'
+}
 
 # files is the complete list of mod files to process
 files=""
@@ -249,7 +252,7 @@ extern "C" {
 #endif
 ' > mod_func.cpp
 for i in $base_names ; do
-  echo 'extern void _'$i'_reg(void);'
+  echo 'extern void _'`remove_spaces "$i"`'_reg(void);'
 done >> mod_func.cpp
 echo '
 void modl_reg(){
@@ -266,7 +269,7 @@ echo '    fprintf(stderr, "'$newline'");
   }' >>mod_func.cpp
 
 for i in $base_names; do
-  echo '  _'$i'_reg();'
+  echo '  _'`remove_spaces "$i"`'_reg();'
   @USING_CMAKE_TRUE@MODOBJS="$MODOBJS ./$i.o"
   @USING_CMAKE_FALSE@MODOBJS="$MODOBJS $i.o"
 done >> mod_func.cpp


### PR DESCRIPTION
- Avoid issues in terminals different than `bash` with white spaces in strings

For example in `zsh` there is a difference in the way `for loops` for strings are handled:
```
magkanar@magkanar-MS-7C73:~/bbp_repos$ cat test.sh 
base_names=" name"
for i in $base_names ; do
  echo $i
done
magkanar@magkanar-MS-7C73:~/bbp_repos$ sh test.sh 
name
magkanar@magkanar-MS-7C73:~/bbp_repos$ zsh test.sh 
 name
 ```
 
 Fixes the following issue when compiled with `-DNRN_ENABLE_TESTS=ON` in `zsh` terminal:
 ```
 mod_func.cpp:9:15: error: expected initializer before 'unitstest_reg'
    9 | extern void _ unitstest_reg(void);
      |               ^~~~~~~~~~~~~
mod_func.cpp:9:15: error: expected initializer before 'pump_reg'
    9 | extern void _ pump_reg(void);
      |               ^~~~~~~~
mod_func.cpp: In function 'void modl_reg()':
mod_func.cpp:18:3: error: '_' was not declared in this scope
   18 |   _ pump_reg();
      |   ^
mod_func.cpp: In function 'void modl_reg()':
mod_func.cpp:18:3: error: '_' was not declared in this scope
   18 |   _ unitstest_reg();
      |   ^
```