### PR TITLE
Mac m1

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -122,20 +122,26 @@ needs to be installed for development.
 
 <a name="Apple-M1-Build-Dependencies"></a>
 ##### Apple M1
-- Command line tools
+
+- Install command line tools as
+
     ```bash
     xcode-select --install
     ```
-- If desire classical NEURON GUI<br>
-    From xquartz.org, click "Releases", click XQuartz-2.8.0_beta3 , and
-follow instructions. (after installing, logout and log back in)
-    If you desire single click button action for x11 when entering a window
+
+- If desire classical NEURON GUI : from [xquartz.org](https://www.xquartz.org/), click "Releases", click XQuartz-2.8.0_beta3 , and follow instructions. After installing, logout and log back in.
+
+    If you desire single click button action for X11 when entering a window then execute below command:
+
     ```bash
     defaults write org.xquartz.X11 wm_ffm -bool true
     ```
-   (For the new default to take effect, logout then log back in)
-- HomeBrew and Pip
+   For the new default to take effect, logout then log back in.
+
+- Install dependencies with HomeBrew and pip as:
+
   ```bash
+  # install brew and initialize shell
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   echo 'eval $(/opt/homebrew/bin/brew shellenv)' >> $HOME/.zprofile
   eval $(/opt/homebrew/bin/brew shellenv)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -98,6 +98,8 @@ Depending on platform you can install these dependencies as follows:
 
 #### Mac OS
 
+This is for x86_64. For Apple M1 (arm64), see [here] (#Apple-M1-Build-Dependencies)
+
 The easiest way to install depndencies on Mac OS is to use [brew](https://brew.sh/) or
 [conda](https://docs.conda.io/projects/conda/en/latest/index.html) package manager. For example,
 once [brew is installed](https://docs.brew.sh/Installation) you can do:
@@ -117,6 +119,63 @@ If the desired python version is not installed, you can install it using
 [official distribution](https://www.python.org/downloads/mac-osx/). Also, note that
 [Xcode Command Line Tools](https://stackoverflow.com/questions/9329243/how-to-install-xcode-command-line-tools)
 needs to be installed for development.
+
+<a name="Apple-M1-Build-Dependencies"></a>
+##### Apple M1
+- Command line tools
+    ```bash
+    xcode-select --install
+    ```
+- If desire classical NEURON GUI<br>
+    From xquartz.org, click "Releases", click XQuartz-2.8.0_beta3 , and
+follow instructions. (after installing, logout and log back in)
+    If you desire single click button action for x11 when entering a window
+    ```bash
+    defaults write org.xquartz.X11 wm_ffm -bool true
+    ```
+   (For the new default to take effect, logout then log back in)
+- HomeBrew and Pip
+  ```bash
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  echo 'eval $(/opt/homebrew/bin/brew shellenv)' >> $HOME/.zprofile
+  eval $(/opt/homebrew/bin/brew shellenv)
+
+  brew install cmake
+  brew install open-mpi
+
+  pip3 install --user --upgrade pip
+  export PATH="$HOME/Library/Python/3.8/bin":$PATH
+  pip3 install --user cython
+  ```
+- Install
+  ```
+  cd $HOME
+  mkdir neuron
+  cd neuron
+  git clone https://github.com/neuronsimulator/nrn nrn
+  cd nrn
+  mkdir build
+  cd build
+  cmake .. -DCMAKE_INSTALL_PREFIX=install -DPYTHON_EXECUTABLE=`which python3` -DNRN_ENABLE_PYTHON_DYNAMIC=ON
+  #Note: without the dynamic python option, the build failed to find the library
+  #  for linking.
+
+  time make -j 6 install # 20s build.
+  ```
+- Environment
+  ```
+  export N=$HOME/neuron/nrn/build/install
+  export PATH=$N/bin:$PATH
+  export PYTHONPATH=$N/lib/python
+  ```
+- Does it work?
+  ```
+  python3 -c 'import neuron ; neuron.test()'
+  nrniv -python -c 'from neuron import h, gui'
+  mpiexec -n 4 nrniv -mpi -python $HOME/nrn/src/parallel/test0.py
+  neurondemo # Currently a bug that requires one hits 'return' in the terminal window if the GUI freezes after closing a window.
+  ```
+
 
 #### Linux
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -98,7 +98,7 @@ Depending on platform you can install these dependencies as follows:
 
 #### Mac OS
 
-This is for x86_64. For Apple M1 (arm64), see [here] (#Apple-M1-Build-Dependencies)
+This is for x86_64. For Apple M1 (arm64), see [here](#Apple-M1-Build-Dependencies)
 
 The easiest way to install dependencies on Mac OS is to use [brew](https://brew.sh/) or
 [conda](https://docs.conda.io/projects/conda/en/latest/index.html) package manager. For example,

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -100,7 +100,7 @@ Depending on platform you can install these dependencies as follows:
 
 This is for x86_64. For Apple M1 (arm64), see [here] (#Apple-M1-Build-Dependencies)
 
-The easiest way to install depndencies on Mac OS is to use [brew](https://brew.sh/) or
+The easiest way to install dependencies on Mac OS is to use [brew](https://brew.sh/) or
 [conda](https://docs.conda.io/projects/conda/en/latest/index.html) package manager. For example,
 once [brew is installed](https://docs.brew.sh/Installation) you can do:
 
@@ -147,35 +147,6 @@ follow instructions. (after installing, logout and log back in)
   export PATH="$HOME/Library/Python/3.8/bin":$PATH
   pip3 install --user cython
   ```
-- Install
-  ```
-  cd $HOME
-  mkdir neuron
-  cd neuron
-  git clone https://github.com/neuronsimulator/nrn nrn
-  cd nrn
-  mkdir build
-  cd build
-  cmake .. -DCMAKE_INSTALL_PREFIX=install -DPYTHON_EXECUTABLE=`which python3` -DNRN_ENABLE_PYTHON_DYNAMIC=ON
-  #Note: without the dynamic python option, the build failed to find the library
-  #  for linking.
-
-  time make -j 6 install # 20s build.
-  ```
-- Environment
-  ```
-  export N=$HOME/neuron/nrn/build/install
-  export PATH=$N/bin:$PATH
-  export PYTHONPATH=$N/lib/python
-  ```
-- Does it work?
-  ```
-  python3 -c 'import neuron ; neuron.test()'
-  nrniv -python -c 'from neuron import h, gui'
-  mpiexec -n 4 nrniv -mpi -python $HOME/nrn/src/parallel/test0.py
-  neurondemo # Currently a bug that requires one hits 'return' in the terminal window if the GUI freezes after closing a window.
-  ```
-
 
 #### Linux
 

--- a/bin/nrnpyenv.sh
+++ b/bin/nrnpyenv.sh
@@ -282,13 +282,25 @@ def nrnpylib_darwin_helper():
         nrnpylib_provenance = "lsof search for libpython..."
         return nrn_pylib
       if re.search(r'[Ll][Ii][Bb].*[Pp]ython', line):
-        cnt += 1  
+        cnt += 1
         if cnt == 1: # skip 1st since it is the python executable
           continue
         if re.search(r'[Pp]ython', line.split('/')[-1]):
           print ("# nrn_pylib from lsof: %s" % line)
-          nrn_pylib = line.strip()
-          nrnpylib_provenance = 'lsof search for second occurrence of [Ll][Ii][Bb].*[Pp]ython'
+          candidate = line.strip()
+          # verify the file defines a PyRun_SimpleString
+          cmd = r'nm %s | grep PyRun_SimpleString' % candidate
+          try:
+            f = os.popen(cmd)
+            i=0
+            for line in f:
+              i += 1
+            if i == 0:
+              continue
+          except:
+            continue
+          nrn_pylib = candidate
+          nrnpylib_provenance = 'lsof search for occurrence of [Ll][Ii][Bb].*[Pp]ython defineing PyRun_SimpleString'
           return nrn_pylib
   else: # figure it out from the os path
     p = os.path.sep.join(os.__file__.split(os.path.sep)[:-1])

--- a/cmake/find_libpython.py
+++ b/cmake/find_libpython.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python
+
+"""
+Locate libpython associated with this Python executable.
+"""
+
+# https://pypi.org/project/find-libpython/
+
+# License
+#
+# Copyright 2018, Takafumi Arakaki
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+from __future__ import print_function, absolute_import
+
+from logging import getLogger
+import ctypes.util
+import functools
+import os
+import sys
+import sysconfig
+
+logger = getLogger("find_libpython")
+
+is_windows = os.name == "nt"
+is_apple = sys.platform == "darwin"
+
+SHLIB_SUFFIX = sysconfig.get_config_var("SHLIB_SUFFIX")
+if SHLIB_SUFFIX is None:
+    if is_windows:
+        SHLIB_SUFFIX = ".dll"
+    else:
+        SHLIB_SUFFIX = ".so"
+if is_apple:
+    # sysconfig.get_config_var("SHLIB_SUFFIX") can be ".so" in macOS.
+    # Let's not use the value from sysconfig.
+    SHLIB_SUFFIX = ".dylib"
+
+
+def linked_libpython():
+    """
+    Find the linked libpython using dladdr (in *nix).
+
+    Calling this in Windows always return `None` at the moment.
+
+    Returns
+    -------
+    path : str or None
+        A path to linked libpython.  Return `None` if statically linked.
+    """
+    if is_windows:
+        return None
+    return _linked_libpython_unix()
+
+
+class Dl_info(ctypes.Structure):
+    _fields_ = [
+        ("dli_fname", ctypes.c_char_p),
+        ("dli_fbase", ctypes.c_void_p),
+        ("dli_sname", ctypes.c_char_p),
+        ("dli_saddr", ctypes.c_void_p),
+    ]
+
+
+def _linked_libpython_unix():
+    libdl = ctypes.CDLL(ctypes.util.find_library("dl"))
+    libdl.dladdr.argtypes = [ctypes.c_void_p, ctypes.POINTER(Dl_info)]
+    libdl.dladdr.restype = ctypes.c_int
+
+    dlinfo = Dl_info()
+    retcode = libdl.dladdr(
+        ctypes.cast(ctypes.pythonapi.Py_GetVersion, ctypes.c_void_p),
+        ctypes.pointer(dlinfo))
+    if retcode == 0:  # means error
+        return None
+    path = os.path.realpath(dlinfo.dli_fname.decode())
+    if path == os.path.realpath(sys.executable):
+        return None
+    return path
+
+
+def library_name(name, suffix=SHLIB_SUFFIX, is_windows=is_windows):
+    """
+    Convert a file basename `name` to a library name (no "lib" and ".so" etc.)
+
+    >>> library_name("libpython3.7m.so")                   # doctest: +SKIP
+    'python3.7m'
+    >>> library_name("libpython3.7m.so", suffix=".so", is_windows=False)
+    'python3.7m'
+    >>> library_name("libpython3.7m.dylib", suffix=".dylib", is_windows=False)
+    'python3.7m'
+    >>> library_name("python37.dll", suffix=".dll", is_windows=True)
+    'python37'
+    """
+    if not is_windows and name.startswith("lib"):
+        name = name[len("lib"):]
+    if suffix and name.endswith(suffix):
+        name = name[:-len(suffix)]
+    return name
+
+
+def append_truthy(list, item):
+    if item:
+        list.append(item)
+
+
+def uniquifying(items):
+    """
+    Yield items while excluding the duplicates and preserving the order.
+
+    >>> list(uniquifying([1, 2, 1, 2, 3]))
+    [1, 2, 3]
+    """
+    seen = set()
+    for x in items:
+        if x not in seen:
+            yield x
+        seen.add(x)
+
+
+def uniquified(func):
+    """ Wrap iterator returned from `func` by `uniquifying`. """
+    @functools.wraps(func)
+    def wrapper(*args, **kwds):
+        return uniquifying(func(*args, **kwds))
+    return wrapper
+
+
+@uniquified
+def candidate_names(suffix=SHLIB_SUFFIX):
+    """
+    Iterate over candidate file names of libpython.
+
+    Yields
+    ------
+    name : str
+        Candidate name libpython.
+    """
+    LDLIBRARY = sysconfig.get_config_var("LDLIBRARY")
+    if LDLIBRARY:
+        yield LDLIBRARY
+
+    LIBRARY = sysconfig.get_config_var("LIBRARY")
+    if LIBRARY:
+        yield os.path.splitext(LIBRARY)[0] + suffix
+
+    dlprefix = "" if is_windows else "lib"
+    sysdata = dict(
+        v=sys.version_info,
+        # VERSION is X.Y in Linux/macOS and XY in Windows:
+        VERSION=(sysconfig.get_config_var("VERSION") or
+                 "{v.major}.{v.minor}".format(v=sys.version_info)),
+        ABIFLAGS=(sysconfig.get_config_var("ABIFLAGS") or
+                  sysconfig.get_config_var("abiflags") or ""),
+    )
+
+    for stem in [
+            "python{VERSION}{ABIFLAGS}".format(**sysdata),
+            "python{VERSION}".format(**sysdata),
+            "python{v.major}".format(**sysdata),
+            "python",
+            ]:
+        yield dlprefix + stem + suffix
+
+
+
+@uniquified
+def candidate_paths(suffix=SHLIB_SUFFIX):
+    """
+    Iterate over candidate paths of libpython.
+
+    Yields
+    ------
+    path : str or None
+        Candidate path to libpython.  The path may not be a fullpath
+        and may not exist.
+    """
+
+    yield linked_libpython()
+
+    # List candidates for directories in which libpython may exist
+    lib_dirs = []
+    append_truthy(lib_dirs, sysconfig.get_config_var('LIBPL'))
+    append_truthy(lib_dirs, sysconfig.get_config_var('srcdir'))
+    append_truthy(lib_dirs, sysconfig.get_config_var("LIBDIR"))
+
+    # LIBPL seems to be the right config_var to use.  It is the one
+    # used in python-config when shared library is not enabled:
+    # https://github.com/python/cpython/blob/v3.7.0/Misc/python-config.in#L55-L57
+    #
+    # But we try other places just in case.
+
+    if is_windows:
+        lib_dirs.append(os.path.join(os.path.dirname(sys.executable)))
+    else:
+        lib_dirs.append(os.path.join(
+            os.path.dirname(os.path.dirname(sys.executable)),
+            "lib"))
+
+    # For macOS:
+    append_truthy(lib_dirs, sysconfig.get_config_var("PYTHONFRAMEWORKPREFIX"))
+
+    lib_dirs.append(sys.exec_prefix)
+    lib_dirs.append(os.path.join(sys.exec_prefix, "lib"))
+
+    lib_basenames = list(candidate_names(suffix=suffix))
+
+    for directory in lib_dirs:
+        for basename in lib_basenames:
+            yield os.path.join(directory, basename)
+
+    # In macOS and Windows, ctypes.util.find_library returns a full path:
+    for basename in lib_basenames:
+        yield ctypes.util.find_library(library_name(basename))
+
+# Possibly useful links:
+# * https://packages.ubuntu.com/bionic/amd64/libpython3.6/filelist
+# * https://github.com/Valloric/ycmd/issues/518
+# * https://github.com/Valloric/ycmd/pull/519
+
+
+def normalize_path(path, suffix=SHLIB_SUFFIX, is_apple=is_apple):
+    """
+    Normalize shared library `path` to a real path.
+
+    If `path` is not a full path, `None` is returned.  If `path` does
+    not exists, append `SHLIB_SUFFIX` and check if it exists.
+    Finally, the path is canonicalized by following the symlinks.
+
+    Parameters
+    ----------
+    path : str ot None
+        A candidate path to a shared library.
+    """
+    if not path:
+        return None
+    if not os.path.isabs(path):
+        return None
+    if os.path.exists(path):
+        return os.path.realpath(path)
+    if os.path.exists(path + suffix):
+        return os.path.realpath(path + suffix)
+    if is_apple:
+        return normalize_path(_remove_suffix_apple(path),
+                              suffix=".so", is_apple=False)
+    return None
+
+
+def _remove_suffix_apple(path):
+    """
+    Strip off .so or .dylib.
+
+    >>> _remove_suffix_apple("libpython.so")
+    'libpython'
+    >>> _remove_suffix_apple("libpython.dylib")
+    'libpython'
+    >>> _remove_suffix_apple("libpython3.7")
+    'libpython3.7'
+    """
+    if path.endswith(".dylib"):
+        return path[:-len(".dylib")]
+    if path.endswith(".so"):
+        return path[:-len(".so")]
+    return path
+
+
+@uniquified
+def finding_libpython():
+    """
+    Iterate over existing libpython paths.
+
+    The first item is likely to be the best one.
+
+    Yields
+    ------
+    path : str
+        Existing path to a libpython.
+    """
+    logger.debug("is_windows = %s", is_windows)
+    logger.debug("is_apple = %s", is_apple)
+    for path in candidate_paths():
+        logger.debug("Candidate: %s", path)
+        normalized = normalize_path(path)
+        if normalized:
+            logger.debug("Found: %s", normalized)
+            yield normalized
+        else:
+            logger.debug("Not found.")
+
+
+def find_libpython():
+    """
+    Return a path (`str`) to libpython or `None` if not found.
+
+    Parameters
+    ----------
+    path : str or None
+        Existing path to the (supposedly) correct libpython.
+    """
+    for path in finding_libpython():
+        return os.path.realpath(path)
+
+
+def print_all(items):
+    for x in items:
+        print(x)
+
+
+def cli_find_libpython(cli_op, verbose):
+    import logging
+    # Importing `logging` module here so that using `logging.debug`
+    # instead of `logger.debug` outside of this function becomes an
+    # error.
+
+    if verbose:
+        logging.basicConfig(
+            format="%(levelname)s %(message)s",
+            level=logging.DEBUG)
+
+    if cli_op == "list-all":
+        print_all(finding_libpython())
+    elif cli_op == "candidate-names":
+        print_all(candidate_names())
+    elif cli_op == "candidate-paths":
+        print_all(p for p in candidate_paths() if p and os.path.isabs(p))
+    else:
+        path = find_libpython()
+        if path is None:
+            return 1
+        print(path, end="")
+
+
+def main(args=None):
+    import argparse
+    parser = argparse.ArgumentParser(
+        description=__doc__)
+    parser.add_argument(
+        "--verbose", "-v", action="store_true",
+        help="Print debugging information.")
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--list-all",
+        action="store_const", dest="cli_op", const="list-all",
+        help="Print list of all paths found.")
+    group.add_argument(
+        "--candidate-names",
+        action="store_const", dest="cli_op", const="candidate-names",
+        help="Print list of candidate names of libpython.")
+    group.add_argument(
+        "--candidate-paths",
+        action="store_const", dest="cli_op", const="candidate-paths",
+        help="Print list of candidate paths of libpython.")
+
+    ns = parser.parse_args(args)
+    parser.exit(cli_find_libpython(**vars(ns)))
+
+
+if __name__ == "__main__":
+    main()

