### PR TITLE
Stop RangeVarPlot keeping species alive.

### DIFF
--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -1416,9 +1416,16 @@ def _nrnpy_rvp_pyobj_callback(f):
   def result(x):
     sp = fref()
     if sp:
-        nodes = sp.nodes(h.cas()(x))
-        total_volume = sum(node.volume for node in nodes)
-        return sum(node.concentration * node.volume for node in nodes) / total_volume
+        try:
+            # h.cas() will fail if there are no sections
+            nodes = sp.nodes(h.cas()(x))
+        except:
+            return None
+        if nodes:
+            total_volume = sum(node.volume for node in nodes)
+            return sum(node.concentration * node.volume for node in nodes) / total_volume
+        else:
+            return None
     return None
 
   return result

--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -102,6 +102,7 @@ $Id: __init__.py,v 1.1 2008/05/26 11:39:44 hines Exp hines $
 import sys
 import os
 import warnings
+import weakref
 
 embedded = True if 'hoc' in sys.modules else False
 
@@ -1411,10 +1412,14 @@ def _nrnpy_rvp_pyobj_callback(f):
   # up the weighted average concentration given an x and h.cas()
   # this is not particularly efficient so it is probably better to use this for
   # fixed timepoints rather than displays that update mid-simulation
+  fref = weakref.ref(f)
   def result(x):
-    nodes = f.nodes(h.cas()(x))
-    total_volume = sum(node.volume for node in nodes)
-    return sum(node.concentration * node.volume for node in nodes) / total_volume
+    sp = fref()
+    if sp:
+        nodes = sp.nodes(h.cas()(x))
+        total_volume = sum(node.volume for node in nodes)
+        return sum(node.concentration * node.volume for node in nodes) / total_volume
+    return None
 
   return result
 

--- a/share/lib/python/neuron/rxd/species.py
+++ b/share/lib/python/neuron/rxd/species.py
@@ -26,7 +26,7 @@ import re
 #set_nonvint_block = neuron.nrn_dll_sym('set_nonvint_block')
 
 # Update the structure_change_cnt & diam_change_cnt if the shape has changed
-_nrn_shape_update = nrn_dll_sym('nrn_shape_update')
+_nrn_shape_update = nrn_dll_sym('nrn_shape_update_always')
 
 fptr_prototype = ctypes.CFUNCTYPE(None)
 

--- a/src/nrnoc/treeset.cpp
+++ b/src/nrnoc/treeset.cpp
@@ -900,11 +900,8 @@ void connection_coef(void)	/* setup a and b */
 #endif
 }
 
-extern "C" void nrn_shape_update(void) {
+extern "C" void nrn_shape_update_always(void) {
 	static int updating;
-	if (section_list->next == section_list) {
-		return;
-	}
     if (!updating || updating != diam_change_cnt) {
 	updating = diam_change_cnt;
 	if (tree_changed) {
@@ -917,6 +914,12 @@ extern "C" void nrn_shape_update(void) {
 		recalc_diam();
 	}
 	updating = 0;
+    }
+}
+
+extern "C" void nrn_shape_update(void) {
+    if (section_list->next != section_list) {
+        nrn_shape_update_always();
     }
 }
 

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -2542,11 +2542,6 @@ static Object* rvp_rxd_to_callable_(Object* obj) {
     PyObject* py_obj = nrnpy_ho2po(obj);
     PyObject* result = PyObject_CallFunctionObjArgs(nrnpy_rvp_pyobj_callback, py_obj, NULL);
     Py_DECREF(py_obj);
-    if (py_obj != result) {
-      // for now, this only happens when using rangevarplot with rxd
-      // prevents keeping section references that should not exist
-      hoc_obj_unref(obj);
-    }
     Object* obj_result = nrnpy_po2ho(result);
     Py_DECREF(result);  // the previous line incremented the reference count
     return obj_result;

--- a/test/rxd/test_rangevarplot.py
+++ b/test/rxd/test_rangevarplot.py
@@ -1,0 +1,56 @@
+import pytest
+import gc
+
+
+@pytest.fixture
+def model_rangevarplot(neuron_instance):
+    h, rxd, data, save_path = neuron_instance
+
+    def make_rvp(with_sec=True, with_species=True):
+        dend = h.Section(name="dend")
+        dend.L = 3
+        dend.diam = 2
+        dend.nseg = 3
+
+        def my_initial(node):
+            if h.distance(node, dend(0)) < 2:
+                return 1
+            else:
+                return 0
+
+        cyt = rxd.Region([dend], name="cyt")
+        c = rxd.Species(cyt, name="c", initial=my_initial)
+
+        g = h.RangeVarPlot(c, dend(0), dend(1))
+        c = c if with_species else None
+        dend = dend if with_sec else None
+        gc.collect()
+        return (dend, cyt, c, g)
+
+    yield (h, rxd, make_rvp)
+
+
+def test_rangevarplot(model_rangevarplot):
+    h, rxd, make_rvp = model_rangevarplot
+    dend, cyt, c, g = make_rvp()
+    vec = h.Vector()
+    g.to_vector(vec)
+    assert vec.to_python() == [0, 1, 1, 0, 0]
+
+
+def test_rangevarplot_no_species(model_rangevarplot):
+    h, rxd, make_rvp = model_rangevarplot
+    dend, cyt, c, g = make_rvp(with_species=False)
+    vec = h.Vector()
+    g.to_vector(vec)
+    assert vec.to_python() == [0, 0, 0, 0, 0]
+
+
+def test_rangevarplot_no_section(model_rangevarplot):
+    h, rxd, make_rvp = model_rangevarplot
+    dend, cyt, c, g = make_rvp(with_sec=False)
+    vec = h.Vector()
+    g.to_vector(vec)
+    for sec in h.allsec():
+        assert False
+    assert vec.to_python() == [0, 0, 0, 0, 0]


### PR DESCRIPTION
I also added an `nrn_shape_update_always` function so that `structure_change_cnt` is updated when a section is deleted. Is there a neater way to do this?

e.g. The following code gives a different number for `structure_change_cnt` after deleting the section, but not if use `nrn_shape_update`.

```
import ctypes
import gc
from neuron import h, nrn_dll_sym

_structure_change_count = nrn_dll_sym('structure_change_cnt', ctypes.c_int)

_nrn_shape_update = nrn_dll_sym('nrn_shape_update_always')
print("create a section")
dend = h.Section()
_nrn_shape_update()
print("_structure_change_count",_structure_change_count.value)

print("\ndelete the section")
del dend
gc.collect()
for sec in h.allsec(): print(sec)
_nrn_shape_update()
print("_structure_change_count",_structure_change_count.value)
```

Also checked nodes as @ramcdougal suggested and added some tests.