### PR TITLE
WindowsInstaller - SKIP_ASSOCIATION_TEST feature

### DIFF
--- a/ci/azure-win-installer-upload.yml
+++ b/ci/azure-win-installer-upload.yml
@@ -17,6 +17,8 @@ steps:
   - task: BatchScript@1
     inputs:
       filename: ci/win_test_installer.cmd
+    env:  
+      SKIP_ASSOCIATION_TEST: true # This test sometimes fails, moreover on Azure. It's run in GHA WindowsInstaller CI
     displayName: "Test Installer"
     condition: succeeded()
 

--- a/ci/win_test_installer.cmd
+++ b/ci/win_test_installer.cmd
@@ -41,10 +41,15 @@ mpiexec -n 2 nrniv %cd%\src\parallel\test0.hoc -mpi || set "errorfound=y"
 mpiexec -n 2 python %cd%\src\parallel\test0.py -mpi --expected-hosts 2 || set "errorfound=y"
 
 :: test of association with hoc files
-start %cd%\ci\association.hoc
-ping -n 15 127.0.0.1
-cat temp.txt
-findstr /i "^hello$" temp.txt || set "errorfound=y"
+:: disable if SKIP_ASSOCIATION_TEST is set
+IF "%SKIP_ASSOCIATION_TEST%"=="" (
+  start %cd%\ci\association.hoc
+  ping -n 20 127.0.0.1
+  cat temp.txt
+  findstr /i "^hello$" temp.txt || set "errorfound=y"
+) else (
+  echo "SKIP_ASSOCIATION_TEST is set, skipping HOC association test"
+)
 
 :: setup for mknrndll/nrnivmodl
 set N=C:\nrn_test


### PR DESCRIPTION
* disable HOC association test on Azure (more prone for test failure)
* increase wait window 15s -> 20s