### PR TITLE
All interthread events on queue before transfer.

### DIFF
--- a/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
+++ b/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
@@ -41,6 +41,7 @@ extern double nrn_ion_charge(Symbol*);
 extern CellGroup* cellgroups_;
 extern NetCvode* net_cvode_instance;
 extern char* pnt_map;
+extern void* nrn_interthread_enqueue(NrnThread*);
 
 /** Populate function pointers by mapping function pointers for callback */
 void map_coreneuron_callbacks(void* handle) {
@@ -755,6 +756,9 @@ NrnCoreTransferEvents* nrn2core_transfer_tqueue(int tid) {
   TQueue* tq = net_cvode_instance_event_queue(&nt);
   TQItem* tqi;
   auto& cg = cellgroups_[tid];
+  // make sure all buffered interthread events are on the queue
+  nrn_interthread_enqueue(&nt);
+
   while ((tqi = tq->atomic_dq(1e15)) != NULL) {
     // removes all items from NEURON queue to reappear in CoreNEURON queue
     DiscreteEvent* de = (DiscreteEvent*)(tqi->data_);

--- a/test/coreneuron/test_datareturn.py
+++ b/test/coreneuron/test_datareturn.py
@@ -199,7 +199,6 @@ def test_datareturn():
                 mode, nthread, cell_permute, max_diff
             )
         )
-        # print([x for x in h.Vector(std).sub(h.Vector(tst))])
         results.append(max_diff)
         if max_diff > 1e-10:
             for i in range(len(std)):

--- a/test/coreneuron/test_datareturn.py
+++ b/test/coreneuron/test_datareturn.py
@@ -1,5 +1,6 @@
 # Test of data return covering most of the functionality.
 import distutils.util
+import itertools
 import os
 import sys
 import traceback
@@ -93,17 +94,20 @@ class Network:
                     pass
         for inst in instances:
             for name in names:
-                d.append(getattr(inst, name))
+                d.append(((mname, name), getattr(inst, name)))
 
     def data(self):
-        d = [h.t]
-        for sec in h.allsec():
-            for seg in sec:
-                d.append(seg.v)
-                d.append(seg.i_membrane_)
-                for mech in seg:
-                    for var in mech:
-                        d.append(var[0])
+        d = [("t", h.t)]
+        for ncell, cell in enumerate(self.cells):
+            for nsec, sec in enumerate(cell.secs):
+                for nseg, seg in enumerate(sec):
+                    d.append(((ncell, nsec, nseg, "v"), seg.v))
+                    d.append(((ncell, nsec, nseg, "i"), seg.i_membrane_))
+                    for mech in seg:
+                        for var in mech:
+                            d.append(
+                                ((ncell, nsec, nseg, mech.name(), var.name()), var[0])
+                            )
 
         # all NetStim, ExpSyn, ...
         for mname in ["NetStim", "Exp2Syn", "IntervalFire"]:
@@ -172,56 +176,52 @@ def test_datareturn():
     print("CoreNEURON run")
     h.CVode().cache_efficient(1)
     coreneuron.enable = True
+    coreneuron.verbose = 0
     coreneuron.gpu = bool(
         distutils.util.strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false"))
     )
+
+    results = []
     cell_permute_values = (1, 2) if coreneuron.gpu else (0, 1)
-
-    coreneuron.cell_permute = cell_permute_values[0]
-    for mode in [0, 1, 2]:
+    for mode, nthread, cell_permute in itertools.product(
+        [0, 1, 2], [1, 2], cell_permute_values
+    ):
+        pc.nthread(nthread)
+        coreneuron.cell_permute = cell_permute
         run(tstop, mode)
         tst = model.data()
-        max_unpermuted = h.Vector(std).sub(h.Vector(tst)).abs().max()
-        print("mode ", mode)
-        print("max diff permute=%d = %g" % (coreneuron.cell_permute, max_unpermuted))
-
-        coreneuron.cell_permute = cell_permute_values[1]
-        run(tstop, mode)
-        tst = model.data()
-        max_permuted = h.Vector(std).sub(h.Vector(tst)).abs().max()
-        print("max diff permute=%d = %g" % (coreneuron.cell_permute, max_permuted))
-
-        pc.nthread(2)
-        run(tstop, mode)
-
-        tst = model.data()
-        max_permuted_thread = h.Vector(std).sub(h.Vector(tst)).abs().max()
-
-        coreneuron.enable = False
-
-        print(
-            "max diff permuted with %d threads = %g"
-            % (pc.nthread(), max_permuted_thread)
+        max_diff = (
+            h.Vector(v for k, v in std).sub(h.Vector(v for k, v in tst)).abs().max()
         )
+        assert len(std) == len(tst)
+        print(
+            "mode={} nthread={} permute={} max diff={}".format(
+                mode, nthread, cell_permute, max_diff
+            )
+        )
+        # print([x for x in h.Vector(std).sub(h.Vector(tst))])
+        results.append(max_diff)
+        if max_diff > 1e-10:
+            for i in range(len(std)):
+                nrn_key, nrn_val = std[i]
+                tst_key, tst_val = tst[i]
+                assert nrn_key == tst_key
+                if abs(nrn_val - tst_val) >= 1e-10:
+                    print(i, nrn_key, nrn_val, tst_val, abs(nrn_val - tst_val))
 
-        assert max_unpermuted < 1e-10
-        assert max_permuted < 1e-10
-        assert max_permuted_thread < 1e-10
-        pc.nthread(1)
+    assert all(max_diff < 1e-10 for max_diff in results)
 
     if __name__ != "__main__":
         # tear down
+        coreneuron.enable = False
         pc.nthread(1)
         pc.gid_clear()
-        return None
-
-    return model
 
 
 if __name__ == "__main__":
     show = False
     try:
-        model = test_datareturn()
+        test_datareturn()
     except:
         traceback.print_exc()
         # Make the CTest test fail


### PR DESCRIPTION
Fixes #1531
Related to BlueBrain/CoreNeuron#691
Adopts @olupton version of test_datareturn.py
Note that there are many warnings from thread sanitizer that should be analyzed.