### PR TITLE
Check fast_imem results on GPU too.

### DIFF
--- a/test/coreneuron/test_datareturn.py
+++ b/test/coreneuron/test_datareturn.py
@@ -63,9 +63,7 @@ class Cell():
 class Network():
   def __init__(self):
     self.cells = [Cell(i) for i in range(5)]
-    # This is not supported on GPU, see:
-    # https://github.com/BlueBrain/CoreNeuron/issues/197
-    cvode.use_fast_imem(not enable_gpu)
+    cvode.use_fast_imem(True)
     # a few intrinsically firing ARTIFICIAL_CELLS with and without gids
     self.acells = [h.IntervalFire() for _ in range(8)]
     r = h.Random()
@@ -99,9 +97,7 @@ class Network():
     for sec in h.allsec():
       for seg in sec:
         d.append(seg.v)
-        # Not supported on GPU, see:
-        # https://github.com/BlueBrain/CoreNeuron/issues/197
-        if not enable_gpu: d.append(seg.i_membrane_)
+        d.append(seg.i_membrane_)
         for mech in seg:
           for var in mech:
             d.append(var[0])

--- a/test/coreneuron/test_direct.hoc
+++ b/test/coreneuron/test_direct.hoc
@@ -64,9 +64,7 @@ proc test_direct_memory_transfer() { localobj po, pc, ic, tv, vvec, i_mem, tvstd
     // compare results
     result1 = tv.eq(tvstd)
     result2 = vvec.cl().sub(vstd).abs().max() < 1e-10
-    // This check is disabled on GPU because fast imem is not implemented on
-    // GPU: https://github.com/BlueBrain/CoreNeuron/issues/197
-    result3 = po.coreneuron.gpu || i_mem.cl().sub(i_memstd).abs().max() < 1e-10
+    result3 = i_mem.cl().sub(i_memstd).abs().max() < 1e-10
     result  = result1 && result2 && result3
     print(result1)
     print(result2)

--- a/test/coreneuron/test_direct.py
+++ b/test/coreneuron/test_direct.py
@@ -44,9 +44,7 @@ def test_direct_memory_transfer():
 
     assert(tv.eq(tvstd))
     assert(v.cl().sub(vstd).abs().max() < 1e-10) # usually v == vstd, some compilers might give slightly different results
-    # This check is disabled on GPU because fast imem is not implemented on
-    # GPU: https://github.com/BlueBrain/CoreNeuron/issues/197
-    assert(coreneuron.gpu or i_mem.cl().sub(i_memstd).abs().max() < 1e-10)
+    assert(i_mem.cl().sub(i_memstd).abs().max() < 1e-10)
     assert(h.Vector(tran_std).sub(h.Vector(tran)).abs().max() < 1e-10)
 
 if __name__ == "__main__":


### PR DESCRIPTION
With https://github.com/BlueBrain/CoreNeuron/pull/574 merged then several exclusions/workarounds can be removed from the NEURON tests.