### PR TITLE
Prepend MPI include paths in case of dynamic MPI build

### DIFF
--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -324,7 +324,7 @@ if(NRN_ENABLE_MPI)
       list(GET NRN_MPI_LIBNAME_LIST ${val} libname)
 
       add_library(${libname}_lib SHARED ${NRN_NRNMPI_SRC_FILES})
-      target_include_directories(${libname}_lib PUBLIC ${include})
+      target_include_directories(${libname}_lib BEFORE PUBLIC ${include})
       # Note that we do not link here to libmpi. That is dlopen first.
       if(MINGW) # type msmpi only
         add_dependencies(${libname}_lib nrniv_lib)


### PR DESCRIPTION
 * (global) include paths added by cmake could contain
   unnecessary/undesirable  MPI library headers (see #1566)
 * in order to have preference for corresponding MPI
   library headers, prepend mpi include path so that they
   have preference. See:
   https://github.com/neuronsimulator/nrn/issues/1566#issuecomment-1003911787

fixes #1566