### PR TITLE
Move MPIEXEC_NAME setting to top-level cmake

### DIFF
--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -151,7 +151,7 @@ jobs:
               echo "CC="$CC
               echo "CXX="$CXX
               cmake $CMAKE_OPTION  -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DNRN_ENABLE_TESTS=ON -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR ..;
-              cmake --build .
+              cmake --build . -- -j 2
               if [ "$RUNNER_OS" == "macOS" ]; then
                 echo $'[install]\nprefix='>src/nrnpython/setup.cfg;
               fi;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,7 +248,10 @@ if(NRN_ENABLE_MPI)
   add_definitions("-DOMPI_SKIP_MPICXX=1")
   add_definitions("-DMPICH_SKIP_MPICXX=1")
 
-  # FindMPI broke backward compatibility with v3.19
+  # Launching mpi executable with full path can mangle different python versions and libraries
+  # (see issue #894). ${MPIEXEC_NAME} would reinsert the full path, but ${CMAKE_COMMAND} -E env
+  # ${MPIEXEC_NAME} does not.
+  # Also, FindMPI broke backward compatibility with v3.19
   if(${CMAKE_VERSION} VERSION_LESS "3.10")
     get_filename_component(MPIEXEC_NAME ${MPIEXEC} NAME)
   else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,13 @@ if(NRN_ENABLE_MPI)
   add_definitions("-DMPI_NO_CPPBIND=1")
   add_definitions("-DOMPI_SKIP_MPICXX=1")
   add_definitions("-DMPICH_SKIP_MPICXX=1")
+
+  # FindMPI broke backward compatibility with v3.19
+  if(${CMAKE_VERSION} VERSION_LESS "3.10")
+    get_filename_component(MPIEXEC_NAME ${MPIEXEC} NAME)
+  else()
+    get_filename_component(MPIEXEC_NAME ${MPIEXEC_EXECUTABLE} NAME)
+  endif()
 else()
   set(NRNMPI 0)
   set(PARANEURON 0)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -135,7 +135,6 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
     if(NRN_ENABLE_MPI)
       find_python_module(mpi4py)
       if(mpi4py_FOUND)
-        get_filename_component(MPIEXEC_NAME ${MPIEXEC} NAME)
         nrn_add_test(
           GROUP rxdmod_tests
           NAME rxd_mpi_tests
@@ -150,7 +149,6 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
     # Launching mpi executable with full path can mangle different python versions and libraries
     # (see issue #894). ${MPIEXEC_NAME} would reinsert the full path, but ${CMAKE_COMMAND} -E env
     # ${MPIEXEC_NAME} does not.
-    get_filename_component(MPIEXEC_NAME ${MPIEXEC} NAME)
     add_test(
       NAME parallel_tests
       COMMAND
@@ -262,7 +260,6 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
             test/gjtests/test_natrans.py)
   if(NRN_ENABLE_MPI)
     find_python_module(mpi4py)
-    get_filename_component(MPIEXEC_NAME ${MPIEXEC} NAME)
     if(mpi4py_FOUND)
       nrn_add_test(
         GROUP coreneuron_modtests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -146,9 +146,6 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
     endif()
   endif()
   if(NRN_ENABLE_MPI)
-    # Launching mpi executable with full path can mangle different python versions and libraries
-    # (see issue #894). ${MPIEXEC_NAME} would reinsert the full path, but ${CMAKE_COMMAND} -E env
-    # ${MPIEXEC_NAME} does not.
     add_test(
       NAME parallel_tests
       COMMAND

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -2,9 +2,5 @@
 # Add tests based on external repositories
 #
 
-# To work around CI failures that seem related to #894 we should run `mpiexec` not
-# `/path/to/mpiexec`
-set(MPIEXEC_NAME ${MPIEXEC_NAME})
-
 add_subdirectory(ringtest)
 add_subdirectory(testcorenrn)

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -2,13 +2,6 @@
 # Add tests based on external repositories
 #
 
-# FindMPI broke backward compatibility with v3.19
-if(${CMAKE_VERSION} VERSION_LESS "3.10")
-  get_filename_component(MPIEXEC_NAME ${MPIEXEC} NAME)
-else()
-  get_filename_component(MPIEXEC_NAME ${MPIEXEC_EXECUTABLE} NAME)
-endif()
-
 # To work around CI failures that seem related to #894 we should run `mpiexec` not
 # `/path/to/mpiexec`
 set(MPIEXEC_NAME ${MPIEXEC_NAME})


### PR DESCRIPTION
For convenience we set in various places the CMake variable `MPIEXEC_NAME`. In `test/external/CMakeLists.txt` this  was not placed inside a test for MPI and caused the build to fail in some cases. This PR sets the variable in the top-level CMakeLists.txt so that the variable can be used everywhere.

This fixes #1140