### PR TITLE
Tweak code to avoid NVHPC 21.7 ICE

### DIFF
--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -238,6 +238,14 @@ set_source_files_properties(${NRN_NRNOC_SRC_DIR}/nrnversion.cpp PROPERTIES OBJEC
 set_source_files_properties(${NRN_OC_SRC_DIR}/hocusr.cpp PROPERTIES OBJECT_DEPENDS
                             ${PROJECT_BINARY_DIR}/src/oc/hocusr.h)
 
+# NVHPC/21.7 cannot compile znorm.c with -O2 or above. See also:
+# https://forums.developer.nvidia.com/t/nvc-21-7-regression-internal-compiler-error-can-only-coerce-indirect-args/184847
+if(("${CMAKE_C_COMPILER_ID}" STREQUAL "PGI" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "NVHPC")
+   AND "${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER_EQUAL 21.7)
+  set_source_files_properties(${PROJECT_SOURCE_DIR}/src/mesch/znorm.c PROPERTIES COMPILE_OPTIONS
+                                                                                 -Mnovect)
+endif()
+
 if(NRN_ENABLE_MPI_DYNAMIC)
   set_source_files_properties(${PROJECT_SOURCE_DIR}/src/nrnmpi/nrnmpi_dynam.cpp PROPERTIES
                               OBJECT_DEPENDS ${NRNMPI_DYNAMIC_INCLUDE_FILE})


### PR DESCRIPTION
Without this change then NEURON fails to compile with the latest NVIDIA HPC compiler release, 21.7. There is an internal compiler error in `znorm.c`, see https://forums.developer.nvidia.com/t/nvc-21-7-regression-internal-compiler-error-can-only-coerce-indirect-args/184847 for more information.

This change disables vectorisation optimisations for that file to sidestep the error, as suggested on the NVIDIA forums.