### PR TITLE
Use nrn_add_test*() helpers in more places.

### DIFF
--- a/.cmake-format.changes.yaml
+++ b/.cmake-format.changes.yaml
@@ -4,7 +4,7 @@ additional_commands:
     kwargs:
       NAME: 1
       SUBMODULE: '?'
-      MODFILE_DIRECTORY: '?'
+      MODFILE_PATTERNS: '*'
       SCRIPT_PATTERNS: '*'
       OUTPUT: '*'
   nrn_add_test:
@@ -13,7 +13,7 @@ additional_commands:
       GROUP: 1
       NAME: 1
       SUBMODULE: '?'
-      MODFILE_DIRECTORY: '?'
+      MODFILE_PATTERNS: '*'
       COMMAND: '+'
       SCRIPT_PATTERNS: '*'
       REQUIRES: '*'

--- a/.cmake-format.changes.yaml
+++ b/.cmake-format.changes.yaml
@@ -18,6 +18,7 @@ additional_commands:
       SCRIPT_PATTERNS: '*'
       REQUIRES: '*'
       CONFLICTS: '*'
+      OUTPUT: '*'
   nrn_add_test_group_comparison:
     pargs: 0
     kwargs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,6 +424,10 @@ if(NEURON_CMAKE_FORMAT)
   if(NOT EXISTS external/coding-conventions/cpp)
     initialize_submodule(external/coding-conventions)
   endif()
+  set(NEURON_CMakeFormat_EXCLUDES_RE
+      ".*/external/\\(backward\\|catch2\\|coding-conventions\\|iv\\|tests\\)/.*$$"
+      ".*/external/coreneuron/\\(external/nmodl\\|external/mod2c\\|external/CLI11\\|CMake/hpc-coding-conventions\\)/.*$$"
+      CACHE STRING "list of regular expressions to exclude CMake files from formatting" FORCE)
   add_subdirectory(external/coding-conventions/cpp)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -490,8 +490,12 @@ if(NRN_ENABLE_TESTS)
   if(NRN_ENABLE_PYTHON AND NOT PYTEST_FOUND)
     message(SEND_ERROR "pytest Python package is required.")
   endif()
-  add_subdirectory(test)
+  # Initialize the submodule *before* including the test/CMakeLists.txt that
+  # uses it. This ensures that the test infrastructure can find the names of
+  # the input data files and set up rules to copy them into the test working
+  # directories.
   initialize_submodule("test/rxd/testdata")
+  add_subdirectory(test)
 endif()
 
 # =============================================================================

--- a/cmake/NeuronTestHelper.cmake
+++ b/cmake/NeuronTestHelper.cmake
@@ -177,10 +177,15 @@ function(nrn_add_test)
     set(modfile_patterns "${NRN_ADD_TEST_MODFILE_PATTERNS}")
   endif()
 
-  # First, make sure the specified submodule is initialised.
-  initialize_submodule(external/${git_submodule})
-  # Construct the name of the source tree directory where the submodule has been checked out.
-  set(test_source_directory "${PROJECT_SOURCE_DIR}/external/${git_submodule}")
+  # First, make sure the specified submodule is initialised. If there is no submodule, everything is
+  # relative to the root nrn/ directory.
+  if(NOT ${git_submodule} STREQUAL "")
+    initialize_submodule(external/${git_submodule})
+    # Construct the name of the source tree directory where the submodule has been checked out.
+    set(test_source_directory "${PROJECT_SOURCE_DIR}/external/${git_submodule}")
+  else()
+    set(test_source_directory "${PROJECT_SOURCE_DIR}")
+  endif()
   # Construct the name of a working directory in the build tree for this group of tests
   set(group_working_directory "${PROJECT_BINARY_DIR}/test/${NRN_ADD_TEST_GROUP}")
   # Finally a working directory for this specific test within the group

--- a/cmake/NeuronTestHelper.cmake
+++ b/cmake/NeuronTestHelper.cmake
@@ -250,11 +250,18 @@ function(nrn_add_test)
   # specific working directory and copy them there.
   file(MAKE_DIRECTORY "${working_directory}")
   foreach(script_pattern ${script_patterns})
-    file(GLOB script_files "${test_source_directory}/${script_pattern}")
-    add_custom_command(
-      TARGET ${prefix} POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${script_files} "${working_directory}"
-      COMMENT "Copying scripts needed to run test ${NRN_ADD_TEST_GROUP}::${NRN_ADD_TEST_NAME}")
+    # We want to preserve directory structures, so if you pass SCRIPT_PATTERNS path/to/*.py then you
+    # end up with {build_directory}/path/to/test_working_directory/path/to/script.py
+    file(
+      GLOB_RECURSE script_files
+      RELATIVE "${test_source_directory}"
+      "${test_source_directory}/${script_pattern}")
+    foreach(script_file ${script_files})
+      add_custom_command(
+        TARGET ${prefix} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${test_source_directory}/${script_file}"
+                "${working_directory}/${script_file}")
+    endforeach()
   endforeach()
 
   # Construct the name of the test and store it in a parent-scope list to be used when setting up

