### PR TITLE
Exp except

### DIFF
--- a/cmake/ConfigFileSetting.cmake
+++ b/cmake/ConfigFileSetting.cmake
@@ -244,6 +244,7 @@ nrn_check_symbol_exists("stty" "" HAVE_STTY)
 nrn_check_symbol_exists("vprintf" "" HAVE_VPRINTF)
 nrn_check_cxx_symbol_exists("getpw" "sys/types.h;pwd.h" HAVE_GETPW)
 nrn_check_cxx_symbol_exists("fesetround" "" HAVE_FESETROUND)
+nrn_check_cxx_symbol_exists("feenableexcept" "" HAVE_FEENABLEEXCEPT)
 # not necessary to check as it should be always there
 set(HAVE_SSTREAM /**/)
 

--- a/cmake_nrnconf.h.in
+++ b/cmake_nrnconf.h.in
@@ -60,6 +60,9 @@
 /* Define to 1 if you have the `fesetround' function. */
 #undef HAVE_FESETROUND
 
+/* Define to 1 if you have the `feenableexcept' function. */
+#undef HAVE_FEENABLEEXCEPT
+
 /* Define to 1 if you have the <float.h> header file. */
 #undef HAVE_FLOAT_H
 

--- a/docs/cmake_doc/options.rst
+++ b/docs/cmake_doc/options.rst
@@ -460,3 +460,12 @@ NRN_ENABLE_INTERNAL_READLINE:BOOL=OFF
 
 Forces use of the readline code distributed with NEURON even if there is a system supplied readline.
 
+NRN_ENABLE_BACKTRACE:BOOL=OFF
+-------------------------------------
+  Generate a backtrace on floating, segfault, and bus exceptions.
+
+  Avoids the need to use gdb to view the backtrace.
+
+  Does not work with python.
+
+  Note: floating exceptions are turned on with :func:`nrn_feenableexcept`.

--- a/docs/hoc/programming/errors.rst
+++ b/docs/hoc/programming/errors.rst
@@ -8,15 +8,15 @@ Error Handling
 
     Description:
         On unix machines, sets a flag which requests (1) a coredump in case 
-        of memory or bus errors. 
-
+        of memory or bus errors --- Or floating exceptions if
+        :func:`nrn_fenableexcept` has been turned on.
 
 ----
 
 .. function:: nrn_feenableexcept
 
     Syntax:
-        ``nrn_feenableexcept(boolean)``
+        ``previous_floating_point_mask = nrn_feenableexcept(boolean)``
 
     Description:
         Sets or turns off a flag which, if on, causes a SIGFPE when a floating error occurs which consist of
@@ -25,6 +25,10 @@ Error Handling
         is most easily done when running under gdb. For a parallel model, one can combine with coredump_on_error
         and, to force a coredump on abort(), use the bash command 'ulimit -c unlimited'.
 
+        Return is the previous value of the floating-point mask. (or -1
+        on failure, or functionality not supported).
+
+        Without an arg, SIGFPE is turned on.
     Note:
         The normal trap for exp(x) for x > 700 in mod files becomes
         a floating exception when x is out of range.

--- a/docs/hoc/programming/errors.rst
+++ b/docs/hoc/programming/errors.rst
@@ -25,6 +25,10 @@ Error Handling
         is most easily done when running under gdb. For a parallel model, one can combine with coredump_on_error
         and, to force a coredump on abort(), use the bash command 'ulimit -c unlimited'.
 
+    Note:
+        The normal trap for exp(x) for x > 700 in mod files becomes
+        a floating exception when x is out of range.
+
 ----
 
 .. function:: show_errmess_always

--- a/docs/hoc/programming/errors.rst
+++ b/docs/hoc/programming/errors.rst
@@ -26,7 +26,8 @@ Error Handling
         and, to force a coredump on abort(), use the bash command 'ulimit -c unlimited'.
 
         Return is the previous value of the floating-point mask. (or -1
-        on failure, or functionality not supported).
+        on failure to set the floating-point flags; or -2 if feenableexcept  
+        does not exist).
 
         Without an arg, SIGFPE is turned on.
     Note:

--- a/docs/python/programming/errors.rst
+++ b/docs/python/programming/errors.rst
@@ -8,8 +8,30 @@ Error Handling
 
     Description:
         On unix machines, sets a flag which requests (1) a coredump in case 
-        of memory or bus errors. 
+        of memory or bus errors --- Or floating exceptions if
+        :func:`nrn_fenableexcept` has been turned on.
 
+----
+
+.. function:: nrn_feenableexcept
+
+    Syntax:
+        ``previous_floating_point_mask = h.nrn_feenableexcept(boolean)``
+
+    Description:
+        Sets or turns off a flag which, if on, causes a SIGFPE when a floating error occurs which consist of
+        divide by zero, overflow, or invalid result. Known to work on linux. Turning on the flag is very helpful
+        in finding the code location at which a variable is assigned a value of NaN or Inf. For a serial model, this
+        is most easily done when running under gdb. For a parallel model, one can combine with coredump_on_error
+        and, to force a coredump on abort(), use the bash command 'ulimit -c unlimited'.
+
+        Return is the previous value of the floating-point mask. (or -1
+        on failure, or functionality not supported).
+
+        Without an arg, SIGFPE is turned on.
+    Note:
+        The normal trap for exp(x) for x > 700 in mod files becomes
+        a floating exception when x is out of range.
 
 ----
 

