### PR TITLE
Fix rxd atexit error message in windows.

### DIFF
--- a/share/lib/python/neuron/rxd/geometry.py
+++ b/share/lib/python/neuron/rxd/geometry.py
@@ -82,13 +82,13 @@ def _make_perimeter_function(scale, diam_scale=1.0):
     def result(sec):
         if not isinstance(sec, nrn.Section):
             sec = sec._sec
-            arc3d = [sec.arc3d(i)
-                     for i in range(sec.n3d())]
-            diam3d = [sec.diam3d(i) * diam_scale
-                      for i in range(sec.n3d())]
-            area_pos = numpy.linspace(0, sec.L, sec.nseg + 1)
-            diams = numpy.interp(area_pos, arc3d, diam3d)
-            return scale * diams  
+        arc3d = [sec.arc3d(i)
+                 for i in range(sec.n3d())]
+        diam3d = [sec.diam3d(i) * diam_scale
+                  for i in range(sec.n3d())]
+        area_pos = numpy.linspace(0, sec.L, sec.nseg + 1)
+        diams = numpy.interp(area_pos, arc3d, diam3d)
+        return scale * diams  
     return result
         
 _surface_areas1d = _make_surfacearea1d_function(numpy.pi)

--- a/share/lib/python/neuron/rxd/rxd.py
+++ b/share/lib/python/neuron/rxd/rxd.py
@@ -1594,12 +1594,18 @@ set_initialize(do_initialize_fptr)
 
 def _windows_remove_dlls():
     global _windows_dll_files, _windows_dll
+    if _windows_dll != []:
+        if hasattr(ctypes,"WinDLL"):
+            kernel32 = ctypes.WinDLL('kernel32')
+            kernel32.FreeLibrary.argtypes = [ctypes.wintypes.HMODULE]
+        else:
+            kernel32 = ctypes.windll.kernel32
     for (dll_ptr,filepath) in zip(_windows_dll,_windows_dll_files):
         dll = dll_ptr()
         if dll:
             handle = dll._handle
             del dll
-            ctypes.windll.kernel32.FreeLibrary(handle)
+            kernel32.FreeLibrary(handle)
         os.remove(filepath)
     _windows_dll_files = []
     _windows_dll = []


### PR DESCRIPTION
The atexit error is mentioned in #1138.
Also correct an inconsistency with  `_make_perimeter_function` (it does not caused any problems as it has only been used with rxd.Section1D).