### PR TITLE
Ensure Python exceptions trigger CTest failures.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -200,9 +200,8 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
     set(py_args -m pytest ${PYTEST_COVERAGE_ARGS} -s)
     set(modtests_launch_py ${nrnpython_mpi_env} ${PYTHON_EXECUTABLE} ${py_args})
     set(modtests_launch_hoc ${CMAKE_BINARY_DIR}/bin/nrniv ${nrniv_mpi_arg})
-    # This tries to use pytest and mpi4py in parallel, which might be fragile.
     set(modtests_launch_py_mpi ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS}
-                               ${PYTHON_EXECUTABLE} ${py_args})
+                               ${PYTHON_EXECUTABLE})
   endif()
   nrn_add_test_group(
     NAME coreneuron_modtests

--- a/test/coreneuron/test_datareturn.py
+++ b/test/coreneuron/test_datareturn.py
@@ -214,4 +214,4 @@ if __name__ == "__main__":
         sys.exit(42)
     # The test doesn't exit without this.
     if enable_gpu:
-        sys.exit(0)
+        h.quit()

--- a/test/coreneuron/test_direct.py
+++ b/test/coreneuron/test_direct.py
@@ -1,6 +1,9 @@
 import os
 import pytest
 import sys
+import traceback
+
+enable_gpu = bool(os.environ.get("CORENRN_ENABLE_GPU", ""))
 
 from neuron import h, gui
 
@@ -37,7 +40,7 @@ def test_direct_memory_transfer():
     from neuron import coreneuron
 
     coreneuron.enable = True
-    coreneuron.gpu = bool(os.environ.get("CORENRN_ENABLE_GPU", ""))
+    coreneuron.gpu = enable_gpu
 
     pc = h.ParallelContext()
     h.stdinit()
@@ -53,5 +56,12 @@ def test_direct_memory_transfer():
 
 
 if __name__ == "__main__":
-    test_direct_memory_transfer()
-    h.quit()
+    try:
+        test_direct_memory_transfer()
+    except:
+        traceback.print_exc()
+        # Make the CTest test fail
+        sys.exit(42)
+    # The test doesn't exit without this.
+    if enable_gpu:
+        h.quit()

--- a/test/coreneuron/test_fornetcon.py
+++ b/test/coreneuron/test_fornetcon.py
@@ -3,6 +3,9 @@
 # in random order.
 import os
 import pytest
+import traceback
+
+enable_gpu = bool(os.environ.get("CORENRN_ENABLE_GPU", ""))
 
 from neuron import h
 
@@ -74,7 +77,7 @@ def test_fornetcon():
     print("CoreNEURON run")
     h.CVode().cache_efficient(1)
     coreneuron.enable = True
-    coreneuron.gpu = bool(os.environ.get("CORENRN_ENABLE_GPU", ""))
+    coreneuron.gpu = enable_gpu
     run(tstop)
     coreneuron.enable = False
     assert len(spiketime) > 0
@@ -88,4 +91,14 @@ def test_fornetcon():
 
 
 if __name__ == "__main__":
-    test_fornetcon()
+    try:
+        test_fornetcon()
+    except:
+        traceback.print_exc()
+        # Make the CTest test fail
+        sys.exit(42)
+    # This test is not actually executed on GPU, but it has this logic anyway
+    # for consistency with the other .py tests in this folder when
+    # https://github.com/BlueBrain/CoreNeuron/issues/512 is resolved.
+    if enable_gpu:
+        h.quit()

--- a/test/coreneuron/test_spikes.py
+++ b/test/coreneuron/test_spikes.py
@@ -1,7 +1,10 @@
 import os
 import pytest
+import sys
+import traceback
 
 # Hacky, but it's non-trivial to pass commandline arguments to pytest tests.
+enable_gpu = bool(os.environ.get("CORENRN_ENABLE_GPU", ""))
 mpi4py_option = bool(os.environ.get("NRN_TEST_SPIKES_MPI4PY", ""))
 file_mode_option = bool(os.environ.get("NRN_TEST_SPIKES_FILE_MODE", ""))
 nrnmpi_init_option = bool(os.environ.get("NRN_TEST_SPIKES_NRNMPI_INIT", ""))
@@ -72,7 +75,7 @@ def test_spikes(
     from neuron import coreneuron
 
     coreneuron.enable = True
-    coreneuron.gpu = bool(os.environ.get("CORENRN_ENABLE_GPU", ""))
+    coreneuron.gpu = enable_gpu
     coreneuron.file_mode = file_mode
     coreneuron.verbose = 0
     h.stdinit()
@@ -90,8 +93,14 @@ def test_spikes(
     assert len(nrn_spike_t) == len(nrn_spike_gids)  # matching no. of gids
     assert nrn_spike_t == corenrn_all_spike_t
     assert nrn_spike_gids == corenrn_all_spike_gids
-    h.quit()
 
 
 if __name__ == "__main__":
-    test_spikes()
+    try:
+        test_spikes()
+    except:
+        traceback.print_exc()
+        # Make the CTest test fail
+        sys.exit(42)
+    # The test doesn't exit without this.
+    sys.exit(0)

--- a/test/coreneuron/test_spikes.py
+++ b/test/coreneuron/test_spikes.py
@@ -94,13 +94,15 @@ def test_spikes(
     assert nrn_spike_t == corenrn_all_spike_t
     assert nrn_spike_gids == corenrn_all_spike_gids
 
+    return h
+
 
 if __name__ == "__main__":
     try:
-        test_spikes()
+        h = test_spikes()
     except:
         traceback.print_exc()
         # Make the CTest test fail
         sys.exit(42)
     # The test doesn't exit without this.
-    sys.exit(0)
+    h.quit()

--- a/test/coreneuron/test_units.py
+++ b/test/coreneuron/test_units.py
@@ -1,4 +1,8 @@
 import os
+import traceback
+
+enable_gpu = bool(os.environ.get("CORENRN_ENABLE_GPU", ""))
+
 from neuron import h
 
 pc = h.ParallelContext()
@@ -18,7 +22,7 @@ def test_units():
 
     h.CVode().cache_efficient(1)
     coreneuron.enable = True
-    coreneuron.gpu = bool(os.environ.get("CORENRN_ENABLE_GPU", ""))
+    coreneuron.gpu = enable_gpu
     pc.set_maxstep(10)
     h.finitialize(-65)
     pc.psolve(h.dt)
@@ -28,8 +32,15 @@ def test_units():
         1e-13 if coreneuron.gpu else 0
     )  # GPU has tiny numerical differences
     assert ghk_std == pp.ghk
-    h.quit()
 
 
 if __name__ == "__main__":
-    test_units()
+    try:
+        model = test_units()
+    except:
+        traceback.print_exc()
+        # Make the CTest test fail
+        sys.exit(42)
+    # The test doesn't exit without this.
+    if enable_gpu:
+        h.quit()


### PR DESCRIPTION
This makes the `test/coreneuron/test_*.py` scripts consistent with one another, and ensures that Python exceptions trigger CTest failures.

For example in [a recent CI job](https://bbpgitlab.epfl.ch/hpc/coreneuron/-/jobs/32931/raw) an assertion failed but the test "passed". 
```
9: Traceback (most recent call last):
9:   File "test/coreneuron/test_direct.py", line 56, in <module>
9:     test_direct_memory_transfer()
9:   File "test/coreneuron/test_direct.py", line 51, in test_direct_memory_transfer
9:     assert i_mem.cl().sub(i_memstd).abs().max() < 1e-10
9: AssertionError
9: >>>
26/54 Test  #9: coreneuron_modtests::direct_py ..............................   Passed    9.55 sec
```

Some logic to deal with this was already there in one test, but this extends to all tests in the folder. This probably only affects GPU builds, where these tests [are launched using `special`](https://github.com/neuronsimulator/nrn/blob/ed85117b29f3068721c1ae5aa872edb2e8712977/test/CMakeLists.txt#L178-L206), but I didn't confirm that. I did check that adding `assert False` to the tests triggers failures in a GPU build.