### PR TITLE
Win CIs: exit with code 1 since %errorlevel% may be off

### DIFF
--- a/ci/win_test_installer.cmd
+++ b/ci/win_test_installer.cmd
@@ -83,5 +83,5 @@ goto :EOF
 
 :: something has failed, teminate with error code
 :error
-echo ERROR : exiting with error code %errorlevel% ..
-exit /b %errorlevel%
+echo ERROR : exiting with error code 1 ..
+exit 1


### PR DESCRIPTION
* avoid relying on %errolevel% and make failure consistent to testing