### PR TITLE
Fix the build issues and tests on Apple M1

### DIFF
--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -1,5 +1,17 @@
 #
 # Add tests based on external repositories
 #
+
+# FindMPI has broke backward compatibility with v3.19
+if(${CMAKE_VERSION} VERSION_LESS "3.10")
+  get_filename_component(MPIEXEC_NAME ${MPIEXEC} NAME)
+else()
+  get_filename_component(MPIEXEC_NAME ${MPIEXEC_EXECUTABLE} NAME)
+endif()
+
+# To work around CI failures that seem related to #894 we should run `mpiexec` not
+# `/path/to/mpiexec`
+set(MPIEXEC_NAME ${MPIEXEC_NAME})
+
 add_subdirectory(ringtest)
 add_subdirectory(testcorenrn)

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Add tests based on external repositories
 #
 
-# FindMPI has broke backward compatibility with v3.19
+# FindMPI broke backward compatibility with v3.19
 if(${CMAKE_VERSION} VERSION_LESS "3.10")
   get_filename_component(MPIEXEC_NAME ${MPIEXEC} NAME)
 else()

--- a/test/external/ringtest/CMakeLists.txt
+++ b/test/external/ringtest/CMakeLists.txt
@@ -20,9 +20,6 @@ nrn_add_test(
   COMMAND special -python ringtest.py -tstop 100
   OUTPUT asciispikes::spk1.std)
 
-# To work around CI failures that seem related to #894 we should run `mpiexec` not
-# `/path/to/mpiexec`
-get_filename_component(MPIEXEC_NAME ${MPIEXEC} NAME)
 nrn_add_test(
   GROUP external_ringtest
   NAME neuron_mpi

--- a/test/external/testcorenrn/CMakeLists.txt
+++ b/test/external/testcorenrn/CMakeLists.txt
@@ -31,8 +31,6 @@ set(test_vecplay_neuron_requirements mod_compatibility)
 set(test_gf_coreneuron_cpu_conflicts gpu) # CoreNEURON-on-CPU test conflicts with GPU being enabled
                                           # in the build
 
-get_filename_component(MPIEXEC_NAME ${MPIEXEC} NAME)
-
 if(${CORENRN_ENABLE_GPU})
   set(gpu_args_online -c arg_coreneuron_gpu=1)
   set(gpu_args_offline --gpu)


### PR DESCRIPTION
 * catch2 submodule updated to latest release to
   support apple m1 build
 * FindMPI.cmake breaks compatibility with latest
   cmake version. See #1052.

Fixes #1052
Fixes #1033