### PR TITLE
deprecation warnings

### DIFF
--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -393,7 +393,7 @@ def psection(section):
 
     https://www.neuron.yale.edu/neuron/static/py_doc/modelspec/programmatic/topology.html?#psection
     """
-    warnings.warn("neuron.psection() is deprecated; use sec.psection() instead", DeprecationWarning)
+    warnings.warn("neuron.psection() is deprecated; use print(sec.psection()) instead", DeprecationWarning)
     h.psection(sec=section)
 
 def init():

--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -101,6 +101,7 @@ $Id: __init__.py,v 1.1 2008/05/26 11:39:44 hines Exp hines $
 
 import sys
 import os
+import warnings
 
 embedded = True if 'hoc' in sys.modules else False
 
@@ -385,11 +386,14 @@ def psection(section):
     Use section.psection() instead to get a data structure that
     contains the same information and more.
 
+    This function is deprecated and will be removed in a future
+    release.
+
     See:
 
     https://www.neuron.yale.edu/neuron/static/py_doc/modelspec/programmatic/topology.html?#psection
-
     """
+    warnings.warn("neuron.psection() is deprecated; use sec.psection() instead", DeprecationWarning)
     h.psection(sec=section)
 
 def init():
@@ -402,7 +406,10 @@ def init():
 
     Use h.finitialize() instead, which allows you to specify the membrane potential
     to initialize to; via e.g. h.finitialize(-65)
-    
+
+    This function is deprecated and will be removed in a future
+    release.
+
     By default, the units used by h.finitialize are in mV, but you can be explicit using
     NEURON's unit's library, e.g.
     
@@ -414,6 +421,8 @@ def init():
     https://www.neuron.yale.edu/neuron/static/py_doc/simctrl/programmatic.html?#finitialize
 
     """
+    warnings.warn("neuron.init() is deprecated; use h.init() instead", DeprecationWarning)
+    
     h.finitialize()
 
 def run(tstop):
@@ -425,6 +434,9 @@ def run(tstop):
     `h.run()` and `h.continuerun(tstop)` are more powerful solutions defined in the `stdrun.hoc` library.
     
     ** This function exists for historical purposes. Use in new code is not recommended. **
+    
+    This function is deprecated and will be removed in a future
+    release.    
     
     For running a simulation, consider doing the following instead:
     
@@ -447,6 +459,8 @@ def run(tstop):
     for your model.
 
     """
+    warnings.warn("neuron.run(tstop) is deprecated; use h.init() and h.continuerun(tstop) instead", DeprecationWarning)
+    
     h('tstop = %g' % tstop)
     h('while (t < tstop) { fadvance() }')
     # what about pc.psolve(tstop)?

--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -33,7 +33,7 @@ Important names and sub-packages
 
 For help on these useful functions, see their docstrings:
 
-  neuron.init, run, psection, load_mechanisms
+  load_mechanisms
 
 
 neuron.h
@@ -494,7 +494,7 @@ def run(tstop):
     for your model.
 
     """
-    warnings.warn("neuron.run(tstop) is deprecated; use h.init() and h.continuerun(tstop) instead", DeprecationWarning, stacklevel=2)
+    warnings.warn("neuron.run(tstop) is deprecated; use h.stdinit() and h.continuerun(tstop) instead", DeprecationWarning, stacklevel=2)
     
     h('tstop = %g' % tstop)
     h('while (t < tstop) { fadvance() }')

--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -393,7 +393,7 @@ def psection(section):
 
     https://www.neuron.yale.edu/neuron/static/py_doc/modelspec/programmatic/topology.html?#psection
     """
-    warnings.warn("neuron.psection() is deprecated; use print(sec.psection()) instead", DeprecationWarning)
+    warnings.warn("neuron.psection() is deprecated; use print(sec.psection()) instead", DeprecationWarning, stacklevel=2)
     h.psection(sec=section)
 
 def init():
@@ -421,7 +421,7 @@ def init():
     https://www.neuron.yale.edu/neuron/static/py_doc/simctrl/programmatic.html?#finitialize
 
     """
-    warnings.warn("neuron.init() is deprecated; use h.init() instead", DeprecationWarning)
+    warnings.warn("neuron.init() is deprecated; use h.init() instead", DeprecationWarning, stacklevel=2)
     
     h.finitialize()
 
@@ -459,7 +459,7 @@ def run(tstop):
     for your model.
 
     """
-    warnings.warn("neuron.run(tstop) is deprecated; use h.init() and h.continuerun(tstop) instead", DeprecationWarning)
+    warnings.warn("neuron.run(tstop) is deprecated; use h.init() and h.continuerun(tstop) instead", DeprecationWarning, stacklevel=2)
     
     h('tstop = %g' % tstop)
     h('while (t < tstop) { fadvance() }')

--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -360,8 +360,43 @@ def new_hoc_class(name,doc=None):
 # Python equivalents to Hoc functions
 # ------------------------------------------------------------------------------
 
-xopen = h.xopen
-quit = h.quit
+def xopen(*args, **kwargs):
+    """
+    Syntax:
+        ``neuron.xopen("hocfile")``
+
+
+        ``neuron.xopen("hocfile", "RCSrevision")``
+
+
+    Description:
+        ``h.xopen()`` executes the commands in ``hocfile``.  This is a convenient way 
+        to define user functions and procedures. 
+        An optional second argument is the RCS revision number in the form of a 
+        string. The RCS file with that revision number is checked out into a 
+        temporary file and executed. The temporary file is then removed.  A file 
+        of the same primary name is unaffected. 
+    
+    This function is deprecated and will be removed in a future release.
+    Use ``h.xopen`` instead.
+    """
+    warnings.warn("neuron.xopen is deprecated; use h.xopen instead", DeprecationWarning, stacklevel=2)
+    return h.xopen(*args, **kwargs)
+
+
+def quit(*args, **kwargs):
+    """
+    Exits the program. Can be used as the action of a button. If edit buffers 
+    are open you will be asked if you wish to save them before the final exit.
+
+    This function is deprecated and will be removed in a future release.
+    Use ``h.quit()`` or ``sys.exit()`` instead. (Note: sys.exit will not prompt
+    for saving edit buffers.)
+    """
+    warnings.warn("neuron.quit() is deprecated; use h.quit() or sys.exit() instead", DeprecationWarning, stacklevel=2)
+    return h.quit(*args, **kwargs)
+  
+
 
 def hoc_execute(hoc_commands, comment=None):
     assert isinstance(hoc_commands,list)


### PR DESCRIPTION
`neuron.run`, `neuron.init`, and `neuron.psection`, `neuron.xopen`, and `neuron.quit` are deprecated as per the developer's meeting on 2021-03-19.