### PR TITLE
Use full repo when building windows installer (#1232)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     
     - name: Download Dependencies
       run: |


### PR DESCRIPTION
* by default depth is 1 and hence only HEAD is checked out
* this gives version below i.e. tag is missing
    NEURON -- VERSION + HEAD (0e9a051+) 2021-04-30