### PR TITLE
Print warning message for CoreNEURON unhandled HocEvent.

### DIFF
--- a/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
+++ b/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
@@ -835,7 +835,7 @@ NrnCoreTransferEvents* nrn2core_transfer_tqueue(int tid) {
         HocEvent* he = (HocEvent*)de;
         // Delivery time was often reduced by a quarter step to avoid
         // fixed step roundoff problems.
-        Fprintf(stderr, "WARNING: HocEvent for delivery time at step nearest %g discarded. CoreNEURON cannot presently handle interpreter events (rank %d, thread %d).\n", nrnmpi_myid, tdeliver, nrnmpi_myid, tid);
+        Fprintf(stderr, "WARNING: CVode.event(...) for delivery at time step nearest %g discarded. CoreNEURON cannot presently handle interpreter events (rank %d, thread %d).\n", nrnmpi_myid, tdeliver, nrnmpi_myid, tid);
       } break;
       case PlayRecordEventType: { // 6
       } break;

--- a/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
+++ b/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
@@ -829,6 +829,13 @@ NrnCoreTransferEvents* nrn2core_transfer_tqueue(int tid) {
         presyn2intdata[nc].push_back(iloc);
       } break;
       case HocEventType: { // 5
+        // Not supported in CoreNEURON, discard and print a warning.
+        core_te->td.pop_back();
+        core_te->type.pop_back();
+        HocEvent* he = (HocEvent*)de;
+        // Delivery time was often reduced by a quarter step to avoid
+        // fixed step roundoff problems.
+        Fprintf(stderr, "WARNING: HocEvent for delivery time at step nearest %g discarded. CoreNEURON cannot presently handle interpreter events (rank %d, thread %d).\n", nrnmpi_myid, tdeliver, nrnmpi_myid, tid);
       } break;
       case PlayRecordEventType: { // 6
       } break;

--- a/test/coreneuron/test_direct.py
+++ b/test/coreneuron/test_direct.py
@@ -46,6 +46,7 @@ def test_direct_memory_transfer():
     pc = h.ParallelContext()
 
     def run(mode):
+        pc.set_maxstep(10)
         h.stdinit()
         if mode == 0:
             pc.psolve(h.tstop)
@@ -74,6 +75,16 @@ def test_direct_memory_transfer():
     pc.nrncore_run(cnargs, 1)
     assert tv.eq(tvstd)
 
+    # print warning if HocEvent on event queue when CoreNEURON starts
+    def test_hoc_event():
+       print("in test_hoc_event() at t=%g"%h.t)
+       if h.t < 1.001:
+           h.CVode().event(h.t + 1.0, test_hoc_event)
+    fi = h.FInitializeHandler(2, test_hoc_event)
+    coreneuron.enable = False
+    run(0)
+    coreneuron.enable = True
+    run(0)
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
Closes  #1442
The test prints
```
hines@hines-T7500:~/neuron/hocevent/test/coreneuron$ python test_direct.py
in test_hoc_event() at t=0
in test_hoc_event() at t=1
in test_hoc_event() at t=2
in test_hoc_event() at t=0
WARNING: HocEvent for delivery time at step nearest 0.99375 discarded. CoreNEURON cannot presently handle interpreter events (rank 0, thread 0).
```
I'm looking into expanding the Warning to include the interpreter statement.