### PR TITLE
Fix nrntest on macOS

### DIFF
--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -21,7 +21,7 @@ FetchContent_Declare(
 FetchContent_Declare(
     nrntest
     GIT_REPOSITORY https://github.com/neuronsimulator/nrntest
-    GIT_TAG 0898b3c
+    GIT_TAG 6857624f4c5db0682311ce6d160d0919c3a923ce
     SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/nrntest
 )
 

--- a/test/external/nrntest/CMakeLists.txt
+++ b/test/external/nrntest/CMakeLists.txt
@@ -1,2 +1,2 @@
 list(APPEND TEST_ENV PATH=${PROJECT_BINARY_DIR}/bin:${PROJECT_SOURCE_DIR}/external/nrntest:$ENV{PATH})
-add_test(external_nrntest ${CMAKE_COMMAND} -E env ${TEST_ENV} $ENV{SHELL} ${PROJECT_SOURCE_DIR}/external/tests/nrntest/runtests)
+add_test(external_nrntest ${CMAKE_COMMAND} -E env ${TEST_ENV} ${PROJECT_SOURCE_DIR}/external/tests/nrntest/runtests)


### PR DESCRIPTION
This fixes the `external_nrntest` CTest test locally on my Mac:
- Do not assume `$SHELL` can be used to run the `runtests` script, which has a `#!/bin/bash` shebang. (`$SHELL` is `zsh` on my machine.)
- Do not assume the `realpath` command is available (https://github.com/neuronsimulator/nrntest/pull/16)

This should also fix the failures in https://github.com/neuronsimulator/nrn-build-ci/actions/runs/1306106657, where `sh` was used instead of `bash`(?).