### PR TITLE
Fix linking against external CoreNEURON libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,8 +345,11 @@ if(NRN_ENABLE_CORENEURON)
     set(CORENEURON_DIR ${PROJECT_SOURCE_DIR}/external/coreneuron)
     # By default `nrnivmodl` should look for `nrnivmodl-core` in the NEURON install prefix.
     set(cnrn_prefix "${CMAKE_INSTALL_PREFIX}")
+    # CoreNEURON exports this list of flags as a property; turn it into a
+    # variable in this scope. If CoreNEURON is installed externally then this
+    # is exported into coreneuron-config.cmake.
+    get_property(CORENEURON_LIB_LINK_FLAGS GLOBAL PROPERTY CORENEURON_LIB_LINK_FLAGS)
   endif()
-  get_property (CORENEURON_LIB_LINK_FLAGS GLOBAL PROPERTY CORENEURON_LIB_LINK_FLAGS)
   set(NRN_ENABLE_BINARY_SPECIAL ON)
 endif()
 

--- a/cmake/NeuronTestHelper.cmake
+++ b/cmake/NeuronTestHelper.cmake
@@ -275,7 +275,6 @@ function(nrn_add_test)
         )
       endif()
       list(APPEND nrnivmodl_dependencies ${CORENEURON_BUILTIN_MODFILES})
-      message(STATUS nrnivmodl_dependencies ${nrnivmodl_dependencies})
     endif()
     add_custom_command(
       OUTPUT ${output_binaries}


### PR DESCRIPTION
When CoreNEURON is built as a submodule NEURON takes the variable `CORENEURON_LIB_LINK_FLAGS` from a global property of the same name. If CoreNEURON is built as an external library this variable will [soon] be exported in `coreneuron-config.cmake` and should not be overwritten by the (empty) property value.

Without this fix then `nrnivmodl -coreneuron` does not correctly link `special` against CoreNEURON if CoreNEURON is installed as an external library, which is fatal in statically-linked GPU builds.

Also remove a status message that wasn't intended to be merged.