### PR TITLE
ParallelContext.mpiabort_on_error(0) means no call to MPI_Abort.

### DIFF
--- a/docs/python/modelspec/programmatic/network/parcon.rst
+++ b/docs/python/modelspec/programmatic/network/parcon.rst
@@ -312,6 +312,20 @@ ParallelContext
 
 ----
 
+.. method:: ParallelContext.mpiabort_on_error
+
+
+    Syntax:
+        ``oldflag = pc.mpiabort_on_error(newflag)``
+
+    Description:
+        Normally, when running with MPI, a hoc error causes a call to MPI_Abort
+        so that all processes can be notified to exit cleanly without
+        any processes hanging. (e.g. waiting for a communicator
+        collective to complete). The call to MPI_Abort can be avoided by
+        calling this method with newflag = 0. This occurs automatically
+        when :func:`execute1` is used.  The method returns the previous
+        value of the flag.
 
 
 .. method:: ParallelContext.submit

--- a/docs/python/programming/dynamiccode.rst
+++ b/docs/python/programming/dynamiccode.rst
@@ -62,7 +62,9 @@ code-executing
         top level of the interpreter. 
          
         When running under MPI, an error in the statement does NOT call
-        MPI_Abort but returns 0.
+        MPI_Abort but returns 0. Note that it is not necessary to use
+        this function to avoid calling MPI_Abort on error. That effect
+        can also be obtained with :meth:`ParallelContext.mpiabort_on_error`.
 
     Example:
         Execute1 is heavily used in the construction of the fitter widgets. 

--- a/docs/python/programming/dynamiccode.rst
+++ b/docs/python/programming/dynamiccode.rst
@@ -61,6 +61,9 @@ code-executing
         of the object. If second arg not present then execute it at the 
         top level of the interpreter. 
          
+        When running under MPI, an error in the statement does NOT call
+        MPI_Abort but returns 0.
+
     Example:
         Execute1 is heavily used in the construction of the fitter widgets. 
         It is also useful to objects in gaining information about the outside with 

--- a/src/ivoc/ocjump.cpp
+++ b/src/ivoc/ocjump.cpp
@@ -52,7 +52,10 @@ void hoc_execute1() {
 	
 	hemold = hoc_execerror_messages;
 	hoc_execerror_messages = hem;
+	int old_mpiabort_flag = nrn_mpiabort_on_error_;
+	nrn_mpiabort_on_error_ = 0;
 	bool b = valid_stmt1(gargstr(1), ob);
+	nrn_mpiabort_on_error_ = old_mpiabort_flag;
 	hoc_execerror_messages = hemold;
 	hoc_ret();
 	hoc_pushx(double(b));

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -75,6 +75,8 @@ int matherr1(void) {
 }
 #endif
 
+int nrn_mpiabort_on_error_{1};
+
 int nrn_feenableexcept_ = 0; // 1 if feenableexcept(FEEXCEPT) is successful
 
 void nrn_feenableexcept() {
@@ -713,12 +715,12 @@ void hoc_execerror_mes(const char* s, const char* t, int prnt){	/* recover from 
 	ctp = cbuf;
 	*ctp = '\0';
 
-	if (oc_jump_target_ && nrnmpi_numprocs_world == 1) {
+	if (oc_jump_target_ && (nrnmpi_numprocs_world == 1 || !nrn_mpiabort_on_error_)) {
 		hoc_newobj1_err();
 		(*oc_jump_target_)();
 	}
 #if NRNMPI
-	if (nrnmpi_numprocs_world > 1) {
+	if (nrnmpi_numprocs_world > 1 && nrn_mpiabort_on_error_) {
 		nrnmpi_abort(-1);
 	}
 #endif

--- a/src/oc/oc_ansi.h
+++ b/src/oc/oc_ansi.h
@@ -278,6 +278,7 @@ extern void bbs_done(void);
 extern int hoc_main1(int, const char**, const char**);
 extern char* cxx_char_alloc(size_t size);
 extern int stoprun;
+extern int nrn_mpiabort_on_error_;
 
 #endif
 

--- a/src/parallel/ocbbs.cpp
+++ b/src/parallel/ocbbs.cpp
@@ -631,6 +631,14 @@ static double set_timeout(void* v) {
 	return double(arg);
 }
 
+static double set_mpiabort_on_error(void*) {
+	double ret = double(nrn_mpiabort_on_error_);
+	if (ifarg(1)) {
+		nrn_mpiabort_on_error_ = int(chkarg(1, 0, 1));
+	}
+	return ret;
+}
+
 static double gid_clear(void* v) {
 	int arg = 0;
 	if (ifarg(1)){
@@ -1042,6 +1050,7 @@ static Member_func members[] = {
 	"vtransfer_time", vtransfer_time,
 	"mech_time", mech_time,
 	"timeout", set_timeout,
+	"mpiabort_on_error", set_mpiabort_on_error,
 
 	"set_gid2node", set_gid2node,
 	"gid_exists", gid_exists,

--- a/test/parallel_tests/test_bas.py
+++ b/test/parallel_tests/test_bas.py
@@ -336,6 +336,20 @@ def compare_dicts(dict1, dict2):
 
 def test_bas():
 
+    # h.execute1(...) does not call mpi_abort on failure
+    assert h.execute1("1/0") == 0
+    assert h.execute1("2/0", 0) == 0  # no error message printed
+
+    # MPI_Abort can be avoided on hoc errors.
+    oldflag = pc.mpiabort_on_error(0)
+    assert h("""3/0""") == 0
+    try:
+        x = h.log(-1)
+        assert False
+    except:
+        assert True
+    pc.mpiabort_on_error(oldflag)
+
     stdspikes = {
         0: [10.925000000099914, 143.3000000001066],
         1: [37.40000000009994, 169.7750000000825],


### PR DESCRIPTION
h.execute1("stmt") does not call MPI_Abort on an error (returns 0).

Fixes #1533
Modifies the policy established by #642
Might be a work around for some issues still existing in #1112