### PR TITLE
Fix RX3D compilation with NVHPC.

### DIFF
--- a/share/lib/python/neuron/rxd/geometry3d/setup.py.in
+++ b/share/lib/python/neuron/rxd/geometry3d/setup.py.in
@@ -3,6 +3,8 @@
 
 import sys
 nrn_srcdir = "@NRN_SRCDIR@"
+@USING_PGI_COMPILER_TRUE@using_pgi=True
+@USING_PGI_COMPILER_FALSE@using_pgi=False
 @BUILD_MINGW_TRUE@mingw = 1
 @BUILD_MINGW_FALSE@mingw = 0
 instdir = "@prefix@"
@@ -11,6 +13,8 @@ if nrn_srcdir[0] == '/' or (len(nrn_srcdir) > 2 and nrn_srcdir[1] == ':'):
 else: # not an absolute path
     # TODO: is this right?
     nrn_srcdir = '../../../../../../' + nrn_srcdir
+
+pgi_compiler_flags = "-noswitcherror"
 
 from distutils.core import setup
 from distutils.extension import Extension
@@ -55,6 +59,7 @@ else:
         define_macros=[('MS_WIN64', None)]
 
     extra_compile_args = ['-O'+olevel] if olevel != "" else []
+    if using_pgi: extra_compile_args.append(pgi_compiler_flags)
 
     include_dirs = [nrn_srcdir + '/share/lib/python/neuron/rxd/geometry3d', '.', numpy.get_include()]
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -122,9 +122,10 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
       NAME rxdmod_tests
       MODFILE_PATTERNS test/rxd/ecs/*.mod
       SCRIPT_PATTERNS test/rxd/*.py test/rxd/testdata/*.dat)
-    if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
-      # This test includes a comparison with a binary blob; Intel builds typically have too-large
-      # numerical differences with the stored values.
+    # This test includes a comparison with a binary blob; Intel and PGI/NVHPC
+    # builds typically have too-large numerical differences with the stored values.
+    set(compiler_blacklist "Intel" "PGI" "NVHPC")
+    if(NOT ${CMAKE_CXX_COMPILER_ID} IN_LIST compiler_blacklist)
       nrn_add_test(
         GROUP rxdmod_tests
         NAME rxd_tests


### PR DESCRIPTION
Fixes #1109. Python itself cannot be built with NVHPC, so it is built with another compiler that, in general, has incompatible command line arguments. When RX3D is built using NVHPC these incompatible flags are inherited from the Python installation and cause build errors; this workaround demotes those to warnings.

With the current BBP software the relevant flags are:
```
nvc++-Warning-Unknown switch: -Wno-unused-result
nvc++-Warning-Unknown switch: -Wsign-compare
nvc++-Warning-Unknown switch: -fwrapv
```

A similar workaround already exists in nrnpython: https://github.com/neuronsimulator/nrn/blob/931b0653a87150cffe540ee08a97c4da7c47d715/src/nrnpython/setup.py.in#L141