### PR TITLE
Introduce support for reloading dynamic libraries

### DIFF
--- a/src/nrnoc/init.cpp
+++ b/src/nrnoc/init.cpp
@@ -1,11 +1,12 @@
 #include <../../nrnconf.h>
 #include <nrnmpiuse.h>
 
-# include	<stdio.h>
+#include <stdio.h>
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <map>
 #include "section.h"
 #include "parse.hpp"
 #include "nrniv_mf.h"
@@ -229,7 +230,15 @@ void* nrn_realpath_dlopen(const char* relpath, int flags) {
 }
 
 int mswin_load_dll(const char* cp1) {
-	void* handle;
+	static std::map<std::string, void*> handle_map;
+
+	// Retrieve handle associated with a given path, allowing us to reload a
+	// dynamic library after an update (i.e., closing the previous handle)
+	auto &handle = handle_map[std::string(cp1)]; //  Ref. needed to update map
+	if (handle) {
+		dlclose(handle);
+	}
+
 	if (nrnmpi_myid < 1) if (!nrn_nobanner_ && nrn_istty_) {
 		fprintf(stderr, "loading membrane mechanisms from %s\n", cp1);
 	}


### PR DESCRIPTION
**IMPORTANT**
This experimental change depends on further discussions on how to properly reload the state of NEURON (e.g., by having a `reload()` method that cleans-up the state to its default). We can begin some of these discussions on this Draft PR, if needed, or in a separate channel.

### Description
Reloading a dynamic library in NEURON would currently load the original version that was previously loaded in memory. This is mostly due to the fact that the `handle` is never stored nor closed, making the shared library ref. count to be always greater than 0. [The following information from the official documentation](https://man7.org/linux/man-pages/man3/dlopen.3.html) confirms our initial hypothesis:

```
       ...
       If the same shared object is opened again with dlopen(), the same
       object handle is returned.  The dynamic linker maintains
       reference counts for object handles, so a dynamically loaded
       shared object is not deallocated until dlclose() has been called
       on it as many times as dlopen() has succeeded on it.
       ...
```

As a consequence, attempting to update the mechanisms by recompiling the library externally would not have any visible impact, even if we manually ask NEURON to load the same library once again.

### How does it work
The proposed change utilizes a static map to cache shared library handles with their correspondent given path. The idea is to retrieve the previous handle stored in the map and close it if the same library is asked to be loaded twice, forcing it to reload.

Ideally, the handle of the libraries would make more sense to be part of the NEURON state, somehow. But this must be part of the discussions when designing the `reload()` method.

### How to Test
Using the HOC interpreter, one can easily test the support for reloading the dynamic library by using `nrn_load_dll()` and a custom .mod file:
```
> create soma
> soma insert MyChannel
> soma psection()
soma { nseg=1  L=100  Ra=35.4
        /*location 0 attached to cell 1*/
        /* First segment only */
        insert morphology { diam=500}
        insert capacitance { cm=1}
        insert MyChannel { g_MyChannel=0.1 e_MyChannel=-70}
}
```
If we now rename `MyChannel` to `MySecondChannel` to avoid conflicts (see limitations below) and recompile the same .mod file without closing the interpreter, the following error appears **by using the current version of NEURON**:
```
> nrn_load_dll("/path/to/library.so")
loading membrane mechanisms from /path/to/library.so
Additional mechanisms from files
 "mytest.mod"
nrniv: The user defined name already exists: MyChannel
 near line 5
 nrn_load_dll("/path/to/library.so")
                                           ^
        nrn_load_dll("/path/to/li...")
```
This is due to the fact that the new shared library is not effectively loaded, meaning that `MySecondChannel` does not exist. **By including the proposed changes**, this is the result:
```
> nrn_load_dll("/path/to/library.so")
> soma insert MySecondChannel
> soma psection()
soma { nseg=1  L=100  Ra=35.4
        /*location 0 attached to cell 1*/
        /* First segment only */
        insert morphology { diam=500}
        insert capacitance { cm=1}
        insert MyChannel { g_MyChannel=0.1 e_MyChannel=-70}
        insert MySecondChannel { g_MySecondChannel=0.2 e_MySecondChannel=-70}
}
```

### Known Limitations
Right now and despite loading the same library with the changes, the name resolution of NEURON prevents conflicting mechanisms to load. In addition, in the previous example `MyChannel` still exists, despite that we reloaded the library that contained its definition, which is incorrect.

Nonetheless, the changes proposed here are required, in some way or another (e.g., closing the shared library handle from the global `reload()` method).