### PR TITLE
Update FindReadline.cmake with hints for multi-arch platforms

### DIFF
--- a/cmake/modules/FindReadline.cmake
+++ b/cmake/modules/FindReadline.cmake
@@ -27,10 +27,18 @@ find_path(
   NAMES readline/readline.h
   HINTS ${Readline_ROOT_DIR}/include)
 
+# On platforms like debian/ubuntu with multi-arch support
+# libraries might be under separate directory like /usr/lib/x86_64-linux-gnu/
+# With NVHPC compilers CMake can not find these librarise, see
+# https://forums.developer.nvidia.com/t/nvhpc-cmake-issues-cmake-library-architecture-is-not-set-and-hence-system-libraries-are-not-found/200659
+# Hence, provide extra directories as hint to search for libraries
+file(GLOB EXTRA_SEARCH_DIRS
+  "${Readline_ROOT_DIR}/lib*/${CMAKE_SYSTEM_PROCESSOR}-*-*")
+
 find_library(
   Readline_LIBRARY
   NAMES readline
-  HINTS ${Readline_ROOT_DIR}/lib)
+  HINTS ${Readline_ROOT_DIR}/lib ${EXTRA_SEARCH_DIRS})
 
 if(Readline_INCLUDE_DIR
    AND Readline_LIBRARY

--- a/docs/cmake_doc/options.rst
+++ b/docs/cmake_doc/options.rst
@@ -372,10 +372,17 @@ NRN_NMODL_CXX_FLAGS:STRING=""
 
 Readline_ROOT_DIR:PATH=/usr
 ---------------------------
-  Path to a file.  
+  Install directory prefix where readline is installed.
 
-  If cmake can't find readline, you
-can give this hint as to where it is.
+  If cmake can't find readline, you can give this hint with the directory
+  path under which readline is installed. Note that on some platforms
+  with multi-arch support (e.g. Debian/Ubuntu), CMake versions < 3.20 are not
+  able to find readline library when NVHPC/PGI compiler is used (for GPU
+  support). In this case you can install newer CMake (>= 3.20) or explicitly
+  specify readline library using `-DReadline_LIBRARY=` option:
+  .. code-block::
+
+    -DReadline_LIBRARY=/usr/lib/x86_64-linux-gnu/libreadline.so
 
 NRN_ENABLE_TESTS:BOOL=OFF
 -------------------------


### PR DESCRIPTION
* In ubuntu/debian multi-arch platforms, libraries are installed
  unser /usr/lib/triplet/.
* These libraries are found with GNU toolchain but with PGI compiler
  CMake < 3.20 fails to find these libraries.
* To help CMake to find such libraries, we provide triplet
  directories (where readline is installed) as hint to find_library()
* This has been reported on nvidia forum
  https://forums.developer.nvidia.com/t/nvhpc-cmake-issues-cmake-library-architecture-is-not-set-and-hence-system-libraries-are-not-found/200659

This is not ideal solution but at least an improvement where common issues on Ubuntu/Debian will be solved.

(partially) fixes #1577