### PR TITLE
Updated hclass's __all__ attribute

### DIFF
--- a/share/lib/python/neuron/hclass3.py
+++ b/share/lib/python/neuron/hclass3.py
@@ -5,7 +5,7 @@
 # using the idiom self.basemethod = self.baseattr('methodname')
 # ------------------------------------------------------------------------------
 
-__all__ = ["hclass", "nonlocal_hclass", "HocBaseObject"]
+__all__ = ["hclass", "HocBaseObject"]
 
 from . import h, hoc
 import nrn


### PR DESCRIPTION
Slight error in #1096, forgot to remove `nonlocal_hclass` from the module's `__all__` attribute