--- a/cmake/NeuronTestHelper.cmake
+++ b/cmake/NeuronTestHelper.cmake
@@ -248,6 +248,13 @@ function(nrn_add_test)
       # here too.
       list(APPEND output_binaries "${special}-core")
       list(APPEND nrnivmodl_dependencies coreneuron)
+      if(NOT DEFINED CORENEURON_BUILTIN_MODFILES)
+        message(
+          WARNING
+            "nrn_add_test couldn't find the names of the builtin CoreNEURON modfiles that nrnivmodl-core implicitly depends on"
+        )
+      endif()
+      list(APPEND nrnivmodl_dependencies ${CORENEURON_BUILTIN_MODFILES})
     endif()
     add_custom_command(
       OUTPUT ${output_binaries}

--- a/cmake/NeuronTestHelper.cmake
+++ b/cmake/NeuronTestHelper.cmake
@@ -314,7 +314,7 @@ function(nrn_add_test)
     "${test_name}"
     PROPERTIES
       ENVIRONMENT
-      "${NRN_TEST_ENV};PATH=${nrnivmodl_working_directory}/${CMAKE_HOST_SYSTEM_PROCESSOR}:$ENV{PATH};CORENEURONLIB=${nrnivmodl_working_directory}/${CMAKE_HOST_SYSTEM_PROCESSOR}/libcorenrnmech.so"
+      "${NRN_TEST_ENV};PATH=${nrnivmodl_working_directory}/${CMAKE_HOST_SYSTEM_PROCESSOR}:$ENV{PATH};CORENEURONLIB=${nrnivmodl_working_directory}/${CMAKE_HOST_SYSTEM_PROCESSOR}/libcorenrnmech${CMAKE_SHARED_LIBRARY_SUFFIX}"
   )
 
   # Construct an expression containing the names of the test output files that will be passed to the

--- a/git2nrnversion_h.sh
+++ b/git2nrnversion_h.sh
@@ -7,7 +7,8 @@ fi
 
 cd $a
 
-if git log > /dev/null && test -d .git ; then
+# Do the fast directory check before the slow git command
+if [ -d .git ] || git rev-parse --git-dir > /dev/null 2>&1; then
         describe="`git describe --tags`"
         branch="`git rev-parse --abbrev-ref HEAD`" # branch name
         modified="`git status -s -uno --porcelain | sed -n '1s/.*/+/p'`" # + if modified

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -86,43 +86,40 @@ list(APPEND TESTS connect_dend)
 # Add pytest
 # =============================================================================
 if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
