### PR TITLE
live debugging for PRs only

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -115,7 +115,9 @@ jobs:
           PYTHON_MAX_NAME: "python${{ env.PY_MAX_VERSION }}"
 
       # This step will set up an SSH connection on tmate.io for live debugging.
-      # To trigger it, simply add 'live-debug-coverage' to your last pushed commit message.
-      - name: live debug session on failure
-        if: failure() && contains(github.event.head_commit.message, 'live-debug-coverage')
+      # To enable it, you have to:
+      #   * add 'live-debug-coverage' to your PR title
+      #   * push something to your PR branch (note that just re-running the pipeline disregards the title update)
+      - name: live debug session on failure (manual steps required, check `.github/coverage.yml`)
+        if: failure() && contains(github.event.pull_request.title, 'live-debug-coverage')
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -70,9 +70,11 @@ jobs:
           echo ::set-output name=status::done;
 
       # This step will set up an SSH connection on tmate.io for live debugging.
-      # To trigger it, simply add 'live-debug-docs' to your last pushed commit message.
-      - name: live debug session on failure
-        if: failure() && contains(github.event.head_commit.message, 'live-debug-docs')
+      # To enable it, you have to:
+      #   * add 'live-debug-docs' to your PR title
+      #   * push something to your PR branch (note that just re-running the pipeline disregards the title update)
+      - name: live debug session on failure (manual steps required, check `.github/docs.yml`)
+        if: failure() && contains(github.event.pull_request.title, 'live-debug-docs')
         uses: mxschmitt/action-tmate@v3
 
       - name: Deploy 🚀

--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -223,10 +223,9 @@ jobs:
           MATRIX_EVAL: ${{ matrix.config.matrix_eval }}
 
       # This step will set up an SSH connection on tmate.io for live debugging.
-      # To trigger it, simply add 'live-debug-ci' to your last pushed commit message.
-      #
-      # IF SEVERAL JOBS ARE FAILING, USE A FORK OR AT LEAST UPDATE THE MATRIX TO RUN ONLY ONE FAILING JOB AT A TIME,
-      #    SO THAT THE MAIN CI DOESN'T GET SLOWED DOWN OR BLOCKED !
-      - name: live debug session on failure
-        if: failure() && contains(github.event.head_commit.message, 'live-debug-ci')
+      # To enable it, you have to:
+      #   * add 'live-debug-ci' to your PR title
+      #   * push something to your PR branch (note that just re-running the pipeline disregards the title update)
+      - name: live debug session on failure (manual steps required, check `.github/neuron-ci.yml`)
+        if: failure() && contains(github.event.pull_request.title, 'live-debug-ci')
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -57,9 +57,11 @@ jobs:
         BUILD_SOURCESDIRECTORY: ${{runner.workspace}}\nrn
 
     # This step will set up an SSH connection on tmate.io for live debugging.
-    # To trigger it, simply add 'live-debug-win' to your last pushed commit message.
-    - name: live debug session on failure
-      if: failure() && contains(github.event.head_commit.message, 'live-debug-win')
+    # To enable it, you have to:
+    #   * add 'live-debug-win' to your PR title
+    #   * push something to your PR branch (note that just re-running the pipeline disregards the title update)
+    - name: live debug session on failure (manual steps required, check `.github/windows.yml`)
+      if: failure() && contains(github.event.pull_request.title, 'live-debug-win')
       uses: mxschmitt/action-tmate@v3
 
     - name: Upload build artifact


### PR DESCRIPTION
* `github.event` content for `pull_request` not consistent with `push`
  * commit info not available
  * cannot easily trigger debugging in that case
* adapt live debugging for PRs only
  * single entry point for debugging
  * easier to maintain
  * matches regular dev workflow