### PR TITLE
Add trailing newline to feature detection code.

### DIFF
--- a/cmake/MacroHelper.cmake
+++ b/cmake/MacroHelper.cmake
@@ -16,16 +16,13 @@ set(CMAKE_REQUIRED_QUIET TRUE)
 # =============================================================================
 macro(nrn_check_dir_exists HEADER VARIABLE)
   # code template to check existence of DIR
-  set(CONFTEST_DIR_TPL
-      "
-    #include <sys/types.h>
-    #include <@dir_header@>
-
-    int main () {
-      if ((DIR *) 0)
-        return 0\;
-      return 0\;
-    }")
+  string(CONCAT CONFTEST_DIR_TPL "#include <sys/types.h>\n"
+                                 "#include <@dir_header@>\n"
+                                 "int main () {\n"
+                                 "  if ((DIR *) 0)\n"
+                                 "    return 0\;\n"
+                                 "  return 0\;\n"
+                                 "}\n")
   # first get header file
   check_include_files(${HEADER} HAVE_HEADER)
   if(${HAVE_HEADER})
@@ -48,15 +45,12 @@ endmacro()
 # =============================================================================
 macro(nrn_check_type_exists HEADER TYPE DEFAULT_TYPE VARIABLE)
   # code template to check existence of specific type
-  set(CONFTEST_TYPE_TPL
-      "
-    #include <@header@>
-
-    int main () {
-      if (sizeof (@type@))
-        return 0\;
-      return 0\;
-    }")
+  string(CONCAT CONFTEST_TYPE_TPL "#include <@header@>\n"
+                                  "int main () {\n"
+                                  "  if (sizeof (@type@))\n"
+                                  "    return 0\;\n"
+                                  "  return 0\;\n"
+                                  "}\n")
   string(REPLACE "@header@" ${HEADER} CONFTEST_TYPE "${CONFTEST_TYPE_TPL}")
   string(REPLACE "@type@" ${TYPE} CONFTEST_TYPE "${CONFTEST_TYPE}")
   file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/conftest.cpp ${CONFTEST_TYPE})
@@ -73,14 +67,11 @@ endmacro()
 # =============================================================================
 macro(nrn_check_signal_return_type VARIABLE)
   # code template to check signal support
-  set(CONFTEST_RETSIGTYPE
-      "
-    #include <sys/types.h>
-    #include <signal.h>
-
-    int main () {
-      return *(signal (0, 0)) (0) == 1;
-    }")
+  string(CONCAT CONFTEST_RETSIGTYPE "#include <sys/types.h>\n"
+                                    "#include <signal.h>\n"
+                                    "int main () {\n"
+                                    "  return *(signal (0, 0)) (0) == 1\;\n"
+                                    "}\n")
   file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/conftest.cpp ${CONFTEST_RETSIGTYPE})
   try_compile(RESULT_VAR ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/conftest.cpp)
   if(RESULT_VAR)


### PR DESCRIPTION
When generating C++ code to test for language features, make sure the last line ends with a new line character. Use `string(CONCAT ...)` to allow better CMake source code indentation.

This fixes the compilation issue reported in https://github.com/BlueBrain/CoreNeuron/issues/580 that occurs when PGI/NVHPC compilers are used with **unpatched** CMake versions between `v3.9` and `v3.19`.

---

CMake versions from [v3.9.0](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/784) to [v3.19.0](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5025) were passing the `-A` (`--strict`) option to the compiler when detecting the presence of certain symbols ([`nrn_check_type_exists`](https://github.com/neuronsimulator/nrn/blob/63bc3116c61447d49e63aaa962abbf10c610e31f/cmake/MacroHelper.cmake#L46-L69)), which makes PGI/NVHPC compilers **very** pedantic. Specifically they were aborting because the code generated by NEURON to detect the presence of `size_t` did not end with a new line character. This meant that NEURON tried to define `size_t` itself and caused walls of error messages.

One reason this does not seem to be such a widespread problem is that the Spack version of CMake [patches out the `-A` flag](https://github.com/spack/spack/blob/9750459e05ce233bcca13d2ba70bc7a337644d70/var/spack/repos/builtin/packages/cmake/package.py#L192-L195) for `v3.15+`. This is why we do not see the issue on BlueBrain systems, where we use v3.15.7 by default.