### PR TITLE
Flush `stderr` in the python print callback.

### DIFF
--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -1350,6 +1350,7 @@ def nrnpy_pr(stdoe, s):
     sys.stdout.write(s.decode())
   else:
     sys.stderr.write(s.decode())
+    sys.stderr.flush()
   return 0
 
 if not embedded:


### PR DESCRIPTION
Flushing `stderr` ensures that in MPI simulations the error message is flushed before `MPI_Abort` is called and the message potentially lost, as discussed in #1112