### PR TITLE
Make rxd test tolerance configurable.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -69,7 +69,7 @@ jobs:
           cmake $CMAKE_OPTION -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DNRN_ENABLE_TESTS=ON -DCMAKE_C_FLAGS="${COVERAGE_FLAGS}" -DCMAKE_CXX_FLAGS="${COVERAGE_FLAGS}" ..;
 
           # Coverage
-          cmake --build . -- -j;
+          cmake --build .
           (cd ..;  lcov --capture  --initial --directory . --no-external --output-file build/coverage-base.info)
           export PATH=`pwd`/bin:$PATH;
           ctest -VV;

--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -151,7 +151,7 @@ jobs:
               echo "CC="$CC
               echo "CXX="$CXX
               cmake $CMAKE_OPTION  -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DNRN_ENABLE_TESTS=ON -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR ..;
-              cmake --build . -- -j;
+              cmake --build .
               if [ "$RUNNER_OS" == "macOS" ]; then
                 echo $'[install]\nprefix='>src/nrnpython/setup.cfg;
               fi;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -122,16 +122,18 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
       NAME rxdmod_tests
       MODFILE_PATTERNS test/rxd/ecs/*.mod
       SCRIPT_PATTERNS test/rxd/*.py test/rxd/3d/*.asc test/rxd/testdata/*.dat)
-    # This test includes a comparison with a binary blob; Intel and PGI/NVHPC builds typically have
-    # too-large numerical differences with the stored values.
-    set(compiler_blacklist "Intel" "PGI" "NVHPC")
-    if(NOT ${CMAKE_CXX_COMPILER_ID} IN_LIST compiler_blacklist)
-      nrn_add_test(
-        GROUP rxdmod_tests
-        NAME rxd_tests
-        COMMAND COVERAGE_FILE=.coverage.rxd_tests ${PYTHON_EXECUTABLE} -m pytest --cov-report=xml
-                --cov=neuron ./test/rxd)
+    # These tests include comparisons against saved data, which appears to have been generated using
+    # GCC. Other compilers produce larger differences.
+    if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
+      set(change_test_tolerance NRN_RXD_TEST_TOLERANCE=1e-8)
+    elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "PGI" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "NVHPC")
+      set(change_test_tolerance NRN_RXD_TEST_TOLERANCE=1e-4)
     endif()
+    nrn_add_test(
+      GROUP rxdmod_tests
+      NAME rxd_tests
+      COMMAND COVERAGE_FILE=.coverage.rxd_tests ${change_test_tolerance} ${PYTHON_EXECUTABLE} -m
+              pytest --cov-report=xml --cov=neuron ./test/rxd)
     if(NRN_ENABLE_MPI)
       find_python_module(mpi4py)
       if(mpi4py_FOUND)
@@ -140,9 +142,9 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
           GROUP rxdmod_tests
           NAME rxd_mpi_tests
           COMMAND
-            COVERAGE_FILE=.coverage.rxd_mpi_tests ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 1
-            ${MPIEXEC_PREFLAGS} ${PYTHON_EXECUTABLE} ${MPIEXEC_POSTFLAGS} -m pytest
-            --cov-report=xml --cov=neuron ./test/rxd --mpi)
+            COVERAGE_FILE=.coverage.rxd_mpi_tests ${change_test_tolerance} ${MPIEXEC_NAME}
+            ${MPIEXEC_NUMPROC_FLAG} 1 ${MPIEXEC_PREFLAGS} ${PYTHON_EXECUTABLE} ${MPIEXEC_POSTFLAGS}
+            -m pytest --cov-report=xml --cov=neuron ./test/rxd --mpi)
       endif()
     endif()
   endif()

--- a/test/rxd/testutils.py
+++ b/test/rxd/testutils.py
@@ -5,7 +5,7 @@ import os
 import numpy
 
 
-tol = 1e-10
+tol = float(os.environ.get('NRN_RXD_TEST_TOLERANCE', '1e-10'))
 dt_eps = 1e-20
 
 def get_data_file_name(frame):
@@ -21,7 +21,7 @@ def get_data_file_name(frame):
 def get_correct_data_for_test():
     """returns a path to the file with the correct data for a test."""
 
-    data_filename = get_data_file_name(frame=3) 
+    data_filename = get_data_file_name(frame=3)
     basepath = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(basepath, 'testdata','test', data_filename)
 


### PR DESCRIPTION
Make these tests run with a looser tolerance in NVHPC and Intel builds instead of disabling them outright.

Note that the required tolerance for NVHPC is quite loose, but at least we will be checking these run properly and so on.

Also remove `-j` flags from `cmake --build` in GitHub Actions CI because compiler processes are being killed.