--- a/docs/python/programming/errors.rst
+++ b/docs/python/programming/errors.rst
@@ -26,7 +26,8 @@ Error Handling
         and, to force a coredump on abort(), use the bash command 'ulimit -c unlimited'.
 
         Return is the previous value of the floating-point mask. (or -1
-        on failure, or functionality not supported).
+        on failure to set the floating-point flags; or -2 if feenableexcept
+        does not exist).
 
         Without an arg, SIGFPE is turned on.
     Note:

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -83,7 +83,7 @@ void nrn_feenableexcept() {
     result = feenableexcept(0);
   }else{
     result = feenableexcept(FEEXCEPT);
-    nrn_feenableexcept_ = result ? 0 : 1;
+    nrn_feenableexcept_ = (result == -1) ? 0 : 1;
   }
 #endif
   hoc_ret();

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -47,12 +47,10 @@ int (*p_nrnpy_pyrun)(const char* fname);
 extern int stdin_event_ready();
 #endif
 
-#if HAVE_FENV_H
-#if defined(linux)
+#if HAVE_FEENABLEEXCEPT
 #define NRN_FLOAT_EXCEPTION 1
 #else
 #define NRN_FLOAT_EXCEPTION 0
-#endif
 #endif
 
 #if NRN_FLOAT_EXCEPTION
@@ -60,7 +58,6 @@ extern int stdin_event_ready();
 #include <fenv.h>
 #define FEEXCEPT (FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW )
 int matherr1(void) {
-#if defined(FE_NOMASK_ENV) /* should be updated to be more generic */
 	/* above gives the signal but for some reason fegetexcept returns 0 */
 	switch(fegetexcept()) {
 	case FE_DIVBYZERO:
@@ -73,17 +70,20 @@ int matherr1(void) {
 		fprintf(stderr, "Floating exception: Overflow\n");
 		break;
 	}
-#endif /*FE_NOMASK_ENV*/
 }
 #endif
 
+int nrn_feenableexcept_ = 0; // 1 if feenableexcept(FEEXCEPT) is successful
+
 void nrn_feenableexcept() {
   int result = -1;
-#if NRN_FLOAT_EXCEPTION && defined(FE_NOMASK_ENV)
+  nrn_feenableexcept_ = 0;
+#if NRN_FLOAT_EXCEPTION
   if (ifarg(1) && chkarg(1, 0., 1.) == 0.) {
     result = feenableexcept(0);
   }else{
     result = feenableexcept(FEEXCEPT);
+    nrn_feenableexcept_ = result ? 0 : 1;
   }
 #endif
   hoc_ret();
@@ -823,7 +823,7 @@ RETSIGTYPE fpecatch(int sig)	/* catch floating point exceptions */
 #if DOS
 _fpreset();
 #endif
-#if 1 && NRN_FLOAT_EXCEPTION
+#if NRN_FLOAT_EXCEPTION
 	matherr1();
 #endif
 	Fprintf(stderr, "Floating point exception\n");
@@ -832,7 +832,7 @@ _fpreset();
 		abort();
 	}
 	signal(SIGFPE, fpecatch);
-	execerror("Aborting.", (char *) 0);
+	execerror("Floating point exception.", (char *) 0);
 }
 
 #if HAVE_SIGSEGV

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -76,7 +76,7 @@ int matherr1(void) {
 int nrn_feenableexcept_ = 0; // 1 if feenableexcept(FEEXCEPT) is successful
 
 void nrn_feenableexcept() {
-  int result = -1;
+  int result = -2; // feenableexcept does not exist.
   nrn_feenableexcept_ = 0;
 #if NRN_FLOAT_EXCEPTION
   if (ifarg(1) && chkarg(1, 0., 1.) == 0.) {

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -80,7 +80,7 @@ void nrn_feenableexcept() {
   nrn_feenableexcept_ = 0;
 #if NRN_FLOAT_EXCEPTION
   if (ifarg(1) && chkarg(1, 0., 1.) == 0.) {
-    result = feenableexcept(0);
+    result = fedisableexcept(FEEXCEPT);
   }else{
     result = feenableexcept(FEEXCEPT);
     nrn_feenableexcept_ = (result == -1) ? 0 : 1;

--- a/src/oc/math.cpp
+++ b/src/oc/math.cpp
@@ -44,7 +44,7 @@ double Log10(double x) {
 extern "C" double hoc_Exp(double x) {
     if (x < -700.) {
         return 0.;
-    } else if (x > 700) {
+    } else if (x > 700 && nrn_feenableexcept_ == 0) {
         errno = ERANGE;
         if (++hoc_errno_count < MAXERRCOUNT) {
             fprintf(stderr, "exp(%g) out of range, returning exp(700)\n", x);

--- a/src/oc/ocfunc.h
+++ b/src/oc/ocfunc.h
@@ -36,6 +36,7 @@ extern void hoc_Setcolor(void);
 extern void hoc_init_space(void);
 extern void hoc_install_hoc_obj(void);
 extern void nrn_feenableexcept(void);
+extern int nrn_feenableexcept_;
 #if DOS
 extern void hoc_settext(void);
 #endif


### PR DESCRIPTION
Partially responds to #1133
nrn_feenableexcept(1) causes out of range exp(x) in mod files to generate a floating exception. (so back trace tells where the problem is.)
CMake determines whether feenableexcept exists and NRN_FLOAT_EXCEPTION is defined accordingly.

Sadly, -DNRN_ENABLE_BACKTRACE=ON only works for nrniv and not for python. So for python still need gdb. See #797 
Since it seems expensive to restore hoc signals on entry to the hoc world and restore the python signals on exit from the hoc world, perhaps user enabling the backtrace could be a user function, turned on when needed (and gdb not desired). Then NRN_ENABLE_BACKTRACE=ON could be the default (or eliminated and cmake determines if it is possible).


