### PR TITLE
Adding long description from README.md

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,8 @@ project_urls =
     Source = https://github.com/neuronsimulator/nrn
 # maintainer is the field chosen for docs `contributors`
 maintainer = Michael Hines
-
+long_description = file: README.md
+long_description_content_type = text/markdown
 
 # Add here all kinds of additional classifiers as defined under
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Latest setuptools allow for external files being used, while
since March, 2018 pypi supports markdown.
Ensured this info in being loaded into sdist PKG-INFO