### PR TITLE
functions for saving and restoring state with rxd

### DIFF
--- a/share/lib/python/neuron/rxd/__init__.py
+++ b/share/lib/python/neuron/rxd/__init__.py
@@ -11,7 +11,7 @@ from .rate import Rate
 from .reaction import Reaction
 from . import geometry
 from .multiCompartmentReaction import MultiCompartmentReaction
-from .rxd import re_init, set_solve_type, nthread
+from .rxd import re_init, set_solve_type, nthread, save_rxd, restore_rxd
 from .rxdmath import v
 
 try:


### PR DESCRIPTION
Added `rxd.save_rxd()` and `rxd.restore_rxd()`.  `rxd.save_rxd()` uses NEURON's `h.SaveState()` and saves concentrations from all "species" as numpy arrays, while `rxd.restore_rxd()` restores a simulation that has been saved using the former method.  Both allow the user to specify a directory to which the simulation state is either saved or from which it is restored, defaulting in both cases to the current directory.