### PR TITLE
bugfix: Stop calling `h.ion_register` for all rxd species.

### DIFF
--- a/share/lib/python/neuron/rxd/species.py
+++ b/share/lib/python/neuron/rxd/species.py
@@ -1448,13 +1448,16 @@ class Species(_SpeciesMathable):
     def _ion_register(self):
         charge = self._charge
         if self._name is not None:
-            ion_type = h.ion_register(self._name, charge)
-            if ion_type == -1:
-                raise RxDException('Unable to register species: %s' % self._name)
+            ion_type = None
             # insert the species if not already present
             regions = self._regions if hasattr(self._regions, '__len__') else [self._regions]
             for r in regions:
                 if r.nrn_region in ('i', 'o'):
+                    if ion_type is None:
+                        ion_type = h.ion_register(self._name, charge)
+                        if ion_type == -1:
+                            raise RxDException('Unable to register species: %s' % self._name)
+
                     for s in r.secs:
                         try:
                             ion_forms = [self._name + 'i', self._name + 'o', 'i' + self._name, 'e' + self._name]

--- a/test/rxd/test_unicode_names.py
+++ b/test/rxd/test_unicode_names.py
@@ -1,0 +1,12 @@
+import pytest
+
+def test_unicode_names(neuron_instance):
+    """A test that species on a region that do not have a nrn_region can have 
+       an unicode name.
+    """
+
+    h, rxd, data, save_path = neuron_instance
+    soma = h.Section(name='soma')
+    cyt = rxd.Region(soma.wholetree(), name='cyt')
+    α = rxd.Parameter(cyt, name="α", value=0.3)
+    h.finitialize(-65)


### PR DESCRIPTION
Only call ion_register for species on an `nrn_region` 'i' or 'o'.