--- a/cmake/modules/FindPythonLibsNew.cmake
+++ b/cmake/modules/FindPythonLibsNew.cmake
@@ -170,6 +170,19 @@ else()
   # If all else fails, just set the name/version and let the linker figure out the path.
   if(NOT PYTHON_LIBRARY)
     set(PYTHON_LIBRARY python${PYTHON_LIBRARY_SUFFIX})
+    # Since this isn't very robust. One more try with find_libpython.py
+    execute_process(
+      COMMAND
+        "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/cmake/find_libpython.py"
+      RESULT_VARIABLE _PYTHON_SUCCESS
+      OUTPUT_VARIABLE _PYTHON_VALUES
+      ERROR_VARIABLE _PYTHON_ERROR_VALUE)
+    if (_PYTHON_SUCCESS MATCHES 0)
+      if (_PYTHON_VALUES)
+        set(PYTHON_LIBRARY "${_PYTHON_VALUES}")
+        message(STATUS "PYTHON_LIBRARY from find_libpython.py: \"${PYTHON_LIBRARY}\"")
+      endif()
+    endif()
   endif()
 endif()
 

--- a/share/lib/python/neuron/rxdtests/run_all.py
+++ b/share/lib/python/neuron/rxdtests/run_all.py
@@ -108,6 +108,7 @@ if __name__ == '__main__':
     import sys
     import shutil
     import subprocess
