### PR TITLE
Refactor neuron.coreneuron for Python 3.10.x

### DIFF
--- a/share/lib/python/neuron/coreneuron.py
+++ b/share/lib/python/neuron/coreneuron.py
@@ -1,92 +1,184 @@
-# Properties settable by user
-enable = False  # Use CoreNEURON when calling ParallelContext.psolve(tstop).
-gpu = False  # Activate GPU computation.
-file_mode = False  # Run via file transfer mode instead of in-memory transfer
-cell_permute = 0  # 0 no permutation; 1 optimize node adjacency
-# 2 optimize parent node adjacency (only for gpu = True)
-warp_balance = 0  # Number of warps to balance. (0 no balance)
-verbose = 2  # 0 quiet, 1 Error, 2 Info, 3 Debug
-prcellstate = -1  # Output prcellstate information for the gid at t=0
-# and at tstop. -1 means no output
+import sys
 
 
-def property_check(tstop):
+class coreneuron(object):
     """
-    Check type and value in range for the user properties.
+    CoreNEURON configuration values.
+
+    An instance of this class stands in as the `neuron.coreneuron` module. Using
+    a class instead of a module allows getter/setter methods to be used, which
+    lets us ensure its properties have consistent types and values.
+
+    Attributes
+    ----------
+    cell_permute
+    enable
+    file_mode
+    gpu
+    prcellstate
+    verbose
+    warp_balance
+
+    Examples
+    --------
+    >>> from neuron import coreneuron
+    >>> coreneuron.enable = True
+    >>> coreneuron.enable
+    True
     """
-    global enable, gpu, cell_permute, warp_balance, verbose, prcellstate
-    tstop = float(tstop)  # error if can't be a float
-    enable = bool(int(enable))
-    gpu = bool(gpu)
-    cell_permute = int(cell_permute)
-    if gpu and cell_permute < 1:
-        cell_permute = 1  # set cell_permute to 1 by default for gpu exec
-    assert cell_permute in range(3)
-    assert cell_permute in ([1, 2] if gpu else [0, 1])
-    warp_balance = int(warp_balance)
-    assert warp_balance >= 0
-    verbose = int(verbose)
-    verbose = 0 if verbose < 0 else 3 if verbose > 3 else verbose
-    prcellstate = int(prcellstate)
 
+    def __init__(self):
+        self._enable = False
+        self._gpu = False
+        self._file_mode = False
+        self._cell_permute = None
+        self._warp_balance = 0
+        self._verbose = 2
+        self._prcellstate = -1
 
-def nrncore_arg(tstop):
-    """
-    Return str that can be used for pc.nrncore_run(str)
-    based on user properties and current NEURON settings.
-    :param tstop: Simulation time (ms)
+    def _valid_cell_permute(self):
+        return {1, 2} if self._gpu else {0, 1}
 
-    """
-    from neuron import h
+    def _default_cell_permute(self):
+        return 1 if self._gpu else 0
 
