### PR TITLE
neurondemo shall be executable in the build folder

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -34,27 +34,29 @@ include(CMakeListsNrnMech)
 # nrnmech_makefile (based on coreneuron Configure templates)
 # =============================================================================
 nrn_configure_file(nrngui bin)
-nrn_configure_file(neurondemo bin)
-nrn_configure_dest_src(nrnivmodl bin/tmp nrnivmodl bin)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nrnivmodl_makefile_cmake.in
                ${PROJECT_BINARY_DIR}/bin/nrnmech_makefile @ONLY)
 
 # if running from the build folder (e.g. make test) may need this.
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/nrnpyenv.sh DESTINATION ${PROJECT_BINARY_DIR}/bin)
-# Make sure nrnivmodl is executable in the build folder, so we can execute it to prepare test files.
+# Make sure nrnivmodl and neurondemo are executable in the build folder, so we can execute it to prepare test files.
 # This can be done more elegantly in newer CMake versions; v3.19+ have file(CHMOD ...) and v3.20+
 # support setting permissions directly in configure_file(...).
-file(
-  COPY ${PROJECT_BINARY_DIR}/bin/tmp/nrnivmodl
-  DESTINATION ${PROJECT_BINARY_DIR}/bin
-  FILE_PERMISSIONS
-    OWNER_READ
-    OWNER_WRITE
-    OWNER_EXECUTE
-    GROUP_READ
-    GROUP_EXECUTE
-    WORLD_READ
-    WORLD_EXECUTE)
+set(NRN_CONFIG_EXE_FILES "nrnivmodl" "neurondemo")
+foreach(NRN_CONFIG_EXE_FILE ${NRN_CONFIG_EXE_FILES})
+  nrn_configure_dest_src(${NRN_CONFIG_EXE_FILE} bin/tmp ${NRN_CONFIG_EXE_FILE} bin)
+  file(
+    COPY ${PROJECT_BINARY_DIR}/bin/tmp/${NRN_CONFIG_EXE_FILE}
+    DESTINATION ${PROJECT_BINARY_DIR}/bin
+    FILE_PERMISSIONS
+      OWNER_READ
+      OWNER_WRITE
+      OWNER_EXECUTE
+      GROUP_READ
+      GROUP_EXECUTE
+      WORLD_READ
+      WORLD_EXECUTE)
+endforeach()
 file(REMOVE_RECURSE ${PROJECT_BINARY_DIR}/bin/tmp)
 
 # =============================================================================


### PR DESCRIPTION
`neurondemo` got broken (is not executable anymore) after autotools removal & binary special update: https://github.com/neuronsimulator/nrntest/pull/7/checks?check_run_id=3586999780 vs 8.0.0 https://github.com/neuronsimulator/nrntest/runs/3589170202?check_suite_focus=true