### PR TITLE
WinInstaller test: bump wait window for `temp.hoc`

### DIFF
--- a/ci/win_test_installer.cmd
+++ b/ci/win_test_installer.cmd
@@ -49,7 +49,7 @@ echo fprint("hello\n") >> .\temp.hoc
 echo wopen() >> .\temp.hoc
 echo quit() >> .\temp.hoc
 start .\temp.hoc
-ping -n 10 127.0.0.1
+ping -n 15 127.0.0.1
 cat temp.txt
 findstr /i "^hello$" temp.txt || set "errorfound=y"
 


### PR DESCRIPTION
* test of association with hoc files can take some time
* bump from 10 to 15 secs
* with 10 seconds we have seen  failures on and off