-    arg = ""
-    property_check(tstop)
-    if not enable:
+    @property
+    def enable(self):
+        """Use CoreNEURON when calling ParallelContext.psolve(tstop)."""
+        return self._enable
+
+    @enable.setter
+    def enable(self, value):
+        self._enable = bool(int(value))
+
+    @property
+    def gpu(self):
+        """Activate GPU computation."""
+        return self._gpu
+
+    @gpu.setter
+    def gpu(self, value):
+        self._gpu = bool(int(value))
+        # If cell_permute has been set to a value incompatible with the new GPU
+        # setting, change it and print a warning.
+        if (
+            self._cell_permute is not None
+            and self._cell_permute not in self._valid_cell_permute()
+        ):
+            print(
+                "WARNING: coreneuron.gpu = {} forbids coreneuron.cell_permute = {}, using {} instead".format(
+                    self._gpu, self._cell_permute, self._default_cell_permute()
+                )
+            )
+            self._cell_permute = self._default_cell_permute()
+
+    @property
+    def file_mode(self):
+        """Run via file transfer mode instead of in-memory transfer."""
+        return self._file_mode
+
+    @file_mode.setter
+    def file_mode(self, value):
+        self._file_mode = bool(value)
+
+    @property
+    def cell_permute(self):
+        """0 no permutation; 1 optimize node adjacency; 2 optimize parent node
+        adjacency (only for gpu = True)"""
+        if self._cell_permute is None:
+            return self._default_cell_permute()
+        return self._cell_permute
+
+    @cell_permute.setter
+    def cell_permute(self, value):
+        value = int(value)
+        assert value in self._valid_cell_permute()
+        self._cell_permute = value
+
+    @property
+    def warp_balance(self):
+        """Number of warps to balance. (0 no balance)"""
+        return self._warp_balance
+
+    @warp_balance.setter
+    def warp_balance(self, value):
+        value = int(value)
+        assert value >= 0
+        self._warp_balance = value
+
+    @property
+    def verbose(self):
+        """0 quiet, 1 Error, 2 Info, 3 Debug"""
+        return self._verbose
+
+    @verbose.setter
+    def verbose(self, value):
+        value = int(value)
+        assert value >= 0 and value <= 3
+        self._verbose = value
+
+    @property
+    def prcellstate(self):
+        """Output prcellstate information for the gid at t=0 and at tstop. -1 means no output"""
+        return self._prcellstate
+
+    @prcellstate.setter
+    def prcellstate(self, value):
+        value = int(value)
+        assert value >= -1
+        self._prcellstate = value
+
+    def property_check(self, tstop):
+        """Legacy check of user property values."""
+        tstop = float(tstop)
+
+    def nrncore_arg(self, tstop):
+        """
+        Return str that can be used for pc.nrncore_run(str)
+        based on user properties and current NEURON settings.
+        :param tstop: Simulation time (ms)
+
+        """
+        from neuron import h
+
+        arg = ""
+        self.property_check(tstop)
+        if not self.enable:
+            return arg
+
+        # note that this name is also used in C++ file nrncore_write.cpp
+        CORENRN_DATA_DIR = "corenrn_data"
+
+        # args derived from user properties
+        arg += " --gpu" if self.gpu else ""
+        arg += " --datpath %s" % CORENRN_DATA_DIR if self.file_mode else ""
+        arg += " --tstop %g" % tstop
+        arg += " --cell-permute %d" % self.cell_permute
+        arg += (" --nwarp %d" % self.warp_balance) if self.warp_balance > 0 else ""
+        arg += (" --prcellgid %d" % self.prcellstate) if self.prcellstate >= 0 else ""
+        arg += " --verbose %d" % self.verbose
+
+        # args derived from current NEURON settings.
+        pc = h.ParallelContext()
+        cvode = h.CVode()
+        arg += " --mpi" if pc.nhost() > 1 else ""
+        arg += " --voltage 1000."
+        binqueue = cvode.queue_mode() & 1
+        arg += " --binqueue" if binqueue else ""
+        spkcompress = int(pc.spike_compress(-1))
+        arg += (" --spkcompress %g" % spkcompress) if spkcompress else ""
+
+        # since multisend is undocumented in NEURON, perhaps it would be best
+        # to make the next three arg set from user properties here
+        multisend = int(pc.send_time(8))
+        if (multisend & 1) == 1:
+            arg += " --multisend"
+            interval = (multisend & 2) / 2 + 1
+            arg += (" --ms_subinterval %d" % interval) if interval != 2 else ""
+            phases = (multisend & 4) / 4 + 1
+            arg += (" --ms_phases %d" % phases) if phases != 2 else ""
+
         return arg
 
-    # note that this name is also used in C++ file nrncore_write.cpp
-    CORENRN_DATA_DIR = "corenrn_data"
 
