### PR TITLE
Coverage for macosx clang needs an extra link flag.

### DIFF
--- a/cmake/Coverage.cmake
+++ b/cmake/Coverage.cmake
@@ -37,6 +37,7 @@ if(NRN_ENABLE_COVERAGE)
   if (NRN_MACOS_BUILD)
     unset(NRN_COVERAGE_LIB)
     set(CMAKE_CXX_FLAGS "-fprofile-arcs")
+    set(CMAKE_C_FLAGS "-fprofile-arcs")
   endif()
 
   if (NRN_COVERAGE_FILES)

--- a/cmake/Coverage.cmake
+++ b/cmake/Coverage.cmake
@@ -36,8 +36,7 @@ if(NRN_ENABLE_COVERAGE)
 
   if (NRN_MACOS_BUILD)
     unset(NRN_COVERAGE_LIB)
-    set(CMAKE_CXX_FLAGS "-fprofile-arcs")
-    set(CMAKE_C_FLAGS "-fprofile-arcs")
+    add_link_options(-fprofile-arcs)
   endif()
 
   if (NRN_COVERAGE_FILES)

--- a/cmake/Coverage.cmake
+++ b/cmake/Coverage.cmake
@@ -33,6 +33,12 @@ if(NRN_ENABLE_COVERAGE)
   set(NRN_COVERAGE_FLAGS_UNQUOTED --coverage -O0 -fno-inline -g)
   set(NRN_COVERAGE_FLAGS "--coverage -O0 -fno-inline -g")
   set(NRN_COVERAGE_LIB gcov)
+
+  if (NRN_MACOS_BUILD)
+    unset(NRN_COVERAGE_LIB)
+    set(CMAKE_CXX_FLAGS "-fprofile-arcs")
+  endif()
+
   if (NRN_COVERAGE_FILES)
     # ~~~
     # cannot figure out how to set specific file flags here. So they are


### PR DESCRIPTION
Not happy with the explicit setting of CMAKE_CXX_FLAGS but was unsuccessful with add_compile_options.
Edit: Just needed add_link_options ...

Tested on arm64 with
```
cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=install -DPYTHON_EXECUTABLE=`which python3` -DCMAKE_OSX_ARCHITECTURES='arm64' -DNRN_ENABLE_MPI_DYNAMIC=ON -DNRN_ENABLE_PYTHON_DYNAMIC=ON -DIV_ENABLE_X11_DYNAMIC=ON -DNRN_ENABLE_TESTS=ON -DNRN_ENABLE_RX3D=OFF -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_COVERAGE=ON -DNRN_COVERAGE_FILES="src/nrniv/partrans.cpp"
```