### PR TITLE
Improve support for external CoreNEURON.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,6 +322,8 @@ if(NRN_ENABLE_CORENEURON)
   find_package(coreneuron QUIET PATHS ${CORENEURON_DIR}/share/cmake ${CORENEURON_DIR})
   if(coreneuron_FOUND)
     message(STATUS "Using external CoreNEURON from ${CORENEURON_DIR}")
+    # By default `nrnivmodl` should look for `nrnivmodl-core` under the external prefix.
+    set(cnrn_prefix "${CORENEURON_DIR}")
   else()
     message(STATUS "Building CoreNEURON from submodule")
     # If NEURON tests are enabled then enable CoreNEURON tests too
@@ -329,6 +331,8 @@ if(NRN_ENABLE_CORENEURON)
     set(CORENRN_ENABLE_LEGACY_UNITS ${NRN_DYNAMIC_UNITS_USE_LEGACY} CACHE BOOL "" FORCE)
     add_external_project(coreneuron)
     set(CORENEURON_DIR ${PROJECT_SOURCE_DIR}/external/coreneuron)
+    # By default `nrnivmodl` should look for `nrnivmodl-core` in the NEURON install prefix.
+    set(cnrn_prefix "${CMAKE_INSTALL_PREFIX}")
   endif()
   get_property (CORENEURON_LIB_LINK_FLAGS GLOBAL PROPERTY CORENEURON_LIB_LINK_FLAGS)
   set(NRN_ENABLE_BINARY_SPECIAL ON)
@@ -516,13 +520,6 @@ nrn_find_project_files(NRN_HEADERS_PATHS ${HEADER_FILES_TO_INSTALL})
 file(COPY ${NRN_HEADERS_PATHS} ${PROJECT_BINARY_DIR}/src/oc/nrnpthread.h
      DESTINATION ${PROJECT_BINARY_DIR}/include)
 install(DIRECTORY ${PROJECT_BINARY_DIR}/include DESTINATION ${CMAKE_INSTALL_PREFIX})
-
-# for external coreneuron, nrnivmodl-core should be install
-if(coreneuron_FOUND)
-  install(PROGRAMS ${CORENEURON_DIR}/bin/nrnivmodl-core DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
-  install(FILES ${CORENEURON_DIR}/bin/nrnivmodl_core_makefile
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
-endif()
 
 # =============================================================================
 # Copy bash executable for windows

--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -22,6 +22,13 @@ else
   @USING_CMAKE_TRUE@libdir="${prefix}/lib"
 fi
 
+if [ -z ${CNRNHOME+x} ]; then
+  # CNRNHOME wasn't set, use the install prefix
+  cnrn_prefix=@cnrn_prefix@
+else
+  cnrn_prefix="${CNRNHOME}"
+fi
+
 if test "${NRNHOME_EXEC}" != "" ; then
   exec_prefix="${NRNHOME_EXEC}"
   bindir="${exec_prefix}/bin"
@@ -313,7 +320,7 @@ if [ "$LinkCoreNEURON" = true ] ; then
         j=`escape_spaces "$j"`
         args="$args $j"
       done
-      $bindir/nrnivmodl-core $args
+      "${cnrn_prefix}/bin/nrnivmodl-core" $args
       cd $MODSUBDIR
     else
       printf "ERROR : CoreNEURON support is not enabled!\n"

--- a/cmake/NeuronTestHelper.cmake
+++ b/cmake/NeuronTestHelper.cmake
@@ -331,7 +331,7 @@ function(nrn_add_test)
     set_tests_properties(${test_name} PROPERTIES DEPENDS ${test_name}::preparation)
   endif()
   if(DEFINED NRN_ADD_TEST_PROCESSORS)
-    set(tests_properties ${test_names} PROPERTIES PROCESSORS ${NRN_ADD_TEST_PROCESSORS})
+    set_tests_properties(${test_names} PROPERTIES PROCESSORS ${NRN_ADD_TEST_PROCESSORS})
   endif()
   set_tests_properties(
     ${test_names}

--- a/cmake/NeuronTestHelper.cmake
+++ b/cmake/NeuronTestHelper.cmake
@@ -225,7 +225,8 @@ function(nrn_add_test)
   endif()
   list(SORT modfiles)
   foreach(modfile ${modfiles})
-    # ${modfile} is an absolute path starting with ${PROJECT_SOURCE_DIR}, let's only add the part below this common prefix to the hash
+    # ${modfile} is an absolute path starting with ${PROJECT_SOURCE_DIR}, let's only add the part
+    # below this common prefix to the hash
     string(LENGTH "${PROJECT_SOURCE_DIR}/" prefix_length)
     string(SUBSTRING "${modfile}" ${prefix_length} -1 relative_modfile)
     list(APPEND hash_components "${relative_modfile}")
@@ -292,9 +293,10 @@ function(nrn_add_test)
   # specific working directory and copy them there.
   file(MAKE_DIRECTORY "${working_directory}")
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E create_symlink
-            "${nrnivmodl_working_directory}/${CMAKE_HOST_SYSTEM_PROCESSOR}"
-            "${working_directory}/${CMAKE_HOST_SYSTEM_PROCESSOR}")
+    COMMAND
+      ${CMAKE_COMMAND} -E create_symlink
+      "${nrnivmodl_working_directory}/${CMAKE_HOST_SYSTEM_PROCESSOR}"
+      "${working_directory}/${CMAKE_HOST_SYSTEM_PROCESSOR}")
   foreach(script_pattern ${script_patterns})
     # We want to preserve directory structures, so if you pass SCRIPT_PATTERNS path/to/*.py then you
     # end up with {build_directory}/path/to/test_working_directory/path/to/script.py
@@ -304,7 +306,8 @@ function(nrn_add_test)
       "${test_source_directory}/${script_pattern}")
     foreach(script_file ${script_files})
       add_custom_command(
-        TARGET ${prefix} POST_BUILD
+        TARGET ${prefix}
+        POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "${test_source_directory}/${script_file}"
                 "${working_directory}/${script_file}")
     endforeach()
