### PR TITLE
Fix MacOS wheel issue: do not link to ncurses/termcap while building wheel 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,8 +189,12 @@ if(READLINE_FOUND)
     # define for src/oc/hoc.cpp
     set(DEF_RL_GETC_FUNCTION use_rl_getc_function)
   endif()
-  find_package(Curses QUIET)
-  find_package(Termcap QUIET)
+  # If we are not using self contained, static readline library
+  # created for building wheel then only look for curses and termcap
+  if(NOT NRN_WHEEL_STATIC_READLINE)
+    find_package(Curses QUIET)
+    find_package(Termcap QUIET)
+  endif()
 endif()
 
 # Reset original CMake library suffixes

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,18 +97,12 @@ jobs:
       cmake --version
     displayName: 'Install OSX System Dependencies'
 
-  # readline & ncurses have been manually built with MACOSX_DEPLOYMENT_TARGET=10.9 and stored as secure files on Azure.
+  # readline has been manually built with MACOSX_DEPLOYMENT_TARGET=10.9 and stored as secure files on Azure.
   # See `packaging/python/Dockerfile` for build instructions.
   #
   # Secure files documentation:
   #   https://docs.microsoft.com/en-us/azure/devops/pipelines/library/secure-files?view=azure-devops
   #   NOTE: when uploading new secure files, access must be permitted from pipeline interface (see message there)
-  - task: DownloadSecureFile@1
-    name: ncursesSF
-    displayName: 'Download ncurses secure file'
-    inputs:
-      secureFile: 'ncurses6.2.tar.gz'
-
   - task: DownloadSecureFile@1
     name: readlineSF
     displayName: 'Download readline secure file'
@@ -121,7 +115,6 @@ jobs:
       export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
       export NRN_BUILD_FOR_UPLOAD=1
       sudo mkdir /opt/nrnwheel
-      sudo tar -zxf $(ncursesSF.secureFilePath) --directory /opt/nrnwheel/
       sudo tar -zxf $(readlineSF.secureFilePath) --directory /opt/nrnwheel/
       packaging/python/build_wheels.bash osx $(python.version)
     displayName: 'Build MacOS Wheel'


### PR DESCRIPTION
* readline library built for building wheel should be self contained
* search for ncurses/termcap only when NRN_WHEEL_STATIC_READLINE is not set
* remove ncurses libraries from Azure; only readline is required

fixes #1413 