### PR TITLE
init.py relative import for HOC - PEP328

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,10 +97,3 @@ if os.environ.get("READTHEDOCS"):
 
     # Execute & convert notebooks + doxygen
     subprocess.run("cd .. && python setup.py docs", check=True, shell=True)
-
-    # Remove `docs` from sys.path since RTD adds it automatically.
-    # Otherwise `docs/hoc` will clash with `hoc` when importing neuron
-    try:
-        sys.path.remove(os.path.abspath('.'))
-    except:
-        pass

--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -130,7 +130,7 @@ except:
   pass
 
 try:
-  import hoc
+  from . import hoc
 except:
   try:
     #Python3.1 extending needs to look into the module explicitly


### PR DESCRIPTION
* resolve clashes when `hoc` folders are found in path