### PR TITLE
Update coreneuron+nmodl with GPU support for derivimplicit method

### DIFF
--- a/test/external/testcorenrn/CMakeLists.txt
+++ b/test/external/testcorenrn/CMakeLists.txt
@@ -3,11 +3,12 @@ include(NeuronTestHelper)
 set(direct_tests netstimdirect)
 set(spike_comparison_tests
     bbcore
+    deriv
     patstim
     vecplay
     vecevent)
 
-set(modfiles mod/Gfluct3.mod mod/hhwatch.mod mod/nacum.mod mod/vecevent.mod)
+set(modfiles mod/Gfluct3.mod mod/hhderiv.mod mod/hhwatch.mod mod/nacum.mod mod/vecevent.mod)
 if(NOT CORENRN_ENABLE_NMODL OR NOT CORENRN_ENABLE_GPU)
   # These .mod files cannot be compiled with NMODL + OpenACC/GPU because of
   # https://github.com/BlueBrain/nmodl/issues/311

--- a/test/external/testcorenrn/CMakeLists.txt
+++ b/test/external/testcorenrn/CMakeLists.txt
@@ -11,9 +11,9 @@ set(modfiles mod/Gfluct3.mod mod/hhwatch.mod mod/nacum.mod mod/vecevent.mod)
 if(NOT CORENRN_ENABLE_NMODL OR NOT CORENRN_ENABLE_GPU)
   # These .mod files cannot be compiled with NMODL + OpenACC/GPU because of
   # https://github.com/BlueBrain/nmodl/issues/311
-  list(APPEND modfiles mod/hhderiv.mod mod/hhkin.mod)
+  list(APPEND modfiles mod/hhkin.mod)
   # These tests depend on the modfiles on the line above.
-  list(APPEND spike_comparison_tests conc deriv kin)
+  list(APPEND spike_comparison_tests conc kin)
 
   list(APPEND spike_comparison_tests gf watch)
 endif()


### PR DESCRIPTION
* Update coreneuron + nmodl: see BlueBrain/nmodl/pull/709
* Enable derivimplicit test on the GPU

## Todos
- [x] Merge CoreNEURON PR BlueBrain/CoreNeuron/pull/596
- [x] Make sure the hhderiv test is correctly enabled and passing on GPU