### PR TITLE
Add missing build dependency of hoc_module.

### DIFF
--- a/src/nrnpython/CMakeLists.txt
+++ b/src/nrnpython/CMakeLists.txt
@@ -248,6 +248,9 @@ if(NRN_ENABLE_MODULE_INSTALL)
   endforeach(pyexe)
 
   add_dependencies(hoc_module nrniv_lib ${nrnpython_lib_list})
+  if(NRN_ENABLE_RX3D)
+    add_dependencies(hoc_module rxd_cython_generated)
+  endif()
 
   #~~~
   # neuron module (possibly with multiple extension versions) was built


### PR DESCRIPTION
Add missing dependency of `hoc_module` on `rxd_cython_generated`.
This declares that `src/nrnpython/setup.py` depends on generated .cpp files such as `share/lib/python/neuron/rxd/geometry3d/graphicsPrimitives.cpp` and fixes build errors such as https://github.com/neuronsimulator/nrn-build-ci/runs/2580705143?check_suite_focus=true:
```
[892/1396] Running utility command for hoc_module
FAILED: src/nrnpython/CMakeFiles/hoc_module.util 
cd /__w/nrn-build-ci/nrn-build-ci/nrn/build/src/nrnpython && /usr/bin/cmake -E copy_directory /__w/nrn-build-ci/nrn-build-ci/nrn/share/lib /__w/nrn-build-ci/nrn-build-ci/nrn/build/share/nrn/lib && /usr/bin/cmake -E copy_directory /__w/nrn-build-ci/nrn-build-ci/nrn/share/demo /__w/nrn-build-ci/nrn-build-ci/nrn/build/share/nrn/demo && cd /__w/nrn-build-ci/nrn-build-ci/nrn/build/src/nrnpython && /usr/bin/cmake -E copy_if_different /__w/nrn-build-ci/nrn-build-ci/nrn/src/nrnpython/inithoc.cpp /__w/nrn-build-ci/nrn-build-ci/nrn/build/src/nrnpython/inithoc.cpp && /usr/bin/python3 setup.py --quiet build --build-lib=/__w/nrn-build-ci/nrn-build-ci/nrn/build/lib/python
gcc: error: ../../share/lib/python/neuron/rxd/geometry3d/graphicsPrimitives.cpp: No such file or directory
gcc: fatal error: no input files
compilation terminated.
error: command '/usr/bin/gcc' failed with exit status 1
```

To reproduce the problem locally I had to reduce the number of parallel build jobs. `nrn-build-ci` uses 2 jobs in Linux runners and 3 for macOS, and only Linux jobs were failing.