### PR TITLE
nrnivmodl succeeds when there are no mod files

### DIFF
--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -135,8 +135,10 @@ if test $# -gt 0 ; then
     fi
   done
 else
-  # Unset LC_ALL for consistent mod order
-  files=$(unset LC_ALL; ls *.mod)
+  if ls *.mod 1> /dev/null 2> /dev/null ; then  # only if there are mod files
+    # Unset LC_ALL for consistent mod order
+    files=$(unset LC_ALL; ls *.mod)
+  fi
 fi
 
 files=`echo "$files" | sed 's/^ *//'`


### PR DESCRIPTION
Closes #1582

In particular, in an empty folder
```nrnivmodl -coreneuron```
will succeed. And
```
$ nrniv -python
NEURON -- VERSION 8.0a-717-g33ea2b983+ master (33ea2b983+) 2022-01-11
Duke, Yale, and the BlueBrain Project -- Copyright 1984-2021
See http://neuron.yale.edu/neuron/credits

loading membrane mechanisms from x86_64/.libs/libnrnmech.so
Additional mechanisms from files

>>> from neuron import h, coreneuron
>>> pc = h.ParallelContext()
>>> coreneuron.enable=True
>>> h.CVode().cache_efficient(1)
True
>>> h.finitialize()
1.0
>>> pc.psolve(5)
 
 Duke, Yale, and the BlueBrain Project -- Copyright 1984-2020
 Version : 1.0 318e25a0 (2021-12-25 11:17:14 +0100)
 
 Additional mechanisms from files
 exp2syn.mod expsyn.mod hh.mod netstim.mod passive.mod pattern.mod stim.mod svclmp.mod

 Memory (MBs) :             After mk_mech : Max 44.2109, Min 44.2109, Avg 44.2109 
 Memory (MBs) :            After MPI_Init : Max 44.2109, Min 44.2109, Avg 44.2109 
 Memory (MBs) :          Before nrn_setup : Max 44.2109, Min 44.2109, Avg 44.2109 
 Setup Done   : 0.00 seconds 
 Model size   : 960 bytes
 Memory (MBs) :          After nrn_setup  : Max 44.2109, Min 44.2109, Avg 44.2109 
GENERAL PARAMETERS
...

 Start time (t) = 0

 Memory (MBs) :  After mk_spikevec_buffer : Max 44.2109, Min 44.2109, Avg 44.2109 
 Memory (MBs) :     After nrn_finitialize : Max 44.2109, Min 44.2109, Avg 44.2109 

psolve |                                                         | t: 0.00   ETApsolve |=========================================================| t: 5.00   ETA: 0h00m00s

Solver Time : 0.000792027


 Simulation Statistics
 Number of cells: 0
 Number of compartments: 0
 Number of presyns: 0
 Number of input presyns: 0
 Number of synapses: 0
 Number of point processes: 0
 Number of transfer sources: 0
 Number of transfer targets: 0
 Number of spikes: 0
 Number of spikes with non negative gid-s: 0
1.0
>>> 

