### PR TITLE
Hines/netpar std

### DIFF
--- a/src/nrniv/bgpdma.cpp
+++ b/src/nrniv/bgpdma.cpp
@@ -843,7 +843,6 @@ int ncs_bgp_mindelays( int **srchost, double **delays )
     (*srchost) = nsrcgid ? new int[nsrcgid] : 0;
     
     i=0;
-    NrnHashIterate(Gid2PreSyn, gid2in_, PreSyn*, ps) {
     for (const auto& iter: gid2in_) {
         PreSyn* ps = iter.second;
         assert(ps->output_index_ < 0);

--- a/src/nrniv/bgpdma.cpp
+++ b/src/nrniv/bgpdma.cpp
@@ -290,8 +290,9 @@ void BGP_ReceiveBuffer::enqueue1() {
 	busy_ = 1;
 	for (int i=0; i < count_; ++i) {
 		NRNMPI_Spike* spk = buffer_[i];
-		PreSyn* ps;
-		nrn_assert(gid2in_->find(spk->gid, ps));
+		auto iter = gid2in_->find(spk->gid);
+		nrn_assert(iter != gid2in_.end()));
+		PreSyn* ps = iter->second;
 		psbuf_[i] = ps;
 		if (use_phase2_ && ps->bgp.dma_send_phase2_) {
 			// cannot do directly because busy_;
@@ -379,23 +380,12 @@ double nrn_bgp_receive_time(int type) { // and others
 		}
 #endif
 		break;
-#if ALTHASH
-	case 5:
-		rt = double(gid2in_->max_chain_length());
-		break;
-	case 6:
-		rt = double(gid2in_->nclash());
-		break;
-	case 7:
-		rt = double(gid2in_->nfind());
-		break;
-#endif
 	case 8: // exchange method properties
 		// bit 0: 0 allgather, 1 multisend (MPI_ISend)
 		// bit 1: unused, legacy
 		// bit 2: n_bgp_interval, 0 means one interval, 1 means 2
 		// bit 3: number of phases, 0 means 1 phase, 1 means 2
-		// bit 4: 1 means althash used
+		// bit 4: unused (1 used to mean althash used)
 		// bit 5: 1 means enqueue separated into two parts for timeing
 	    {
 		int method = use_bgpdma_ ? 1 : 0;
@@ -768,15 +758,16 @@ void bgp_dma_setup() {
 int ncs_bgp_sending_info( int **sendlist2build )
 {
 	int nsrcgid = 0;
-	NrnHashIterate(Gid2PreSyn, gid2out_, PreSyn*, ps) {
-		if (ps->output_index_ >= 0) {
+	for (const auto& iter: gid2out_) {
+		if (iter.second->output_index_ >= 0) {
 			++nsrcgid;
 		}
-	}}}
+	}
 
 	*sendlist2build = nsrcgid ? new int[nsrcgid] : 0;
 	int i = 0;
-	NrnHashIterate(Gid2PreSyn, gid2out_, PreSyn*, ps) {
+	for (const auto& iter: gid2out) {
+		PreSyn* ps = iter.second;
 		if (ps->output_index_ >= 0) {
 			(*sendlist2build)[i] = ps->gid_;
 			++i;
@@ -791,8 +782,9 @@ int ncs_bgp_sending_info( int **sendlist2build )
 //function to access the sending information of a presyn
 int ncs_bgp_target_hosts( int gid, int** targetnodes )
 {
-    PreSyn* ps;
-    nrn_assert(gid2out_->find(gid, ps));
+    auto iter = gid2out_->find(gid);
+    nrn_assert(iter != gid2out_.end());
+    PreSyn* ps = iter->second;
     if( ps->bgp.dma_send_ ) {
         (*targetnodes) = ps->bgp.dma_send_->ntarget_hosts_? new int[ps->bgp.dma_send_->ntarget_hosts_] : 0;
         return ps->bgp.dma_send_->ntarget_hosts_;
@@ -806,32 +798,31 @@ int ncs_bgp_target_info( int **presyngids )
 {
     //(*presyngids) = 0;
 
-	int i, nsrcgid;
-	PreSyn* ps;
+    int i, nsrcgid;
     nsrcgid = 0;
 
-	// some target PreSyns may not have any input
-	// so initialize all to -1
-	NrnHashIterate(Gid2PreSyn, gid2in_, PreSyn*, ps) {
-		assert(ps->output_index_ < 0);
-		if( ps->bgp.srchost_ != -1 )  //has input
-        {
+    // some target PreSyns may not have any input
+    // so initialize all to -1
+    for (const auto& iter: gid2in_) {
+        PreSyn* ps = iter.second;
+        assert(ps->output_index_ < 0);
+        if( ps->bgp.srchost_ != -1 ) { //has input
             ++nsrcgid;
             //printf( "Node %d: Presyn for gid %d has src %d\n", nrnmpi_myid, ps->gid_, ps->bgp.srchost_ );
         }
-	}}}
+    }
     
     (*presyngids) = nsrcgid ? new int[nsrcgid] : 0;
     
     i=0;
-    NrnHashIterate(Gid2PreSyn, gid2in_, PreSyn*, ps) {
-		assert(ps->output_index_ < 0);
-		if( ps->bgp.srchost_ != -1 )  //has input
-        {
+    for (const auto& iter: gid2in_) {
+        PreSyn* ps = iter.second;
+        assert(ps->output_index_ < 0);
+        if( ps->bgp.srchost_ != -1 ) { //has input
             (*presyngids)[i] = ps->gid_;
             ++i;
         }
-	}}}
+    }
     
     return nsrcgid;
 }
@@ -840,27 +831,28 @@ int ncs_bgp_mindelays( int **srchost, double **delays )
 {
     int i, nsrcgid=0;
 
-	NrnHashIterate(Gid2PreSyn, gid2in_, PreSyn*, ps) {
+    for (const auto& iter: gid2in_) {
+        PreSyn* ps = iter.second;
         assert(ps->output_index_ < 0);
-        if( ps->bgp.srchost_ != -1 )  //has input
-        {
+        if( ps->bgp.srchost_ != -1 ) { //has input
             ++nsrcgid;
         }
-	}}}
+    }
 
     (*delays) = nsrcgid ? new double[nsrcgid] : 0;
     (*srchost) = nsrcgid ? new int[nsrcgid] : 0;
     
     i=0;
     NrnHashIterate(Gid2PreSyn, gid2in_, PreSyn*, ps) {
-		assert(ps->output_index_ < 0);
-		if( ps->bgp.srchost_ != -1 )  //has input
-        {
+    for (const auto& iter: gid2in_) {
+        PreSyn* ps = iter.second;
+        assert(ps->output_index_ < 0);
+        if( ps->bgp.srchost_ != -1 ) { //has input
             (*delays)[i] = ps->mindelay();
             (*srchost)[i] = ps->bgp.srchost_;
             ++i;
         }
-	}}}
+    }
     
     return nsrcgid;
 }

--- a/src/nrniv/bgpdma.cpp
+++ b/src/nrniv/bgpdma.cpp
@@ -548,7 +548,7 @@ void bgp_dma_receive(NrnThread* nt) {
 	int ncons = 0;
 	int& s = bgp_receive_buffer[current_rbuf]->nsend_;
 	int& r = bgp_receive_buffer[current_rbuf]->nrecv_;
-#if ENQUEUE == 2
+#if ENQUEUE == 2 && TBUFSIZE
 	unsigned long tfind, tsend;
 #endif
 	w1 = nrnmpi_wtime();
@@ -556,7 +556,7 @@ void bgp_dma_receive(NrnThread* nt) {
     if (use_bgpdma_) {
 	nrnbgp_messager_advance();
 	TBUF
-#if ENQUEUE == 2
+#if ENQUEUE == 2 && TBUFSIZE
 	// want the overlap with computation, not conserve
 	tfind = enq2_find_time_;
 	tsend = enq2_enqueue_time_ - enq2_find_time_;

--- a/src/nrniv/bgpdmasetup.cpp
+++ b/src/nrniv/bgpdmasetup.cpp
@@ -178,7 +178,7 @@ public:
 	// to send the ith group of phase2 targets.
 };
 
-using Int2TarList = std::unordered_map<int, TarList*>;
+using Int2TarList = std::unordered_map<int, std::unique_ptr<TarList>>;
 
 TarList::TarList() {
 	size = 0;
@@ -305,7 +305,7 @@ static void fill_dma_send_lists(int sz, int* r) {
 	for (int i = 0; i < sz;) {
 		int gid = r[i++];
 		int size = r[i++];
-		PreSyn* ps = NULL;
+		PreSyn* ps{nullptr};
 		if (use_phase2_) { // look in gid2in first
 		    auto iter = gid2in_.find(gid);
 		    if (iter != gid2in_.end()) {
@@ -608,7 +608,6 @@ static int setup_target_lists(int** r_return) {
 				s[sdispl[tl->rank]++] = tl->list[i];
 			}
 		}
-		delete tl;
 	}
 	del(sdispl);
 	sdispl = newoffset(scnt, nhost);

--- a/src/nrniv/bgpdmasetup.cpp
+++ b/src/nrniv/bgpdmasetup.cpp
@@ -9,18 +9,18 @@ the source host owning the gid.
 */
 
 #if 0
-void celldebug(const char* p, Gid2PreSyn* map) {
+void celldebug(const char* p, Gid2PreSyn& map) {
 	FILE* f;
 	char fname[100];
 	sprintf(fname, "debug.%d", nrnmpi_myid);
 	f = fopen(fname, "a");
-	PreSyn* ps;
 	fprintf(f, "\n%s\n", p);
 	int rank = nrnmpi_myid;
 	fprintf(f, "  %2d:", rank);
-	NrnHashIterateKeyValue(Gid2PreSyn, map, int, gid, PreSyn*, ps) {
+	for (const auto& iter: map) {
+		int gid = iter.first;
 		fprintf(f, " %2d", gid);
-	}}}
+	}
 	fprintf(f, "\n");
 	fclose(f);
 }
@@ -50,7 +50,7 @@ void alltoalldebug(const char* p, int* s, int* scnt, int* sdispl, int* r, int* r
 	fclose(f);
 }
 #else
-void celldebug(const char* p, Gid2PreSyn* map) {}
+void celldebug(const char* p, Gid2PreSyn& map) {}
 void alltoalldebug(const char* p, int* s, int* scnt, int* sdispl, int* r, int* rcnt, int* rdispl){}
 #endif
 
@@ -60,15 +60,15 @@ void phase1debug() {
 	char fname[100];
 	sprintf(fname, "debug.%d", nrnmpi_myid);
 	f = fopen(fname, "a");
-	PreSyn* ps;
 	fprintf(f, "\nphase1debug %d", nrnmpi_myid);
-	NrnHashIterate(Gid2PreSyn, gid2out_, PreSyn*, ps) {
+	for (const auto* iter: gid2out_) {
+		PreSyn* ps = iter.second;
 		fprintf(f, "\n %2d:", ps->gid_);
 		BGP_DMASend* bs = ps->bgp.dma_send_;
 		for (int i=0; i < bs->ntarget_hosts_; ++i) {
 			fprintf(f, " %2d", bs->target_hosts_[i]);
 		}
-	}}}
+	}
 	fprintf(f, "\n");
 	fclose(f);
 }
@@ -78,9 +78,9 @@ void phase2debug() {
 	char fname[100];
 	sprintf(fname, "debug.%d", nrnmpi_myid);
 	f = fopen(fname, "a");
-	PreSyn* ps;
 	fprintf(f, "\nphase2debug %d", nrnmpi_myid);
-	NrnHashIterate(Gid2PreSyn, gid2in_, PreSyn*, ps) {
+	for (const auto& iter: gid2in_) {
+		PreSyn* ps = iter.second;
 		fprintf(f, "\n %2d:", ps->gid_);
 		BGP_DMASend_Phase2* bs = ps->bgp.dma_send_phase2_;
 	    if (bs) {
@@ -88,7 +88,7 @@ void phase2debug() {
 			fprintf(f, " %2d", bs->target_hosts_phase2_[i]);
 		}
 	    }
-	}}}
+	}
 	fprintf(f, "\n");
 	fclose(f);
 }
@@ -269,7 +269,8 @@ static void fill_dma_send_lists(int, int*);
 
 static void setup_presyn_dma_lists() {
 	// Create and attach BGP_DMASend instances to output Presyn
-	NrnHashIterate(Gid2PreSyn, gid2out_, PreSyn*, ps) {
+	for (const auto& iter: gid2out_) {
+		PreSyn* ps = iter.second;
 		// only ones that generate spikes. eg. multisplit
 		// registers a gid and even associates with a cell piece, but
 		// that piece may not send spikes.
@@ -277,13 +278,14 @@ static void setup_presyn_dma_lists() {
 			bgpdma_cleanup_presyn(ps);
 			ps->bgp.dma_send_ = new BGP_DMASend();
 		}
-	}}}
+	}
 
 	// Need to use the bgp union slot for dma_send_phase2_.
 	// Only will be non-NULL if the input is a phase 2 sender.
-	NrnHashIterate(Gid2PreSyn, gid2in_, PreSyn*, ps) {
+	for (const auto& iter: gid2in_) {
+		PreSyn* ps = iter.second;
 		ps->bgp.srchost_ = 0;
-	}}}
+	}
 
 	int* r;
 	int sz = setup_target_lists(&r);
@@ -303,9 +305,11 @@ static void fill_dma_send_lists(int sz, int* r) {
 	for (int i = 0; i < sz;) {
 		int gid = r[i++];
 		int size = r[i++];
-		PreSyn* ps = 0;
+		PreSyn* ps = NULL;
 		if (use_phase2_) { // look in gid2in first
-		    if (gid2in_->find(gid, ps)) { // phase 2 target list
+		    auto iter = gid2in_.find(gid);
+		    if (iter != gid2in_.end()) {
+			ps = iter->second;
 			BGP_DMASend_Phase2* bsp = new BGP_DMASend_Phase2();
 			ps->bgp.dma_send_phase2_ = bsp;
 			bsp->ntarget_hosts_phase2_ = size;
@@ -319,7 +323,9 @@ static void fill_dma_send_lists(int sz, int* r) {
 		    }
 		}
 		if (!ps) { // phase 1 target list (or whole list if use_phase2 is 0)
-			nrn_assert(gid2out_->find(gid, ps));
+			auto iter = gid2out_.find(gid);
+			nrn_assert(iter != gid2out_.end());
+			ps = iter->second;
 			BGP_DMASend* bs =  ps->bgp.dma_send_;
 			bs->ntarget_hosts_phase1_ = size;
 			if (use_phase2_ == 0) {
@@ -341,7 +347,8 @@ static void fill_dma_send_lists(int sz, int* r) {
 	// compute max_ntarget_host and max_multisend_targets
 	max_ntarget_host = 0;
 	max_multisend_targets = 0;
-	NrnHashIterate(Gid2PreSyn, gid2out_, PreSyn*, ps) {
+	for (const auto& iter: gid2out_) {
+		PreSyn* ps = iter.second;
 		if (ps->output_index_ >= 0) { // only ones that generate spikes
 			BGP_DMASend* bs = ps->bgp.dma_send_;
 			if (max_ntarget_host < bs->ntarget_hosts_) {
@@ -351,13 +358,14 @@ static void fill_dma_send_lists(int sz, int* r) {
 				max_multisend_targets = bs->NTARGET_HOSTS_PHASE1;
 			}
 		}
-	}}}
-	if (use_phase2_) NrnHashIterate(Gid2PreSyn, gid2in_, PreSyn*, ps) {
+	}
+	if (use_phase2_) for (const auto& iter: gid2in_) {
+		PreSyn* ps = iter.second;
 		BGP_DMASend_Phase2* bsp = ps->bgp.dma_send_phase2_;
 		if (bsp && max_multisend_targets < bsp->ntarget_hosts_phase2_) {
 			max_multisend_targets = bsp->ntarget_hosts_phase2_;
 		}
-	}}}
+	}
 }
 
 // return is vector and its size. The vector encodes a sequence of
@@ -376,18 +384,18 @@ static int setup_target_lists(int** r_return) {
 
 	// scnt is number of input gids from target
 	scnt = newintval(0, nhost);
-	NrnHashIterateKeyValue(Gid2PreSyn, gid2in_, int, gid, PreSyn*, ps) {
-                assert(ps->gid_ == gid); // avoid unused warning
+	for (const auto& iter: gid2in_) {
+		int gid = iter.first;
 		++scnt[gid%nhost];
-	}}}
+	}
 
 	// s are the input gids from target to be sent to the various intermediates
 	sdispl = newoffset(scnt, nhost);
 	s = newintval(0, sdispl[nhost]);
-	NrnHashIterateKeyValue(Gid2PreSyn, gid2in_, int, gid, PreSyn*, ps) {
-		assert(ps->gid_ == gid); // avoid unused warning
+	for (const auto& iter: gid2in_) {
+		int gid = iter.first;
 		s[sdispl[gid%nhost]++] = gid;
-	}}}
+	}
 	// Restore sdispl for the message.
 	del(sdispl);
 	sdispl = newoffset(scnt, nhost);
@@ -459,20 +467,24 @@ static int setup_target_lists(int** r_return) {
 	// be tested for random distributions of gids.
 	// How many on the source rank?
 	scnt = newintval(0, nhost);
-	NrnHashIterateKeyValue(Gid2PreSyn, gid2out_, int, gid, PreSyn*, ps) {
+	for (const auto& iter: gid2out_) {
+		PreSyn* ps = iter.second;
+		int gid = iter.first;
 		if (ps->output_index_ >= 0) { // only ones that generate spikes
 			++scnt[gid%nhost];
 		}
-	}}}
+	}
 	sdispl = newoffset(scnt, nhost);
 
 	// what are the gids of those target lists
 	s = newintval(0, sdispl[nhost]);
-	NrnHashIterateKeyValue(Gid2PreSyn, gid2out_, int, gid, PreSyn*, ps) {
+	for (const auto& iter: gid2out_) {
+		PreSyn* ps = iter.second;
+		int gid = iter.first;
 		if (ps->output_index_ >= 0) { // only ones that generate spikes
 			s[sdispl[gid%nhost]++] = gid;
 		}
-	}}}
+	}
 	// Restore sdispl for the message.
 	del(sdispl);
 	sdispl = newoffset(scnt, nhost);

--- a/src/nrniv/bgpdmasetup.cpp
+++ b/src/nrniv/bgpdmasetup.cpp
@@ -178,7 +178,7 @@ public:
 	// to send the ith group of phase2 targets.
 };
 
