### PR TITLE
If GPU is enabled, use it both online and offline.

### DIFF
--- a/test/pynrn/test_fast_imem.py
+++ b/test/pynrn/test_fast_imem.py
@@ -312,7 +312,9 @@ def test_fastimem_corenrn():
 
     coreneuron.enable = True
     coreneuron.verbose = 0
-    coreneuron.cell_permute = 0
+    coreneuron.gpu = distutils.util.strtobool(
+        os.environ.get("CORENRN_ENABLE_GPU", "false")
+    )
     run(tstop)
     compare()
     coreneuron.enable = False
@@ -349,9 +351,6 @@ def test_fastimem_corenrn():
     # args needed for offline run of coreneuron
     coreneuron.enable = True
     coreneuron.file_mode = True
-    coreneuron.gpu = bool(
-        distutils.util.strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false"))
-    )
 
     arg = coreneuron.nrncore_arg(tstop)
     coreneuron.enable = False


### PR DESCRIPTION
Previously GPU offload was only enabled for the offline test.

With https://github.com/neuronsimulator/nrn/pull/1528 the wrapping `bool` should no longer be needed, and `cell_permute` will default to `0` in CPU runs and `1` in GPU runs.