### PR TITLE
Integration of tqperf model for CI and CoreNEURON testing

### DIFF
--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -70,9 +70,6 @@ while test -n "$1" ; do
     -loadflags)
         # extra link flags, paths, libraries (NEURON only)
         UserLDFLAGS="$2"
-        shift
-        shift;;
-    -l)
         # extra lin flags, paths. libraries (CoreNEURON)
         UserCOREFLAGS="$UserCOREFLAGS -l $2"
         shift

--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -50,24 +50,40 @@ if command -v xcrun; then
 fi
 
 LinkCoreNEURON=false
-if [ "$1" = "-coreneuron" ] ; then
-      LinkCoreNEURON=true
-      shift
-fi
-
 UserINCFLAGS=""
-if [ "$1" = "-incflags" ] ; then
-      UserINCFLAGS="$2"
-      shift
-      shift
-fi
-
 UserLDFLAGS=""
-if [ "$1" = "-loadflags" ] ; then
-       UserLDFLAGS="$2"
-       shift
-       shift
-fi
+UserCOREFLAGS=""
+
+# - options come first but can be in any order.
+while test -n "$1" ; do
+    opt="$1"
+    case "$opt" in
+    -coreneuron)
+        # also run nrnivmodl-core
+        LinkCoreNEURON=true
+        shift;;
+    -incflags)
+        # extra include flags and paths (NEURON only)
+        UserINCFLAGS="$2"
+        shift
+        shift;;
+    -loadflags)
+        # extra link flags, paths, libraries (NEURON only)
+        UserLDFLAGS="$2"
+        shift
+        shift;;
+    -l)
+        # extra lin flags, paths. libraries (CoreNEURON)
+        UserCOREFLAGS="$UserCOREFLAGS -l $2"
+        shift
+        shift;;
+    -*)
+        echo "$opt unrecognized"
+        exit 1;;
+    *)
+        break;;
+    esac
+done
 
 pwd
 
@@ -279,7 +295,7 @@ if [ "$LinkCoreNEURON" = true ] ; then
       j=`escape_spaces "$j"`
       args="$args $j"
     done
-    "${cnrn_prefix}/bin/nrnivmodl-core" $args
+    "${cnrn_prefix}/bin/nrnivmodl-core" $UserCOREFLAGS $args
     cd $MODSUBDIR
   else
     printf "ERROR : CoreNEURON support is not enabled!\n"

--- a/share/lib/python/neuron/coreneuron.py
+++ b/share/lib/python/neuron/coreneuron.py
@@ -201,12 +201,10 @@ class coreneuron(object):
         multisend = int(pc.send_time(8))
         if (multisend & 1) == 1:
             arg += " --multisend"
-            interval = (multisend & 4) / 4 + 1
-            if interval != 2:
-                arg += " --ms-subintervals %d" % interval
-            phases = (multisend & 8) / 8 + 1
-            if phases != 2:
-                arg += " --ms-phases %d" % phases
+            interval = 2 if multisend & 4 else 1
+            arg += " --ms-subintervals %d" % interval
+            phases = 2 if multisend & 8 else 1
+            arg += " --ms-phases %d" % phases
 
         return arg
 

