### PR TITLE
Beginning a "Developer Builds" topic under BUILDING.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Welcome to NEURON's documentation!
 
    install/install
    cmake_doc/index
+   install/developer
 
 .. toctree::
    :maxdepth: 2

--- a/docs/install/code_coverage.md
+++ b/docs/install/code_coverage.md
@@ -1,9 +1,3 @@
-Introduction
-============
-
-Developer builds for creating Binary distributions, tests,
-documentation, code coverage. Each aspect generally has extra dependencies and
-special instructions.
 
 Code Coverage
 -------------
@@ -28,7 +22,7 @@ But you will generally want ```-DNRN_ENABLE_TESTS=ON``` to see what
 effect your new tests have on coverage.
 ```
 COVERAGE_FLAGS="--coverage -O0 -fno-inline -g"
-ccmake .. -DCMAKE_INSTALL_PREFIX=install -DCMAKE_C_FLAGS="${COVERAGE_FLAGS}" -DCMAKE_CXX_FLAGS="${COVERAGE_FLAGS}" -DNRN_ENABLE_TESTS=ON
+cmake .. -DCMAKE_INSTALL_PREFIX=install -DCMAKE_C_FLAGS="${COVERAGE_FLAGS}" -DCMAKE_CXX_FLAGS="${COVERAGE_FLAGS}" -DNRN_ENABLE_TESTS=ON
 make -j install
 ```
 

--- a/docs/install/developer.rst
+++ b/docs/install/developer.rst
@@ -1,0 +1,7 @@
+Developer Builds
+============
+
+.. toctree::
+   :maxdepth: 2
+
+   developer_build.md

--- a/docs/install/developer.rst
+++ b/docs/install/developer.rst
@@ -1,7 +1,12 @@
 Developer Builds
 ============
 
+Developer builds for creating Binary distributions, tests,
+documentation, code coverage. Each aspect generally has extra
+dependencies and special instructions.
+
+
 .. toctree::
    :maxdepth: 2
 
-   developer_build.md
+   code_coverage.md

--- a/docs/install/developer_build.md
+++ b/docs/install/developer_build.md
@@ -1,0 +1,79 @@
+Introduction
+============
+
+Developer builds for creating Binary distributions, tests,
+documentation, code coverage. Each aspect generally has extra dependencies and
+special instructions.
+
+Code Coverage
+-------------
+
+**Dependencies** (Linux)
+```
+sudo apt install lcov
+```
+
+**Instructions**
+
+Clone the nrn repository and get ready to build.
+```
+    git clone https://github.com/neuronsimulator/nrn nrn
+    cd nrn
+    mkdir build
+    cd build
+```
+
+In addition to the COVERAGE_FLAGS use whatever cmake options you desire.
+But you will generally want ```-DNRN_ENABLE_TESTS=ON``` to see what
+effect your new tests have on coverage.
+```
+COVERAGE_FLAGS="--coverage -O0 -fno-inline -g"
+ccmake .. -DCMAKE_INSTALL_PREFIX=install -DCMAKE_C_FLAGS="${COVERAGE_FLAGS}" -DCMAKE_CXX_FLAGS="${COVERAGE_FLAGS}" -DNRN_ENABLE_TESTS=ON
+make -j install
+```
+
+Set proper PATH (and PYTHONPATH if needed).
+```
+export PATH=`pwd`/install/bin
+export PYTHONPATH=`pwd`/install/lib/python
+```
+
+Create a baseline report in coverage-base.info
+
+A baseline report is recommended in order to
+ensure that the percentage of total lines covered is correct
+even when not  all  source  code  files  were loaded during the test.
+
+```
+(cd ..;  lcov --capture  --initial --directory . --no-external --output-file build/coverage-base.info)
+```
+
+Any nrniv runs will accumulate information about coverage in the .gdca files associated with the .o files
+E.g. run tests with
+```
+ctest -VV
+```
+
+and create a report with all the coverage so far.
+```
+(cd ..; lcov --capture  --directory . --no-external --output-file build/coverage-run.info)
+```
+
+Combine baseline and test coverage data.
+```
+lcov --add-tracefile coverage-base.info --add-tracefile coverage-run.info --output-file coverage-combined.info
+```
+
+You can get a summary of the coverage so far.
+```
+lcov --summary coverage-combined.info
+```
+
+You can get a full html report.
+(the output-directory avoids creating several dozen files in the top of the
+build folder and hence it is easier to remove).
+```
+genhtml coverage-combined.info --output-directory html
+```
+
+And view the report by loading ```./html/index.html``` into your browser.


### PR DESCRIPTION
  Seeding with notes on Code Coverage.

All the code coverage substance is due to @alexsavulescu.
But at least this is the kind of information I need in order to use it. And it seems findable now.

I can imagine it may be useful to have a separate file for every Developer Build topic. I'm happy to adopt a better organizational structure. I'm thinking of trying my hand at "Mac Package Build" next.
