### PR TITLE
Add error on int overflow [CellGroup::mk_cellgroups]

### DIFF
--- a/src/nrniv/nrncore_write/data/cell_group.cpp
+++ b/src/nrniv/nrncore_write/data/cell_group.cpp
@@ -121,8 +121,12 @@ CellGroup* CellGroup::mk_cellgroups(CellGroup* cgs) {
                     if (agid < std::numeric_limits<int>::min() ||
                         agid > std::numeric_limits<int>::max()) {
                         std::ostringstream oss;
-                        oss << "cannot store cgs[" << i << "].output_vindex[" << npre
-                            << "]=" << agid;
+                        oss << "maximum of ~" << std::numeric_limits<int>::max() / 1000
+                            << " artificial cells of a given type can be created per NrnThread, "
+                               "this model has "
+                            << ml->nodecount << " instances of " << memb_func[type].sym->name
+                            << " (cannot store cgs[" << i << "].output_vindex[" << npre
+                            << "]=" << agid << ')';
                         hoc_execerror("integer overflow", oss.str().c_str());
                     }
                     cgs[i].output_vindex[npre] = agid;

--- a/src/nrniv/nrncore_write/data/cell_group.cpp
+++ b/src/nrniv/nrncore_write/data/cell_group.cpp
@@ -5,6 +5,8 @@
 #include "nrnmpi.h"
 #include "netcon.h"
 
+#include <limits>
+#include <sstream>
 
 extern short* nrn_is_artificial_;
 extern bool corenrn_direct;
@@ -86,15 +88,19 @@ CellGroup* CellGroup::mk_cellgroups(CellGroup* cgs) {
                     Point_process *pnt = (Point_process *) ml->pdata[j][1]._pvoid;
                     PreSyn *ps = (PreSyn *) pnt->presyn_;
                     cgs[i].output_ps[npre] = ps;
-                    int agid = -1;
+                    long agid = -1;
                     if (nrn_is_artificial_[type]) {
-                        agid = -(type + 1000 * nrncore_art2index(pnt->prop->param));
+                        // static_cast<long> ensures the RHS is calculated with
+                        // `long` precision, not `int` precision. This lets us
+                        // check for overflow below.
+                        agid = -(type +
+                                 1000 * static_cast<long>(nrncore_art2index(pnt->prop->param)));
                     } else { // POINT_PROCESS with net_event
                         int sz = nrn_prop_param_size_[type];
                         double *d1 = ml->data[0];
                         double *d2 = pnt->prop->param;
                         assert(d2 >= d1 && d2 < (d1 + (sz * ml->nodecount)));
-                        int ix = (d2 - d1) / sz;
+                        long ix{(d2 - d1) / sz};
                         agid = -(type + 1000 * ix);
                     }
                     if (ps) {
@@ -110,7 +116,15 @@ CellGroup* CellGroup::mk_cellgroups(CellGroup* cgs) {
                     } else { // if an acell is never a source, it will not have a presyn
                         cgs[i].output_gid[npre] = -1;
                     }
-                    // the way we associate an acell PreSyn with the Point_process.
+                    // the way we associate an acell PreSyn with the
+                    // Point_process.
+                    if (agid < std::numeric_limits<int>::min() ||
+                        agid > std::numeric_limits<int>::max()) {
+                        std::ostringstream oss;
+                        oss << "cannot store cgs[" << i << "].output_vindex[" << npre
+                            << "]=" << agid;
+                        hoc_execerror("integer overflow", oss.str().c_str());
+                    }
                     cgs[i].output_vindex[npre] = agid;
                     ++npre;
                 }

--- a/src/nrniv/nrncore_write/data/cell_group.cpp
+++ b/src/nrniv/nrncore_write/data/cell_group.cpp
@@ -118,8 +118,7 @@ CellGroup* CellGroup::mk_cellgroups(CellGroup* cgs) {
                     }
                     // the way we associate an acell PreSyn with the
                     // Point_process.
-                    if (agid < std::numeric_limits<int>::min() ||
-                        agid > std::numeric_limits<int>::max()) {
+                    if (agid < std::numeric_limits<int>::min() || agid >= -1) {
                         std::ostringstream oss;
                         oss << "maximum of ~" << std::numeric_limits<int>::max() / 1000
                             << " artificial cells of a given type can be created per NrnThread, "


### PR DESCRIPTION
With this change we abort instead of quietly triggering an [[implementation-defined]](https://en.cppreference.com/w/cpp/language/implicit_conversion#Integral_conversions) narrowing conversion.

CoreNEURON was crashing during model initialisation in a model with ~1400 cells and ~3000 synapses/cell on one thread. The `output_vindex` values written by NEURON included values near the min/max of a 32-bit signed integer.

With this change, the same model produces an error while NEURON is writing the input files for CoreNEURON:
```
Starting CoreNEURON data generation
.../neuron/x86_64/special: integer overflow cannot store cgs[0].output_vindex[2148892]=-2147484063
 in .../lib/hoclib/init.hoc near line 279
 prun()
       ^
        ParallelContext[0].nrnbbcore_write("coredat")
      prun()
```