### PR TITLE
fix Mismatched free() / delete / delete []

### DIFF
--- a/src/ivoc/ivocvect.cpp
+++ b/src/ivoc/ivocvect.cpp
@@ -3161,7 +3161,7 @@ static Object** v_medfltr(void* v)
   for (i=0;i <n; i++) {
     ans->elem(i) = res[i];
   }
-  delete [] res;
+  free(res);
   if (flag) {
   	delete v1;
   }


### PR DESCRIPTION
Strangely, shows up with
```
valgrind `pyenv which python` -m pytest test_vector_api.py
```
but not with
```
valgrind `pyenv which python` test_vector_api.py
```

Well, not so strange. Nothing is executed for the latter.