### PR TITLE
Fix VecPlayContinuous direct mode error with multiple threads.

### DIFF
--- a/ci/win_build_cmake.sh
+++ b/ci/win_build_cmake.sh
@@ -29,7 +29,7 @@ cd $BUILD_SOURCESDIRECTORY/build
 	-DMPI_CXX_LIB_NAMES:STRING=msmpi \
 	-DMPI_C_LIB_NAMES:STRING=msmpi \
 	-DMPI_msmpi_LIBRARY:FILEPATH=c:/msmpi/lib/x64/msmpi.lib
-make -j
+make -j 2
 ctest -VV
 make install
 make setup_exe

--- a/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
+++ b/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
@@ -535,13 +535,12 @@ void part2_clean() {
 // at present. Assertion errors are generated if not type 0 of if we
 // cannot determine the index into the NrnThread._data .
 
-int nrnthread_dat2_vecplay(int tid, int& n) {
+int nrnthread_dat2_vecplay(int tid, std::vector<int>& indices) {
     if (tid >= nrn_nthread) { return 0; }
     NrnThread& nt = nrn_threads[tid];
 
-    // count the instances for this thread
+    // add the index of each instance in fixed_play_ for thread tid.
     // error if not a VecPlayContinuous with no discon vector
-    n = 0;
     PlayRecList* fp = net_cvode_instance->fixed_play_;
     for (int i=0; i < fp->count(); ++i){
         if (fp->item(i)->type() == VecPlayContinuousType) {
@@ -549,7 +548,7 @@ int nrnthread_dat2_vecplay(int tid, int& n) {
             if (vp->discon_indices_ == NULL) {
                 if (vp->ith_ == nt.id) {
                     assert(vp->y_ && vp->t_);
-                    ++n;
+                    indices.push_back(i);
                 }
             }else{
                 assert(0);

--- a/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.h
+++ b/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.h
@@ -49,7 +49,7 @@ int nrnthread_dat2_3(int tid, int nweight, int*& output_vindex, double*& output_
 int nrnthread_dat2_corepointer(int tid, int& n);
 int nrnthread_dat2_corepointer_mech(int tid, int type,
                                     int& icnt, int& dcnt, int*& iarray, double*& darray);
-int nrnthread_dat2_vecplay(int tid, int& n);
+int nrnthread_dat2_vecplay(int tid, std::vector<int>& n);
 int nrnthread_dat2_vecplay_inst(int tid, int i, int& vptype, int& mtype,
                                 int& ix, int& sz, double*& yvec, double*& tvec);
 

--- a/src/nrniv/nrncore_write/io/nrncore_io.cpp
+++ b/src/nrniv/nrncore_write/io/nrncore_io.cpp
@@ -285,12 +285,11 @@ double* contiguous_art_data(double** data, int nitem, int szitem) {
 
 
 void nrnbbcore_vecplay_write(FILE* f, NrnThread& nt) {
-    // Get the indices in fixed_play for this thread
+    // Get the indices in NetCvode.fixed_play_ for this thread
     // error if not a VecPlayContinuous with no discon vector
     std::vector<int> indices;
     nrnthread_dat2_vecplay(nt.id, indices);
     fprintf(f, "%d VecPlay instances\n", int(indices.size()));
-    PlayRecList* fp = net_cvode_instance->fixed_play_;
     for (auto i: indices) {
         int vptype, mtype, ix, sz; double *yvec, *tvec;
         // the 'if' is not necessary as item i is certainly in this thread 

--- a/src/nrniv/nrncore_write/io/nrncore_io.cpp
+++ b/src/nrniv/nrncore_write/io/nrncore_io.cpp
@@ -285,14 +285,15 @@ double* contiguous_art_data(double** data, int nitem, int szitem) {
 
 
 void nrnbbcore_vecplay_write(FILE* f, NrnThread& nt) {
-    // count the instances for this thread
+    // Get the indices in fixed_play for this thread
     // error if not a VecPlayContinuous with no discon vector
-    int n;
-    nrnthread_dat2_vecplay(nt.id, n);
-    fprintf(f, "%d VecPlay instances\n", n);
+    std::vector<int> indices;
+    nrnthread_dat2_vecplay(nt.id, indices);
+    fprintf(f, "%d VecPlay instances\n", int(indices.size()));
     PlayRecList* fp = net_cvode_instance->fixed_play_;
-    for (int i=0; i < fp->count(); ++i) {
+    for (auto i: indices) {
         int vptype, mtype, ix, sz; double *yvec, *tvec;
+        // the 'if' is not necessary as item i is certainly in this thread 
         if (nrnthread_dat2_vecplay_inst(nt.id, i, vptype, mtype, ix, sz, yvec, tvec)) {
             fprintf(f, "%d\n", vptype);
             fprintf(f, "%d\n", mtype);


### PR DESCRIPTION
Fixes #1154 
This PR is related to BlueBrain/CoreNeuron#521
```
$ ctest -R testcorenrn_vecplay
```
works with
```
hines@hines-T7500:~/neuron/vecplay-transfer/external/tests/testcorenrn$ git diffdiff --git a/testvecplay.hoc b/testvecplay.hoc
index ac1cc82..a9e34aa 100644
--- a/testvecplay.hoc
+++ b/testvecplay.hoc
@@ -45,6 +45,8 @@ for (gid = pc.id; gid < ncell; gid += pc.nhost) {
   cells.append(cell)
 }
 
+pc.nthread(2)
+
 pc.spike_record(-1, tvec, idvec)
 
 cvode.cache_efficient(1)
```