### PR TITLE
Fix UndefinedBehaviourSanitizer errors.

### DIFF
--- a/src/modlunit/units.cpp
+++ b/src/modlunit/units.cpp
@@ -161,7 +161,7 @@ static int Getc(FILE* inp)
 }
 
 #define UNIT_STK_SIZE	20
-static struct unit unit_stack[UNIT_STK_SIZE], *usp;
+static struct unit unit_stack[UNIT_STK_SIZE], *usp{nullptr};
 
 static char* neuronhome() {
 #if defined(WIN32)
@@ -214,9 +214,13 @@ char *Unit_str(unit* up)
 }
 
 void unit_pop() {
-	IFUNITS
-	assert(usp >= unit_stack);
-	--usp;
+    IFUNITS
+    assert(usp >= unit_stack);
+    if (usp == unit_stack) {
+        usp = nullptr;
+    } else {
+        --usp;
+    }
 }
 
 void unit_swap() { /*exchange top two elements of stack*/
@@ -277,20 +281,23 @@ void ucopypush(unit* up)
 	usp->isnum = up->isnum;
 }
 
-void Unit_push(char* str)
-{
-	IFUNITS
-	assert(usp < unit_stack + (UNIT_STK_SIZE - 1));
-	++usp;
-	pc = str;
-	if (str) {
-		usp->isnum = 0;
-	}else{
-		pc = "";
-		usp->isnum = 1;
-	}
-	convr(usp);
-/*printf("unit_push %s\n", str); units(usp);*/
+void Unit_push(char* str) {
+    IFUNITS
+    assert(usp < unit_stack + (UNIT_STK_SIZE - 1));
+    if (usp) {
+        ++usp;
+    } else {
+        usp = unit_stack;
+    }
+    pc = str;
+    if (str) {
+        usp->isnum = 0;
+    } else {
+        pc = "";
+        usp->isnum = 1;
+    }
+    convr(usp);
+    /*printf("unit_push %s\n", str); units(usp);*/
 }
 
 void unit_push_num(double d)
@@ -565,10 +572,10 @@ fprintf(stderr, "The previous expression needs the conversion factor (%g)\n",
 }
 
 void unit_stk_clean() {
-	IFUNITS
-	usp = unit_stack - 1;
+    IFUNITS
+    usp = nullptr;
 }
-	
+
 // allow the outside world to call either modl_units() or unit_init().
 static void units_alloc() {
   int i;

--- a/src/nrniv/nonlinz.cpp
+++ b/src/nrniv/nonlinz.cpp
@@ -532,20 +532,21 @@ void NonLinImpRep::dsds() {
 	}
 }
 
-void NonLinImpRep::current(int im, Memb_list* ml, int in) { // assume there is in fact a current method
-	Pvmi s = memb_func[im].current;
-	// fake a 1 element memb_list
-	Memb_list mfake;
+void NonLinImpRep::current(int im, Memb_list* ml, int in) {  // assume there is in fact a current
+                                                             // method
+    Pvmi s = memb_func[im].current;
+    // fake a 1 element memb_list
+    Memb_list mfake;
 #if CACHEVEC != 0
-	mfake.nodeindices = ml->nodeindices + in;
+    mfake.nodeindices = ml->nodeindices + in;
 #endif
-	mfake.nodelist = ml->nodelist+in;
-	mfake.data = ml->data + in;
-	mfake.pdata = ml->pdata + in;
-	mfake.prop = ml->prop + in;
-	mfake.nodecount = 1;
-	mfake._thread = ml->_thread;
-	(*s)(nrn_threads, &mfake, im);
+    mfake.nodelist = ml->nodelist + in;
+    mfake.data = ml->data + in;
+    mfake.pdata = ml->pdata + in;
+    mfake.prop = ml->prop ? ml->prop + in : nullptr;
+    mfake.nodecount = 1;
+    mfake._thread = ml->_thread;
+    (*s)(nrn_threads, &mfake, im);
 }
 
 void NonLinImpRep::ode(int im, Memb_list* ml) { // assume there is in fact an ode method


### PR DESCRIPTION
This PR contains fixes for issues uncovered by the UndefinedBehaviour sanitizer: https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html. 

## units.cpp: index -1 out of bounds for type 'struct unit [20]'
A `unit*` pointer `usp`used the -1th element of an array as an invalid value. Fixed by using `nullptr` instead.
```
{path}/nrn/src/nmodl/../modlunit/units.cpp:569:19: runtime error: index -1 out of bounds for type 'struct unit [20]'
    #0 0x10fc3bfcf in unit_stk_clean() units.cpp:569
    #1 0x10fc3c7ed in unit_init() units.cpp:667
    #2 0x10fc3c069 in modl_units() units.cpp:607
    #3 0x10fb8aea8 in yyparse() parse1.ypp:1112
    #4 0x10fbdb9f7 in main modl.cpp:164
    #5 0x7fff20423f3c in start+0x0 (libdyld.dylib:x86_64+0x15f3c)
```

## parallel_partrans test, null pointer arithmetic
```
{path}/nrn/src/nrniv/nonlinz.cpp:545:24: runtime error: applying non-zero offset 8 to null pointer
    #0 0x10178d03d in NonLinImpRep::current(int, Memb_list*, int) nonlinz.cpp:545
    #1 0x10177f71b in NonLinImpRep::didv() nonlinz.cpp:349
    #2 0x10177bc43 in NonLinImp::compute(double, double, int) nonlinz.cpp:148
    #3 0x101681cd3 in Imp::compute(double, bool, int) impedanc.cpp:265
    #4 0x101686917 in compute(void*) impedanc.cpp
    #5 0x101995f66 in hoc_call_ob_proc hoc_oop.cpp:759
    #6 0x10199913d in hoc_object_component() hoc_oop.cpp:1174
    #7 0x101dd135d in component(PyHocObject*) nrnpy_hoc.cpp:464
    #8 0x101dd03df in fcall(void*, void*) nrnpy_hoc.cpp:660
    #9 0x101837a7a in OcJumpImpl::fpycall(void* (*)(void*, void*), void*, void*) ocjump.cpp:222
    #10 0x101dcfe4d in hocobj_call(PyHocObject*, _object*, _object*) nrnpy_hoc.cpp:764
    #11 0x102a2ab13 in _PyObject_MakeTpCall+0x109 (Python:x86_64+0x32b13)
    #12 0x102ad3df2 in call_function+0x1c6 (Python:x86_64+0xdbdf2)
    #13 0x102ad1354 in _PyEval_EvalFrameDefault+0x6416 (Python:x86_64+0xd9354)
    #14 0x102a2b1b8 in function_code_fastcall+0x60 (Python:x86_64+0x331b8)
    #15 0x102ad3dbe in call_function+0x192 (Python:x86_64+0xdbdbe)
    #16 0x102ad13f2 in _PyEval_EvalFrameDefault+0x64b4 (Python:x86_64+0xd93f2)
    #17 0x102ad4897 in _PyEval_EvalCode+0x75e (Python:x86_64+0xdc897)
    #18 0x102acae85 in PyEval_EvalCode+0x38 (Python:x86_64+0xd2e85)
    #19 0x102b05a14 in run_eval_code_obj+0x6d (Python:x86_64+0x10da14)
    #20 0x102b04be8 in run_mod+0x66 (Python:x86_64+0x10cbe8)
    #21 0x102b04d66 in pyrun_file+0xd7 (Python:x86_64+0x10cd66)
    #22 0x102b033dd in PyRun_SimpleFileExFlags+0x2a3 (Python:x86_64+0x10b3dd)
    #23 0x101dcacc2 in nrnpython_start nrnpython.cpp:184
    #24 0x101451d97 in ivocmain_session(int, char const**, char const**, int) ivocmain.cpp:859
    #25 0x101451755 in ivocmain(int, char const**, char const**) ivocmain.cpp:415
    #26 0x10141da8f in main nrnmain.cpp:53
    #27 0x7fff20423f3c in start+0x0 (libdyld.dylib:x86_64+0x15f3c)
```
coming from https://github.com/neuronsimulator/nrn/blob/5873be8a580973b790d187a91b36102cb99a431d/src/nrniv/nonlinz.cpp#L545
fixed with `mfake.prop = ml->prop ? ml->prop + in : nullptr;`

## Others
This is not comprehensive. https://github.com/neuronsimulator/nrn/pull/1479 and https://github.com/neuronsimulator/nrn/issues/1483 both describe additional issues.