### PR TITLE
Tune tqperf test.

### DIFF
--- a/.cmake-format.changes.yaml
+++ b/.cmake-format.changes.yaml
@@ -21,6 +21,8 @@ additional_commands:
       CONFLICTS: '*'
       OUTPUT: '*'
       PROCESSORS: '?'
+      SIM_DIRECTORY: '?'
+      NRNIVMODL_ARGS: '+'
   nrn_add_test_group_comparison:
     pargs: 0
     kwargs:

--- a/cmake/NeuronTestHelper.cmake
+++ b/cmake/NeuronTestHelper.cmake
@@ -42,7 +42,8 @@
 #                 [MODFILE_PATTERNS mod_file_pattern ...]
 #                 [OUTPUT datatype::file.ext otherdatatype::otherfile.ext ...]
 #                 [SCRIPT_PATTERNS "*.py" ...]
-#                 [SIM_DIRECTORY sim_dir])
+#                 [SIM_DIRECTORY sim_dir]
+#                 [NRNIVMODL_ARGS arg1 ...])
 #
 #    Create a new integration test inside the given group, which must have
 #    previously been created using nrn_add_test_group. The COMMAND option is
@@ -54,7 +55,8 @@
 #    if certain features are, or are not, available. Seven features are currently
 #    supported: coreneuron, cpu, gpu, mod_compatibility, mpi, nmodl and python.
 #    The SIM_DIRECTORY argument is used to override the default directory in which
-#    the simulation is run.
+#    the simulation is run. The NRNIVMODL_ARGS argument allows extra arguments
+#    to be passed to nrnivmodl.
 #
 # 3. nrn_add_test_group_comparison(GROUP group_name
 #                                  REFERENCE_OUTPUT datatype::file.ext [...])

--- a/cmake/NeuronTestHelper.cmake
+++ b/cmake/NeuronTestHelper.cmake
@@ -109,7 +109,8 @@ function(nrn_add_test)
       CONFLICTS
       MODFILE_PATTERNS
       PRECOMMAND
