### PR TITLE
wheel versioning: use only annotated tags

### DIFF
--- a/git2nrnversion_h.sh
+++ b/git2nrnversion_h.sh
@@ -9,7 +9,9 @@ cd $a
 
 # Do the fast directory check before the slow git command
 if [ -d .git ] || git rev-parse --git-dir > /dev/null 2>&1; then
-        describe="`git describe --tags`"
+        # Official Versioning shall rely on annotated tags (don't use `--tags` or `--all`)
+        # (please refer to NEURON SCM documentation)
+        describe="`git describe`"
         branch="`git rev-parse --abbrev-ref HEAD`" # branch name
         modified="`git status -s -uno --porcelain | sed -n '1s/.*/+/p'`" # + if modified
         gcs=`git -c log.showSignature=false log --format="%h" -n 1` #short commit hash

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,11 @@ if os.name != "posix":
 # Main source of the version. Dont rename, used by Cmake
 try:
     # github actions somehow fails with check_output and python3
+
+    # Official Versioning shall rely on annotated tags (don't use `--tags` or `--all`)
+    # (please refer to NEURON SCM documentation)
     v = (
-        subprocess.run(["git", "describe", "--tags"], stdout=subprocess.PIPE)
+        subprocess.run(["git", "describe"], stdout=subprocess.PIPE)
         .stdout.strip()
         .decode()
     )


### PR DESCRIPTION
By using lightweight tags (n.r. `git describe --tags`) the versioning can come off wrong via latest tag.  Following our SCM release guideline, we shall use only annotated tags for versioning.

For example, by adding lightweight `ni_pci_6229` tag in #1402: 
```bash
+ auditwheel repair dist/NEURON_nightly-ni_pci_6229.44-cp36-cp36m-linux_x86_64.whl
INFO:auditwheel.main_repair:Repairing NEURON_nightly-ni_pci_6229.44-cp36-cp36m-linux_x86_64.whl
Traceback (most recent call last):
  File "/root/nrn/nrn_build_venv36_-6855681/bin/auditwheel", line 8, in <module>
    sys.exit(main())
  File "/root/nrn/nrn_build_venv36_-6855681/lib/python3.6/site-packages/auditwheel/main.py", line 51, in main
    rval = args.func(args, p)
  File "/root/nrn/nrn_build_venv36_-6855681/lib/python3.6/site-packages/auditwheel/main_repair.py", line 129, in execute
    strip=args.STRIP)
  File "/root/nrn/nrn_build_venv36_-6855681/lib/python3.6/site-packages/auditwheel/repair.py", line 53, in repair_wheel
    wheel_fname)
ValueError: ('Failed to parse wheel file name: %s', 'NEURON_nightly-ni_pci_6229.44-cp36-cp36m-linux_x86_64.whl')
```