### PR TITLE
CondaEnvironment: get rid of `file:` URI syntax

### DIFF
--- a/docs/conda_environment.yml
+++ b/docs/conda_environment.yml
@@ -11,4 +11,4 @@ dependencies:
   - cython
   - pip
   - pip:
-      - -r file:docs_requirements.txt
+      - -r docs_requirements.txt


### PR DESCRIPTION
* newer pip is stricter with the `file:` URI syntax