-      SIM_DIRECTORY)
+      SIM_DIRECTORY
+      NRNIVMODL_ARGS)
   cmake_parse_arguments(NRN_ADD_TEST "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
   if(DEFINED NRN_ADD_TEST_MISSING_VALUES)
     message(
@@ -211,8 +212,8 @@ function(nrn_add_test)
   # Add a rule to build the modfiles for this test. The assumption is that it is likely that most
   # members of the group will ask for exactly the same thing, so it's worth de-duplicating. TODO:
   # allow extra arguments to be inserted here
-  set(nrnivmodl_command cmake -E env ${NRN_TEST_ENV} ${CMAKE_BINARY_DIR}/bin/nrnivmodl)
-  set(hash_components nrnivmodl)
+  set(nrnivmodl_command cmake -E env ${NRN_TEST_ENV} ${CMAKE_BINARY_DIR}/bin/nrnivmodl ${NRN_ADD_TEST_NRNIVMODL_ARGS})
+  set(hash_components nrnivmodl ${NRN_ADD_TEST_NRNIVMODL_ARGS})
   if(requires_coreneuron)
     # TODO: consider replacing the condition here with NRN_ENABLE_CORENEURON; this would tend to
     # reduce the number of times we call nrnivmodl.

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -30,8 +30,8 @@ FetchContent_Declare(
 
 FetchContent_Declare(
   tqperf
-  GIT_REPOSITORY https://github.com/neuronsimulator/tqperf.git
-  GIT_TAG c976b5a43e
+  GIT_REPOSITORY https://github.com/olupton/tqperf.git
+  GIT_TAG 7fd4605a3679f9cf50401733a2a0543b090a71bc
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/tqperf)
 
 FetchContent_MakeAvailable(nrntest reduced_dentate ringtest testcorenrn tqperf)

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -30,8 +30,8 @@ FetchContent_Declare(
 
 FetchContent_Declare(
   tqperf
-  GIT_REPOSITORY https://github.com/olupton/tqperf.git
-  GIT_TAG 7fd4605a3679f9cf50401733a2a0543b090a71bc
+  GIT_REPOSITORY https://github.com/neuronsimulator/tqperf.git
+  GIT_TAG 79df2a59ac4a56be3be840b4887222cea761b1ff
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/tqperf)
 
 FetchContent_MakeAvailable(nrntest reduced_dentate ringtest testcorenrn tqperf)

--- a/test/external/tqperf/CMakeLists.txt
+++ b/test/external/tqperf/CMakeLists.txt
@@ -2,30 +2,15 @@ include(NeuronTestHelper)
 nrn_add_test_group(
   NAME tqperf
   SUBMODULE tests/tqperf
-  # Need non-empty MODFILE_PATTERNS even though not used by the COMMAND
-  # to avoid CI errors of the form
-  #cd: ... : No such file or directory
-  MODFILE_PATTERNS mod/*.mod
-  SCRIPT_PATTERNS "*.py" "*.hoc" "ci-test.sh" "mod/*.mod" "modx/*.mod")
-
+  MODFILE_PATTERNS "mod/*.mod" "modx/*.mod"
+  SCRIPT_PATTERNS "test1.py" "*.hoc")
 set(tqperf_mpi_ranks 16)
-set(tqperf_sim_time 100)
-set(tqperf_neuron_prefix
-    OMP_NUM_THREADS=1
-    ${MPIEXEC_NAME}
-    ${MPIEXEC_NUMPROC_FLAG}
-    ${tqperf_mpi_ranks}
-    ${MPIEXEC_OVERSUBSCRIBE}
-    ${MPIEXEC_PREFLAGS}
-    special
-    ${MPIEXEC_POSTFLAGS}
-    -mpi
-    -python
-    )
 nrn_add_test(
   GROUP tqperf
-  NAME neuron
+  NAME coreneuron
   REQUIRES mpi python coreneuron
   PROCESSORS ${tqperf_mpi_ranks}
-  COMMAND MPIEXEC_OVERSUBSCRIBE=${MPIEXEC_OVERSUBSCRIBE} bash "./ci-test.sh"
-)
+  NRNIVMODL_ARGS -loadflags -lcrypto
+  COMMAND
+    ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} ${tqperf_mpi_ranks}
+    ${MPIEXEC_OVERSUBSCRIBE} ${MPIEXEC_PREFLAGS} special ${MPIEXEC_POSTFLAGS} -mpi -python test1.py)

--- a/test/external/tqperf/CMakeLists.txt
+++ b/test/external/tqperf/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 nrn_add_test(
   GROUP tqperf
   NAME coreneuron
+  CONFLICTS nmodl # https://github.com/BlueBrain/nmodl/issues/794
   REQUIRES mpi python coreneuron
   PROCESSORS ${tqperf_mpi_ranks}
   NRNIVMODL_ARGS -loadflags -lcrypto

--- a/test/external/tqperf/CMakeLists.txt
+++ b/test/external/tqperf/CMakeLists.txt
@@ -4,7 +4,11 @@ nrn_add_test_group(
   SUBMODULE tests/tqperf
   MODFILE_PATTERNS "mod/*.mod" "modx/*.mod"
   SCRIPT_PATTERNS "test1.py" "*.hoc")
-set(tqperf_mpi_ranks 16)
+if("tqperf-heavy" IN_LIST NRN_ENABLE_MODEL_TESTS)
+  set(tqperf_mpi_ranks 16)
+else()
+  set(tqperf_mpi_ranks 2)
+endif()
 nrn_add_test(
   GROUP tqperf
   NAME coreneuron


### PR DESCRIPTION
This tunes the `tqperf` test introduced in https://github.com/neuronsimulator/nrn/pull/1556 by:
- Using 2 ranks instead of 16, unless the "heavy" version of the test is explicitly requested.
- Adding an `NRNIVMODL_ARGS` argument to `nrn_add_test` and using it, so `tqperf` does not need a custom bash shim to run `nrnivmodl`.
- Disable the test when NMODl is used (https://github.com/BlueBrain/nmodl/issues/794).

TODO:
- [x] Check if https://github.com/neuronsimulator/tqperf/blob/c976b5a43e914e9afa62083a09072cec246d89fb/ci-test.sh#L11-L15 needs to be translated to CMake too. Note that after https://github.com/neuronsimulator/nrn/pull/1571 the test is only enabled if OpenSSL can be found by CMake.
- [x] Merge https://github.com/neuronsimulator/tqperf/pull/9.
- [x] Update not-a-submodule after merging https://github.com/neuronsimulator/tqperf/pull/9.
