### PR TITLE
Missing include that defines USE_PYTHON

### DIFF
--- a/src/nrnoc/secref.cpp
+++ b/src/nrnoc/secref.cpp
@@ -19,6 +19,7 @@ access s1.sec	// soma becomes the default section
 #include "section.h"
 #include "parse.hpp"
 #include "hoc_membf.h"
+#include <nrnpython_config.h>
 
 extern int hoc_return_type_code; 
 


### PR DESCRIPTION
Fixes #1028

I only checked that I can add hh channels to all the sections. I used the test
```
$ cat cellbild_pysec.py
# section is unnamed when importing Python sections into CellBuilder #1028

from neuron import h, gui

soma = h.Section(name='soma')
dend = h.Section(name='dend')
dend2 = h.Section(name='dend2')
dend.connect(soma)
dend2.connect(soma)

h.load_file("celbild.hoc")
cb = h.CellBuild()
cb.manage.iport()
```
and ran with
```
python -i cellbild_pysec.py
```