### PR TITLE
Hines/transfer bug

### DIFF
--- a/src/nrniv/nrncore_write.cpp
+++ b/src/nrniv/nrncore_write.cpp
@@ -95,6 +95,7 @@ correctness has not been validated for cells without gids.
 #include "parse.hpp"
 #include "nrnmpi.h"
 #include "netcon.h"
+#include "nrncvode.h"
 
 #include "vrecitem.h" // for nrnbbcore_vecplay_write
 #include "nrnsection_mapping.h"
@@ -353,6 +354,8 @@ int nrncore_psolve(double tstop, int file_mode) {
       // data return nt._t so copy to t
       t = nrn_threads[0]._t;
       free(arg);
+      // Really just want to get NetParEvent back onto queue.
+      nrn_spike_exchange_init();
       return 0;
     }
   }

--- a/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
+++ b/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
@@ -827,10 +827,14 @@ NrnCoreTransferEvents* nrn2core_transfer_tqueue(int tid) {
       } break;
       case PreSynType: { // 4
         PreSyn* ps = (PreSyn*)de;
-        assert(ps->nt_);
-        // Skip if does not belong to this thread.
-        // (NEURON puts PreSyn on every thread queue)
-        if (ps->nt_->id != tid) {
+
+        // NEURON puts PreSyn on every thread queue
+        // Skip if PreSyn not associated with this thread.
+        bool skip = (ps->nt_ && (ps->nt_->id != tid)) ? true : false;
+        // Skip if effectively an InputPresyn (ps->nt_ == NULL)
+        //     and this is not thread 0.
+        skip = (!ps->nt_ && tid != 0) ? true : skip;
+        if (skip) {
           // erase what was already added
           core_te->type.pop_back();
           core_te->td.pop_back();

--- a/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
+++ b/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
@@ -827,6 +827,15 @@ NrnCoreTransferEvents* nrn2core_transfer_tqueue(int tid) {
       } break;
       case PreSynType: { // 4
         PreSyn* ps = (PreSyn*)de;
+        assert(ps->nt_);
+        // Skip if does not belong to this thread.
+        // (NEURON puts PreSyn on every thread queue)
+        if (ps->nt_->id != tid) {
+          // erase what was already added
+          core_te->type.pop_back();
+          core_te->td.pop_back();
+          break;
+        }
         // Output PreSyn similar to NetCon but more data.
         // Input PreSyn (ps->output_index = -1 and ps->gid >= 0)
         // is distinquished from PreSyn (ps->output_index == ps->gid


### PR DESCRIPTION
https://github.com/nrnhines/tqperf for #1527 is proving to be a fertile finder of bugs. Multiple threads + back and forth pc.psolve with ```coreneuron.enable``` alternately ```[True,False]``` revealed that on return from a coreneuron psolve, and continuing with a NEURON psolve, would fail numerically because on the NEURON side there were no NetParEvent events initialized on the thread queues (which are required for synchronization every minimum NetCon delay integration interval). Of  course that also would break MPI simulations as well if one tried to continue simulating on the NEURON side after returning from CoreNEURON wiithout an explicit call to ```finitialize```.  This multiple thread test also revealed an error due to different handling of PreSyn::send in NEURON and CoreNEURON.
One can run the relevant test by cloning the above tqperf repository and
```
git checkout hines/test1
nrnivmodl -coreneuron mod
python test1.py
```
That will succeed with the this pull request.
A combination of MPI and multiple threads, ```mpiexec -n 4 nrniv -mpi -python test1.py```, currently fails and is being investigated. edit: the last changeset fixes that issue.