### PR TITLE
Set OpenMP thread limits for ringtest.

### DIFF
--- a/test/external/ringtest/CMakeLists.txt
+++ b/test/external/ringtest/CMakeLists.txt
@@ -56,15 +56,17 @@ foreach(processor cpu gpu)
     COMMAND OMP_NUM_THREADS=1 ${ringtest_special_core} --mpi -d coredat/ -e 100 ${special_gpu_arg}
     OUTPUT asciispikes::out.dat)
 
-  set(ringtest_num_threads 2)
+  # Following suggestion on #1552, run a test with more threads than datasets.
+  set(ringtest_num_threads 3)
+  set(ringtest_num_datasets 2)
   math(EXPR ringtest_mpi_ranks_times_threads "${ringtest_mpi_ranks}*${ringtest_num_threads}")
   nrn_add_test(
     GROUP external_ringtest
     NAME coreneuron_${processor}_mpi_threads
     REQUIRES coreneuron mpi python ${processor}
     PROCESSORS ${ringtest_mpi_ranks_times_threads}
-    COMMAND OMP_NUM_THREADS=2 ${ringtest_special} -tstop 100 -coreneuron -nt
-            ${ringtest_num_threads} ${gpu_arg})
+    COMMAND OMP_NUM_THREADS=${ringtest_num_threads} ${ringtest_special} -tstop 100 -coreneuron -nt
+            ${ringtest_num_datasets} ${gpu_arg})
 endforeach()
 # Step 3 -- add a job that compares the outputs of all the tests added in Step 2
 nrn_add_test_group_comparison(

--- a/test/external/ringtest/CMakeLists.txt
+++ b/test/external/ringtest/CMakeLists.txt
@@ -8,6 +8,12 @@ nrn_add_test_group(
   OUTPUT asciispikes::spk2.std # which output data to compare
   SCRIPT_PATTERNS "*.py" "*.hoc")
 
+set(ringtest_mpi_ranks 2)
+set(ringtest_prefix ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} ${ringtest_mpi_ranks}
+                    ${MPIEXEC_OVERSUBSCRIBE} ${MPIEXEC_PREFLAGS})
+set(ringtest_special ${ringtest_prefix} special ${MPIEXEC_POSTFLAGS} -mpi -python ringtest.py)
+set(ringtest_special_core ${ringtest_prefix} special-core ${MPIEXEC_POSTFLAGS})
+
 # Step 2 -- add configurations to the group (e.g. here NEURON without MPI) When CoreNEURON is
 # enabled then TABLE statements are disabled in hh.mod, which causes slight numerical differences in
 # the results from both NEURON and CoreNEURON. Consequently, if neither CoreNEURON nor
@@ -17,16 +23,15 @@ nrn_add_test(
   GROUP external_ringtest
   NAME neuron
   REQUIRES mod_compatibility python
-  COMMAND special -python ringtest.py -tstop 100
+  COMMAND OMP_NUM_THREADS=1 special -python ringtest.py -tstop 100
   OUTPUT asciispikes::spk1.std)
 
 nrn_add_test(
   GROUP external_ringtest
   NAME neuron_mpi
   REQUIRES mod_compatibility mpi python
-  PROCESSORS 2
-  COMMAND ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_OVERSUBSCRIBE} ${MPIEXEC_PREFLAGS}
-          special ${MPIEXEC_POSTFLAGS} -mpi -python ringtest.py -tstop 100)
+  PROCESSORS ${ringtest_mpi_ranks}
+  COMMAND OMP_NUM_THREADS=1 ${ringtest_special} -tstop 100)
 
 foreach(processor cpu gpu)
   if("${processor}" STREQUAL "gpu")
@@ -40,39 +45,26 @@ foreach(processor cpu gpu)
     GROUP external_ringtest
     NAME coreneuron_${processor}_mpi
     REQUIRES coreneuron mpi python ${processor}
-    PROCESSORS 2
-    COMMAND ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_OVERSUBSCRIBE} ${MPIEXEC_PREFLAGS}
-            special ${MPIEXEC_POSTFLAGS} -mpi -python ringtest.py -tstop 100 -coreneuron ${gpu_arg})
+    PROCESSORS ${ringtest_mpi_ranks}
+    COMMAND OMP_NUM_THREADS=1 ${ringtest_special} -tstop 100 -coreneuron ${gpu_arg})
   nrn_add_test(
     GROUP external_ringtest
     NAME coreneuron_${processor}_mpi_offline
     REQUIRES coreneuron mpi python ${processor}
-    PROCESSORS 2
-    PRECOMMAND ${MPIEXEC_NAME}
-               ${MPIEXEC_NUMPROC_FLAG}
-               2
-               ${MPIEXEC_OVERSUBSCRIBE}
-               ${MPIEXEC_PREFLAGS}
-               special
-               ${MPIEXEC_POSTFLAGS}
-               -mpi
-               -python
-               ringtest.py
-               -tstop
-               0
-               -coreneuron
-               -dumpmodel
-    COMMAND ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_OVERSUBSCRIBE} ${MPIEXEC_PREFLAGS}
-            special-core ${MPIEXEC_POSTFLAGS} --mpi -d coredat/ -e 100 ${special_gpu_arg}
+    PROCESSORS ${ringtest_mpi_ranks}
+    PRECOMMAND OMP_NUM_THREADS=1 ${ringtest_special} -tstop 0 -coreneuron -dumpmodel
+    COMMAND OMP_NUM_THREADS=1 ${ringtest_special_core} --mpi -d coredat/ -e 100 ${special_gpu_arg}
     OUTPUT asciispikes::out.dat)
+
+  set(ringtest_num_threads 2)
+  math(EXPR ringtest_mpi_ranks_times_threads "${ringtest_mpi_ranks}*${ringtest_num_threads}")
   nrn_add_test(
     GROUP external_ringtest
     NAME coreneuron_${processor}_mpi_threads
     REQUIRES coreneuron mpi python ${processor}
-    PROCESSORS 2
-    COMMAND
-      ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_OVERSUBSCRIBE} ${MPIEXEC_PREFLAGS}
-      special ${MPIEXEC_POSTFLAGS} -mpi -python ringtest.py -tstop 100 -coreneuron -nt 2 ${gpu_arg})
+    PROCESSORS ${ringtest_mpi_ranks_times_threads}
+    COMMAND OMP_NUM_THREADS=2 ${ringtest_special} -tstop 100 -coreneuron -nt
+            ${ringtest_num_threads} ${gpu_arg})
 endforeach()
 # Step 3 -- add a job that compares the outputs of all the tests added in Step 2
 nrn_add_test_group_comparison(


### PR DESCRIPTION
Previously `OMP_NUM_THREADS` was not set, which could lead to large values being assumed on some machines.