@@ -437,7 +440,8 @@ function(nrn_add_test_group_comparison)
                          reference_file_string_addition "${reference_expression}")
     set(reference_file_string "${reference_file_string}::${reference_file_string_addition}")
     add_custom_command(
-      TARGET ${prefix} POST_BUILD
+      TARGET ${prefix}
+      POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_SOURCE_DIR}/${reference_path}"
               "${test_directory}/${reference_path}"
       COMMENT "Copying reference file for test group ${NRN_ADD_TEST_GROUP_COMPARISON_GROUP}")
@@ -445,7 +449,8 @@ function(nrn_add_test_group_comparison)
 
   # Copy the comparison script
   add_custom_command(
-    TARGET ${prefix} POST_BUILD
+    TARGET ${prefix}
+    POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
             "${PROJECT_SOURCE_DIR}/test/scripts/compare_test_results.py" "${test_directory}"
     COMMENT "Copying test comparison script for test group ${NRN_ADD_TEST_GROUP_COMPARISON_GROUP}")

--- a/cmake/NeuronTestHelper.cmake
+++ b/cmake/NeuronTestHelper.cmake
@@ -258,13 +258,14 @@ function(nrn_add_test)
       # here too.
       list(APPEND output_binaries "${special}-core")
       list(APPEND nrnivmodl_dependencies coreneuron)
-      if(NOT DEFINED CORENEURON_BUILTIN_MODFILES)
+      if((NOT coreneuron_FOUND) AND (NOT DEFINED CORENEURON_BUILTIN_MODFILES))
         message(
           WARNING
-            "nrn_add_test couldn't find the names of the builtin CoreNEURON modfiles that nrnivmodl-core implicitly depends on"
+            "nrn_add_test couldn't find the names of the builtin CoreNEURON modfiles that nrnivmodl-core implicitly depends on *and* CoreNEURON is being built internally"
         )
       endif()
       list(APPEND nrnivmodl_dependencies ${CORENEURON_BUILTIN_MODFILES})
