### PR TITLE
liblto_plugin-0.dll not available anymore

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -83,6 +83,8 @@ jobs:
       working-directory: ${{runner.workspace}}\nrn
 
     - name: Test Installer
-      run: .\ci\win_test_installer.cmd
+      # temporarily disable rxd testing ( ci/win_test_installer.cmd <-> ci/win_test_installer_wo_rxd.cmd)
+      # see https://github.com/neuronsimulator/nrn/issues/1522
+      run: .\ci\win_test_installer_wo_rxd.cmd
       shell: cmd
       working-directory: ${{runner.workspace}}\nrn

--- a/ci/azure-win-installer-upload.yml
+++ b/ci/azure-win-installer-upload.yml
@@ -18,7 +18,9 @@ steps:
 
   - task: BatchScript@1
     inputs:
-      filename: ci/win_test_installer.cmd
+      # temporarily disable rxd testing ( ci/win_test_installer.cmd <-> ci/win_test_installer_wo_rxd.cmd)
+      # see https://github.com/neuronsimulator/nrn/issues/1522
+      filename: ci/win_test_installer_wo_rxd.cmd
     displayName: "Test Installer"
     condition: succeeded()
 

--- a/ci/win_test_installer_wo_rxd.cmd
+++ b/ci/win_test_installer_wo_rxd.cmd
@@ -1,0 +1,78 @@
+:: temporarily disable rxd testing ( ci/win_test_installer.cmd <-> ci/win_test_installer_wo_rxd.cmd)
+:: see https://github.com/neuronsimulator/nrn/issues/1522
+
+@echo on
+
+:: error variable
+set "errorfound="
+
+:: setup environment
+set PATH=C:\nrn_test\bin;%PATH%
+set PYTHONPATH=C:\nrn_test\lib\python;%PYTHONPATH%
+set NEURONHOME=C:\nrn_test
+
+echo %PATH%
+echo %PYTHONPATH%
+echo %NEURONHOME%
+
+:: Mitigation strategy -> for reasons uknown(thank you Windows), association.hoc.out may not be generated from previous step.
+:: If so, try again to generate it. No wait required like previous strategies, we rely on testing entropy from this point on.
+if not exist association.hoc.out (start /wait /REALTIME %cd%\ci\association.hoc)
+
+:: test all pythons
+C:\Python36\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
+C:\Python37\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
+C:\Python38\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
+C:\Python39\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
+
+:: install numpy dependency
+python -m pip install numpy
+:: run also using whatever is system python
+python --version
+python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
+
+:: test python and nrniv
+python -c "from neuron import h; s = h.Section(); s.insert('hh'); quit()" || set "errorfound=y"
+nrniv -python -c "from neuron import h; s = h.Section(); s.insert('hh'); quit()" || set "errorfound=y"
+
+:: test mpi
+mpiexec -n 2 nrniv %cd%\src\parallel\test0.hoc -mpi || set "errorfound=y"
+mpiexec -n 2 python %cd%\src\parallel\test0.py -mpi --expected-hosts 2 || set "errorfound=y"
+
+:: setup for mknrndll/nrnivmodl
+set N=C:\nrn_test
+set PATH=C:\nrn_test\mingw\usr\bin;%PATH%
+
+:: test mknrndll
+copy /A share\examples\nrniv\nmodl\cacum.mod .
+C:\nrn_test\mingw\usr\bin\bash -c "mknrndll" || set "errorfound=y"
+python -c "import neuron; from neuron import h; s = h.Section(); s.insert('cacum'); print('cacum inserted'); quit()" || set "errorfound=y"
+
+:: test nrnivmodl
+rm -f cacum* mod_func* nrnmech.dll
+copy /A share\examples\nrniv\nmodl\cacum.mod .
+call nrnivmodl
+echo "nrnivmodl successfull"
+python -c "import neuron; from neuron import h; s = h.Section(); s.insert('cacum'); print('cacum inserted'); quit()" || set "errorfound=y"
+
+:: Test of association with hoc files. This test is very tricky to handle. We do it in two steps.
+:: 2nd step -> check association.hoc output after we've launched 1step in previous CI step
+cat association.hoc.out
+findstr /i "^hello$" association.hoc.out || set "errorfound=y"
+
+echo "All tests finished!"
+
+:: uninstall neuron
+C:\nrn_test\uninstall /S || set "errorfound=y"
+echo "Uninstalled NEURON"
+
+:: if something failed, exit with error
+if defined errorfound (goto :error)
+
+:: if all goes well, go to end
+goto :EOF
+
+:: something has failed, teminate with error code
+:error
+echo ERROR : exiting with error code 1 ..
+exit 1

--- a/mingw_files/nrnmingwenv.sh
+++ b/mingw_files/nrnmingwenv.sh
@@ -93,7 +93,7 @@ copy mingw64/lib/gcc/x86_64-w64-mingw32/$gccver '
 cc1.exe
 libgcc.a
 libgcc_s.a
-liblto_plugin-0.dll
+liblto_plugin.dll
 '
 cp_dlls $NM/mingw64/lib/gcc/x86_64-w64-mingw32/$gccver $NM/mingw64/bin
 rm -f $NM/mingw64/bin/libwinpthread-1.dll # already in $N/bin


### PR DESCRIPTION
We are hitting #1522 sooner rather than later following our workaround in #1529. 

Given the vast amount of time spent on trying to fix the issue, the only common sense mitigation we can think of is temporarily disabling RXD tests in the Windows CIs. 

CC: @ramcdougal @adamjhn 