-    # args derived from user properties
-    arg += " --gpu" if gpu else ""
-    arg += " --datpath %s" % CORENRN_DATA_DIR if file_mode else ""
-    arg += " --tstop %g" % tstop
-    arg += (" --cell-permute %d" % cell_permute) if cell_permute > 0 else ""
-    arg += (" --nwarp %d" % warp_balance) if warp_balance > 0 else ""
-    arg += (" --prcellgid %d" % prcellstate) if prcellstate >= 0 else ""
-    arg += (" --verbose %d" % verbose) if verbose >= 0 and verbose < 4 else ""
-
-    # args derived from current NEURON settings.
-    pc = h.ParallelContext()
-    cvode = h.CVode()
-    arg += " --mpi" if pc.nhost() > 1 else ""
-    arg += " --voltage 1000."
-    binqueue = cvode.queue_mode() & 1
-    arg += " --binqueue" if binqueue else ""
-    spkcompress = int(pc.spike_compress(-1))
-    arg += (" --spkcompress %g" % spkcompress) if spkcompress else ""
-
-    # since multisend is undocumented in NEURON, perhaps it would be best
-    # to make the next three arg set from user properties here
-    multisend = int(pc.send_time(8))
-    if (multisend & 1) == 1:
-        arg += " --multisend"
-        interval = (multisend & 2) / 2 + 1
-        arg += (" --ms_subinterval %d" % interval) if interval != 2 else ""
-        phases = (multisend & 4) / 4 + 1
-        arg += (" --ms_phases %d" % phases) if phases != 2 else ""
-
-    return arg
-
-
-if __name__ == "__main__":
-    enable = True
-    print(nrncore_arg(5.0))
-    gpu = True
-    cell_permute = 2
-    warp_balance = 32
-    prcellstate = 7
-    pc = h.ParallelContext()
-    # multisend cannot be used with cmake build
-    # pc.spike_compress(0, 0, 1)
-    print(nrncore_arg(10.0))
+sys.modules[__name__] = coreneuron()

--- a/share/lib/python/neuron/rxd/node.py
+++ b/share/lib/python/neuron/rxd/node.py
@@ -313,7 +313,7 @@ class Node(object):
                 source[0]
             except:
                 raise RxDException("HocObject must be a pointer")
-        elif len(args) == 1 and isinstance(args[0], collections.Callable):
+        elif len(args) == 1 and isinstance(args[0], collections.abc.Callable):
             flux_type = 2
             source = args[0]
             warnings.warn(

--- a/test/coreneuron/test_datareturn.py
+++ b/test/coreneuron/test_datareturn.py
@@ -175,20 +175,21 @@ def test_datareturn():
     coreneuron.gpu = bool(
         distutils.util.strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false"))
     )
+    cell_permute_values = (1, 2) if coreneuron.gpu else (0, 1)
 
-    coreneuron.cell_permute = 0
+    coreneuron.cell_permute = cell_permute_values[0]
     for mode in [0, 1, 2]:
         run(tstop, mode)
         tst = model.data()
         max_unpermuted = h.Vector(std).sub(h.Vector(tst)).abs().max()
         print("mode ", mode)
-        print("max diff unpermuted = %g" % max_unpermuted)
+        print("max diff permute=%d = %g" % (coreneuron.cell_permute, max_unpermuted))
 
-        coreneuron.cell_permute = 1
+        coreneuron.cell_permute = cell_permute_values[1]
         run(tstop, mode)
         tst = model.data()
         max_permuted = h.Vector(std).sub(h.Vector(tst)).abs().max()
-        print("max diff permuted = %g" % max_permuted)
+        print("max diff permute=%d = %g" % (coreneuron.cell_permute, max_permuted))
 
         pc.nthread(2)
         run(tstop, mode)


### PR DESCRIPTION
This fixes some Python 3.10.0 incompatibilities, as partly discussed in #1525.

The main changes are:
 - Reorganise `neuron.coreneuron` to be a class instance with getter/setter methods, so that properties like `coreneuron.enable` and `coreneuron.cell_permute` always have consistent values of consistent types. This stops us from relying on implicit `float` -> `int` conversions in the Python C API, as described in #1525.
 - Use `collections.abc.Callable` instead of `collections.Callable`, which is deprecated.
 - In `test/coreneuron/test_datareturn.py` compare the two `coreneuron.cell_permute` values that are valid given `coreneuron.gpu`, instead of always trying to compare `0` and `1`.

Closes #1525.

I tested this on BB5 + GPU (with Python 3.8) and on Fedora 35 in Docker. I still saw a couple of failures locally, but I **think** these are unrelated and that something is slightly broken in my macOS + Docker + Fedora 35 + MPI environment.