### PR TITLE
removed Python 2 workaround for neuron.units

### DIFF
--- a/share/lib/python/neuron/units.py
+++ b/share/lib/python/neuron/units.py
@@ -5,15 +5,15 @@
 mM = 1
 ms = 1
 mV = 1
-um = 1
+µm = um = 1
 
 # concentration
-uM = 1e-3 * mM
+µM = uM = 1e-3 * mM
 nM = 1e-6 * mM
 M = 1e3 * mM
 
 # time
-us = 1e-3 * ms
+µs = us = 1e-3 * ms
 s = sec = 1e3 * ms
 minute = 60 * sec
 hour = 60 * minute
@@ -26,12 +26,5 @@ cm = 10 * mm
 m = 100 * cm
 
 # voltage
-uV = 1e-3 * mV
+μV = uV = 1e-3 * mV
 V = 1e3 * mV
-
-# variants using mu instead of u (available in Python3 only)
-# have to do it this way to avoid a SyntaxError in Python2
-globals()["μV"] = 1e-3 * mV
-globals()["μM"] = 1e-3 * mM
-globals()["μs"] = 1e-3 * ms
-globals()["μm"] = 1 * um


### PR DESCRIPTION
Python 2.x did not allow non-ASCII characters in variable names, so even defining µm was a SyntaxError; now that we know users won't be running Python 2.x, we can directly define µm, µM, etc... This change helps with static code analysis and autocomplete.

NEURON support for Python 2.x was dropped in 069fb66bad59d6e55b29188df16fb285b5ba1b99 (#1276)