### PR TITLE
Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Ignore blame of black formatting
+4c6fd585f2d6138db5f77513a795a53cc56b0646


### PR DESCRIPTION
Ignores blame of the black reformatting commit