### PR TITLE
Fix leak of strings_to_free vector when there is a HOC error

### DIFF
--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -9,6 +9,7 @@
 #include "nrnpy_utils.h"
 #include "../nrniv/shapeplt.h"
 #include <vector>
+#include <memory>
 #if defined(HAVE_DLFCN_H)
 #include <dlfcn.h>
 #endif
@@ -334,7 +335,7 @@ static Inst* save_pc(Inst* newpc) {
   return savpc;
 }
 
-static int hocobj_pushargs(PyObject* args, std::vector<char*>& s2free) {
+static int hocobj_pushargs(PyObject* args, std::vector<std::unique_ptr<char[]>>& s2free) {
   int i, narg = PyTuple_Size(args);
   for (i = 0; i < narg; ++i) {
     PyObject* po = PyTuple_GetItem(args, i);
@@ -354,11 +355,11 @@ static int hocobj_pushargs(PyObject* args, std::vector<char*>& s2free) {
         // So get the message, clear, and make the message
         // part of the execerror.
         *ts = str.get_pyerr();
-        s2free.push_back(*ts);
+        s2free.push_back(std::unique_ptr<char[]>(*ts));
         hoc_execerr_ext("python string arg cannot decode into c_str. Pyerr message: %s", *ts);
       }
       *ts = str.c_str();
-      s2free.push_back(*ts);
+      s2free.push_back(std::unique_ptr<char[]>(*ts));
       hoc_pushstr(ts);
     } else if (PyObject_TypeCheck(po, hocobject_type)) {
       // The PyObject_TypeCheck above used to be PyObject_IsInstance. The
@@ -402,13 +403,7 @@ static int hocobj_pushargs(PyObject* args, std::vector<char*>& s2free) {
   return narg;
 }
 
-static void hocobj_pushargs_free_strings(std::vector<char*>& s2free) {
-  std::vector<char*>::iterator it = s2free.begin();
-  for (; it != s2free.end(); ++it) {
-    if (*it) {
-      free(*it);
-    }
-  }
+static void hocobj_pushargs_free_strings(std::vector<std::unique_ptr<char[]>>& s2free) {
   s2free.clear();
 }
 
@@ -649,9 +644,7 @@ static void* fcall(void* vself, void* vargs) {
     hoc_push_object(self->ho_);
   }
 
-  //TODO: this will still have some memory leaks in case of errors.
-  //      see discussion in https://github.com/neuronsimulator/nrn/pull/1437
-  std::vector<char*> strings_to_free;
+  std::vector<std::unique_ptr<char[]>> strings_to_free;
 
   int narg = hocobj_pushargs((PyObject*)vargs, strings_to_free);
   int var_type;


### PR DESCRIPTION
- As suggested by @alexsavulescu in #1454 strings_to_free vector was updated to contain unique_pts so they can be deleted once the vector goes out of scope.

@pramodk @nrnhines 