+    import platform
     
     abspath = os.path.abspath(__file__)
     dname = os.path.dirname(abspath)
@@ -131,9 +132,8 @@ if __name__ == '__main__':
             # compile any mod files
             os.chdir(os.path.join('tests', dr))
             # remove old compiled files
-            #TODO: is x86_64 universal
             try:
-                shutil.rmtree('x86_64')
+                shutil.rmtree(platform.machine())
             except OSError:
                 pass
             os.system('nrnivmodl')

--- a/src/mac/activate-apps-cmake.sh
+++ b/src/mac/activate-apps-cmake.sh
@@ -21,7 +21,6 @@ if test "$2" = "" ; then
 	exit
 fi
 
-CPU=$1
 #ignore $1 and use
 CPU=`uname -m`
 NRN_INSTALL=$2

--- a/src/mac/activate-apps-cmake.sh
+++ b/src/mac/activate-apps-cmake.sh
@@ -22,6 +22,8 @@ if test "$2" = "" ; then
 fi
 
 CPU=$1
+#ignore $1 and use
+CPU=`uname -m`
 NRN_INSTALL=$2
 NRN_SRC=$3
 ivlibdir=$4

--- a/src/mac/clean-for-pkg-cmake.sh
+++ b/src/mac/clean-for-pkg-cmake.sh
@@ -6,7 +6,7 @@ if test "$1" = "" ; then
 fi
 
 NRN_INST="$1"
-CPU=x86_64
+CPU=`uname -m`
 
 #strip the dylibs
 cd ${NRN_INST}/lib
@@ -63,7 +63,7 @@ install_name_tool $f "$ff"
 
 #this one needs to be done from nrnivmodl, same as all the libnrnmech.so
 if false ; then
-ff="$NRN_INST/share/nrn/demo/release/x86_64/libnrnmech*.dylib"
+ff="$NRN_INST/share/nrn/demo/release/$CPU/libnrnmech*.dylib"
 f=`otool -L $ff | sed -n "s,.*$NRN_INST/lib/\(.*dylib\).*,\
 -change $NRN_INST/lib/\1 @executable_path/../lib/\1,p"`
 install_name_tool $f $ff

--- a/src/nrncvode/cvtrset.cpp
+++ b/src/nrncvode/cvtrset.cpp
@@ -7,8 +7,6 @@
 #include	"cvodeobj.h"
 #include	"nonvintblock.h"
 
-typedef int (*Pfridot)(...);
-
 #include	"membfunc.h"
 #include	"neuron.h"
 
@@ -64,7 +62,7 @@ void Cvode::rhs_memb(CvMembList* cmlist, NrnThread* _nt) {
 	errno = 0;
 	for (cml = cmlist; cml; cml = cml->next) {
 		Memb_func* mf = memb_func + cml->index;
-		Pfridot s = (Pfridot)mf->current;
+		Pvmi s = mf->current;
 		if (s) {
 			Memb_list* ml = cml->ml;
 			(*s)(_nt, ml, cml->index);
@@ -109,9 +107,9 @@ void Cvode::lhs_memb(CvMembList* cmlist, NrnThread* _nt) {
 	for (cml = cmlist; cml; cml = cml->next) {
 		Memb_func* mf = memb_func + cml->index;
 		Memb_list* ml = cml->ml;
-		Pfridot s = (Pfridot)mf->jacob;
+		Pvmi s = mf->jacob;
 		if (s) {
-			Pfridot s = (Pfridot)mf->jacob;
+			Pvmi s = mf->jacob;
 			(*s)(_nt, ml, cml->index);
 			if (errno) {
 				if (nrn_errno_check(cml->index)) {

--- a/src/nrncvode/occvode.cpp
+++ b/src/nrncvode/occvode.cpp
@@ -11,7 +11,6 @@
 #include "vrecitem.h"
 #include "membfunc.h"
 #include "nonvintblock.h"
-typedef int (*Pfridot)(...);
 extern void setup_topology(), v_setup_vectors();
 extern void nrn_mul_capacity(NrnThread*, Memb_list*);
 extern void nrn_div_capacity(NrnThread*, Memb_list*);
@@ -148,7 +147,7 @@ void Cvode::init_eqn(){
 	z.neq_v_ = z.nonvint_offset_ = zneq;
 	// now add the membrane mechanism ode's to the count
 	for (cml = z.cv_memb_list_; cml; cml = cml->next) {
-		Pfridot s = (Pfridot)memb_func[cml->index].ode_count;
+		nrn_ode_count_t s = memb_func[cml->index].ode_count;
 		if (s) {
 			zneq += cml->ml->nodecount * (*s)(cml->index);
 		}
@@ -248,12 +247,13 @@ printf("%d Cvode::init_eqn id=%d neq_v_=%d #nonvint=%d #nonvint_extra=%d nvsize=
 		int n;
 		ml = cml->ml;
 		mf = memb_func + cml->index;
-		Pfridot sc = (Pfridot)mf->ode_count;
+		nrn_ode_count_t sc = mf->ode_count;
 		if (sc && ( (n = (*sc)(cml->index)) > 0)) {
-			Pfridot s = (Pfridot)mf->ode_map;
+			nrn_ode_map_t s = mf->ode_map;
 			if (mf->hoc_mech) {
 				for (j=0; j < ml->nodecount; ++j) {
-(*s)(ieq, z.pv_ + ieq, z.pvdot_ + ieq, ml->prop[j], atv + ieq);
+//(*s)(ieq, z.pv_ + ieq, z.pvdot_ + ieq, ml->prop[j], atv + ieq);
+assert(0); // fixme
 					ieq += n;
 				}
 			}else{
@@ -357,7 +357,7 @@ void Cvode::daspk_init_eqn(){
 	z.neq_v_ = z.nonvint_offset_ = zneq;
 	// now add the membrane mechanism ode's to the count
 	for (cml = z.cv_memb_list_; cml; cml = cml->next) {
-		Pfridot s = (Pfridot)memb_func[cml->index].ode_count;
+		nrn_ode_count_t s = memb_func[cml->index].ode_count;
 		if (s) {
 			zneq += cml->ml->nodecount * (*s)(cml->index);
 		}
@@ -420,13 +420,14 @@ void Cvode::daspk_init_eqn(){
 	for (cml = z.cv_memb_list_; cml; cml = cml->next) {
 		int n;
 		mf = memb_func + cml->index;
-		Pfridot sc = (Pfridot)mf->ode_count;
+		nrn_ode_count_t sc = mf->ode_count;
 		if (sc && ( (n = (*sc)(cml->index)) > 0)) {
 			Memb_list* ml = cml->ml;
-			Pfridot s = (Pfridot)mf->ode_map;
+			nrn_ode_map_t s = mf->ode_map;
 			if (mf->hoc_mech) {
 				for (j=0; j < ml->nodecount; ++j) {
-(*s)(ieq, z.pv_ + ieq, z.pvdot_ + ieq, ml->prop[j], atv + ieq);
+//(*s)(ieq, z.pv_ + ieq, z.pvdot_ + ieq, ml->prop[j], atv + ieq);
+assert(0); // fixme
 					ieq += n;
 				}
 			}else{
@@ -462,7 +463,7 @@ void Cvode::scatter_y(double* y, int tid){
 	for (cml = z.cv_memb_list_; cml; cml = cml->next) {
 		Memb_func* mf = memb_func + cml->index;
 		if (mf->ode_synonym) {
-			Pfridot s = (Pfridot)mf->ode_synonym;
+			nrn_ode_synonym_t s = mf->ode_synonym;
 			Memb_list* ml = cml->ml;
 			(*s)(ml->nodecount, ml->data, ml->pdata);
 		}
@@ -629,13 +630,14 @@ void Cvode::solvemem(NrnThread* nt) {
 		Memb_func* mf = memb_func + cml->index;
 		if (mf->ode_matsol) {
 			Memb_list* ml = cml->ml;
-			Pfridot s = (Pfridot)mf->ode_matsol;
+			Pvmi s = mf->ode_matsol;
 			if (mf->hoc_mech) {
 				int j, count;
 				count = ml->nodecount;
 				for (j = 0; j < count; ++j) {
 					Node* nd = ml->nodelist[j];
-					(*s)(nd, ml->prop[j]);
+//					(*s)(nd, ml->prop[j]);
+assert(0); // fixme
 				}
 			}else{
 				(*s)(nt, ml, cml->index);
@@ -759,7 +761,7 @@ void Cvode::before_after(BAMechList* baml, NrnThread* nt) {
 	BAMechList* ba;
 	int i, j;
 	for (ba = baml; ba; ba = ba->next) {
-		Pfridot f = (Pfridot)ba->bam->f;
+		nrn_bamech_t f = ba->bam->f;
 		Memb_list* ml = ba->ml;
 		for (i=0; i < ml->nodecount; ++i) {
 	(*f)(ml->nodelist[i], ml->data[i], ml->pdata[i], ml->_thread, nt);
@@ -886,14 +888,15 @@ void Cvode::do_ode(NrnThread* _nt){
 	for (cml = z.cv_memb_list_; cml; cml = cml->next) { // probably can start at 6 or hh
 		mf = memb_func + cml->index;
 		if (mf->ode_spec) {
-			Pfridot s = (Pfridot)mf->ode_spec;
+			Pvmi s = mf->ode_spec;
 			Memb_list* ml = cml->ml;
 			if (mf->hoc_mech) {
 				int j, count;
 				count = ml->nodecount;
 				for (j = 0; j < count; ++j) {
 					Node* nd = ml->nodelist[j];
-					(*s)(nd, ml->prop[j]);
+//					(*s)(nd, ml->prop[j]);
+assert(0); //fixme
 				}
 			}else{
 				(*s)(_nt, ml, cml->index);
@@ -930,7 +933,7 @@ void Cvode::do_nonode(NrnThread* _nt) { // all the hacked integrators, etc, in S
 	 if (mf->state) {
 	  Memb_list* ml = cml->ml;
 	  if (!mf->ode_spec){
-		Pfridot s = (Pfridot)mf->state;
+		Pvmi s = mf->state;
 		(*s)(_nt, ml, cml->index);
 #if 0
 		if (errno) {
@@ -940,7 +943,7 @@ hoc_warning("errno set during calculation of states", (char*)0);
 		}
 #endif
 	  }else if (mf->singchan_) {
-		Pfridot s = (Pfridot)mf->singchan_;
+		Pvmi s = mf->singchan_;
 		(*s)(_nt, ml, cml->index);
 	  }
 	 }

--- a/src/nrniv/nonlinz.cpp
+++ b/src/nrniv/nonlinz.cpp
@@ -549,20 +549,8 @@ void NonLinImpRep::current(int im, Memb_list* ml, int in) { // assume there is i
 }
 
 void NonLinImpRep::ode(int im, Memb_list* ml) { // assume there is in fact an ode method
-	int i, nc;
 	Pvmi s = memb_func[im].ode_spec;
-	nc = ml->nodecount;
-	if (memb_func[im].hoc_mech) {
-		int j, count;
-		count = ml->nodecount;
-		for (j=0; j < count; ++j) {
-			Node* nd = ml->nodelist[j];
-//			(*s)(nd, ml->prop[j]);
-assert(0); //fixme
-		}
-	}else{
-		(*s)(nrn_threads, ml, im);
-	}
+	(*s)(nrn_threads, ml, im);
 }
 
 int NonLinImpRep::gapsolve() {

--- a/src/nrniv/nonlinz.cpp
+++ b/src/nrniv/nonlinz.cpp
@@ -8,8 +8,6 @@
 #include "cspmatrix.h"
 #include "membfunc.h"
 
-typedef int (*Pfridot)(...);
-
 extern "C" int structure_change_cnt;
 extern void v_setup_vectors();
 extern void nrn_rhs(NrnThread*);
@@ -226,7 +224,7 @@ NonLinImpRep::NonLinImpRep() {
 	for (NrnThreadMembList* tml = _nt->tml; tml; tml = tml->next) {
 		Memb_list* ml = tml->ml;
 		i = tml->index;
-		Pfridot s = (Pfridot)memb_func[i].ode_count;
+		nrn_ode_count_t s = memb_func[i].ode_count;
 		if (s) {
 			cnt = (*s)(i);
 			n_ode_ += cnt * ml->nodecount;
@@ -286,11 +284,11 @@ void NonLinImpRep::delta(double deltafac){ // also defines pv_,pvdot_ map for od
 		Memb_list* ml = tml->ml;
 		i = tml->index;
 		nc = ml->nodecount;
-		Pfridot s = (Pfridot)memb_func[i].ode_count;
+		nrn_ode_count_t s = memb_func[i].ode_count;
 		if (s && (cnt = (*s)(i)) > 0) {
-			s = (Pfridot)memb_func[i].ode_map;
+			nrn_ode_map_t m = memb_func[i].ode_map;
 			for (j=0; j < nc; ++j) {
-(*s)(ieq, pv_ + ieq, pvdot_ + ieq, ml->data[j], ml->pdata[j], deltavec_ + ieq, i);
+(*m)(ieq, pv_ + ieq, pvdot_ + ieq, ml->data[j], ml->pdata[j], deltavec_ + ieq, i);
 				ieq += cnt;
 			}
 		}
@@ -375,7 +373,7 @@ void NonLinImpRep::dids() {
 	  i = tml->index;
 	  if (memb_func[i].ode_count && ml->nodecount) {
 		int nc = ml->nodecount;
-		Pfridot s = (Pfridot)memb_func[i].ode_count;
+		nrn_ode_count_t s = memb_func[i].ode_count;
 		int cnt = (*s)(i);
 	    if (memb_func[i].current) {
 		double* x1 = rv_; // use as temporary storage
@@ -422,7 +420,7 @@ void NonLinImpRep::dsdv() {
 	  i = tml->index;
 	  if (memb_func[i].ode_count && ml->nodecount) {
 		int nc = ml->nodecount;
-		Pfridot s = (Pfridot)memb_func[i].ode_count;
+		nrn_ode_count_t s = memb_func[i].ode_count;
 		int cnt = (*s)(i);
 	    if (memb_func[i].current) {
 		double* x1 = rv_; // use as temporary storage
@@ -482,7 +480,7 @@ void NonLinImpRep::dsds() {
 	  i = tml->index;
 	  if (memb_func[i].ode_count && ml->nodecount) {
 		int nc = ml->nodecount;
-		Pfridot s = (Pfridot)memb_func[i].ode_count;
+		nrn_ode_count_t s = memb_func[i].ode_count;
 		int cnt = (*s)(i);
 		double* x1 = rv_; // use as temporary storage
 		double* x2 = jv_;
@@ -535,7 +533,7 @@ void NonLinImpRep::dsds() {
 }
 
 void NonLinImpRep::current(int im, Memb_list* ml, int in) { // assume there is in fact a current method
-	Pfridot s = (Pfridot)memb_func[im].current;
+	Pvmi s = memb_func[im].current;
 	// fake a 1 element memb_list
 	Memb_list mfake;
 #if CACHEVEC != 0
@@ -552,14 +550,15 @@ void NonLinImpRep::current(int im, Memb_list* ml, int in) { // assume there is i
 
 void NonLinImpRep::ode(int im, Memb_list* ml) { // assume there is in fact an ode method
 	int i, nc;
-	Pfridot s = (Pfridot)memb_func[im].ode_spec;
+	Pvmi s = memb_func[im].ode_spec;
 	nc = ml->nodecount;
 	if (memb_func[im].hoc_mech) {
 		int j, count;
 		count = ml->nodecount;
 		for (j=0; j < count; ++j) {
 			Node* nd = ml->nodelist[j];
-			(*s)(nd, ml->prop[j]);
+//			(*s)(nd, ml->prop[j]);
+assert(0); //fixme
 		}
 	}else{
 		(*s)(nrn_threads, ml, im);

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -1727,25 +1727,28 @@ extern int (*rl_getc_function)(void);
 static int getc_hook(void) {
     while(1) {
     	int r;
-    	unsigned char c;
-	run_til_stdin();
-	if ((r = read(0, &c, sizeof(c))) == sizeof(c)) {
-		return (int)c;
-	}else{
-		/* this seems consistent with the internal readline and the
-		   current master version 8.0. That is, rl_getc in the
-		   internal readline gets the return value of read and only
-		   cares about r == 1, loops if errno == EINTR, and returns
-		   EOF otherwise. (Note: internal readline does not have
-		   rl_getc_function.). Version 8.0 rl_getc is complex but in
-		   terms of read, it returns c if r == 1, returns EOF if
-		   r == 0, loops if errno == EINTR, and generally returns EOF
-		   if some other error occurred.
-		 */
-		if (errno != EINTR) {
-			return EOF;
-		}
-	}
+        unsigned char c;
+        if (run_til_stdin() == 0) {
+            // nothing in stdin  (happens when windows are dismissed)
+            continue;
+        }
+        if ((r = read(0, &c, sizeof(c))) == sizeof(c)) {
+            return (int)c;
+        }else{
+            /* this seems consistent with the internal readline and the
+                current master version 8.0. That is, rl_getc in the
+                internal readline gets the return value of read and only
+                cares about r == 1, loops if errno == EINTR, and returns
+                EOF otherwise. (Note: internal readline does not have
+                rl_getc_function.). Version 8.0 rl_getc is complex but in
+                terms of read, it returns c if r == 1, returns EOF if
+                r == 0, loops if errno == EINTR, and generally returns EOF
+                if some other error occurred.
+            */
+            if (errno != EINTR) {
+                return EOF;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
How to install NEURON natively on an Apple M1.
Instructions in INSTALL.md
The only really substantive issue was a segfault when cvode was activated. Fixed by matching prototypes of variable time step related calls into mod files. This revealed prototype issue in several places related to ```hoc_mech``` which handles mechanisms defined in hoc files. In these places  I commented out the function call and added ```assert(0); // fixme```. These are perhaps places of future implementation which never took place since all the hoc_mech callbacks are in fact NULL.
Also nrnpyenv.sh was generating an incorrect path for NRN_PYLIB. Fixed by making sure a candidate path declared PyRun_SimpleString.

Noticed several remaining issues. It is likely there are more.
1) neurondemo: the GUI regularly hangs when a window is closed and can be resolved by pressing "return" in the terminal window.
2) Running neurondemo under python does not suffer from the gui hang problem but the "MovieRun" for the "Stylized" demo does not work. (In fact this is also the case on an x86_64 mac.)  The way to run neurondemo under python is with:
```
$ cat nrnpydemo.py
#/usr/bin/python3
NRNDEMO='/Users/hines/neuron/nrn/build/install/share/nrn/demo'
import os
os.chdir(NRNDEMO)
from neuron import h, gui
h.nrn_load_dll("release/arm64/libnrnmech.dylib")
h.load_file("demo.hoc")
```
```
python3 -i nrnpydemo.py
```
3) The nrntest repository fails in two areas. One was simple to fix. Ie. use ```uname -m``` to determine the arch that nrnivmodl used to build the libnrnmech.dylib. The other is that ```fast/t16.hoc``` is not producing exactly the standard results for some variable step method runs. The symptom is the use of slightly different time steps and it does not have a clear diagnosis yet.