### PR TITLE
Support NVHPC compiler with CMake v3.20.

### DIFF
--- a/cmake/CompilerHelper.cmake
+++ b/cmake/CompilerHelper.cmake
@@ -9,9 +9,14 @@ else()
   set(UNDEFINED_SYMBOLS_IGNORE_FLAG "--unresolved-symbols=ignore-all")
 endif()
 
-if(CMAKE_C_COMPILER_ID MATCHES "PGI")
+if(CMAKE_C_COMPILER_ID MATCHES "PGI" OR CMAKE_C_COMPILER_ID MATCHES "NVHPC")
   set(USING_PGI_COMPILER_TRUE "")
   set(USING_PGI_COMPILER_FALSE "#")
+  # See https://gitlab.kitware.com/cmake/cmake/-/issues/22168, upper limit of
+  # 3.20.3 is based on the current assigned milestone there.
+  if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.20" AND ${CMAKE_VERSION} VERSION_LESS "3.20.3")
+    string(APPEND CMAKE_DEPFILE_FLAGS_CXX "-MD<DEP_FILE>")
+  endif()
 else()
   set(USING_PGI_COMPILER_TRUE "#")
   set(USING_PGI_COMPILER_FALSE "")


### PR DESCRIPTION
- Without this fix then CMake `v3.20.{0..2}` does not correctly track include dependencies with the Ninja build system: [CMake issue #22168](https://gitlab.kitware.com/cmake/cmake/-/issues/22168).
- In CMake v3.20 the NVHPC compilers have the ID "NVHPC" instead of "PGI".

See also: https://github.com/BlueBrain/CoreNeuron/pull/543