### PR TITLE
rxd select 3d, cleaner error handling, docstr fix

### DIFF
--- a/share/lib/python/neuron/rxd/node.py
+++ b/share/lib/python/neuron/rxd/node.py
@@ -561,7 +561,9 @@ class Node3D(Node):
 
         If a nrn.Section object or RxDSection is provided, returns True if the Node lies in the section; else False.
         If a Region object is provided, returns True if the Node lies in the Region; else False.
-        If a number between 0 and 1 is provided, returns True if the normalized position lies within the Node; else False.
+        If a tuple is provided of length 3, return True if the Node contains the (x, y, z) point; else False.
+
+        Does not currently support numbers between 0 and 1.
         """
         if isinstance(condition, nrn.Section) or isinstance(condition, rxdsection.RxDSection):
             return self._in_sec(condition)
@@ -569,12 +571,23 @@ class Node3D(Node):
             return self.region == condition
         elif isinstance(condition, nrn.Segment):
             return self.segment == condition
+        elif isinstance(condition, tuple) and len(condition) == 3:
+            x, y, z = condition
+            mesh = self._r._mesh_grid
+            return (
+                int((x - mesh["xlo"]) / mesh['dx']) == self._i and
+                int((y - mesh["ylo"]) / mesh['dy']) == self._j and
+                int((z - mesh["zlo"]) / mesh['dz']) == self._k 
+            )
         position_type = False
+        did_error = False
         try:
             if 0 <= condition <= 1:
                 position_type = True
         except:
-            raise RxDException('unrecognized node condition: %r' % condition)    
+            did_error = True
+        if did_error:
+            raise RxDException('unrecognized node condition: %r' % condition)
         if position_type:
             # TODO: the trouble here is that you can't do this super-directly based on x
             #       the way to do this is to find the minimum and maximum x values contained in the grid

--- a/test/rxd/3d/test_node_selection.py
+++ b/test/rxd/3d/test_node_selection.py
@@ -1,0 +1,19 @@
+def test_node_selection(neuron_instance):
+    """Test selection of 3D nodes"""
+
+    h, rxd, data, save_path = neuron_instance
+
+    rxd.set_solve_type(dimension=3)
+    dend = h.Section(name="dend")
+    dend.L = 10
+    dend.diam = 2 
+
+    cyt = rxd.Region([dend])
+    c = rxd.Species(cyt)
+
+    nodes = c.nodes
+
+    assert(nodes((5,0,0.26))[0].x3d == 5)
+    assert(nodes((5,0,0.26))[0].y3d == 0)
+    assert(nodes((5,0,0.26))[0].z3d == 0.25)
+    assert(len(nodes((5, 0, 0))) == 1)


### PR DESCRIPTION
The old approach was to raise the RxDException inside the except handler, but that just displayed both tracebacks with a message about how one error occurred during handling of the other.