### PR TITLE
test_wheels: consistent `python` <-> `$python_exe`

### DIFF
--- a/packaging/python/test_wheels.sh
+++ b/packaging/python/test_wheels.sh
@@ -78,7 +78,7 @@ run_serial_test () {
       ./x86_64/special -python -c "import neuron; neuron.test(); neuron.test_rxd(); quit()"
       nrniv -python -c "import neuron; neuron.test(); neuron.test_rxd(); quit()"
     else
-      python -c "import neuron; neuron.test(); neuron.test_rxd(); quit()"
+      $python_exe -c "import neuron; neuron.test(); neuron.test_rxd(); quit()"
     fi
 
     # Test 8: run demo


### PR DESCRIPTION
* fix inconsistency that may lead to python version clash for non-venv testing