+      message(STATUS nrnivmodl_dependencies ${nrnivmodl_dependencies})
     endif()
     add_custom_command(
       OUTPUT ${output_binaries}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -124,12 +124,15 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
       NAME rxdmod_tests
       MODFILE_PATTERNS test/rxd/ecs/*.mod
       SCRIPT_PATTERNS test/rxd/*.py test/rxd/testdata/*.dat)
-    nrn_add_test(
-      GROUP rxdmod_tests
-      NAME rxd_tests
-      COMMAND
-        COVERAGE_FILE=.coverage.rxd_tests ${PYTHON_EXECUTABLE} -m pytest --cov-report=xml
-        --cov=neuron ./test/rxd)
+    if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
+      # This test includes a comparison with a binary blob; Intel builds typically have too-large numerical differences with the stored values.
+      nrn_add_test(
+        GROUP rxdmod_tests
+        NAME rxd_tests
+        COMMAND
+          COVERAGE_FILE=.coverage.rxd_tests ${PYTHON_EXECUTABLE} -m pytest --cov-report=xml
+          --cov=neuron ./test/rxd)
+    endif()
     if(NRN_ENABLE_MPI)
       find_python_module(mpi4py)
       if(mpi4py_FOUND)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,10 @@ add_custom_command(
 # Note that DYLD_LIBRARY_PATH is not required and interfere with dlopen
 set(TEST_ENV NEURONHOME=${PROJECT_BINARY_DIR}/share/nrn NRNHOME=${PROJECT_BINARY_DIR}
              LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH})
+if(NOT coreneuron_FOUND)
+  # CoreNEURON is being built internally
+  list(APPEND TEST_ENV "CNRNHOME=${PROJECT_BINARY_DIR}")
+endif()
 if(NRN_ENABLE_PYTHON)
   list(
     APPEND

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,8 @@ endif()
 # Copy necessary hoc files to build directory if they have not been copied yet
 # =============================================================================
 add_custom_command(
-  TARGET testneuron POST_BUILD
+  TARGET testneuron
+  POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/share/lib
           ${PROJECT_BINARY_DIR}/share/nrn/lib)
 
@@ -30,10 +31,8 @@ if(NOT coreneuron_FOUND)
   list(APPEND TEST_ENV "CNRNHOME=${PROJECT_BINARY_DIR}")
 endif()
 if(NRN_ENABLE_PYTHON)
-  list(
-    APPEND
-      TEST_ENV
-      PYTHONPATH=${PROJECT_BINARY_DIR}/lib/python:${PROJECT_SOURCE_DIR}/test/rxd:$ENV{PYTHONPATH})
+  list(APPEND TEST_ENV
+       PYTHONPATH=${PROJECT_BINARY_DIR}/lib/python:${PROJECT_SOURCE_DIR}/test/rxd:$ENV{PYTHONPATH})
 endif()
 # Give the environment string a more descriptive name that can be used in NeuronTestHelper.cmake
 set(NRN_TEST_ENV "${TEST_ENV}")
@@ -113,9 +112,8 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
   nrn_add_test(
     GROUP pynrn_tests
     NAME basic_tests
-    COMMAND
-      COVERAGE_FILE=.coverage.basic_tests ${PYTHON_EXECUTABLE} -m pytest --cov-report=xml
-      --cov=neuron ./test/pynrn
+    COMMAND COVERAGE_FILE=.coverage.basic_tests ${PYTHON_EXECUTABLE} -m pytest --cov-report=xml
+            --cov=neuron ./test/pynrn
     MODFILE_PATTERNS test/pynrn/*.mod
     SCRIPT_PATTERNS test/pynrn/*.py)
 
@@ -125,13 +123,13 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
       MODFILE_PATTERNS test/rxd/ecs/*.mod
       SCRIPT_PATTERNS test/rxd/*.py test/rxd/testdata/*.dat)
     if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
-      # This test includes a comparison with a binary blob; Intel builds typically have too-large numerical differences with the stored values.
+      # This test includes a comparison with a binary blob; Intel builds typically have too-large
+      # numerical differences with the stored values.
       nrn_add_test(
         GROUP rxdmod_tests
         NAME rxd_tests
-        COMMAND
-          COVERAGE_FILE=.coverage.rxd_tests ${PYTHON_EXECUTABLE} -m pytest --cov-report=xml
-          --cov=neuron ./test/rxd)
+        COMMAND COVERAGE_FILE=.coverage.rxd_tests ${PYTHON_EXECUTABLE} -m pytest --cov-report=xml
+                --cov=neuron ./test/rxd)
     endif()
     if(NRN_ENABLE_MPI)
       find_python_module(mpi4py)
@@ -160,107 +158,105 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
         ${PROJECT_SOURCE_DIR}/test/parallel_tests/test_subworld.py)
     list(APPEND TESTS parallel_tests)
   endif()
-  # CoreNEURON's reports require MPI and segfault if it is not initialised. This is a crude workaround.
+  # CoreNEURON's reports require MPI and segfault if it is not initialised. This is a crude
+  # workaround.
   if(CORENRN_ENABLE_REPORTING)
     set(nrniv_mpi_arg -mpi)
     set(nrnpython_mpi_env NEURON_INIT_MPI=1)
   endif()
 
-    # When GPU support is enabled then CoreNEURON is linked statically (libcorenrnmech.a) and cannot
-    # be dynamically loaded by Python. This is why all the tests that rely on that dynamic loading
-    # declare `CONFLICTS gpu`.
-    nrn_add_test_group(
-      NAME coreneuron_modtests
-      SCRIPT_PATTERNS test/coreneuron/*.py
-      MODFILE_PATTERNS test/coreneuron/mod/*.mod test/pynrn/unitstest.mod test/gjtests/natrans.mod)
-    nrn_add_test(
-      GROUP coreneuron_modtests
-      NAME direct_py
-      REQUIRES coreneuron
-      CONFLICTS gpu
-      COMMAND
-        ${nrnpython_mpi_env} COVERAGE_FILE=.coverage.coreneuron_direct_py ${PYTHON_EXECUTABLE} -m pytest
-        --cov-report=xml --cov=neuron test/coreneuron/test_direct.py)
-    nrn_add_test(
-      GROUP coreneuron_modtests
-      NAME direct_hoc
-      REQUIRES coreneuron
-      SCRIPT_PATTERNS test/coreneuron/test_direct.hoc
-      COMMAND ${nrnpython_mpi_env} ${CMAKE_BINARY_DIR}/bin/nrniv ${nrniv_mpi_arg} test/coreneuron/test_direct.hoc)
-    nrn_add_test(
-      GROUP coreneuron_modtests
-      NAME spikes_py
-      REQUIRES coreneuron
-      CONFLICTS gpu
-      COMMAND
-      ${nrnpython_mpi_env} COVERAGE_FILE=.coverage.coreneuron_spikes_py ${PYTHON_EXECUTABLE} -m pytest
-        --cov-report=xml --cov=neuron test/coreneuron/test_spikes.py)
-    nrn_add_test(
-      GROUP coreneuron_modtests
-      NAME spikes_file_mode_py
-      REQUIRES coreneuron
-      CONFLICTS gpu
-      COMMAND ${nrnpython_mpi_env} ${PYTHON_EXECUTABLE} test/coreneuron/test_spikes.py file_mode)
-    nrn_add_test(
-      GROUP coreneuron_modtests
-      NAME fornetcon_py
-      REQUIRES coreneuron
-      CONFLICTS gpu
-      COMMAND
-      ${nrnpython_mpi_env} COVERAGE_FILE=.coverage.coreneuron_fornetcon_py ${PYTHON_EXECUTABLE} -m pytest
-        --cov-report=xml --cov=neuron test/coreneuron/test_fornetcon.py)
-    nrn_add_test(
-      GROUP coreneuron_modtests
-      NAME datareturn_py
-      REQUIRES coreneuron
-      CONFLICTS gpu
-      COMMAND
-      ${nrnpython_mpi_env} COVERAGE_FILE=.coverage.coreneuron_datareturn_py ${PYTHON_EXECUTABLE} -m pytest
-        --cov-report=xml --cov=neuron test/coreneuron/test_datareturn.py)
-    nrn_add_test(
-      GROUP coreneuron_modtests
-      NAME test_units_py
-      REQUIRES coreneuron
-      CONFLICTS gpu
-      COMMAND
-      ${nrnpython_mpi_env} COVERAGE_FILE=.coverage.coreneuron_test_units_py ${PYTHON_EXECUTABLE} -m pytest
-        --cov-report=xml --cov=neuron test/coreneuron/test_units.py)
-    nrn_add_test(
-      GROUP coreneuron_modtests
-      NAME test_natrans_py
-      REQUIRES coreneuron
-      CONFLICTS gpu
-      SCRIPT_PATTERNS test/gjtests/test_natrans.py
-      COMMAND
-      ${nrnpython_mpi_env} COVERAGE_FILE=.coverage.coreneuron_test_natrans_py ${PYTHON_EXECUTABLE} -m pytest
-        --cov-report=xml --cov=neuron test/gjtests/test_natrans.py)
-    if(NRN_ENABLE_MPI)
-      find_python_module(mpi4py)
-      # Using -pyexe was a first workaround for GitHub issue #894, but it seems that we also need to
-      # avoid using the full path to mpiexec (see other discussion in #894). Replacing ${MPIEXEC}
-      # with ${CMAKE_COMMAND} -E env ${MPIEXEC_NAME} achieves this.
-      get_filename_component(MPIEXEC_NAME ${MPIEXEC} NAME)
-      if(mpi4py_FOUND)
-        nrn_add_test(
-          GROUP coreneuron_modtests
-          NAME spikes_mpi_py
-          REQUIRES coreneuron
-          CONFLICTS gpu
-          PROCESSORS 2
-          COMMAND
-            ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} ${PYTHON_EXECUTABLE}
-            ${MPIEXEC_POSTFLAGS} test/coreneuron/test_spikes.py mpi4py)
-      endif()
+  # When GPU support is enabled then CoreNEURON is linked statically (libcorenrnmech.a) and cannot
+  # be dynamically loaded by Python. This is why all the tests that rely on that dynamic loading
+  # declare `CONFLICTS gpu`.
+  nrn_add_test_group(
+    NAME coreneuron_modtests
+    SCRIPT_PATTERNS test/coreneuron/*.py
+    MODFILE_PATTERNS test/coreneuron/mod/*.mod test/pynrn/unitstest.mod test/gjtests/natrans.mod)
+  nrn_add_test(
+    GROUP coreneuron_modtests
+    NAME direct_py
+    REQUIRES coreneuron
+    CONFLICTS gpu
+    COMMAND ${nrnpython_mpi_env} COVERAGE_FILE=.coverage.coreneuron_direct_py ${PYTHON_EXECUTABLE}
+            -m pytest --cov-report=xml --cov=neuron test/coreneuron/test_direct.py)
+  nrn_add_test(
+    GROUP coreneuron_modtests
+    NAME direct_hoc
+    REQUIRES coreneuron
+    SCRIPT_PATTERNS test/coreneuron/test_direct.hoc
+    COMMAND ${nrnpython_mpi_env} ${CMAKE_BINARY_DIR}/bin/nrniv ${nrniv_mpi_arg}
+            test/coreneuron/test_direct.hoc)
+  nrn_add_test(
+    GROUP coreneuron_modtests
+    NAME spikes_py
+    REQUIRES coreneuron
+    CONFLICTS gpu
+    COMMAND ${nrnpython_mpi_env} COVERAGE_FILE=.coverage.coreneuron_spikes_py ${PYTHON_EXECUTABLE}
+            -m pytest --cov-report=xml --cov=neuron test/coreneuron/test_spikes.py)
+  nrn_add_test(
+    GROUP coreneuron_modtests
+    NAME spikes_file_mode_py
+    REQUIRES coreneuron
+    CONFLICTS gpu
+    COMMAND ${nrnpython_mpi_env} ${PYTHON_EXECUTABLE} test/coreneuron/test_spikes.py file_mode)
+  nrn_add_test(
+    GROUP coreneuron_modtests
+    NAME fornetcon_py
+    REQUIRES coreneuron
+    CONFLICTS gpu
+    COMMAND
+      ${nrnpython_mpi_env} COVERAGE_FILE=.coverage.coreneuron_fornetcon_py ${PYTHON_EXECUTABLE} -m
+      pytest --cov-report=xml --cov=neuron test/coreneuron/test_fornetcon.py)
+  nrn_add_test(
+    GROUP coreneuron_modtests
+    NAME datareturn_py
+    REQUIRES coreneuron
+    CONFLICTS gpu
+    COMMAND
+      ${nrnpython_mpi_env} COVERAGE_FILE=.coverage.coreneuron_datareturn_py ${PYTHON_EXECUTABLE} -m
+      pytest --cov-report=xml --cov=neuron test/coreneuron/test_datareturn.py)
+  nrn_add_test(
+    GROUP coreneuron_modtests
+    NAME test_units_py
+    REQUIRES coreneuron
+    CONFLICTS gpu
+    COMMAND
+      ${nrnpython_mpi_env} COVERAGE_FILE=.coverage.coreneuron_test_units_py ${PYTHON_EXECUTABLE} -m
+      pytest --cov-report=xml --cov=neuron test/coreneuron/test_units.py)
+  nrn_add_test(
+    GROUP coreneuron_modtests
+    NAME test_natrans_py
+    REQUIRES coreneuron
+    CONFLICTS gpu
+    SCRIPT_PATTERNS test/gjtests/test_natrans.py
+    COMMAND
+      ${nrnpython_mpi_env} COVERAGE_FILE=.coverage.coreneuron_test_natrans_py ${PYTHON_EXECUTABLE}
+      -m pytest --cov-report=xml --cov=neuron test/gjtests/test_natrans.py)
+  if(NRN_ENABLE_MPI)
+    find_python_module(mpi4py)
+    # Using -pyexe was a first workaround for GitHub issue #894, but it seems that we also need to
+    # avoid using the full path to mpiexec (see other discussion in #894). Replacing ${MPIEXEC} with
+    # ${CMAKE_COMMAND} -E env ${MPIEXEC_NAME} achieves this.
+    get_filename_component(MPIEXEC_NAME ${MPIEXEC} NAME)
+    if(mpi4py_FOUND)
       nrn_add_test(
         GROUP coreneuron_modtests
-        NAME spikes_mpi_file_mode_py
+        NAME spikes_mpi_py
         REQUIRES coreneuron
+        CONFLICTS gpu
         PROCESSORS 2
-        COMMAND
-          ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} special
-          ${MPIEXEC_POSTFLAGS} -python -pyexe ${PYTHON_EXECUTABLE} test/coreneuron/test_spikes.py
-          nrnmpi_init file_mode)
+        COMMAND ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} ${PYTHON_EXECUTABLE}
+                ${MPIEXEC_POSTFLAGS} test/coreneuron/test_spikes.py mpi4py)
     endif()
+    nrn_add_test(
+      GROUP coreneuron_modtests
+      NAME spikes_mpi_file_mode_py
+      REQUIRES coreneuron
+      PROCESSORS 2
+      COMMAND
+        ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} special ${MPIEXEC_POSTFLAGS}
+        -python -pyexe ${PYTHON_EXECUTABLE} test/coreneuron/test_spikes.py nrnmpi_init file_mode)
+  endif()
 endif()
 
 # ============================================
@@ -295,9 +291,8 @@ set(MODFILES_REJECT ${PROJECT_SOURCE_DIR}/src/nrnoc/pattern.mod)
 
 add_custom_target(
   modlunit_test ALL
-  COMMAND
-    ${CMAKE_COMMAND} -E env ${TEST_ENV} $ENV{SHELL} ${PROJECT_BINARY_DIR}/run_modlunit.bash
-    \"${MODFILES_ACCEPT}\" \"${MODFILES_REJECT}\"
+  COMMAND ${CMAKE_COMMAND} -E env ${TEST_ENV} $ENV{SHELL} ${PROJECT_BINARY_DIR}/run_modlunit.bash
+          \"${MODFILES_ACCEPT}\" \"${MODFILES_REJECT}\"
   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
   DEPENDS ${PROJECT_BINARY_DIR}/bin/modlunit)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -157,8 +157,12 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
         ${PROJECT_SOURCE_DIR}/test/parallel_tests/test_subworld.py)
     list(APPEND TESTS parallel_tests)
   endif()
+  # CoreNEURON's reports require MPI and segfault if it is not initialised. This is a crude workaround.
+  if(CORENRN_ENABLE_REPORTING)
+    set(nrniv_mpi_arg -mpi)
+    set(nrnpython_mpi_env NEURON_INIT_MPI=1)
+  endif()
 
-  if(NRN_ENABLE_CORENEURON)
     # When GPU support is enabled then CoreNEURON is linked statically (libcorenrnmech.a) and cannot
     # be dynamically loaded by Python. This is why all the tests that rely on that dynamic loading
     # declare `CONFLICTS gpu`.
@@ -172,35 +176,35 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
       REQUIRES coreneuron
       CONFLICTS gpu
       COMMAND
-        COVERAGE_FILE=.coverage.coreneuron_direct_py ${PYTHON_EXECUTABLE} -m pytest
+        ${nrnpython_mpi_env} COVERAGE_FILE=.coverage.coreneuron_direct_py ${PYTHON_EXECUTABLE} -m pytest
         --cov-report=xml --cov=neuron test/coreneuron/test_direct.py)
     nrn_add_test(
       GROUP coreneuron_modtests
       NAME direct_hoc
       REQUIRES coreneuron
       SCRIPT_PATTERNS test/coreneuron/test_direct.hoc
-      COMMAND ${CMAKE_BINARY_DIR}/bin/nrniv test/coreneuron/test_direct.hoc)
+      COMMAND ${nrnpython_mpi_env} ${CMAKE_BINARY_DIR}/bin/nrniv ${nrniv_mpi_arg} test/coreneuron/test_direct.hoc)
     nrn_add_test(
       GROUP coreneuron_modtests
       NAME spikes_py
       REQUIRES coreneuron
       CONFLICTS gpu
       COMMAND
-        COVERAGE_FILE=.coverage.coreneuron_spikes_py ${PYTHON_EXECUTABLE} -m pytest
+      ${nrnpython_mpi_env} COVERAGE_FILE=.coverage.coreneuron_spikes_py ${PYTHON_EXECUTABLE} -m pytest
         --cov-report=xml --cov=neuron test/coreneuron/test_spikes.py)
     nrn_add_test(
       GROUP coreneuron_modtests
       NAME spikes_file_mode_py
       REQUIRES coreneuron
       CONFLICTS gpu
-      COMMAND ${PYTHON_EXECUTABLE} test/coreneuron/test_spikes.py file_mode)
+      COMMAND ${nrnpython_mpi_env} ${PYTHON_EXECUTABLE} test/coreneuron/test_spikes.py file_mode)
     nrn_add_test(
       GROUP coreneuron_modtests
       NAME fornetcon_py
       REQUIRES coreneuron
       CONFLICTS gpu
       COMMAND
-        COVERAGE_FILE=.coverage.coreneuron_fornetcon_py ${PYTHON_EXECUTABLE} -m pytest
+      ${nrnpython_mpi_env} COVERAGE_FILE=.coverage.coreneuron_fornetcon_py ${PYTHON_EXECUTABLE} -m pytest
         --cov-report=xml --cov=neuron test/coreneuron/test_fornetcon.py)
     nrn_add_test(
       GROUP coreneuron_modtests
@@ -208,7 +212,7 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
       REQUIRES coreneuron
       CONFLICTS gpu
       COMMAND
-        COVERAGE_FILE=.coverage.coreneuron_datareturn_py ${PYTHON_EXECUTABLE} -m pytest
+      ${nrnpython_mpi_env} COVERAGE_FILE=.coverage.coreneuron_datareturn_py ${PYTHON_EXECUTABLE} -m pytest
         --cov-report=xml --cov=neuron test/coreneuron/test_datareturn.py)
     nrn_add_test(
       GROUP coreneuron_modtests
@@ -216,7 +220,7 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
       REQUIRES coreneuron
       CONFLICTS gpu
       COMMAND
-        COVERAGE_FILE=.coverage.coreneuron_test_units_py ${PYTHON_EXECUTABLE} -m pytest
+      ${nrnpython_mpi_env} COVERAGE_FILE=.coverage.coreneuron_test_units_py ${PYTHON_EXECUTABLE} -m pytest
         --cov-report=xml --cov=neuron test/coreneuron/test_units.py)
     nrn_add_test(
       GROUP coreneuron_modtests
@@ -225,7 +229,7 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
       CONFLICTS gpu
       SCRIPT_PATTERNS test/gjtests/test_natrans.py
       COMMAND
-        COVERAGE_FILE=.coverage.coreneuron_test_natrans_py ${PYTHON_EXECUTABLE} -m pytest
+      ${nrnpython_mpi_env} COVERAGE_FILE=.coverage.coreneuron_test_natrans_py ${PYTHON_EXECUTABLE} -m pytest
         --cov-report=xml --cov=neuron test/gjtests/test_natrans.py)
     if(NRN_ENABLE_MPI)
       find_python_module(mpi4py)
@@ -254,7 +258,6 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
           ${MPIEXEC_POSTFLAGS} -python -pyexe ${PYTHON_EXECUTABLE} test/coreneuron/test_spikes.py
           nrnmpi_init file_mode)
     endif()
-  endif()
 endif()
 
 # ============================================


### PR DESCRIPTION
This PR contains fixes and improvements for running NEURON with CoreNEURON installed as an external library. `nrnivmodl -coreneuron` now works even if CoreNEURON is installed as an external library.

There are also some other fixes for issues uncovered when testing in this configuration:
- The `rxdmod_tests::rxd_tests` test is now disabled in Intel builds due to numerical differences.
- Some CoreNEURON reporting code does not cope well if MPI is not initialised; in this configuration we now explicitly tell NEURON to initialise MPI.
- Minor bugfix for the `PROCESSORS` argument to `nrn_add_test`
- Minor change to how `nrn_add_test` calculates build directory names to try and be more reproducible.
- `cmake-format` of affected files.