### PR TITLE
GHA CIs: drop previous runs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,9 @@
 name: NEURON Code Coverage
 
+concurrency:
+  group: ${{ github.workflow }}#${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,9 @@
 name: NEURON Documentation
 
+concurrency:
+  group: ${{ github.workflow }}#${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -1,5 +1,9 @@
 name: NEURON CI
 
+concurrency: 
+  group: ${{ github.workflow }}#${{ github.ref }}
+  cancel-in-progress: true  
+
 on:
   push:
     branches: 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,5 +1,9 @@
 name: Windows Installer
 
+concurrency: 
+  group: ${{ github.workflow }}#${{ github.ref }}
+  cancel-in-progress: true  
+
 on:
   push:
     branches: 


### PR DESCRIPTION
* drop previous runs for subsequent updates (master, release & PRs)
* make use of new GHA concurrency feature
* concurrency group consists of workflow_name#github_ref
* see https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency