### PR TITLE
Only use one MPI rank for a problematic GPU test.

### DIFF
--- a/test/external/testcorenrn/CMakeLists.txt
+++ b/test/external/testcorenrn/CMakeLists.txt
@@ -75,9 +75,15 @@ foreach(test ${spike_comparison_tests})
           ${MPIEXEC_OVERSUBSCRIBE} ${MPIEXEC_PREFLAGS} special ${MPIEXEC_POSTFLAGS} -mpi -c
           arg_tstop=100 -c arg_coreneuron=1 ${${processor}_args_online} test${test}.hoc)
     endif()
+    # This is a workaround to reduce the number of MPI ranks in the GPU version of the patstim test
+    # and, we hope, avoid https://github.com/BlueBrain/CoreNeuron/issues/563
+    set(local_mpi_ranks ${num_ranks})
     set(extra_args)
     if("${test}" STREQUAL "patstim")
       list(APPEND extra_args --pattern patstim.spk)
+      if("${processor}" STREQUAL "gpu")
+        set(local_mpi_ranks 1)
+      endif()
     endif()
     # Set up a test that runs the simulation using CoreNEURON's offline mode. First we must run
     # NEURON and tell it to dump the model without simulating it.
@@ -86,12 +92,12 @@ foreach(test ${spike_comparison_tests})
       NAME coreneuron_${processor}_offline
       REQUIRES coreneuron mpi ${processor}
       CONFLICTS ${test_${test}_coreneuron_${processor}_conflicts}
-      PROCESSORS ${num_ranks}
+      PROCESSORS ${local_mpi_ranks}
       PRECOMMAND OMP_NUM_THREADS=1
                  HOC_LIBRARY_PATH=.
                  ${MPIEXEC_NAME}
                  ${MPIEXEC_NUMPROC_FLAG}
-                 ${num_ranks}
+                 ${local_mpi_ranks}
                  ${MPIEXEC_OVERSUBSCRIBE}
                  ${MPIEXEC_PREFLAGS}
                  special
@@ -103,7 +109,7 @@ foreach(test ${spike_comparison_tests})
                  arg_dump_coreneuron_model=1
                  test${test}.hoc
       COMMAND
-        OMP_NUM_THREADS=1 ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} ${num_ranks}
+        OMP_NUM_THREADS=1 ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} ${local_mpi_ranks}
         ${MPIEXEC_OVERSUBSCRIBE} ${MPIEXEC_PREFLAGS} special-core ${MPIEXEC_POSTFLAGS} -d coredat
         --mpi -e 100 ${extra_args} ${${processor}_args_offline}
       OUTPUT asciispikes::out.dat)


### PR DESCRIPTION
`testcorenrn_patstim::coreneuron_gpu_offline` now only runs with one MPI rank, which should work around CI failures due to https://github.com/BlueBrain/CoreNeuron/issues/563.