-  add_test(
+  include(NeuronTestHelper)
+  # TODO: consider allowing the group-related parts to be dropped here
+  nrn_add_test_group(NAME pynrn_tests)
+  nrn_add_test(
+    GROUP pynrn_tests
     NAME basic_tests
     COMMAND
-      ${CMAKE_COMMAND} -E env COVERAGE_FILE=.coverage.basic_tests ${PYTHON_EXECUTABLE} -m pytest
-      --cov-report=xml --cov=neuron ${PROJECT_SOURCE_DIR}/test/pynrn
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test/pynrn)
-  list(APPEND TESTS basic_tests)
-  add_custom_target(
-    pynrn_mod ALL
-    COMMAND ${CMAKE_COMMAND} -E env ${TEST_ENV} ${CMAKE_BINARY_DIR}/bin/nrnivmodl
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test/pynrn
-    DEPENDS ${PROJECT_SOURCE_DIR}/test/pynrn/unitstest.mod nocmodl)
-  add_dependencies(pynrn_mod nrniv)
-
-  add_custom_target(
-    rxdmod ALL
-    COMMAND ${CMAKE_COMMAND} -E env ${TEST_ENV} ${CMAKE_BINARY_DIR}/bin/nrnivmodl ./ecs
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test/rxd)
-  add_dependencies(rxdmod nrniv)
+      COVERAGE_FILE=.coverage.basic_tests ${PYTHON_EXECUTABLE} -m pytest --cov-report=xml
+      --cov=neuron ./test/pynrn
+    MODFILE_PATTERNS test/pynrn/*.mod
+    SCRIPT_PATTERNS test/pynrn/*.py)
 
   if(NRN_ENABLE_RX3D)
-    add_test(
+    nrn_add_test_group(
+      NAME rxdmod_tests
+      MODFILE_PATTERNS test/rxd/ecs/*.mod
+      SCRIPT_PATTERNS test/rxd/*.py test/rxd/testdata/*.dat)
+    nrn_add_test(
+      GROUP rxdmod_tests
       NAME rxd_tests
       COMMAND
-        ${CMAKE_COMMAND} -E env COVERAGE_FILE=.coverage.rxd_tests ${PYTHON_EXECUTABLE} -m pytest
-        --cov-report=xml --cov=neuron ${PROJECT_SOURCE_DIR}/test/rxd)
-    list(APPEND TESTS rxd_tests)
+        COVERAGE_FILE=.coverage.rxd_tests ${PYTHON_EXECUTABLE} -m pytest --cov-report=xml
+        --cov=neuron ./test/rxd)
     if(NRN_ENABLE_MPI)
       find_python_module(mpi4py)
       if(mpi4py_FOUND)
-        add_test(
+        get_filename_component(MPIEXEC_NAME ${MPIEXEC} NAME)
+        nrn_add_test(
+          GROUP rxdmod_tests
           NAME rxd_mpi_tests
           COMMAND
-            ${MPIEXEC} -np 1 ${CMAKE_COMMAND} -E env COVERAGE_FILE=.coverage.rxd_mpi_tests
-            ${PYTHON_EXECUTABLE} -m pytest --cov-report=xml --cov=neuron
-            ${PROJECT_SOURCE_DIR}/test/rxd --mpi)
-        list(APPEND TESTS rxd_mpi_tests)
+            COVERAGE_FILE=.coverage.rxd_mpi_tests ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 1
+            ${MPIEXEC_PREFLAGS} ${PYTHON_EXECUTABLE} ${MPIEXEC_POSTFLAGS} -m pytest
+            --cov-report=xml --cov=neuron ./test/rxd --mpi)
       endif()
     endif()
   endif()
@@ -152,101 +149,87 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
   endif()
 
   if(NRN_ENABLE_CORENEURON)
-    file(COPY ${PROJECT_SOURCE_DIR}/test/coreneuron/mod DESTINATION ${PROJECT_BINARY_DIR}/test/)
-    file(COPY ${PROJECT_SOURCE_DIR}/test/pynrn/unitstest.mod
-         DESTINATION ${PROJECT_BINARY_DIR}/test/mod)
-    file(COPY ${PROJECT_SOURCE_DIR}/test/gjtests/natrans.mod
-         DESTINATION ${PROJECT_BINARY_DIR}/test/mod)
-    # Build test-specific MOD files
-    add_custom_target(
-      coreneuron_mod ALL
+    nrn_add_test_group(
+      NAME coreneuron_modtests
+      SCRIPT_PATTERNS test/coreneuron/*.py
+      MODFILE_PATTERNS test/coreneuron/mod/*.mod test/pynrn/unitstest.mod test/gjtests/natrans.mod)
+    nrn_add_test(
+      GROUP coreneuron_modtests
+      NAME direct_py
+      REQUIRES coreneuron
       COMMAND
-        ${CMAKE_COMMAND} -E env ${TEST_ENV} ${CMAKE_BINARY_DIR}/bin/nrnivmodl -coreneuron .
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
-    add_dependencies(coreneuron_mod nrniv nrniv-core)
-
-    add_test(
-      NAME coreneuron_direct_py
+        COVERAGE_FILE=.coverage.coreneuron_direct_py ${PYTHON_EXECUTABLE} -m pytest
+        --cov-report=xml --cov=neuron test/coreneuron/test_direct.py)
+    nrn_add_test(
+      GROUP coreneuron_modtests
+      NAME direct_hoc
+      REQUIRES coreneuron
+      SCRIPT_PATTERNS test/coreneuron/test_direct.hoc
+      COMMAND ${CMAKE_BINARY_DIR}/bin/nrniv test/coreneuron/test_direct.hoc)
+    nrn_add_test(
+      GROUP coreneuron_modtests
+      NAME spikes_py
+      REQUIRES coreneuron
       COMMAND
-        ${CMAKE_COMMAND} -E env COVERAGE_FILE=.coverage.coreneuron_direct_py ${PYTHON_EXECUTABLE} -m
-        pytest --cov-report=xml --cov=neuron ${PROJECT_SOURCE_DIR}/test/coreneuron/test_direct.py
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
-    add_test(
-      NAME coreneuron_direct_hoc
-      COMMAND ${CMAKE_BINARY_DIR}/bin/nrniv ${PROJECT_SOURCE_DIR}/test/coreneuron/test_direct.hoc
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
-    add_test(
-      NAME coreneuron_spikes_py
+        COVERAGE_FILE=.coverage.coreneuron_spikes_py ${PYTHON_EXECUTABLE} -m pytest
+        --cov-report=xml --cov=neuron test/coreneuron/test_spikes.py)
+    nrn_add_test(
+      GROUP coreneuron_modtests
+      NAME spikes_file_mode_py
+      REQUIRES coreneuron
+      COMMAND ${PYTHON_EXECUTABLE} test/coreneuron/test_spikes.py file_mode)
+    nrn_add_test(
+      GROUP coreneuron_modtests
+      NAME fornetcon_py
+      REQUIRES coreneuron
       COMMAND
-        ${CMAKE_COMMAND} -E env COVERAGE_FILE=.coverage.coreneuron_spikes_py ${PYTHON_EXECUTABLE} -m
-        pytest --cov-report=xml --cov=neuron ${PROJECT_SOURCE_DIR}/test/coreneuron/test_spikes.py
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
-    add_test(
-      NAME coreneuron_spikes_file_mode_py
-      COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/coreneuron/test_spikes.py file_mode
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
-    add_test(
-      NAME coreneuron_fornetcon_py
+        COVERAGE_FILE=.coverage.coreneuron_fornetcon_py ${PYTHON_EXECUTABLE} -m pytest
+        --cov-report=xml --cov=neuron test/coreneuron/test_fornetcon.py)
+    nrn_add_test(
+      GROUP coreneuron_modtests
+      NAME datareturn_py
+      REQUIRES coreneuron
       COMMAND
-        ${CMAKE_COMMAND} -E env COVERAGE_FILE=.coverage.coreneuron_fornetcon_py ${PYTHON_EXECUTABLE}
-        -m pytest --cov-report=xml --cov=neuron
-        ${PROJECT_SOURCE_DIR}/test/coreneuron/test_fornetcon.py
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
-    add_test(
-      NAME coreneuron_datareturn_py
+        COVERAGE_FILE=.coverage.coreneuron_datareturn_py ${PYTHON_EXECUTABLE} -m pytest
+        --cov-report=xml --cov=neuron test/coreneuron/test_datareturn.py)
+    nrn_add_test(
+      GROUP coreneuron_modtests
+      NAME test_units_py
+      REQUIRES coreneuron
       COMMAND
-        ${CMAKE_COMMAND} -E env COVERAGE_FILE=.coverage.coreneuron_datareturn_py
-        ${PYTHON_EXECUTABLE} -m pytest --cov-report=xml --cov=neuron
-        ${PROJECT_SOURCE_DIR}/test/coreneuron/test_datareturn.py
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
-    add_test(
-      NAME coreneuron_test_units_py
+        COVERAGE_FILE=.coverage.coreneuron_test_units_py ${PYTHON_EXECUTABLE} -m pytest
+        --cov-report=xml --cov=neuron test/coreneuron/test_units.py)
+    nrn_add_test(
+      GROUP coreneuron_modtests
+      NAME test_natrans_py
+      REQUIRES coreneuron
+      SCRIPT_PATTERNS test/gjtests/test_natrans.py
       COMMAND
-        ${CMAKE_COMMAND} -E env COVERAGE_FILE=.coverage.coreneuron_test_units_py
-        ${PYTHON_EXECUTABLE} -m pytest --cov-report=xml --cov=neuron
-        ${PROJECT_SOURCE_DIR}/test/coreneuron/test_units.py
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
-    add_test(
-      NAME coreneuron_test_natrans_py
-      COMMAND
-        ${CMAKE_COMMAND} -E env COVERAGE_FILE=.coverage.coreneuron_test_natrans_py
-        ${PYTHON_EXECUTABLE} -m pytest --cov-report=xml --cov=neuron
-        ${PROJECT_SOURCE_DIR}/test/gjtests/test_natrans.py
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
-    list(
-      APPEND TESTS
-             coreneuron_direct_py
-             coreneuron_direct_hoc
-             coreneuron_spikes_py
-             coreneuron_spikes_file_mode_py
-             coreneuron_fornetcon_py
-             coreneuron_datareturn_py
-             coreneuron_test_units_py
-             coreneuron_test_natrans_py)
+        COVERAGE_FILE=.coverage.coreneuron_test_natrans_py ${PYTHON_EXECUTABLE} -m pytest
+        --cov-report=xml --cov=neuron test/gjtests/test_natrans.py)
     if(NRN_ENABLE_MPI)
       find_python_module(mpi4py)
-      if(mpi4py_FOUND)
-        add_test(
-          NAME coreneuron_spikes_mpi_py
-          COMMAND
-            ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} ${PYTHON_EXECUTABLE}
-            ${MPIEXEC_POSTFLAGS} ${PROJECT_SOURCE_DIR}/test/coreneuron/test_spikes.py mpi4py
-          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
-        list(APPEND TESTS coreneuron_spikes_mpi_py)
-      endif()
       # Using -pyexe was a first workaround for GitHub issue #894, but it seems that we also need to
       # avoid using the full path to mpiexec (see other discussion in #894). Replacing ${MPIEXEC}
       # with ${CMAKE_COMMAND} -E env ${MPIEXEC_NAME} achieves this.
       get_filename_component(MPIEXEC_NAME ${MPIEXEC} NAME)
-      add_test(
-        NAME coreneuron_spikes_mpi_file_mode_py
+      if(mpi4py_FOUND)
+        nrn_add_test(
+          GROUP coreneuron_modtests
+          NAME spikes_mpi_py
+          REQUIRES coreneuron
+          COMMAND
+            ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} ${PYTHON_EXECUTABLE}
+            ${MPIEXEC_POSTFLAGS} test/coreneuron/test_spikes.py mpi4py)
+      endif()
+      nrn_add_test(
+        GROUP coreneuron_modtests
+        NAME spikes_mpi_file_mode_py
+        REQUIRES coreneuron
         COMMAND
-          ${CMAKE_COMMAND} -E env ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS}
-          ${CMAKE_HOST_SYSTEM_PROCESSOR}/special ${MPIEXEC_POSTFLAGS} -python -pyexe
-          ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/coreneuron/test_spikes.py nrnmpi_init
-          file_mode
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/mod)
-      list(APPEND TESTS coreneuron_spikes_mpi_file_mode_py)
+          ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} special
+          ${MPIEXEC_POSTFLAGS} -python -pyexe ${PYTHON_EXECUTABLE} test/coreneuron/test_spikes.py
+          nrnmpi_init file_mode)
     endif()
   endif()
 endif()

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -20,8 +20,8 @@ if(NRN_ENABLE_PYTHON) # This could be translated into `REQUIRES python` if neede
     GROUP external_ringtest
     NAME neuron
     REQUIRES mod_compatibility
-    COMMAND
-      special -python ringtest.py -tstop 100 OUTPUT asciispikes::spk1.std)
+    COMMAND special -python ringtest.py -tstop 100
+    OUTPUT asciispikes::spk1.std)
 
   if(NRN_ENABLE_MPI) # This could be translated into `REQUIRES mpi` if needed
     # To work around CI failures that seem related to #894 we should run `mpiexec` not

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NRN_ENABLE_PYTHON) # This could be translated into `REQUIRES python` if neede
   nrn_add_test_group(
     NAME external_ringtest
     SUBMODULE tests/ringtest # git submodule where the relevant tests are defined
-    MODFILE_DIRECTORY "mod"
+    MODFILE_PATTERNS "mod/*.mod"
     OUTPUT asciispikes::spk2.std # which output data to compare
     SCRIPT_PATTERNS "*.py" "*.hoc")
 


### PR DESCRIPTION
This PR includes some small improvements to the utilities added in https://github.com/neuronsimulator/nrn/pull/997 and uses them to set up more of the NEURON tests. This:
- speeds up the build, as more dependencies are declared correctly so less work is wasted
- reduces duplication (CMake logic for running `nrnivmodl`)

Changes to the helpers:
- Reduce usage of `cmake -E env` as the very long command lines that it generated could be problematic.
- Include a symlink in each test working directory to the relevant build (`test/working/dir/x86_64` -> `build_dir/test/<hash>/x86_64`). This reduces the amount of environment hacking needed to make tests run.
- Make the `SUBMODULE` argument optional; if it is not specified then interpret paths as being relative to the parent NEURON (nrn) repository.
- Replace `MODFILE_DIRECTORY` with `MODFILE_PATTERNS` in the `nrn_add_test_*()` helpers. This adds flexibility which helps migrate more tests to use the helpers.
- Adjust `SCRIPT_PATTERNS` handling: preserve directory structure (`external/submodule/path/script.py` -> `test/working/dir/path/script.py`)

Additionally:
- The `git2nrnversion_h.sh` script gains a faster am-I-a-git-repository check. Previously it piped the whole git history to `/dev/null`. In my setup this was a noticeable part of the incremental build time.
- Discourage cmake-format from touching submodules (a better fix is presumably possible in https://github.com/BlueBrain/hpc-coding-conventions, but this improves the situation in the meantime)