### PR TITLE
Allow python section.disconnect().

### DIFF
--- a/docs/python/modelspec/programmatic/topology.rst
+++ b/docs/python/modelspec/programmatic/topology.rst
@@ -143,6 +143,37 @@ This document describes the construction and manipulation of a stylized topology
 
 
 
+.. method:: Section.disconnect
+
+
+    Syntax:
+        ``section.disconnect()``
+
+    Description:
+        Disconnect the section. The section becomes the root of its subtree.
+
+    Example:
+
+        .. code::
+
+            from neuron import h
+            sl = [h.Section(name="s_%d" % i) for i in range(4)]
+            for i, sec in enumerate(sl[1:]):
+                sec.connect(sl[i](1))
+
+            h.topology()
+            sl[2].disconnect()
+            h.topology()
+            sl[2].connect(sl[0](.5), 1)
+            h.topology()
+            sl[2].disconnect()
+            h.topology()
+            sl[2].connect(sl[0](.5))
+            h.topology()
+
+----
+
+
 .. data:: Section.nseg
 
     Syntax:
@@ -475,7 +506,8 @@ This document describes the construction and manipulation of a stylized topology
 
     Description:
         Disconnect ``section`` from its parent. Such 
-        a parent can be reconnected with the connect method. 
+        a section can be reconnected with the connect method. The alternative
+        :meth:`Section.disconnect` is recommended.
 
     .. warning::
 

--- a/src/nrnoc/cabcode.cpp
+++ b/src/nrnoc/cabcode.cpp
@@ -316,6 +316,9 @@ void delete_section(void) {
 	Item** pitm;
 	Symbol* sym;
 	int i;
+	if (ifarg(1)) {
+		hoc_execerror("delete_section takes no positional arguments and deletes the HOC currently accessed section. If using Python, did you mean a named arg of the form, sec=section?", NULL);
+	}
 	sec = chk_access();
 	if (!sec->prop) { /* already deleted */
 		hoc_retpushx(0.0);
@@ -557,6 +560,9 @@ static void reverse_sibling_list(Section* sec)
 }
 
 void disconnect(void) {
+	if (ifarg(1)) {
+		hoc_execerror("disconnect takes no positional arguments and disconnects the HOC currently accessed section. If using Python, did you mean a named arg of the form, sec=section? Or you can use section.disconnect().", NULL);
+	}
 	nrn_disconnect(chk_access());
 	hoc_retpushx(0.);
 }

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -897,6 +897,13 @@ static PyObject* newpyseghelp(Section* sec, double x) {
   return (PyObject*)seg;
 }
 
+static PyObject* pysec_disconnect(NPySecObj* self) {
+  CHECK_SEC_INVALID(self->sec_);
+  nrn_disconnect(self->sec_);
+  Py_INCREF(Py_None);
+  return Py_None;
+}
+
 static PyObject* pysec_parentseg(NPySecObj* self) {
   CHECK_SEC_INVALID(self->sec_);
   Section* psec = self->sec_->parentsec;
@@ -2276,6 +2283,8 @@ static PyMethodDef NPySecObj_methods[] = {
      "Section"},
     {"hoc_internal_name", (PyCFunction)hoc_internal_name, METH_NOARGS,
      "Hoc accepts this name wherever a section is syntactically valid."},
+    {"disconnect", (PyCFunction)pysec_disconnect, METH_NOARGS,
+     "disconnect from the parent section."},
     {"parentseg", (PyCFunction)pysec_parentseg, METH_NOARGS,
      "Return the nrn.Segment specified by the connect method. Possibly None."},
     {"trueparentseg", (PyCFunction)pysec_trueparentseg, METH_NOARGS,

--- a/test/pynrn/test_basic.py
+++ b/test/pynrn/test_basic.py
@@ -323,8 +323,44 @@ def test_deleted_sec():
     return s, seg, mech, rvlist, vref, gnabarref, dend
 
 
+def test_disconnect():
+    print("test_disconnect")
+    for sec in h.allsec():
+        h.delete_section(sec=sec)
+    h.topology()
+    n = 5
+
+    def setup(n):
+        sections = [h.Section(name="s%d" % i) for i in range(n)]
+        for i, sec in enumerate(sections[1:]):
+            sec.connect(sections[i])
+        return sections
+
+    sl = setup(n)
+
+    def chk(sections, i):
+        print(sections, i)
+        h.topology()
+        x = len(sections[0].wholetree())
+        assert x == i
+
+    chk(sl, n)
+
+    h.disconnect(sec=sl[2])
+    chk(sl, 2)
+
+    sl = setup(n)
+    sl[2].disconnect()
+    chk(sl, 2)
+
+    sl = setup(n)
+    expect_err("h.disconnect(sl[2])")
+    expect_err("h.delete_section(sl[2])")
+
+
 if __name__ == "__main__":
     set_quiet(False)
     test_soma()
     test_simple_sim()
-    result = test_deleted_sec()
+    test_deleted_sec()
+    test_disconnect()


### PR DESCRIPTION
Raise error if arg given to the hoc functions disconnect or
delete_section.

There are many such functions. Should this PR raise errors for those as well?
@ramcdougal , I thought you did a bunch of these but I can't find the changeset.

Closes #1447

A test of this has been added to test_basic.py and  prints:
```
CHECKING: h.disconnect(sl[2])
NEURON: disconnect takes no positional arguments and disconnects the HOC currently accessed section. If using Python, did you mean a named arg of the form sec=section? Or you can use section.disconnect().
...
CHECKING: h.delete_section(sl[2])
NEURON: delete_section takes no positional arguments and deletes the HOC currently accessed section. If using Python, did you mean a named arg of the form, sec=section?
```

I think most of the offending functions could use one or the other of those styles, so they could become function calls that check if an arg exists and raise an error with the name substituted in  the two or three places.