### PR TITLE
Revert "temporarily use choco install until #1522 is fixed (#1529)"

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,13 +27,6 @@ jobs:
     timeout-minutes: 45
 
     steps:
-    # TODO: temporarily use choco install until #1522 is fixed
-    # we need to move out of the way the image installed msys64
-    - name: Move installed msys64
-      run: |
-        move C:\msys64 C:\msys64-from-image
-      shell: cmd
-
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -199,13 +199,6 @@ jobs:
 
   steps:
 
-  # TODO: temporarily use choco install until #1522 is fixed
-  # we need to move out of the way the image installed msys64
-  - script: |
-      move C:\msys64 C:\msys64-from-image
-    displayName: "Move installed msys64"
-    condition: succeeded()
-
   - task: BatchScript@1
     inputs:
       filename: ci/win_download_deps.cmd

--- a/ci/win_install_deps.cmd
+++ b/ci/win_install_deps.cmd
@@ -45,8 +45,7 @@ cp 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64\rcdll.dll' 'C:\P
 
 :: install msys2 / mingw packages.
 :: NOTE: msys2 is already installed in the CI VM image. Otherwise it could be installed with the following line:
-:: TODO: temporarily use choco install until #1522 is fixed
-choco install --no-progress msys2 --params="/InstallDir:%MSYS2_ROOT% /NoUpdate /NoPath" || goto :error
+:: choco install --no-progress msys2 --params="/InstallDir:%MSYS2_ROOT% /NoUpdate /NoPath" || goto :error
 set PATH=%MSYS2_ROOT%\usr\bin;%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem;%PATH%
 
 


### PR DESCRIPTION
This reverts commit 40f5822858ebe4b13b84ac12aaf146b6bc3dadc0.
No longer of use.