--- a/src/nrncvode/netcvode.cpp
+++ b/src/nrncvode/netcvode.cpp
@@ -5949,11 +5949,12 @@ void NetCvode::deliver_net_events(NrnThread* nt) { // for default method
 		// instead of every time step --- but here we are
 		// already in a multithread job, so what is the overhead of
 		// starting such a small one in nrn_spike_exchange.
+#if NRNMPI
 		extern bool nrn_use_compress_;
 		if (nrn_use_compress_ && nrn_nthread > 1) {
 			p[tid].enqueue(this, nt);
 		}
-
+#endif
 		while ((q = p[tid].tqe_->dequeue_bin()) != 0) {
 			DiscreteEvent* db = (DiscreteEvent*)q->data_;
 #if PRINT_EVENT

--- a/src/nrncvode/netcvode.cpp
+++ b/src/nrncvode/netcvode.cpp
@@ -5942,6 +5942,18 @@ void NetCvode::deliver_net_events(NrnThread* nt) { // for default method
     // but I do not want to affect the case of not using a bin queue.
 
 	if (nrn_use_bin_queue_) {
+		// it was noticed on binq + compressed spike exchange +
+		// threads that a transferred event may be languishing in
+		// the interthread event buffer. Perhaps this is better done
+		// as a multithread job at the end of nrn_spike_exchange
+		// instead of every time step --- but here we are
+		// already in a multithread job, so what is the overhead of
+		// starting such a small one in nrn_spike_exchange.
+		extern bool nrn_use_compress_;
+		if (nrn_use_compress_ && nrn_nthread > 1) {
+			p[tid].enqueue(this, nt);
+		}
+
 		while ((q = p[tid].tqe_->dequeue_bin()) != 0) {
 			DiscreteEvent* db = (DiscreteEvent*)q->data_;
 #if PRINT_EVENT

--- a/src/nrncvode/netcvode.cpp
+++ b/src/nrncvode/netcvode.cpp
@@ -2860,7 +2860,7 @@ void NetCvode::clear_events() {
 		}
 #if BBTQ == 5
 		d.tqe_->nshift_ = -1;
-		d.tqe_->shift_bin(nt_t);
+		d.tqe_->shift_bin(nt_t - 0.5*nt_dt);
 #endif
 	}
 	// I don't believe this is needed anymore since cvode not needed

--- a/src/nrncvode/sptbinq.h
+++ b/src/nrncvode/sptbinq.h
@@ -94,11 +94,12 @@ public:
 	int nshift_;
 	void deleteitem(TQItem*);
 public:
-	const BinQ* binq(){return binq_;}
+	BinQ* binq(){return binq_;}
 private:
 	double least_t_nolock(){if (least_) { return least_->t_;}else{return 1e15;}}
 	void move_least_nolock(double tnew);
 	SPTREE<TQItem>* sptree_;
+	BinQ* binq_;
 	TQItem* least_;
 	TQItemPool* tpool_;
 	MUTDEC

--- a/src/nrncvode/sptbinq.h
+++ b/src/nrncvode/sptbinq.h
@@ -93,11 +93,12 @@ public:
 	void forall_callback(void (*)(const TQItem*, int));
 	int nshift_;
 	void deleteitem(TQItem*);
+public:
+	BinQ* binq_; // made public for nrn2core_transfer_tqueue
 private:
 	double least_t_nolock(){if (least_) { return least_->t_;}else{return 1e15;}}
 	void move_least_nolock(double tnew);
 	SPTREE<TQItem>* sptree_;
-	BinQ* binq_;
 	TQItem* least_;
 	TQItemPool* tpool_;
 	MUTDEC

--- a/src/nrncvode/sptbinq.h
+++ b/src/nrncvode/sptbinq.h
@@ -94,7 +94,7 @@ public:
 	int nshift_;
 	void deleteitem(TQItem*);
 public:
-	BinQ* binq_; // made public for nrn2core_transfer_tqueue
+	const BinQ* binq(){return binq_;}
 private:
 	double least_t_nolock(){if (least_) { return least_->t_;}else{return 1e15;}}
 	void move_least_nolock(double tnew);

--- a/src/nrniv/bgpdma.cpp
+++ b/src/nrniv/bgpdma.cpp
@@ -698,7 +698,7 @@ static void bgpdma_cleanup() {
 }
 
 #ifndef BGPTIMEOUT
-#define BGPTIMEOUT 1
+#define BGPTIMEOUT 0
 #endif
 
 #if BGPTIMEOUT

--- a/src/nrniv/bgpdma.cpp
+++ b/src/nrniv/bgpdma.cpp
@@ -140,8 +140,10 @@ public:
 	NRNMPI_Spike** buffer_;
 	SpkPool* pool_;
 
+#if ENQUEUE == 1
 	void enqueue1();
 	void enqueue2();
+#endif
 	PreSyn** psbuf_;
 	void phase2send();
 	int phase2_head_;
@@ -310,6 +312,7 @@ void BGP_ReceiveBuffer::enqueue() {
 	phase2send();
 }
 
+#if ENQUEUE == 1
 void BGP_ReceiveBuffer::enqueue1() {
 //printf("%d %lx.enqueue count=%d t=%g nrecv=%d nsend=%d\n", nrnmpi_myid, (long)this, t, count_, nrecv_, nsend_);
 	assert(busy_ == 0);
@@ -350,6 +353,7 @@ void BGP_ReceiveBuffer::enqueue2() {
 	nsend_cell_ = 0;
 	busy_ = 0;
 }
+#endif // ENQUEUE == 1
 
 void BGP_ReceiveBuffer::phase2send() {
 	while (phase2_head_ != phase2_tail_) {

--- a/src/nrniv/bgpdma.cpp
+++ b/src/nrniv/bgpdma.cpp
@@ -671,9 +671,6 @@ void bgp_dma_send(PreSyn* ps, double t) {
 	if (ps->bgp.dma_send_) ps->bgp.dma_send_->send(ps->output_index_, t);
 }
 
-void bgpdma_send_init(PreSyn* ps) {
-}
-
 void bgpdma_cleanup_presyn(PreSyn* ps) {
 	if (ps->bgp.dma_send_) {
 		if (ps->output_index_ >= 0) {
@@ -695,6 +692,16 @@ static void bgpdma_cleanup() {
 	NrnHashIterate(Gid2PreSyn, gid2in_, PreSyn*, ps) {
 		bgpdma_cleanup_presyn(ps);
 	}}}
+	if (!use_bgpdma_ && bgp_receive_buffer[1]) {
+		delete bgp_receive_buffer[0];
+		bgp_receive_buffer[0] = NULL;
+	}
+#if BGP_INTERVAL == 2
+	if ((!use_bgpdma_ || n_bgp_interval != 2) && bgp_receive_buffer[1]) {
+		delete bgp_receive_buffer[1];
+		bgp_receive_buffer[1] = NULL;
+	}
+#endif
 }
 
 #ifndef BGPTIMEOUT

--- a/src/nrniv/bgpdmasetup.cpp
+++ b/src/nrniv/bgpdmasetup.cpp
@@ -356,7 +356,7 @@ static void fill_dma_send_lists(int sz, int* r) {
 		}
 	}}}
 	if (use_phase2_) NrnHashIterate(Gid2PreSyn, gid2in_, PreSyn*, ps) {
-		BGP_DMASend_Phase2* bsp = new BGP_DMASend_Phase2();
+		BGP_DMASend_Phase2* bsp = ps->bgp.dma_send_phase2_;
 		if (bsp && max_multisend_targets < bsp->ntarget_hosts_phase2_) {
 			max_multisend_targets = bsp->ntarget_hosts_phase2_;
 		}
@@ -598,6 +598,7 @@ static int setup_target_lists(int** r_return) {
 		delete tl;
 	}}}
 	delete gid2tarlist;
+	del(sdispl);
 	sdispl = newoffset(scnt, nhost);
 	all2allv_int(s, scnt, sdispl, r, rcnt, rdispl, "lists");
 	del(s);

--- a/src/nrniv/bgpdmasetup.cpp
+++ b/src/nrniv/bgpdmasetup.cpp
@@ -121,7 +121,6 @@ static int* newoffset(int* acnt, int size) {
 
 // input scnt, sdispl ; output, newly allocated rcnt, rdispl
 static void all2allv_helper(int* scnt, int* sdispl, int*& rcnt, int*& rdispl) {
-	int i;
 	int np = nrnmpi_numprocs;
 	int* c = newintval(1, np);
 	rdispl = newoffset(c, np);
@@ -380,6 +379,7 @@ static int setup_target_lists(int** r_return) {
 	// scnt is number of input gids from target
 	scnt = newintval(0, nhost);
 	NrnHashIterateKeyValue(Gid2PreSyn, gid2in_, int, gid, PreSyn*, ps) {
+                assert(ps->gid_ == gid); // avoid unused warning
 		++scnt[gid%nhost];
 	}}}
 
@@ -387,6 +387,7 @@ static int setup_target_lists(int** r_return) {
 	sdispl = newoffset(scnt, nhost);
 	s = newintval(0, sdispl[nhost]);
 	NrnHashIterateKeyValue(Gid2PreSyn, gid2in_, int, gid, PreSyn*, ps) {
+		assert(ps->gid_ == gid); // avoid unused warning
 		s[sdispl[gid%nhost]++] = gid;
 	}}}
 	// Restore sdispl for the message.
@@ -528,6 +529,7 @@ static int setup_target_lists(int** r_return) {
 	// how much to send to each rank
 	scnt = newintval(0, nhost);
 	NrnHashIterateKeyValue(Int2TarList, gid2tarlist, int, gid, TarList*, tl) {
+		assert(gid >= 0); // avoid unused warning
 		if (tl->rank < 0) {
 			// When the output gid does not generate spikes, that rank
 			// is not interested if there is a target list for it.

--- a/src/nrniv/netpar.cpp
+++ b/src/nrniv/netpar.cpp
@@ -1468,6 +1468,7 @@ int nrnmpi_spike_compress(int nspike, bool gid_compress, int xchng_meth) {
 	use_bgpdma_ = (xchng_meth & 1) == 1;
 	use_phase2_ = (xchng_meth & 8) ? 1 : 0;
 	if (use_bgpdma_) { assert(BGPDMA); }
+	bgpdma_cleanup();
 #else // BGPDMA == 0
 	assert(xchng_meth == 0);
 #endif

--- a/src/nrniv/netpar.cpp
+++ b/src/nrniv/netpar.cpp
@@ -965,7 +965,6 @@ void nrn_cleanup_presyn(PreSyn* ps) {
 #if BGPDMA
 	bgpdma_cleanup_presyn(ps);
 #endif
-	PreSyn* pss;
 	if (ps->output_index_ >= 0 && gid2out_) {
 		gid2out_->remove(ps->output_index_);
 		ps->output_index_ = -1;
@@ -987,7 +986,7 @@ void nrnmpi_gid_clear(int arg) {
 	if (arg == 0 || arg == 2 || arg == 4) { nrnmpi_multisplit_clear(); }
 	if (arg == 2 || arg == 3) { return; }
 	if (!gid2out_) { return; }
-	PreSyn* ps, *psi;
+	PreSyn* psi;
 	NrnHashIterate(Gid2PreSyn, gid2out_, PreSyn*, ps) {
 		if (ps && !gid2in_->find(ps->gid_, psi)) {
 		    if (arg == 4) {
@@ -1318,7 +1317,7 @@ int nrnthread_all_spike_vectors_return(std::vector<double>& spiketvec, std::vect
             all_spikegidvec->vec().insert(all_spikegidvec->end(), spikegidvec.begin(), spikegidvec.end());
             
         }else{ // different underlying vectors for PreSyns
-            for (int i = 0; i < spikegidvec.size(); ++i ) {
+            for (size_t i = 0; i < spikegidvec.size(); ++i ) {
                 PreSyn* ps;
                 if (gid2out_->find(spikegidvec[i], ps)) {
                     ps->record(spiketvec[i]);
@@ -1538,7 +1537,6 @@ PreSyn* nrn_gid2presyn(int gid) { // output PreSyn
 }
 
 void nrn_gidout_iter(PFIO callback) {
-	PreSyn* ps;
 	NrnHashIterate(Gid2PreSyn, gid2out_, PreSyn*, ps) {
 		if (ps) {
 			int gid = ps->gid_;
@@ -1558,7 +1556,6 @@ static int weightcnt(NetCon* nc) {
 }
 
 size_t nrncore_netpar_bytes() {
-  PreSyn* ps;
   size_t ntot, nin, nout, nnet, nweight;
   ntot = nin = nout = nnet = nweight = 0;
 size_t npnt = 0;
@@ -1609,7 +1606,6 @@ void nrncore_netpar_cellgroups_helper(CellGroup* cgs) {
     gidcnt[i] = 0;
   }
 
-  PreSyn* ps;
   NrnHashIterate(Gid2PreSyn, gid2out_, PreSyn*, ps) {
     if (ps && ps->thvar_) {
       int ith = ps->nt_->id;

--- a/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
+++ b/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
@@ -5,6 +5,7 @@
 #include "nrnmpi.h"
 #include "section.h"
 #include "netcon.h"
+#include "nrncvode.h"
 #include "nrniv_mf.h"
 #include "hocdec.h"
 #include "nrncore_write/data/cell_group.h"
@@ -935,6 +936,14 @@ NrnCoreTransferEvents* nrn2core_transfer_tqueue(int tid) {
   }
 
   return core_te;
+}
+
+/** @brief Initialize queues before transfer
+    Probably aleady clear, but if binq then must be initialized to time.
+ */
+void core2nrn_clear_queues(double time) {
+    nrn_threads[0]._t = time; // used by clear_event_queue
+    clear_event_queue();
 }
 
 /** @brief Called from CoreNEURON core2nrn_tqueue_item.

--- a/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
+++ b/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
@@ -897,7 +897,7 @@ NrnCoreTransferEvents* nrn2core_transfer_tqueue(int tid) {
   if (nrn_use_bin_queue_) {
     // does not remove items but the entire queue will be cleared
     // before using again. 
-    for (tqi = tq->binq_->first(); tqi; tqi = tq->binq_->next(tqi)) {
+    for (tqi = tq->binq()->first(); tqi; tqi = tq->binq()->next(tqi)) {
       set_info(tqi, tid, core_te, netcon2intdata, presyn2intdata, weight2intdata);
     }
   }

--- a/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.h
+++ b/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.h
@@ -74,6 +74,8 @@ int core2nrn_corepointer_mech(int tid, int type,
 
 // For direct transfer of event queue information from CoreNEURON
 extern "C" {
+void core2nrn_clear_queues(double t);
+
 void core2nrn_NetCon_event(int tid, double td, size_t nc_index);
 
 void core2nrn_SelfEvent_event(int tid, double td,
@@ -155,6 +157,7 @@ static core2nrn_callback_t cnbs[]  = {
         {"core2nrn_vecplay_", (CNB)core2nrn_vecplay},
         {"core2nrn_vecplay_events_", (CNB)core2nrn_vecplay_events},
 
+        {"core2nrn_clear_queues_", (CNB)core2nrn_clear_queues},
         {"core2nrn_corepointer_mech_", (CNB)core2nrn_corepointer_mech},
         {"core2nrn_NetCon_event_", (CNB)core2nrn_NetCon_event},
         {"core2nrn_SelfEvent_event_", (CNB)core2nrn_SelfEvent_event},

--- a/src/nrnoc/nrncvode.h
+++ b/src/nrnoc/nrncvode.h
@@ -22,6 +22,6 @@ extern void nrn_update_2d(NrnThread*);
 extern void nrn_capacity_current(NrnThread* _nt, Memb_list* ml);
 extern void nrn_spike_exchange_init(void);
 extern void nrn_spike_exchange(NrnThread* nt);
-
+extern bool nrn_use_bin_queue_;
 
 #endif

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -31,7 +31,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   tqperf
   GIT_REPOSITORY https://github.com/neuronsimulator/tqperf.git
-  GIT_TAG afc07c1929
+  GIT_TAG 9dbb4e68bd
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/tqperf)
 
 FetchContent_MakeAvailable(nrntest reduced_dentate ringtest testcorenrn tqperf)

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -31,7 +31,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   tqperf
   GIT_REPOSITORY https://github.com/nrnhines/tqperf
-  GIT_TAG 94b89d841
+  GIT_TAG 6db04361
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/tqperf)
 
 FetchContent_MakeAvailable(nrntest reduced_dentate ringtest testcorenrn tqperf)

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -28,12 +28,19 @@ FetchContent_Declare(
   GIT_TAG 70f363d7f82dfe6037fbddd8ed2e58cb20df6343
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/reduced_dentate)
 
-FetchContent_MakeAvailable(nrntest reduced_dentate ringtest testcorenrn)
+FetchContent_Declare(
+  tqperf
+  GIT_REPOSITORY https://github.com/nrnhines/tqperf
+  GIT_TAG 94b89d841
+  SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/tqperf)
+
+FetchContent_MakeAvailable(nrntest reduced_dentate ringtest testcorenrn tqperf)
 
 add_subdirectory(nrntest)
 add_subdirectory(reduced_dentate)
 add_subdirectory(ringtest)
 add_subdirectory(testcorenrn)
+add_subdirectory(tqperf)
 
 if("channel-benchmark" IN_LIST NRN_ENABLE_MODEL_TESTS)
   FetchContent_Declare(

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -31,7 +31,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   tqperf
   GIT_REPOSITORY https://github.com/neuronsimulator/tqperf.git
-  GIT_TAG 9dbb4e68bd
+  GIT_TAG c976b5a43e
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/tqperf)
 
 FetchContent_MakeAvailable(nrntest reduced_dentate ringtest testcorenrn tqperf)

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -30,8 +30,8 @@ FetchContent_Declare(
 
 FetchContent_Declare(
   tqperf
-  GIT_REPOSITORY https://github.com/nrnhines/tqperf
-  GIT_TAG 6ab9a73f33
+  GIT_REPOSITORY https://github.com/pramodk/tqperf.git
+  GIT_TAG b13deec425
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/tqperf)
 
 FetchContent_MakeAvailable(nrntest reduced_dentate ringtest testcorenrn tqperf)

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -31,7 +31,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   tqperf
   GIT_REPOSITORY https://github.com/nrnhines/tqperf
-  GIT_TAG 65473682c
+  GIT_TAG 6ab9a73f33
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/tqperf)
 
 FetchContent_MakeAvailable(nrntest reduced_dentate ringtest testcorenrn tqperf)

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -31,7 +31,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   tqperf
   GIT_REPOSITORY https://github.com/nrnhines/tqperf
-  GIT_TAG 6db04361
+  GIT_TAG 532250d28
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/tqperf)
 
 FetchContent_MakeAvailable(nrntest reduced_dentate ringtest testcorenrn tqperf)

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -31,7 +31,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   tqperf
   GIT_REPOSITORY https://github.com/nrnhines/tqperf
-  GIT_TAG 532250d28
+  GIT_TAG 65473682c
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/tqperf)
 
 FetchContent_MakeAvailable(nrntest reduced_dentate ringtest testcorenrn tqperf)

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -30,8 +30,8 @@ FetchContent_Declare(
 
 FetchContent_Declare(
   tqperf
-  GIT_REPOSITORY https://github.com/pramodk/tqperf.git
-  GIT_TAG b13deec425
+  GIT_REPOSITORY https://github.com/neuronsimulator/tqperf.git
+  GIT_TAG afc07c1929
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/tqperf)
 
 FetchContent_MakeAvailable(nrntest reduced_dentate ringtest testcorenrn tqperf)

--- a/test/external/tqperf/CMakeLists.txt
+++ b/test/external/tqperf/CMakeLists.txt
@@ -2,6 +2,10 @@ include(NeuronTestHelper)
 nrn_add_test_group(
   NAME tqperf
   SUBMODULE tests/tqperf
+  # Need non-empty MODFILE_PATTERNS even though not used by the COMMAND
+  # to avoid CI errors of the form
+  #cd: ... : No such file or directory
+  MODFILE_PATTERNS mod/*.mod
   SCRIPT_PATTERNS "*.py" "*.hoc" "ci-test.sh" "mod/*.mod" "modx/*.mod")
 
 set(tqperf_mpi_ranks 16)

--- a/test/external/tqperf/CMakeLists.txt
+++ b/test/external/tqperf/CMakeLists.txt
@@ -27,5 +27,5 @@ nrn_add_test(
   NAME neuron
   REQUIRES mpi python coreneuron
   PROCESSORS ${tqperf_mpi_ranks}
-  COMMAND bash "./ci-test.sh"
+  COMMAND MPIEXEC_OVERSUBSCRIBE=${MPIEXEC_OVERSUBSCRIBE} bash "./ci-test.sh"
 )

--- a/test/external/tqperf/CMakeLists.txt
+++ b/test/external/tqperf/CMakeLists.txt
@@ -2,7 +2,6 @@ include(NeuronTestHelper)
 nrn_add_test_group(
   NAME tqperf
   SUBMODULE tests/tqperf
-  MODFILE_PATTERNS "mod/*.mod modx/*.mod"
   SCRIPT_PATTERNS "*.py" "*.hoc" "ci-test.sh" "mod/*.mod" "modx/*.mod")
 
 set(tqperf_mpi_ranks 16)

--- a/test/external/tqperf/CMakeLists.txt
+++ b/test/external/tqperf/CMakeLists.txt
@@ -1,0 +1,28 @@
+include(NeuronTestHelper)
+nrn_add_test_group(
+  NAME tqperf
+  SUBMODULE tests/tqperf
+  MODFILE_PATTERNS "mod/*.mod modx/*.mod"
+  SCRIPT_PATTERNS "*.py" "*.hoc" "mod/*.mod" "modx/*.mod")
+
+set(tqperf_mpi_ranks 16)
+set(tqperf_sim_time 100)
+set(tqperf_neuron_prefix
+    OMP_NUM_THREADS=1
+    ${MPIEXEC_NAME}
+    ${MPIEXEC_NUMPROC_FLAG}
+    ${tqperf_mpi_ranks}
+    ${MPIEXEC_OVERSUBSCRIBE}
+    ${MPIEXEC_PREFLAGS}
+    special
+    ${MPIEXEC_POSTFLAGS}
+    -mpi
+    -python
+    )
+nrn_add_test(
+  GROUP tqperf
+  NAME neuron
+  REQUIRES mpi python coreneuron
+  PROCESSORS ${tqperf_mpi_ranks}
+  COMMAND bash "./ci-test.sh"
+)

--- a/test/external/tqperf/CMakeLists.txt
+++ b/test/external/tqperf/CMakeLists.txt
@@ -3,7 +3,7 @@ nrn_add_test_group(
   NAME tqperf
   SUBMODULE tests/tqperf
   MODFILE_PATTERNS "mod/*.mod modx/*.mod"
-  SCRIPT_PATTERNS "*.py" "*.hoc" "mod/*.mod" "modx/*.mod")
+  SCRIPT_PATTERNS "*.py" "*.hoc" "ci-test.sh" "mod/*.mod" "modx/*.mod")
 
 set(tqperf_mpi_ranks 16)
 set(tqperf_sim_time 100)


### PR DESCRIPTION
Extending the tqperf repository test1.py to the cases of binq and spike compression exposed a half dozen or so bugs in the categories of BinQ initialization, incomplete  BinQ queue transfer, and failure to enqueue the interthread event buffers in a timely manner. The tqperf test  now does a SHA1 hash comparison of all spike input and output times of all the artificial cells. This test is run from the latest http://github.com/nrnhines/tqperf.git branch hines/test1 branch. See instructions in https://github.com/nrnhines/tqperf/blob/hines/test1/README.md 

This PR depends on the hines/spike-compress branch of coreneuron. BlueBrain/CoreNeuron#701
This PR uses changes in #1537

A goal of this PR should be to add external/tqperf for continuous integration.
Need to check for memory leaks. edit: the memory leak situation is, before and after d377041
```
mpiexec -output-filename temp -n 4 nrniv -mpi -python test1.py
```
```
AddressSanitizer: 3850148 byte(s) leaked in 137147 allocation(s).   per rank
AddressSanitizer: 13048 byte(s) leaked in 92 allocation(s). per rank
```


Rebased hines/binq-fix #1548 onto current master with no hines/multisend-fix (already merged) duplicates.
Note that this PR depends on the hines/spike-compress branch of coreneuron. BlueBrain/CoreNeuron#701
```
$ git rebase --interactive master

d 81f541c2b Multisend available in NEURON by default.   
d 715858c3a BGPDMA is on only if NRNMPI is on.   
d 7823c3137 When ~PreSyn, remove from gid to PreSyn maps.   
d b6ce9046a update to coreneuron master   
pick 4a2997e19 Interthread enqueuing must occur after spike exchange. This is n$
pick 7dd731066 nrn binq must be initialized before core2nrn queue transfer.
pick 4be02b573 nrn2core queue transfer must also iterate over BinQ.
pick 9cccbab3e nrnivmodl option can be in any order. The -l flags options are p$
pick 71ce2229f coreneuron at latest hines/spike-compress branch
pick d37704196 fix some memory leaks
pick cbee33cfe Refactoring makes nrn2core queue transfer more understandable.
pick b6a5baecc neuron.coreneuron: if --multisend then also --ms-subintervals an$
pick 0e619851b Fix most of the -Wall warnings for these files.
pick 7aade0365 tqperf is a ci test
pick fb778c409 missing a file
pick 85569e8c3 update tqperf
pick 4ff2d3878 conditionally compile enqueue1 and enqueue2
pick dec820ffc Do not specify MODFILE_PATTERNS for tqperf (need special link).
pick 5d4cf8126 fix use of freed memory
pick f46354b29 BGPTIMEOUT default 0
pick 31cbb70ad Free some memory when no longer needed.
```