### PR TITLE
Initialize fast_imem structs to 0

### DIFF
--- a/src/nrnoc/multicore.cpp
+++ b/src/nrnoc/multicore.cpp
@@ -603,8 +603,8 @@ static void fast_imem_alloc() {
 				free(fi->_nrn_sav_d);
 			}
 			if (n > 0) {
-				CACHELINE_ALLOC(fi->_nrn_sav_rhs, double, n);
-				CACHELINE_ALLOC(fi->_nrn_sav_d, double, n);
+				CACHELINE_CALLOC(fi->_nrn_sav_rhs, double, n);
+				CACHELINE_CALLOC(fi->_nrn_sav_d, double, n);
 			}
 			fast_imem_size_[i] = n;
 		}


### PR DESCRIPTION
Initialize fast_imem structs to 0 in the beginning of the simulation, so that reporting in the first time step doesn't return garbage values

Similar to https://github.com/BlueBrain/CoreNeuron/pull/507