### PR TITLE
Update CoreNEURON submodule to latest master and fix broken RTD.io link

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -51,7 +51,7 @@ Existing models should work without any changes.  In order to upgrade NEURON ver
 - Install from source, preferably using CMake build system 
 - For new version, it's always a good idea to start over from scratch with nrnivmodl (deleting existing directory like `x86_64`)
 
-See `Installation` section under [nrn.readthedocs.io/](nrn.readthedocs.io/). In the very rare case that numerical differences exist, check selection of legacy vs modern units.
+See `Installation` section under [nrn.readthedocs.io/en/8.0.0](https://nrn.readthedocs.io/en/8.0.0/). In the very rare case that numerical differences exist, check selection of legacy vs modern units.
 
 ## Contributors
 


### PR DESCRIPTION
* CoreNEURON submodule is update to latest master
  * this version contains large number of fixes esp for
     GPU execution using NMODL and Eigen
  * number of models like BBP, Olfactory 3D bulb,
    reduced_dentate etc can be now run on GPU
    using mod2c or nmodl (sympy or eigen) 
  * this version/commit should provide a version
     ready for benchmarking for frontiers paper
* Update broken URL to changelog on readthedocs.org