### PR TITLE
Set CRAYPE_LINK_TYPE=dynamic on Cray systems.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,23 @@
 cmake_minimum_required(VERSION 3.8.2 FATAL_ERROR)
+# Note that this needs to happen **before** the call to project(...). This is
+# because CMake reads the CRAYPE_LINK_TYPE environment variable inside the call
+# to project(...) and sets various flags and properties based on its value.
+# Because we are so early in the CMake processing, we have to figure out for
+# ourselves whether or not we are running on a Cray system by looking for Cray
+# environment variables directly.
+if(DEFINED ENV{CRAYPE_VERSION})
+  # Older versions of the Cray software prefer static linking by default, which
+  # doesn't work with NEURON with some compilers (GCC and Intel at the time of
+  # writing). Note that this variable will not be set in the compiler and
+  # linker runtime environments, so we are relying on CMake baking in the
+  # correct compiler flags based on the value we set here. In more recent
+  # versions of the Cray software the default has changed; CMake knows about
+  # this in v3.15.3 and newer, but to support older CMake versions we still
+  # need to set this explicitly.
+  # See: https://github.com/neuronsimulator/nrn/issues/1153
+  set(ENV{CRAYPE_LINK_TYPE} dynamic)
+  message(STATUS "Cray system detected...setting CRAYPE_LINK_TYPE=dynamic")
+endif()
 project(NEURON C CXX)
 
 # =============================================================================

--- a/docs/cmake_doc/options.rst
+++ b/docs/cmake_doc/options.rst
@@ -432,6 +432,9 @@ NRN_ENABLE_SHARED:BOOL=ON
 
     nrniv -python
 
+  Note that the top-level ``CMakeLists.txt`` file includes some custom configuration for Cray platforms.
+  This may need to be adapted if you specify ``NRN_ENABLE_SHARED=OFF``.
+
 NRN_ENABLE_THREADS:BOOL=ON
 --------------------------
   Allow use of Pthreads  

--- a/docs/coreneuron/how-to/coreneuron.md
+++ b/docs/coreneuron/how-to/coreneuron.md
@@ -57,10 +57,6 @@ CoreNEURON is a submodule of the NEURON git repository. If you are a NEURON user
    module load cuda nvidia-hpc-sdk
    ```
    Make sure to change module names based on your system.
-   Also, if you are building on a Cray system with the GNU toolchain, you have to set the following environment variable:
-   ```
-   export CRAYPE_LINK_TYPE=dynamic
-   ```
 
 4. Run CMake with the appropriate [options](https://github.com/neuronsimulator/nrn#build-using-cmake) and additionally enable CoreNEURON with `-DNRN_ENABLE_CORENEURON=ON`:
 

--- a/docs/install/install_instructions.md
+++ b/docs/install/install_instructions.md
@@ -199,14 +199,7 @@ build system, and they can be installed together as shown below:
   cd build
   ```
 
-3. If you are building on Cray systems with a GNU toolchain, you have to set the following environmental variable:
-
-  ```
-  export CRAYPE_LINK_TYPE=dynamic
-
-  ```
-
-4. Run `cmake` with the appropriate options (see below for a list of common options). A full list of options
+3. Run `cmake` with the appropriate options (see below for a list of common options). A full list of options
 can be found in `nrn/CMakeLists.txt` and defaults are shown in `nrn/cmake/BuildOptionDefaults.cmake`. e.g. a bare-bones installation:
 
 
@@ -218,14 +211,14 @@ can be found in `nrn/CMakeLists.txt` and defaults are shown in `nrn/cmake/BuildO
    -DCMAKE_INSTALL_PREFIX=/path/to/install/directory
   ```
 
-5. Build the code:
+4. Build the code:
 
   ```
   make -j
   make install
   ```
 
-6. Set PATH and PYTHONPATH environmental variables to use the installation:
+5. Set PATH and PYTHONPATH environmental variables to use the installation:
 
   ```
   export PATH=/path/to/install/directory/bin:$PATH


### PR DESCRIPTION
Remove references to setting this explicitly from the documentation.

Closes #1153.