-using Int2TarList = std::unordered_map<int, std::unique_ptr<TarList>>;
+using Int2TarList = std::unordered_map<int, TarList*>;
 
 TarList::TarList() {
 	size = 0;
@@ -596,7 +596,6 @@ static int setup_target_lists(int** r_return) {
 					s[sdispl[rank]++] = tl->list[j];
 				}
 			}
-			
 		}else{
 			// gid, list size, list
 			s[sdispl[tl->rank]++] = gid;
@@ -608,6 +607,7 @@ static int setup_target_lists(int** r_return) {
 				s[sdispl[tl->rank]++] = tl->list[i];
 			}
 		}
+		delete tl;
 	}
 	del(sdispl);
 	sdispl = newoffset(scnt, nhost);

--- a/src/nrniv/bgpdmasetup.cpp
+++ b/src/nrniv/bgpdmasetup.cpp
@@ -497,7 +497,6 @@ static int setup_target_lists(int** r_return) {
 		int b = rdispl[rank];
 		int e = rdispl[rank+1];
 		for (int i=b; i < e; ++i) {
-			TarList* tl;
 			// note that there may be input gids with no corresponding
 			// output gid so that the find may not return true and in
 			// that case the tl->rank remains -1.

--- a/src/nrniv/netpar.cpp
+++ b/src/nrniv/netpar.cpp
@@ -117,14 +117,14 @@ int ncs_netcon_mindelays( int**hosts, double **delays )
 
 double ncs_netcon_localmindelay( int srcgid )
 {
-    PreSyn *ps = gid2out_.at[srcgid];
+    PreSyn *ps = gid2out_.at(srcgid);
     return ps->mindelay();
 }
 
 //get the number of netcons for an object, if it sends here
 int ncs_netcon_count( int srcgid, bool localNetCons )
 {
-    PreSyn *ps = NULL;
+    PreSyn *ps{nullptr};
     if( localNetCons ) {
         auto iter = gid2out_.find(srcgid);
         if (iter != gid2out_.end()) {
@@ -881,7 +881,7 @@ static void mk_localgid_rep() {
 // will get the spike delivered and nobody gets it twice.
 
 extern "C" void nrn_fake_fire(int gid, double spiketime, int fake_out) {
-	PreSyn* ps = NULL;
+	PreSyn* ps{nullptr};
 	if (fake_out < 2) {
 		auto iter = gid2in_.find(gid);
 		if (iter != gid2in_.end()) {
@@ -939,7 +939,7 @@ void BBS::set_gid2node(int gid, int nid) {
 			sprintf(m, "gid=%d already exists on this process as an output port", gid);
 			hoc_execerror(m, 0);                            
 		}
-		gid2out_[gid] = NULL;
+		gid2out_[gid] = nullptr;
 	}
 }
 
@@ -1099,7 +1099,9 @@ void BBS::spike_record(int gid, IvocVect* spikevec, IvocVect* gidvec) {
 
 void BBS::spike_record(IvocVect* gids, IvocVect* spikevec, IvocVect* gidvec) {
 	int sz = vector_capacity(gids);
-	all_spiketvec = NULL, all_spikegidvec = NULL; // invalidate global spike vectors
+        // invalidate global spike vectors
+	all_spiketvec = nullptr;
+	all_spikegidvec = nullptr;
 	double* pd = vector_vec(gids);
 	for (int i = 0; i < sz; ++i) {
 		int gid = int(pd[i]);

--- a/src/nrniv/netpar.cpp
+++ b/src/nrniv/netpar.cpp
@@ -7,12 +7,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unordered_map>
-#define ALTHASH 1
-#if ALTHASH
-#include <nrnhash_alt.h>
-#else
-#include <nrnhash.h>
-#endif
 #include <bbs.h>
 
 #undef MD
@@ -21,8 +15,7 @@
 class PreSyn;
 
 // hash table where buckets are binary search maps
-declareNrnHash(Gid2PreSyn, int, PreSyn*)
-implementNrnHash(Gid2PreSyn, int, PreSyn*)
+using Gid2PreSyn = std::unordered_map<int, PreSyn*>;
 
 #include <errno.h>
 #include <netcon.h>
@@ -37,8 +30,8 @@ static int n_bgp_interval;
 #endif
 
 static Symbol* netcon_sym_;
-static Gid2PreSyn* gid2out_;
-static Gid2PreSyn* gid2in_;
+static Gid2PreSyn gid2out_;
+static Gid2PreSyn gid2in_;
 static IvocVect* all_spiketvec = NULL;
 static IvocVect* all_spikegidvec = NULL;
 static double t_exchange_;
@@ -124,22 +117,25 @@ int ncs_netcon_mindelays( int**hosts, double **delays )
 
 double ncs_netcon_localmindelay( int srcgid )
 {
-    PreSyn *ps;
-    gid2out_->find( srcgid, ps );
-    assert(ps);
-    
+    PreSyn *ps = gid2out_.at[srcgid];
     return ps->mindelay();
 }
 
 //get the number of netcons for an object, if it sends here
 int ncs_netcon_count( int srcgid, bool localNetCons )
 {
-    PreSyn *ps;
-    int flag = false;
-    if( localNetCons )
-        gid2out_->find( srcgid, ps );
-    else
-        gid2in_->find( srcgid, ps );
+    PreSyn *ps = NULL;
+    if( localNetCons ) {
+        auto iter = gid2out_.find(srcgid);
+        if (iter != gid2out_.end()) {
+            ps = iter->second;
+        }
+    }else{
+        auto iter = gid2in_.find(srcgid);
+        if (iter != gid2in_.end()) {
+            ps = iter->second;
+        }
+    }
     if( !ps ) {  //no cells on this cpu receive from the given gid
         fprintf( stderr, "should never happen!\n" );
         return 0;
@@ -153,10 +149,17 @@ void ncs_netcon_inject( int srcgid, int netconIndex, double spikeTime, bool loca
 {
     PreSyn *ps;
     NetCvode* ns = net_cvode_instance;
-    if( localNetCons )
-        gid2out_->find( srcgid, ps );
-    else
-        gid2in_->find( srcgid, ps );
+    if( localNetCons ) {
+        auto iter = gid2out_.find(srcgid);   
+        if (iter != gid2out_.end()) {
+            ps = iter->second;
+        }
+    }else{
+        auto iter = gid2in_.find(srcgid);
+        if (iter != gid2in_.end()) {
+            ps = iter->second;
+        }
+    }
     if( !ps ) {  //no cells on this cpu receive from the given gid
         return;
     }
@@ -179,10 +182,6 @@ int ncs_gid_receiving_info( int **presyngids ) {
 
 //given the gid of a cell, retrieve its target count
 int ncs_gid_sending_count( int **sendlist2build ) {
-    if( !gid2out_ ) {
-        fprintf( stderr, "gid2out_ not allocated\n" );
-        return -1;
-    }
     return ncs_bgp_sending_info( sendlist2build );
 }
 
@@ -619,8 +618,9 @@ void nrn_spike_exchange(NrnThread* nt) {
 		int nn = spbufin_[i].nspike;
 		if (nn > nrn_spikebuf_size) { nn = nrn_spikebuf_size; }
 		for (j=0; j < nn; ++j) {
-			PreSyn* ps;
-			if (gid2in_->find(spbufin_[i].gid[j], ps)) {
+			auto iter = gid2in_.find(spbufin_[i].gid[j]);
+			if (iter != gid2in_.end()) {
+				PreSyn* ps = iter->second;
 				ps->send(spbufin_[i].spiketime[j], net_cvode_instance, nt);
 #if NRNSTAT
 				++nrecv_useful_;
@@ -631,8 +631,9 @@ void nrn_spike_exchange(NrnThread* nt) {
 	n = ovfl_;
 #endif // nrn_spikebuf_size > 0
 	for (i = 0; i < n; ++i) {
-		PreSyn* ps;
-		if (gid2in_->find(spikein_[i].gid, ps)) {
+		auto iter = gid2in_.find(spikein_[i].gid);
+		if (iter != gid2in_.end()) {
+			PreSyn* ps = iter->second;
 			ps->send(spikein_[i].spiketime, net_cvode_instance, nt);
 #if NRNSTAT
 			++nrecv_useful_;
@@ -729,7 +730,9 @@ void nrn_spike_exchange_compressed(NrnThread* nt) {
 			int lgid = (int)spfixin_[idx];
 			idx += localgid_size_;
 			PreSyn* ps;
-			if (gps->find(lgid, ps)) {
+			auto iter = gps->find(lgid);
+			if (iter != gps->end()) {
+				PreSyn* ps = iter->second;
 				ps->send(firetime + 1e-10, net_cvode_instance, nt);
 #if NRNSTAT
 				++nrecv_useful_;
@@ -740,8 +743,9 @@ void nrn_spike_exchange_compressed(NrnThread* nt) {
 			double firetime = spfixin_ovfl_[idxov++]*dt + t_exchange_;
 			int lgid = (int)spfixin_ovfl_[idxov];
 			idxov += localgid_size_;
-			PreSyn* ps;
-			if (gps->find(lgid, ps)) {
+			auto iter = gps->find(lgid);
+			if (iter != gps->end()) {
+				PreSyn* ps = iter->second;
 				ps->send(firetime+1e-10, net_cvode_instance, nt);
 #if NRNSTAT
 				++nrecv_useful_;
@@ -761,8 +765,9 @@ void nrn_spike_exchange_compressed(NrnThread* nt) {
 			double firetime = spfixin_[idx++]*dt + t_exchange_;
 			int gid = spupk(spfixin_ + idx);
 			idx += localgid_size_;
-			PreSyn* ps;
-			if (gid2in_->find(gid, ps)) {
+			auto iter = gid2in_.find(gid);
+			if (iter != gid2in_.end()) {
+				PreSyn* ps = iter->second;
 				ps->send(firetime+1e-10, net_cvode_instance, nt);
 #if NRNSTAT
 				++nrecv_useful_;
@@ -776,8 +781,9 @@ void nrn_spike_exchange_compressed(NrnThread* nt) {
 		double firetime = spfixin_ovfl_[idx++]*dt + t_exchange_;
 		int gid = spupk(spfixin_ovfl_ + idx);
 		idx += localgid_size_;
-		PreSyn* ps;
-		if (gid2in_->find(gid, ps)) {
+		auto iter = gid2in_.find(gid);
+		if (iter != gid2in_.end())  {
+			PreSyn* ps = iter->second;
 			ps->send(firetime+1e-10, net_cvode_instance, nt);
 #if NRNSTAT
 			++nrecv_useful_;
@@ -797,11 +803,12 @@ static void mk_localgid_rep() {
 	// how many gids are there on this machine
 	// and can they be compressed into one byte
 	int ngid = 0;
-	NrnHashIterate(Gid2PreSyn, gid2out_, PreSyn*, ps) {
+	for (const auto& iter: gid2out_) {
+		PreSyn* ps = iter.second;
 		if (ps->output_index_ >= 0) {
 			++ngid;
 		}
-	}}}
+	}
 	int ngidmax = nrnmpi_int_allmax(ngid);
 	if (ngidmax > 256) {
 		//do not compress
@@ -818,13 +825,14 @@ static void mk_localgid_rep() {
 	++sbuf;
 	ngid = 0;
 	// define the local gid and fill with the gids on this machine
-	NrnHashIterate(Gid2PreSyn, gid2out_, PreSyn*, ps) {
+	for (const auto& iter: gid2out_) {
+		PreSyn* ps = iter.second;
 		if (ps->output_index_ >= 0) {
 			ps->localgid_ = (unsigned char)ngid;
 			sbuf[ngid] = ps->output_index_;
 			++ngid;
 		}
-	}}}
+	}
 	--sbuf;
 
 	// exchange everything
@@ -838,17 +846,7 @@ static void mk_localgid_rep() {
 	localmaps_ = new Gid2PreSyn*[nrnmpi_numprocs];
 	localmaps_[nrnmpi_myid] = 0;
 	for (i = 0; i < nrnmpi_numprocs; ++i) if (i != nrnmpi_myid) {
-		// how many do we need?
-		sbuf = rbuf + i*(ngidmax + 1);
-		ngid = *(sbuf++); // at most
-		// of which we actually use...
-		for (k=0, j=0; k < ngid; ++k) {
-			if (gid2in_ && gid2in_->find(int(sbuf[k]), ps)) {
-				++j;
-			}
-		}
-		// oh well. there is probably a rational way to choose but...
-		localmaps_[i] = new Gid2PreSyn((j > 19) ? 19 : j+1);
+		localmaps_[i] = new Gid2PreSyn();
 	}
 
 	// fill in the maps
@@ -856,12 +854,10 @@ static void mk_localgid_rep() {
 		sbuf = rbuf + i*(ngidmax + 1);
 		ngid = *(sbuf++);
 		for (k=0; k < ngid; ++k) {
-			if (gid2in_ && gid2in_->find(int(sbuf[k]), ps)) {
-#if ALTHASH
-				localmaps_[i]->insert(k, ps);
-#else
+			auto iter = gid2in_.find(int(sbuf[k]));
+			if (iter != gid2in_.end()) {
+				PreSyn* ps = iter->second;
 				(*localmaps_[i])[k] = ps;
-#endif
 			}
 		}
 	}
@@ -889,36 +885,33 @@ static void mk_localgid_rep() {
 // will get the spike delivered and nobody gets it twice.
 
 extern "C" void nrn_fake_fire(int gid, double spiketime, int fake_out) {
-	assert(gid2in_);
-	PreSyn* ps;
-	if (fake_out < 2 && gid2in_->find(gid, ps)) {
-		assert(ps);
+	PreSyn* ps = NULL;
+	if (fake_out < 2) {
+		auto iter = gid2in_.find(gid);
+		if (iter != gid2in_.end()) {
+			ps = iter->second;
 //printf("nrn_fake_fire %d %g\n", gid, spiketime);
-		ps->send(spiketime, net_cvode_instance, nrn_threads);
+			ps->send(spiketime, net_cvode_instance, nrn_threads);
 #if NRNSTAT
-		++nrecv_useful_;
+			++nrecv_useful_;
+		}
 #endif
-	}else if (fake_out && gid2out_->find(gid, ps)) {
-		assert(ps);
+	}else if (fake_out && !ps) {
+		auto iter = gid2out_.find(gid);
+		if (iter != gid2out_.end()) {
+			ps = iter->second;
 //printf("nrn_fake_fire fake_out %d %g\n", gid, spiketime);
-		ps->send(spiketime, net_cvode_instance, nrn_threads);
+			ps->send(spiketime, net_cvode_instance, nrn_threads);
 #if NRNSTAT
-		++nrecv_useful_;
+			++nrecv_useful_;
 #endif
+		}
 	}
-
 }
 
 static void alloc_space() {
-	if (!gid2out_) {
+	if (!netcon_sym_) {
 		netcon_sym_ = hoc_lookup("NetCon");
-#if ALTHASH
-		gid2out_ = new Gid2PreSyn(1000);
-		gid2in_ = new Gid2PreSyn(500000);
-#else
-		gid2out_ = new Gid2PreSyn(211);
-		gid2in_ = new Gid2PreSyn(2311);
-#endif
 #if NRNMPI
 		ocapacity_  = 100;
 		spikeout_ = (NRNMPI_Spike*)hoc_Emalloc(ocapacity_*sizeof(NRNMPI_Spike)); hoc_malchk();
@@ -941,22 +934,16 @@ void BBS::set_gid2node(int gid, int nid) {
 	{
 #endif
 //printf("gid %d defined on %d\n", gid, nrnmpi_myid);
-		PreSyn* ps;
 		char m[200];
-		if (gid2in_->find(gid, ps)) {
+		if (gid2in_.find(gid) != gid2in_.end()) {
 			sprintf(m, "gid=%d already exists as an input port", gid);
 			hoc_execerror(m, "Setup all the output ports on this process before using them as input ports.");
 		}
-		if (gid2out_->find(gid, ps)) {
+		if (gid2out_.find(gid) != gid2out_.end()) {
 			sprintf(m, "gid=%d already exists on this process as an output port", gid);
 			hoc_execerror(m, 0);                            
 		}
-#if ALTHASH
-		gid2out_->insert(gid, NULL);
-#else
-		(*gid2out_)[gid] = NULL;
-#endif
-//		gid2out_->insert(pair<const int, PreSyn*>(gid, NULL));
+		gid2out_[gid] = NULL;
 	}
 }
 
@@ -969,13 +956,13 @@ void nrn_cleanup_presyn(PreSyn* ps) {
         if (gid_donot_remove) {
 		return;
 	}
-	if (ps->output_index_ >= 0 && gid2out_) {
-		gid2out_->remove(ps->output_index_);
+	if (ps->output_index_ >= 0) {
+		gid2out_.erase(ps->output_index_);
 		ps->output_index_ = -1;
 		ps->gid_ = -1;
 	}
-	if (ps->gid_ >= 0 && gid2in_) {
-		gid2in_->remove(ps->gid_);
+	if (ps->gid_ >= 0) {
+		gid2in_.erase(ps->gid_);
 		ps->gid_ = -1;
 	}
 }
@@ -989,11 +976,10 @@ void nrnmpi_gid_clear(int arg) {
 	}
 	if (arg == 0 || arg == 2 || arg == 4) { nrnmpi_multisplit_clear(); }
 	if (arg == 2 || arg == 3) { return; }
-	if (!gid2out_) { return; }
-	PreSyn* psi;
 	gid_donot_remove = 1;
-	NrnHashIterate(Gid2PreSyn, gid2out_, PreSyn*, ps) {
-		if (ps && !gid2in_->find(ps->gid_, psi)) {
+	for (const auto& iter: gid2out_) {
+		PreSyn* ps = iter.second;
+		if (ps && gid2in_.find(ps->gid_) != gid2in_.end()) {
 		    if (arg == 4) {
 			delete ps;
 		    }else{
@@ -1007,8 +993,9 @@ void nrnmpi_gid_clear(int arg) {
 			}
 		    }
 		}
-	}}}
-	NrnHashIterate(Gid2PreSyn, gid2in_, PreSyn*, ps) {
+	}
+	for (const auto& iter: gid2in_) {
+	    PreSyn* ps = iter.second;
 	    if (arg == 4) {
 		delete ps;
 	    }else{
@@ -1021,26 +1008,18 @@ void nrnmpi_gid_clear(int arg) {
 			delete ps;
 		}
 	    }
-	}}}
+	}
 	gid_donot_remove = 0;
-#if ALTHASH
-	gid2in_->remove_all();
-	gid2out_->remove_all();
-#else
-	int i;
-	for (i = gid2out_->size_ - 1; i >= 0; --i) {
-		gid2out_->at(i).clear();
-	}
-	for (i = gid2in_->size_ - 1; i >= 0; --i) {
-		gid2in_->at(i).clear();
-	}
-#endif
+	gid2in_.clear();
+	gid2out_.clear();
 }
 
 int nrn_gid_exists(int gid) {
 	PreSyn* ps;
 	alloc_space();
-	if (gid2out_->find(gid, ps)) {
+	auto iter = gid2out_.find(gid);
+	if (iter != gid2out_.end()) {
+		PreSyn* ps = iter->second;
 //printf("%d gid %d exists\n", nrnmpi_myid, gid);
 		if (ps) {
 			return (ps->output_index_ >= 0 ? 3 : 2);
@@ -1054,10 +1033,11 @@ int BBS::gid_exists(int gid) {return nrn_gid_exists(gid);}
 
 double BBS::threshold() {
 	int gid = int(chkarg(1, 0., MD));
-	PreSyn* ps;
-	if (!gid2out_->find(gid, ps) || ps == NULL) {
+	auto iter = gid2out_.find(gid);
+	if (iter == gid2out_.end() || iter->second == NULL) {
 		hoc_execerror("gid not associated with spike generation location", 0);
 	}
+	PreSyn* ps = iter->second;
 	if (ifarg(2)) {
 		ps->threshold_ = *getarg(2);
 	}
@@ -1066,14 +1046,13 @@ double BBS::threshold() {
 
 void BBS::cell() {
 	int gid = int(chkarg(1, 0., MD));
-	PreSyn* ps;
 	alloc_space();
-	if (gid2in_->find(gid, ps)) {
+	if (gid2in_.find(gid) != gid2in_.end()) {
 		char buf[100];
 		sprintf(buf, "gid=%d is in the input list. Must register prior to connecting", gid);
 		hoc_execerror(buf, 0);
 	}
-	if (gid2out_->find(gid, ps) == 0) {
+	if (gid2out_.find(gid) == gid2out_.end()) {
 		char buf[100];
 		sprintf(buf, "gid=%d has not been set on rank %d", gid, nrnmpi_myid);
 		hoc_execerror(buf, 0);
@@ -1083,13 +1062,9 @@ void BBS::cell() {
 		check_obj_type(ob, "NetCon");
 	}
 	NetCon* nc = (NetCon*)ob->u.this_pointer;
-	ps = nc->src_;
+	PreSyn* ps = nc->src_;
 //printf("%d cell %d %s\n", nrnmpi_myid, gid, hoc_object_name(ps->ssrc_ ? nrn_sec2cell(ps->ssrc_) : ps->osrc_));
-#if ALTHASH
-	gid2out_->insert(gid, ps);
-#else
-	(*gid2out_)[gid] = ps;
-#endif
+	gid2out_[gid] = ps;
 	ps->gid_ = gid;
 	if (ifarg(3) && !chkarg(3, 0., 1.)) {
 		ps->output_index_ = -2; //prevents destruction of PreSyn
@@ -1099,38 +1074,43 @@ void BBS::cell() {
 }
 
 void BBS::outputcell(int gid) {
-	PreSyn* ps;
-	nrn_assert(gid2out_->find(gid, ps));
+	auto iter = gid2out_.find(gid);
+	nrn_assert(iter != gid2out_.end());
+	PreSyn* ps = iter->second;
 	assert(ps);
 	ps->output_index_ = gid;
 	ps->gid_ = gid;
 }
 
 void BBS::spike_record(int gid, IvocVect* spikevec, IvocVect* gidvec) {
-	PreSyn* ps;
     if (gid >= 0) {
         all_spiketvec = NULL, all_spikegidvec = NULL; // invalidate global spike vectors
-        nrn_assert(gid2out_->find(gid, ps));
+
+        auto iter = gid2out_.find(gid);
+        nrn_assert(iter != gid2out_.end());
+        PreSyn* ps = iter->second;
         assert(ps);
         ps->record(spikevec, gidvec, gid);
     }else{ // record all output spikes.
         all_spiketvec = spikevec, all_spikegidvec = gidvec; // track global spike vectors (optimisation)
-        NrnHashIterate(Gid2PreSyn, gid2out_, PreSyn*, ps) {
+        for (const auto& iter: gid2out_) {
+            PreSyn* ps = iter.second;
             if (ps->output_index_ >= 0) {
                 ps->record(all_spiketvec, all_spikegidvec, ps->output_index_);
             }
-        }}}
+        }
     }
 }
 
 void BBS::spike_record(IvocVect* gids, IvocVect* spikevec, IvocVect* gidvec) {
 	int sz = vector_capacity(gids);
-    all_spiketvec = NULL, all_spikegidvec = NULL; // invalidate global spike vectors
+	all_spiketvec = NULL, all_spikegidvec = NULL; // invalidate global spike vectors
 	double* pd = vector_vec(gids);
 	for (int i = 0; i < sz; ++i) {
-		PreSyn* ps;
 		int gid = int(pd[i]);
-		nrn_assert(gid2out_->find(gid, ps));
+		auto iter = gid2out_.find(gid);
+		nrn_assert(iter != gid2out_.end());
+		PreSyn* ps = iter->second;
 		assert(ps);
 		ps->record(spikevec, gidvec, gid);
 	}
@@ -1139,8 +1119,9 @@ void BBS::spike_record(IvocVect* gids, IvocVect* spikevec, IvocVect* gidvec) {
 static Object* gid2obj_(int gid) {
 	Object* cell = 0;
 //printf("%d gid2obj gid=%d\n", nrnmpi_myid, gid);
-	PreSyn* ps;
-	nrn_assert(gid2out_->find(gid, ps));
+	auto iter = gid2out_.find(gid);
+	nrn_assert(iter != gid2out_.end());
+	PreSyn* ps = iter->second;
 //printf(" found\n");
 	assert(ps);
 	cell = ps->ssrc_ ? nrn_sec2cell(ps->ssrc_) : ps->osrc_;
@@ -1155,8 +1136,9 @@ Object** BBS::gid2obj(int gid) {
 Object** BBS::gid2cell(int gid) {
 	Object* cell = 0;
 //printf("%d gid2obj gid=%d\n", nrnmpi_myid, gid);
-	PreSyn* ps;
-	nrn_assert(gid2out_->find(gid, ps));
+	auto iter = gid2out_.find(gid);
+	nrn_assert(iter != gid2out_.end());
+	PreSyn* ps = iter->second;
 //printf(" found\n");
 	assert(ps);
 	if (ps->ssrc_) {
@@ -1184,26 +1166,28 @@ Object** BBS::gid_connect(int gid) {
 	}
 	alloc_space();
 	PreSyn* ps;
-	if (gid2out_->find(gid, ps)) {
+	auto iter_out = gid2out_.find(gid);
+	if (iter_out != gid2out_.end()) {
 		// the gid is owned by this machine so connect directly
+		ps = iter_out->second;
 		if (!ps) {
 			char buf[100];
 			sprintf(buf, "gid %d owned by %d but no associated cell", gid, nrnmpi_myid);
 			hoc_execerror(buf, 0);
 		}
-	}else if (gid2in_->find(gid, ps)) {
-		// the gid stub already exists
-//printf("%d connect %s from already existing %d\n", nrnmpi_myid, hoc_object_name(target), gid);
 	}else{
+		auto iter_in = gid2in_.find(gid);
+		if (iter_in != gid2in_.end()) {
+			// the gid stub already exists
+			ps = iter_in->second;
+//printf("%d connect %s from already existing %d\n", nrnmpi_myid, hoc_object_name(target), gid);
+		}else{
 //printf("%d connect %s from new PreSyn for %d\n", nrnmpi_myid, hoc_object_name(target), gid);
-		ps = new PreSyn(NULL, NULL, NULL);
-		net_cvode_instance->psl_append(ps);
-#if ALTHASH
-		gid2in_->insert(gid, ps);
-#else
-		(*gid2in_)[gid] = ps;
-#endif
-		ps->gid_ = gid;
+			ps = new PreSyn(NULL, NULL, NULL);
+			net_cvode_instance->psl_append(ps);
+			gid2in_[gid] = ps;
+			ps->gid_ = gid;
+		}
 	}
 	NetCon* nc;
 	Object** po;
@@ -1322,8 +1306,9 @@ int nrnthread_all_spike_vectors_return(std::vector<double>& spiketvec, std::vect
             
         }else{ // different underlying vectors for PreSyns
             for (size_t i = 0; i < spikegidvec.size(); ++i ) {
-                PreSyn* ps;
-                if (gid2out_->find(spikegidvec[i], ps)) {
+                auto iter = gid2out_.find(spikegidvec[i]);
+                if (iter != gid2out_.end()) {
+                    PreSyn* ps = iter->second;
                     ps->record(spiketvec[i]);
                 }
             }
@@ -1348,12 +1333,13 @@ static double set_mindelay(double maxdelay) {
     }
 #if NRNMPI
     else{
-	NrnHashIterate(Gid2PreSyn, gid2in_, PreSyn*, ps) {
+	for (const auto& iter: gid2in_) {
+		PreSyn* ps = iter.second;
 		double md = ps->mindelay();
 		if (mindelay > md) {
 			mindelay = md;
 		}
-	}}}
+	}
     }
 	if (nrnmpi_use) {active_ = 1;}
 	if (use_compress_) {
@@ -1524,9 +1510,9 @@ Printf("Notice: gid compression did not succeed. Probably more than 255 cells on
 }
 
 PreSyn* nrn_gid2outputpresyn(int gid) { // output PreSyn
-        PreSyn* ps;
-        if (gid2out_->find(gid, ps)) {
-	        return ps;
+        auto iter = gid2out_.find(gid);
+        if (iter != gid2out_.end()) {
+	        return iter->second;
 	}
 	return NULL;
 }
@@ -1536,19 +1522,20 @@ Object* nrn_gid2obj(int gid) {
 }
 
 PreSyn* nrn_gid2presyn(int gid) { // output PreSyn
-	PreSyn* ps;
-	nrn_assert(gid2out_->find(gid, ps));
-	return ps;
+	auto iter = gid2out_.find(gid);
+	nrn_assert(iter != gid2out_.end());
+	return iter->second;
 }
 
 void nrn_gidout_iter(PFIO callback) {
-	NrnHashIterate(Gid2PreSyn, gid2out_, PreSyn*, ps) {
+	for (const auto& iter: gid2out_) {
+		PreSyn* ps = iter.second;
 		if (ps) {
 			int gid = ps->gid_;
 			Object* c = gid2obj_(gid);
 			(*callback)(gid, c);
 		}
-	}}}
+	}
 }
 
 #include "nrncore_write.h"
@@ -1568,31 +1555,33 @@ size_t npnt = 0;
     printf("size Presyn=%ld NetCon=%ld Point_process=%ld Prop=%ld\n",
       sizeof(PreSyn), sizeof(NetCon), sizeof(Point_process), sizeof(Prop));
   }
-  NrnHashIterate(Gid2PreSyn, gid2out_, PreSyn*, ps) {
+  for (const auto& iter: gid2out_) {
+    PreSyn* ps = iter.second;
     if (ps) {
       nout += 1;
       int n = ps->dil_.count();
       nnet += n;
       for (int i=0; i < n; ++i) {
         nweight += weightcnt(ps->dil_.item(i));
-NetCon* nc = ps->dil_.item(i);
-if (nc->target_) { npnt += 1; }
+        NetCon* nc = ps->dil_.item(i);
+        if (nc->target_) { npnt += 1; }
       }
     }
-  }}}
+  }
 //printf("output Presyn npnt = %ld nweight = %ld\n", npnt, nweight);
-  NrnHashIterate(Gid2PreSyn, gid2in_, PreSyn*, ps) {
+  for (const auto& iter: gid2in_) {
+    PreSyn* ps = iter.second;
     if (ps) {
       nin += 1;
       int n = ps->dil_.count();
       nnet += n;
       for (int i=0; i < n; ++i) {
         nweight += weightcnt(ps->dil_.item(i));
-NetCon* nc = ps->dil_.item(i);
-if (nc->target_) { npnt += 1; }
+        NetCon* nc = ps->dil_.item(i);
+        if (nc->target_) { npnt += 1; }
       }
     }
-  }}}
+  }
 //printf("after input Presyn total npnt = %ld  nweight = %ld\n", npnt, nweight);
   ntot = (nin + nout)*sizeof(PreSyn) + nnet*sizeof(NetCon) + nweight*sizeof(double);
 //  printf("%d rank output Presyn %ld  input Presyn %ld  NetCon %ld  bytes %ld\n",
@@ -1611,7 +1600,8 @@ void nrncore_netpar_cellgroups_helper(CellGroup* cgs) {
     gidcnt[i] = 0;
   }
 
-  NrnHashIterate(Gid2PreSyn, gid2out_, PreSyn*, ps) {
+  for (const auto& iter: gid2out_) {
+    PreSyn* ps = iter.second;
     if (ps && ps->thvar_) {
       int ith = ps->nt_->id;
       assert(ith >= 0 && ith < nrn_nthread);
@@ -1624,7 +1614,7 @@ void nrncore_netpar_cellgroups_helper(CellGroup* cgs) {
       cgs[ith].output_vindex[i] = inode;
       ++gidcnt[ith];
     }
-  }}}
+  }
 #if 0 // allow real cells to NOT have a direct voltage threshold.
   for (int i=0; i < nrn_nthread; ++ i) {
     assert(nrn_threads[i].ncell == gidcnt[i]);

--- a/src/nrniv/netpar.cpp
+++ b/src/nrniv/netpar.cpp
@@ -979,7 +979,7 @@ void nrnmpi_gid_clear(int arg) {
 	gid_donot_remove = 1;
 	for (const auto& iter: gid2out_) {
 		PreSyn* ps = iter.second;
-		if (ps && gid2in_.find(ps->gid_) != gid2in_.end()) {
+		if (ps && gid2in_.find(ps->gid_) == gid2in_.end()) {
 		    if (arg == 4) {
 			delete ps;
 		    }else{
@@ -1015,7 +1015,6 @@ void nrnmpi_gid_clear(int arg) {
 }
 
 int nrn_gid_exists(int gid) {
-	PreSyn* ps;
 	alloc_space();
 	auto iter = gid2out_.find(gid);
 	if (iter != gid2out_.end()) {

--- a/src/nrniv/netpar.cpp
+++ b/src/nrniv/netpar.cpp
@@ -729,7 +729,6 @@ void nrn_spike_exchange_compressed(NrnThread* nt) {
 			double firetime = spfixin_[idx++]*dt + t_exchange_;
 			int lgid = (int)spfixin_[idx];
 			idx += localgid_size_;
-			PreSyn* ps;
 			auto iter = gps->find(lgid);
 			if (iter != gps->end()) {
 				PreSyn* ps = iter->second;
@@ -797,9 +796,6 @@ void nrn_spike_exchange_compressed(NrnThread* nt) {
 }
 
 static void mk_localgid_rep() {
-	int i, j, k;
-	PreSyn* ps;
-
 	// how many gids are there on this machine
 	// and can they be compressed into one byte
 	int ngid = 0;
@@ -845,15 +841,15 @@ static void mk_localgid_rep() {
 	// perfect hash functions, or even simple Vectors.
 	localmaps_ = new Gid2PreSyn*[nrnmpi_numprocs];
 	localmaps_[nrnmpi_myid] = 0;
-	for (i = 0; i < nrnmpi_numprocs; ++i) if (i != nrnmpi_myid) {
+	for (int i = 0; i < nrnmpi_numprocs; ++i) if (i != nrnmpi_myid) {
 		localmaps_[i] = new Gid2PreSyn();
 	}
 
 	// fill in the maps
-	for (i = 0; i < nrnmpi_numprocs; ++i) if (i != nrnmpi_myid) {
+	for (int i = 0; i < nrnmpi_numprocs; ++i) if (i != nrnmpi_myid) {
 		sbuf = rbuf + i*(ngidmax + 1);
 		ngid = *(sbuf++);
-		for (k=0; k < ngid; ++k) {
+		for (int k=0; k < ngid; ++k) {
 			auto iter = gid2in_.find(int(sbuf[k]));
 			if (iter != gid2in_.end()) {
 				PreSyn* ps = iter->second;

--- a/src/nrniv/netpar.cpp
+++ b/src/nrniv/netpar.cpp
@@ -6,6 +6,7 @@
 #include <nrnoc2iv.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unordered_map>
 #define ALTHASH 1
 #if ALTHASH
 #include <nrnhash_alt.h>

--- a/src/nrniv/nrnmusic.cpp
+++ b/src/nrniv/nrnmusic.cpp
@@ -127,10 +127,11 @@ void NRNMUSIC::EventOutputPort::gid2index(int gid, int gi) {
 	// except pc.cell(gid, nc) has already been called and this
 	// will add this to the PreSyn.music_out_ list.
 	alloc_music_space();
-	PreSyn* ps;
-	if (!gid2out_->find(gid, ps)) {
+	auto iter = gid2out_.find(gid);
+	if (iter == gid2out_.end()) {
 		return;
-	}	
+	}
+	PreSyn* ps = iter->second;
 	ps->music_port_ = new MusicPortPair((void*)this, gi, ps->music_port_);
 
 	// to create an IndexList for a later map, need to

--- a/src/nrnoc/hh.mod
+++ b/src/nrnoc/hh.mod
@@ -30,7 +30,7 @@ NEURON {
         NONSPECIFIC_CURRENT il
         RANGE gnabar, gkbar, gl, el, gna, gk
         : `GLOBAL minf` will be replaced with `RANGE minf` if CoreNEURON enabled
-        GLOBAL minf, hinf, ninf, mtau, htau, ntau
+        RANGE minf, hinf, ninf, mtau, htau, ntau
 	THREADSAFE : assigned GLOBALs will be per thread
 }
  
@@ -94,7 +94,7 @@ PROCEDURE rates(v(mV)) {  :Computes rate and other constants at current v.
                       :Call once from HOC to initialize inf at resting v.
         LOCAL  alpha, beta, sum, q10
         : `TABLE minf` will be replaced with `:TABLE minf` if CoreNEURON enabled)
-        TABLE minf, mtau, hinf, htau, ninf, ntau DEPEND celsius FROM -100 TO 100 WITH 200
+        :TABLE minf, mtau, hinf, htau, ninf, ntau DEPEND celsius FROM -100 TO 100 WITH 200
 
 UNITSOFF
         q10 = 3^((celsius - 6.3)/10)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -174,6 +174,13 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
         ${PROJECT_SOURCE_DIR}/test/pynrn/test_partrans.py)
     list(APPEND TESTS parallel_tests parallel_partrans)
     add_test(
+      NAME parallel_netpar
+      COMMAND
+        ${CMAKE_COMMAND} -E env PYTHONPATH=$PYTHONPATH:${PROJECT_SOURCE_DIR}/test/pynrn ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_OVERSUBSCRIBE}
+        ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/bin/nrniv ${MPIEXEC_POSTFLAGS} -mpi -python
+        ${PROJECT_SOURCE_DIR}/test/pynrn/test_netpar.py)
+    list(APPEND TESTS parallel_tests parallel_netpar)
+    add_test(
       NAME parallel_bas
       COMMAND
         ${CMAKE_COMMAND} -E env ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS}

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -31,7 +31,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   tqperf
   GIT_REPOSITORY https://github.com/nrnhines/tqperf
-  GIT_TAG bab556b0
+  GIT_TAG d17270d35
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/tqperf)
 
 FetchContent_MakeAvailable(nrntest reduced_dentate ringtest testcorenrn tqperf)

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -31,7 +31,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   tqperf
   GIT_REPOSITORY https://github.com/nrnhines/tqperf
-  GIT_TAG 6db04361
+  GIT_TAG bab556b0
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/tqperf)
 
 FetchContent_MakeAvailable(nrntest reduced_dentate ringtest testcorenrn tqperf)

--- a/test/pynrn/test_netpar.py
+++ b/test/pynrn/test_netpar.py
@@ -93,6 +93,9 @@ def err_test2():
     pc.max_histogram(v1)
     v2 = h.Vector(10)
     pc.max_histogram()
+    # cover nrn_gid2outpresyn
+    pc.prcellstate(10000, "tmp")
+    pc.prcellstate(0, "tmp")
 
     pc.gid_clear()
     del r

--- a/test/pynrn/test_netpar.py
+++ b/test/pynrn/test_netpar.py
@@ -1,0 +1,114 @@
+# Error tests for netpar.cpp
+# Some minor coverage increase for netpar.cpp when nhost > 1
+
+from neuron import h
+
+pc = h.ParallelContext()
+
+from neuron.expect_hocerr import expect_err
+from test_hoc_po import Ring
+
+cvode = h.CVode()
+
+
+def run(tstop):
+    pc.set_maxstep(1)
+    h.finitialize(-65)
+    pc.psolve(tstop)
+
+
+def mpi_test1():  # pgvts_deliver and pc.spike_record
+    dtsav = h.dt
+    r = Ring(3, 2)
+    for gid, cell in r.cells.items():
+        if type(cell) == type(h):
+            cell.axon.disconnect()
+            pc.multisplit(cell.axon(0), gid)
+            pc.multisplit(cell.soma(1), gid)
+
+    pc.multisplit()
+    gids = h.Vector([gid for gid in r.cells])
+    pc.spike_record(gids, r.spiketime, r.spikegid)
+    cvode.active(1)
+    cvode.condition_order(1)  # investigate why condition_order(2) fails
+    cvode.debug_event(1)
+    run(3.0)
+
+    cvode.queue_mode(1, 0)
+    pc.spike_compress(3, 1)
+
+    cvode.active(0)
+    h.dt = dtsav
+    pc.gid_clear()
+    cvode.debug_event(0)
+    cvode.condition_order(1)
+
+
+def mpi_test2():
+    return
+
+
+def err_test1():
+    r = Ring(3, 2)
+    expect_err("pc.set_gid2node(0, pc.id())")
+    nc = pc.gid_connect(10000, r.cells[0].syn)
+    expect_err("pc.set_gid2node(10000, pc.id())")
+    expect_err("pc.threshold(10000)")
+    expect_err("pc.cell(10000)")
+    expect_err("pc.cell(99999)")
+    expect_err("pc.cell(0, None)")
+    expect_err("pc.gid_connect(0, None)")
+    pc.set_gid2node(99999, pc.id())
+    expect_err("pc.gid_connect(99999, r.cells[0].syn)")
+    expect_err("pc.gid_connect(1, r.cells[0].syn, h.Vector())")
+    nc = h.NetCon(None, r.cells[1].syn)
+    expect_err("pc.gid_connect(1, r.cells[0].syn, nc)")
+    nc = h.NetCon(None, r.cells[0].syn)
+    pc.gid_connect(1, r.cells[0].syn, nc)
+
+    pc.gid_clear()
+    del nc, r
+    locals()
+
+
+def err_test2():
+    r = Ring(3, 2)
+    r.ncs[0].delay = 0
+    pc.nthread(2)
+    pc.set_maxstep(1)
+    expect_err("h.finitialize(-65)")
+    pc.nthread(1)
+    r.ncs[0].delay = h.dt
+    pc.set_maxstep(h.dt)
+    h.finitialize(-65)
+    expect_err("pc.psolve(1.0)")  # wonder if this is too stringent an error
+    r.ncs[0].delay = 0
+    assert pc.set_maxstep(1) == 1.0
+    cvode.queue_mode(0, 1)
+    pc.set_maxstep(1)
+    h.finitialize(-65)
+    pc.psolve(1)
+    assert cvode.queue_mode() == 0
+    v1 = h.Vector(10)
+    pc.max_histogram(v1)
+    v2 = h.Vector(10)
+    pc.max_histogram()
+
+    pc.gid_clear()
+    del r
+    locals()
+
+
+def test_1():
+    if pc.nhost() > 1:
+        mpi_test1()
+        mpi_test2()
+    else:
+        err_test1()
+        err_test2()
+
+
+if __name__ == "__main__":
+    test_1()
+    pc.barrier()
+    h.quit()


### PR DESCRIPTION
using std::unordered_map as Gid2PreSyn

tqperf test is taking too long at 42 seconds but should be dramatically reduceable while still maintaining the coverage:
```
                                        lines               functions
bgpdma.cpp                    87.2%             100%
bgpdmasetup.cpp           98.9%             100%
netpar.cpp                       88.0%              92.6%
```