### PR TITLE
removed features: drop tagging & add short SHA

### DIFF
--- a/docs/removed_features.rst
+++ b/docs/removed_features.rst
@@ -4,23 +4,27 @@ Removed Features
 This page aims at providing a short knowledge base designed to track dropped and potentially useful features for future development.
 To that end, the following table's columns constitute:
 
-* the name of the feature; it will also be used to tag last commit holding the feature.
+* the name of the feature; also stands as a keyword.
 * a short description; the main purpose is to have the feature as greppable as possible.
 * removal PR number(s) related to their removal from the codebase.
+* Short SHA pointing to the last master commit holding the feature for easy checkout.
 
 .. list-table:: Removed Features
-   :widths: 25 60 15
+   :widths: 20 60 13 7
    :header-rows: 1
    :class: fixed-table
 
    * - Name / Tag
      - Short description
      - Removal PR(s)
+     - SHA
    * - ni_pci_6229
      - This related to a circa 2007 project implementing hard real time dynamic clamp under RTAI linux.
        The development was done in conjunction with National Instruments' NI PCI-6229 DAQ card.
      - `#1399 <https://github.com/neuronsimulator/nrn/pull/1399>`_
+     - c46dbc7
    * - bluegene
      - Code related to BlueGene L, P and Q; support for BlueGene Checkpoint API (keywords: BGLCheckpoint, BGLCheckpointInit).
      - `#1286 <https://github.com/neuronsimulator/nrn/pull/1286>`_
+     - 74d3db9
 

--- a/docs/removed_features.rst
+++ b/docs/removed_features.rst
@@ -14,7 +14,7 @@ To that end, the following table's columns constitute:
    :header-rows: 1
    :class: fixed-table
 
-   * - Name / Tag
+   * - Name / Keyword
      - Short description
      - Removal PR(s)
      - SHA


### PR DESCRIPTION
* lightweight tags can interfere with tools like spack or other scripts relying on tags
* also can be misleading on GH since they are linked to releases