### PR TITLE
WinCI: new strategy for hoc file association test 

### DIFF
--- a/ci/association.hoc
+++ b/ci/association.hoc
@@ -1,9 +1,10 @@
 objref f
 f = new File()
-f.ropen("temp.txt")
+f.ropen("association.hoc.out")
 f.close()
 f.unlink()
-f.wopen("temp.txt")
+f.wopen("association.hoc.out")
 f.printf("%s\n","hello")
+f.flush()
 f.close()
 quit()

--- a/ci/azure-win-installer-upload.yml
+++ b/ci/azure-win-installer-upload.yml
@@ -17,8 +17,6 @@ steps:
   - task: BatchScript@1
     inputs:
       filename: ci/win_test_installer.cmd
-    env:  
-      SKIP_ASSOCIATION_TEST: true # This test sometimes fails, moreover on Azure. It's run in GHA WindowsInstaller CI
     displayName: "Test Installer"
     condition: succeeded()
 


### PR DESCRIPTION
* yet another attempt: run the the test in two steps
* 1st step -> launch association.hoc and rely on runner entropy to test the output after all other tests at the end.
* 2nd step -> check association.hoc output after we've run all other tests.