### PR TITLE
Re-enable build parallelism in CI.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -69,7 +69,10 @@ jobs:
           cmake $CMAKE_OPTION -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DNRN_ENABLE_TESTS=ON -DCMAKE_C_FLAGS="${COVERAGE_FLAGS}" -DCMAKE_CXX_FLAGS="${COVERAGE_FLAGS}" ..;
 
           # Coverage
-          cmake --build .
+          # The Linux runners apparently have 2 cores, but jobs were being killed when we did not specify this explicitly.
+          # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+          # By default we get a modern version of CMake that understands --parallel.
+          cmake --build . --parallel 2
           (cd ..;  lcov --capture  --initial --directory . --no-external --output-file build/coverage-base.info)
           export PATH=`pwd`/bin:$PATH;
           ctest -VV;

--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -151,7 +151,16 @@ jobs:
               echo "CC="$CC
               echo "CXX="$CXX
               cmake $CMAKE_OPTION  -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DNRN_ENABLE_TESTS=ON -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR ..;
-              cmake --build .
+              # Autodetection does not seem to work well, compiler processes were getting killed.
+              # These core counts are taken from
+              # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+              if [ "$RUNNER_OS" == "macOS" ]; then
+                BUILD_PARALLEL_LEVEL=3
+              else
+                BUILD_PARALLEL_LEVEL=2
+              fi
+              # The --parallel option to CMake was only added in v3.12
+              cmake --build . -- -j ${BUILD_PARALLEL_LEVEL}
               if [ "$RUNNER_OS" == "macOS" ]; then
                 echo $'[install]\nprefix='>src/nrnpython/setup.cfg;
               fi;


### PR DESCRIPTION
This was disabled in https://github.com/neuronsimulator/nrn/pull/1137 because the jobs were being killed.

It seemed that `-j` was too aggressive, this PR explicitly uses `-j 2` or `-j 3` according to the GitHub documentation.