### PR TITLE
OpenMPI<v3 CMake warning & test workaround.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,14 +271,33 @@ if(NRN_ENABLE_MPI)
   add_definitions("-DOMPI_SKIP_MPICXX=1")
   add_definitions("-DMPICH_SKIP_MPICXX=1")
 
-  # Launching mpi executable with full path can mangle different python versions and libraries
-  # (see issue #894). ${MPIEXEC_NAME} would reinsert the full path, but ${CMAKE_COMMAND} -E env
-  # ${MPIEXEC_NAME} does not.
-  # Also, FindMPI broke backward compatibility with v3.19
+  # FindMPI broke backward compatibility with v3.19
   if(${CMAKE_VERSION} VERSION_LESS "3.10")
-    get_filename_component(MPIEXEC_NAME ${MPIEXEC} NAME)
+    set(NRN_MPIEXEC_EXECUTABLE ${MPIEXEC})
   else()
-    get_filename_component(MPIEXEC_NAME ${MPIEXEC_EXECUTABLE} NAME)
+    set(NRN_MPIEXEC_EXECUTABLE ${MPIEXEC_EXECUTABLE})
+  endif()
+
+  # Launching mpi executable with full path can mangle different python versions and libraries (see
+  # issue #894). ${MPIEXEC_NAME} would reinsert the full path, but ${CMAKE_COMMAND} -E env
+  # ${MPIEXEC_NAME} does not.
+  get_filename_component(MPIEXEC_NAME ${NRN_MPIEXEC_EXECUTABLE} NAME)
+
+  # Detect if we have an OpenMPI v2 or older.
+  execute_process(
+    COMMAND "${NRN_MPIEXEC_EXECUTABLE}" --version
+    RESULT_VARIABLE OPENMPI_TEST_RESULT
+    OUTPUT_VARIABLE OPENMPI_TEST_OUTPUT)
+  set(NRN_HAVE_OPENMPI2_OR_LESS OFF)
+  if(${OPENMPI_TEST_RESULT} EQUAL 0 AND "${OPENMPI_TEST_OUTPUT}" MATCHES
+                                        "^mpiexec \\(OpenRTE\\) ([0-9\.]+)")
+    set(NRN_OPENMPI_VERSION "${CMAKE_MATCH_1}")
+    message(STATUS "Detected OpenMPI ${NRN_OPENMPI_VERSION}")
+    if("${NRN_OPENMPI_VERSION}" VERSION_LESS 3)
+      set(NRN_HAVE_OPENMPI2_OR_LESS ON)
+      message(STATUS "OpenMPI<v3: `mpirun python` may not work, try `mpirun special -python`.")
+      message(STATUS "See also: https://www.neuron.yale.edu/phpBB/viewtopic.php?t=4297")
+    endif()
   endif()
 else()
   set(NRNMPI 0)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ set(TEST_SOURCES unit_tests/oc/hoc_interpreter.cpp)
 add_executable(testneuron unit_tests/unit_test.cpp ${TEST_SOURCES})
 target_compile_features(testneuron PUBLIC cxx_std_11)
 target_link_libraries(testneuron Catch2::Catch2 nrniv_lib)
-if (${USE_PTHREAD} EQUAL 1)
+if(${USE_PTHREAD} EQUAL 1)
   target_link_libraries(testneuron Threads::Threads)
 endif()
 if(NOT MINGW)
@@ -120,7 +120,8 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
   nrn_add_test(
     GROUP pynrn_tests
     NAME basic_tests
-    COMMAND COVERAGE_FILE=.coverage.basic_tests ${PYTHON_EXECUTABLE} -m pytest ${PYTEST_COVERAGE_ARGS} ./test/pynrn
+    COMMAND COVERAGE_FILE=.coverage.basic_tests ${PYTHON_EXECUTABLE} -m pytest
+            ${PYTEST_COVERAGE_ARGS} ./test/pynrn
     MODFILE_PATTERNS test/pynrn/*.mod
     SCRIPT_PATTERNS test/pynrn/*.py)
 
@@ -187,6 +188,7 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
     set(modtests_launch_hoc CORENRN_ENABLE_GPU=true special -mpi)
     set(modtests_launch_py ${modtests_launch_hoc} -python -pyexe ${PYTHON_EXECUTABLE})
     set(modtests_launch_py_mpi
+        CORENRN_ENABLE_GPU=true
         ${MPIEXEC_NAME}
         ${MPIEXEC_NUMPROC_FLAG}
         2
@@ -273,15 +275,34 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
         PROCESSORS 2
         COMMAND NRN_TEST_SPIKES_MPI4PY=1 ${modtests_launch_py_mpi} test/coreneuron/test_spikes.py)
     endif()
+    # See https://www.neuron.yale.edu/phpBB/viewtopic.php?t=4297 and links therein for more
+    # discussion. Launching this test via `python` (not `special`) does not work on Linux with
+    # OpenMPI 2.x and without dynamic MPI enabled in NEURON, which corresponds to the GitHub Actions
+    # environment. GPU builds are already launched using `special`.
+    if(NOT NRN_ENABLE_MPI_DYNAMIC
+       AND NOT CORENEURON_ENABLE_GPU
+       AND NRN_HAVE_OPENMPI2_OR_LESS)
+      set(launch_spikes_mpi_file_mode_py
+          ${MPIEXEC_NAME}
+          ${MPIEXEC_NUMPROC_FLAG}
+          2
+          ${MPIEXEC_PREFLAGS}
+          special
+          ${MPIEXEC_POSTFLAGS}
+          -python
+          -pyexe
+          ${PYTHON_EXECUTABLE})
+      message(STATUS "Hitting workaround")
+    else()
+      set(launch_spikes_mpi_file_mode_py ${modtests_launch_py_mpi})
+    endif()
     nrn_add_test(
       GROUP coreneuron_modtests
       NAME spikes_mpi_file_mode_py
       REQUIRES coreneuron
       PROCESSORS 2
-      COMMAND
-        NRN_TEST_SPIKES_NRNMPI_INIT=1 NRN_TEST_SPIKES_FILE_MODE=1 ${MPIEXEC_NAME}
-        ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} special ${MPIEXEC_POSTFLAGS} -python -pyexe
-        ${PYTHON_EXECUTABLE} test/coreneuron/test_spikes.py)
+      COMMAND NRN_TEST_SPIKES_NRNMPI_INIT=1 NRN_TEST_SPIKES_FILE_MODE=1
+              ${launch_spikes_mpi_file_mode_py} test/coreneuron/test_spikes.py)
   endif()
 endif()
 


### PR DESCRIPTION
It seems there is a "known" issue with using older versions of OpenMPI and launching using `python`: https://www.neuron.yale.edu/phpBB/viewtopic.php?t=4297

We ran into this in the GitHub CI when I changed an MPI-enabled test that used to be launched via `special` to be launched via `python`, for consistency with some other non-MPI tests: https://github.com/neuronsimulator/nrn/pull/1192#issuecomment-885879507

This PR detects if we are in a "dangerous" configuration and, if so, prints a warning and activates a workaround for the test. It also enables GPU execution of the same (`coreneuron_modtests::spikes_mpi_file_mode_py`) test in GPU-enabled builds.

While in a sense this PR just creates a problem and then fixes it, I think the end result is something a bit more robust that will lead to less head-scratching.