### PR TITLE
Update coding conventions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,8 +532,8 @@ include("${CODING_CONV_CMAKE}/3rdparty.cmake")
 # =============================================================================
 # Add coding-conventions submodule if code formatting enabled
 # =============================================================================
-if(NEURON_CMAKE_FORMAT)
-  set(NEURON_CMakeFormat_EXCLUDES_RE
+if(NRN_CMAKE_FORMAT OR NRN_CLANG_FORMAT)
+  set(NRN_CMakeFormat_EXCLUDES_RE
       ".*/external/\\(backward\\|catch2\\|coding-conventions\\|iv\\|tests\\)/.*$$"
       ".*/external/coreneuron/\\(external/nmodl\\|external/mod2c\\|external/CLI11\\|CMake/hpc-coding-conventions\\)/.*$$"
       CACHE STRING "list of regular expressions to exclude CMake files from formatting" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,10 +533,6 @@ include("${CODING_CONV_CMAKE}/3rdparty.cmake")
 # Add coding-conventions submodule if code formatting enabled
 # =============================================================================
 if(NRN_CMAKE_FORMAT OR NRN_CLANG_FORMAT)
-  set(NRN_CMakeFormat_EXCLUDES_RE
-      ".*/external/\\(backward\\|catch2\\|coding-conventions\\|iv\\|tests\\)/.*$$"
-      ".*/external/coreneuron/\\(external/nmodl\\|external/mod2c\\|external/CLI11\\|CMake/hpc-coding-conventions\\)/.*$$"
-      CACHE STRING "list of regular expressions to exclude CMake files from formatting" FORCE)
   add_subdirectory(external/coding-conventions/cpp)
 endif()
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,19 +96,20 @@ The [Neuron Development Topics](https://neuronsimulator.github.io/nrn/dev/index.
 
 ### Code Formatting
 
-Currently we have enabled CMake code formatting using [cmake-format](https://github.com/cheshirekow/cmake_format). Before submitting PR, if you have changed any CMake build related code, make sure to run cmake-format as below:
+Currently we have enabled CMake and Clang code formatting using [cmake-format](https://github.com/cheshirekow/cmake_format) and [clang-format](https://clang.llvm.org/docs/ClangFormat.html). Before submitting a PR, make sure to run cmake-format as below:
 
-* Make sure to install cmake-format utility with Python version you are using:
+* Make sure to install clang-format and cmake-format with Python version you are using:
 
 ```
 pip3.7 install cmake-format==0.6.0 pyyaml --user
+brew install clang-format # or your favorite package manager
 ```
-Now you should have `cmake-format` command available.
+Now you should have the `clang-format` and `cmake-format` commands available.
 
-* Use `-DNEURON_CMAKE_FORMAT=ON` option of CMake to enable CMake code formatting targets:
+* Use `-DNRN_CMAKE_FORMAT=ON` option of CMake to enable CMake code formatting targets:
 
 ```
-cmake .. -DPYTHON_EXECUTABLE=`which python3.7` -DNEURON_CMAKE_FORMAT=ON
+cmake .. -DPYTHON_EXECUTABLE=`which python3.7` -DNRN_CMAKE_FORMAT=ON
 ```
 
 With this, new target called **cmake-format** can be used to automatically format all CMake files:
@@ -140,6 +141,26 @@ Or,
 ```
 
 See [cmake-format](https://github.com/cheshirekow/cmake_format) documentation for details.
+
+For `clang-format` you should restrict formatting to only the code parts relevant to your change.
+This can be eachieved by setting following build options:
+
+```
+cmake .. -DNRN_CLANG_FORMAT=ON \
+    -DNRN_CMAKE_FORMAT=ON \
+    -DNRN_FORMATTING_ON="since-ref:master" \
+    -DNRN_FORMATTING_CPP_CHANGES_ONLY=ON
+```
+
+Note: Sometimes it might be necessary to point your build-system to the clang-format-diff utility,
+this can be done by supplying an additional flag:
+`-DClangFormatDiff_EXECUTABLE=/path/to/share/clang/clang-format-diff.py`
+
+You can then run the `clang-format` target after a full build:
+
+```
+make && make clang-format
+```
 
 ## Python Contributions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ The [Neuron Development Topics](https://neuronsimulator.github.io/nrn/dev/index.
 
 ### Code Formatting
 
-Currently we have enabled CMake and Clang code formatting using [cmake-format](https://github.com/cheshirekow/cmake_format) and [clang-format](https://clang.llvm.org/docs/ClangFormat.html). Before submitting a PR, make sure to run cmake-format as below:
+Currently we have enabled CMake and Clang code formatting using [cmake-format](https://github.com/cheshirekow/cmake_format) and [clang-format](https://clang.llvm.org/docs/ClangFormat.html). Before submitting a PR, make sure to run cmake-format and clang-format as below:
 
 * Make sure to install clang-format and cmake-format with Python version you are using:
 
@@ -142,8 +142,8 @@ Or,
 
 See [cmake-format](https://github.com/cheshirekow/cmake_format) documentation for details.
 
-For `clang-format` you should restrict formatting to only the code parts relevant to your change.
-This can be eachieved by setting following build options:
+* For `clang-format` you should restrict formatting to only the code parts relevant to your change.
+  This can be eachieved by setting following build options:
 
 ```
 cmake .. -DNRN_CLANG_FORMAT=ON \
@@ -156,7 +156,7 @@ Note: Sometimes it might be necessary to point your build-system to the clang-fo
 this can be done by supplying an additional flag:
 `-DClangFormatDiff_EXECUTABLE=/path/to/share/clang/clang-format-diff.py`
 
-You can then run the `clang-format` target after a full build:
+* You can then run the `clang-format` target after a full build:
 
 ```
 make && make clang-format

--- a/docs/cmake_doc/options.rst
+++ b/docs/cmake_doc/options.rst
@@ -422,9 +422,9 @@ NRN_COVERAGE_FILES:STRING=
 
   ``-DNRN_COVERAGE_FILES="src/nrniv/partrans.cpp;src/nmodl/parsact.cpp;src/nrnpython/nrnpy_hoc.cpp"``
 
-NEURON_CMAKE_FORMAT:BOOL=OFF
+NRN_CMAKE_FORMAT:BOOL=OFF
 ----------------------------
-  Enable CMake code formatting  
+  Enable CMake code formatting
 
   Clones the submodule coding-conventions from https://github.com/BlueBrain/hpc-coding-conventions.git.
   Also need to ``pip install cmake-format=0.6.0 --user``.
@@ -432,23 +432,16 @@ NEURON_CMAKE_FORMAT:BOOL=OFF
   See nrn/CONTRIBUTING.md for further details.
   How does one reformat a specific cmake file?
 
-NEURON_CLANG_FORMAT:BOOL=OFF
+NRN_CLANG_FORMAT:BOOL=OFF
 -------------------------
-  Enable code formatting
+  Enable code formatting  
 
   Clones the submodule coding-conventions from https://github.com/BlueBrain/hpc-coding-conventions.git.
   For mac, need: ``brew install clang-format``
   After a build using ``make``, can reformat all sources with ``make clang_format``
-  Note: this option is not yet available and this paragraph is a
-  placeholder for what is intended. Until it is available, one can
-  prepare for manual use of clang-format by using
-  ``-DNEURON_CMAKE_FORMAT=ON`` to clone into external/coding-conventions
-  and ``cp external/coding-conventions/cpp/clang-format-11 .clang-format``
-  which seems to work also for ``clang-format version 12.0.1``
-
-  To reformat one file, run in the top folder, e.g.
-  
-  ``clang-format --style=file -i src/nrniv/bbsavestate.cpp``
+  Incremental code formatting (of the current patch) can be done by setting additional build flags
+  ``NRN_FORMATTING_ON="since-ref:master"`` and ``NRN_FORMATTING_CPP_CHANGES_ONLY=ON``.
+  ```
 
 Miscellaneous Rarely used options specific to NEURON:
 =====================================================


### PR DESCRIPTION
This allows incremental code formatting per patch:

```
cmake .. -DNRN_CLANG_FORMAT=ON \
    -DNRN_CMAKE_FORMAT=ON \
    -DNRN_FORMATTING_ON="since-ref:master" \
    -DNRN_FORMATTING_CPP_CHANGES_ONLY=ON
```