### PR TITLE
NEURON can dynamically link to Python3.10

### DIFF
--- a/mingw_files/howto-cmake
+++ b/mingw_files/howto-cmake
@@ -1,6 +1,6 @@
 #!/bin/bash
 # howto-cmake 36   # builds for 3.6
-# howto-cmake 27 35 36 37 38 # builds for all those
+# howto-cmake 36 37 38 39 310 # builds for all those
 
 set -e
 set -x

--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -602,7 +602,8 @@ def nrn_dll_sym_nt(name, type):
         if h.nrnversion(8).find("i686") == 0:
             b = "bin"
         path = os.path.join(h.neuronhome().replace("/", "\\"), b)
-        p = sys.version_info[0] * 10 + sys.version_info[1]
+        fac = 10 if sys.version_info[1] < 10 else 100 # 3.9 is 39 ; 3.10 is 310
+        p = sys.version_info[0] * fac + sys.version_info[1]
         for dllname in ["libnrniv.dll", "libnrnpython%d.dll" % p]:
             p = os.path.join(path, dllname)
             try:

--- a/src/nrnpython/inithoc.cpp
+++ b/src/nrnpython/inithoc.cpp
@@ -315,6 +315,9 @@ extern "C" PyObject* PyInit_hoc() {
   nrn_nobanner_ = 1;
   const char* pyver = Py_GetVersion();
   nrn_is_python_extension = (pyver[0]-'0')*10 + (pyver[2] - '0');
+  if (isdigit(pyver[3])) { // minor >= 10 e.g. 3.10  is 310
+    nrn_is_python_extension = nrn_is_python_extension*10 + pyver[3] - '0';
+  }
   p_nrnpython_finalize = nrnpython_finalize;
 #if NRNMPI
   if (libnrnmpi_is_loaded) {


### PR DESCRIPTION
The python3.10 relevant changes of  #1524

It might be a good idea to add the code to make a python3.10 wheel installer.