### PR TITLE
Re-enable tests fixed upstream in CoreNEURON

### DIFF
--- a/test/external/testcorenrn/CMakeLists.txt
+++ b/test/external/testcorenrn/CMakeLists.txt
@@ -31,11 +31,6 @@ set(test_vecplay_neuron_requirements mod_compatibility)
 set(test_gf_coreneuron_cpu_conflicts gpu) # CoreNEURON-on-CPU test conflicts with GPU being enabled
                                           # in the build
 
-# Flag some combinations of test + processor + platform that are currently buggy.
-set(test_patstim_coreneuron_gpu_conflicts cpu) # cpu is always enabled, so this disables patstim-on-
-                                               # GPU
-set(test_vecplay_coreneuron_gpu_conflicts cpu)
-
 get_filename_component(MPIEXEC_NAME ${MPIEXEC} NAME)
 
 if(${CORENRN_ENABLE_GPU})


### PR DESCRIPTION
- Bump CoreNEURON to commit including https://github.com/BlueBrain/CoreNeuron/pull/502 and https://github.com/BlueBrain/CoreNeuron/pull/504
- Enable the tests that were fixed by these PRs.

cc: @pramodk who did the real work!