### PR TITLE
SaveState supports rxd

### DIFF
--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -1372,6 +1372,18 @@ class DensityMechanism:
         return [nmodl.to_nmodl(ont.ontology_id) for ont in onts]
 
 
+my_data = b"This was write_savestate"
+def _store_savestate():
+    print("inside _store_savestate")
+    return bytearray(my_data)
+
+
+def _restore_savestate(data):
+    # convert from bytearray
+    data = bytes(data)
+    print("hello from _restore_savestate")
+    print("data:", data)
+
 try:
     import ctypes
 
@@ -1421,8 +1433,10 @@ try:
     _rvp_plot_callback = ctypes.py_object(_rvp_plot)
     _plotshape_plot_callback = ctypes.py_object(_plotshape_plot)
     _get_mech_object_callback = ctypes.py_object(_get_mech_object)
+    _restore_savestate_callback = ctypes.py_object(_restore_savestate)
+    _store_savestate_callback = ctypes.py_object(_store_savestate)
     set_toplevel_callbacks(
-        _rvp_plot_callback, _plotshape_plot_callback, _get_mech_object_callback
+        _rvp_plot_callback, _plotshape_plot_callback, _get_mech_object_callback, _store_savestate_callback, _restore_savestate_callback
     )
 except:
     pass

--- a/share/lib/python/neuron/rxd/__init__.py
+++ b/share/lib/python/neuron/rxd/__init__.py
@@ -77,7 +77,7 @@ def save_state():
     for sp in species._all_species:
         s = sp()
         if s is not None:
-            my_state = s.state
+            my_state = s._state
             state.append(array.array("Q", [len(my_state)]).tobytes())
             state.append(my_state)
             num_species += 1
@@ -134,6 +134,6 @@ def restore_state(oldstate):
         size = size_array[0]
         data.frombytes(oldstate[position : position + size])
         position += size
-        sp.state = bytes(data)
+        sp._state = bytes(data)
     if position != len(oldstate):
         raise RxDException("Invalid state data: bad length")

--- a/share/lib/python/neuron/rxd/__init__.py
+++ b/share/lib/python/neuron/rxd/__init__.py
@@ -105,6 +105,7 @@ def restore_state(oldstate):
             s = sp()
             if s is not None:
                 raise RxDException("Invalid state data: inconsistent number of Species")
+        return
     metadata = array.array("Q")
     metadata.frombytes(oldstate[:16])
     version, length = metadata

--- a/share/lib/python/neuron/rxd/__init__.py
+++ b/share/lib/python/neuron/rxd/__init__.py
@@ -60,3 +60,72 @@ def _model_view(tree):
             % len([r for r in rxd._all_reactions if r() is not None]),
         )
         tree.append(rxd_head)
+
+
+def save_state():
+    """return a bytestring representation of the current rxd state
+
+    Note: this is dependent on the order items were created."""
+    from . import species
+    import array
+    import itertools
+    import gzip
+
+    version = 0
+    state = []
+    num_species = 0
+    for sp in species._all_species:
+        s = sp()
+        if s is not None:
+            my_state = s.state
+            state.append(array.array("Q", [len(my_state)]).tobytes())
+            state.append(my_state)
+            num_species += 1
+    data = gzip.compress(
+        array.array("Q", [num_species]).tobytes()
+        + bytes(itertools.chain.from_iterable(state))
+    )
+    metadata = array.array("Q", [version, len(data)]).tobytes()
+    return metadata + data
+
+
+def restore_state(oldstate):
+    """restore rxd state from a bytestring
+
+    Note: this is dependent on the order items were created."""
+    from . import species
+    import array
+    import itertools
+    import gzip
+
+    metadata = array.array("Q")
+    metadata.frombytes(oldstate[:16])
+    version, length = metadata
+    if version != 0:
+        raise RxDException("Unsupported state version")
+    # discard header and decompress remainder
+    if len(oldstate) != length + 16:
+        raise RxDException("Invalid state data: bad length")
+    oldstate = gzip.decompress(oldstate[16:])
+    metadata = array.array("Q")
+    metadata.frombytes(oldstate[:8])
+    num_species = metadata[0]
+    active_species = []
+    for sp in species._all_species:
+        s = sp()
+        if s is not None:
+            active_species.append(s)
+    if len(active_species) != num_species:
+        raise RxDException("Invalid state data: inconsistent number of Species")
+    position = 8
+    for sp in active_species:
+        data = array.array("d")
+        size_array = array.array("Q")
+        size_array.frombytes(oldstate[position : position + 8])
+        position += 8
+        size = size_array[0]
+        data.frombytes(oldstate[position : position + size])
+        position += size
+        sp.state = bytes(data)
+    if position != len(oldstate):
+        raise RxDException("Invalid state data: bad length")

--- a/share/lib/python/neuron/rxd/__init__.py
+++ b/share/lib/python/neuron/rxd/__init__.py
@@ -81,6 +81,8 @@ def save_state():
             state.append(array.array("Q", [len(my_state)]).tobytes())
             state.append(my_state)
             num_species += 1
+    if num_species == 0:
+        return b""
     data = gzip.compress(
         array.array("Q", [num_species]).tobytes()
         + bytes(itertools.chain.from_iterable(state))
@@ -98,6 +100,11 @@ def restore_state(oldstate):
     import itertools
     import gzip
 
+    if oldstate == b"":
+        for sp in species._all_species:
+            s = sp()
+            if s is not None:
+                raise RxDException("Invalid state data: inconsistent number of Species")
     metadata = array.array("Q")
     metadata.frombytes(oldstate[:16])
     version, length = metadata

--- a/share/lib/python/neuron/rxd/rxd.py
+++ b/share/lib/python/neuron/rxd/rxd.py
@@ -1997,6 +1997,16 @@ def _do_nbs_register():
         #
         _cvode_object.extra_scatter_gather(0, _after_advance)
 
+        # register save state mechanism
+        import neuron
+        from neuron import rxd
+
+        neuron.register_savestate(
+            "rxd-9e015bfa-93ba-485c-9dd2-09857ae58e4d",
+            rxd.save_state,
+            rxd.restore_state,
+        )
+
 
 # register the Python callbacks
 do_setup_fptr = fptr_prototype(_setup)

--- a/share/lib/python/neuron/rxd/species.py
+++ b/share/lib/python/neuron/rxd/species.py
@@ -1950,7 +1950,7 @@ class Species(_SpeciesMathable):
             # happens when not a multiple of 8 bytes
             raise RxDException("Invalid state data length") from None
         # at 8 bytes per data point, the total number of bytes should match the stored
-        if len(data) * 8 != length:
+        if len(data) * 8 != length or len(data) != len(self.nodes):
             raise RxDException("Invalid state data length")
         self.nodes.concentration = data
 

--- a/share/lib/python/neuron/rxd/species.py
+++ b/share/lib/python/neuron/rxd/species.py
@@ -1924,7 +1924,7 @@ class Species(_SpeciesMathable):
         return [all_states[i] for i in numpy.sort(self.indices())]
 
     @property
-    def state(self):
+    def _state(self):
         """return a bytestring representing the Species state"""
         # format: version identifier (unsigned long long), size (unsigned long long), binary data
         import array
@@ -1933,8 +1933,8 @@ class Species(_SpeciesMathable):
         data = array.array("d", self.nodes.concentration).tobytes()
         return array.array("Q", [version, len(data)]).tobytes() + data
 
-    @state.setter
-    def state(self, oldstate):
+    @_state.setter
+    def _state(self, oldstate):
         """restore Species state"""
         import array
 

--- a/share/lib/python/neuron/rxd/species.py
+++ b/share/lib/python/neuron/rxd/species.py
@@ -1923,6 +1923,37 @@ class Species(_SpeciesMathable):
         all_states = node._get_states()
         return [all_states[i] for i in numpy.sort(self.indices())]
 
+    @property
+    def state(self):
+        """return a bytestring representing the Species state"""
+        # format: version identifier (unsigned long long), size (unsigned long long), binary data
+        import array
+
+        version = 0
+        data = array.array("d", self.nodes.concentration).tobytes()
+        return array.array("Q", [version, len(data)]).tobytes() + data
+
+    @state.setter
+    def state(self, oldstate):
+        """restore Species state"""
+        import array
+
+        metadata_array = array.array("Q")
+        metadata_array.frombytes(oldstate[:16])
+        version, length = metadata_array
+        if version != 0:
+            raise RxdException("Unsupported state data version")
+        data = array.array("d")
+        try:
+            data.frombytes(oldstate[16:])
+        except ValueError:
+            # happens when not a multiple of 8 bytes
+            raise RxDException("Invalid state data length") from None
+        # at 8 bytes per data point, the total number of bytes should match the stored
+        if len(data) * 8 != length:
+            raise RxDException("Invalid state data length")
+        self.nodes.concentration = data
+
     def _setup_matrices3d(self, euler_matrix):
         return
         # TODO: REmove this

--- a/src/nrniv/savstate.cpp
+++ b/src/nrniv/savstate.cpp
@@ -674,7 +674,11 @@ void SaveState::restore(int type) {
 		prs_[i]->savestate_restore();
 	}
 	restorenet();
-	if (nrnpy_restore_savestate) {
+	if (plugin_size_) {
+		if (!nrnpy_restore_savestate) {
+			hoc_execerror("SaveState:",
+				"This state requires Python to unpack.");
+		}
 		nrnpy_restore_savestate(plugin_size_, plugin_data_);
 	}
 }

--- a/src/nrniv/savstate.cpp
+++ b/src/nrniv/savstate.cpp
@@ -552,6 +552,11 @@ void SaveState::ssfree() {
 		delete [] prs_;
 	}
 	nprs_ = 0;
+	if (plugin_data_) {
+		delete[] plugin_data_;
+		plugin_data_ = NULL;
+		plugin_size_ = 0;
+	}
 }
 
 void SaveState::save() {
@@ -811,7 +816,12 @@ void SaveState::read(OcFile* ocf, bool close) {
 	// if version 7, load new plugin data
 	if (version == 7) {
 		ASSERTfread(&plugin_size_, sizeof(int64_t), 1, f);
-		plugin_data_ = new char[plugin_size_];
+		try {
+			plugin_data_ = new char[plugin_size_];
+		} catch (const std::bad_alloc& e) {
+			ocf -> close();
+			hoc_execerror("SaveState:", "Failed to allocate memory.");
+		}
 		if (plugin_data_ == NULL) {
 			ocf -> close();
 			hoc_execerror("SaveState:", "Failed to allocate memory.");

--- a/src/nrniv/savstate.cpp
+++ b/src/nrniv/savstate.cpp
@@ -813,6 +813,7 @@ void SaveState::read(OcFile* ocf, bool close) {
 	// any old plugin information is no longer relevant regardless of what version
 	if (plugin_data_) {
 		delete[] plugin_data_;
+		plugin_data_ = NULL;
 	}
 	plugin_size_ = 0;
 	// if version 7, load new plugin data

--- a/src/nrniv/savstate.cpp
+++ b/src/nrniv/savstate.cpp
@@ -143,15 +143,7 @@ void tqcallback(const TQItem* tq, int i) {
 		this_savestate->tqsave(tq, i);
 	}
 }
-/*
-#if __sgi && 0
-// fixed in version 5 of os
-StateStructInfo* SaveState::ssi;
-#else
-SaveState::StateStructInfo* SaveState::ssi;
-#endif
-cTemplate* SaveState::nct;
-*/
+
 SaveState::SaveState() {
 	int i, j;
 	nct = NULL;

--- a/src/nrniv/savstate.cpp
+++ b/src/nrniv/savstate.cpp
@@ -591,7 +591,11 @@ void SaveState::save() {
 		}
 	}
 	savenet();
-	nrnpy_store_savestate(&plugin_data_, &plugin_size_);
+	if (nrnpy_store_savestate) {
+		nrnpy_store_savestate(&plugin_data_, &plugin_size_);
+	} else {
+		plugin_size_ = 0;
+	}
 }
 
 void SaveState::savenode(NodeState& ns, Node* nd) {

--- a/src/nrniv/savstate.cpp
+++ b/src/nrniv/savstate.cpp
@@ -105,8 +105,8 @@ private:
 	int tqcnt_; // volatile for index of forall_callback
 	int nprs_;
 	PlayRecordSave** prs_;
-	static StateStructInfo* ssi;
-	static cTemplate* nct;
+	StateStructInfo* ssi;
+	cTemplate* nct;
 	char* plugin_data_;
 	uint64_t plugin_size_;
 private:
@@ -143,7 +143,7 @@ void tqcallback(const TQItem* tq, int i) {
 		this_savestate->tqsave(tq, i);
 	}
 }
-
+/*
 #if __sgi && 0
 // fixed in version 5 of os
 StateStructInfo* SaveState::ssi;
@@ -151,9 +151,10 @@ StateStructInfo* SaveState::ssi;
 SaveState::StateStructInfo* SaveState::ssi;
 #endif
 cTemplate* SaveState::nct;
-
+*/
 SaveState::SaveState() {
 	int i, j;
+	nct = NULL;
 	ssi_def();
 	nroot_ = 0;
 	ss_ = NULL;

--- a/src/nrniv/savstate.cpp
+++ b/src/nrniv/savstate.cpp
@@ -600,6 +600,7 @@ void SaveState::save() {
 		nrnpy_store_savestate(&plugin_data_, &plugin_size_);
 	} else {
 		plugin_size_ = 0;
+		plugin_data_ = NULL;
 	}
 }
 

--- a/test/rxd/test_savestate.py
+++ b/test/rxd/test_savestate.py
@@ -1,0 +1,44 @@
+def test_savestate(neuron_instance):
+    """Test rxd SaveState
+    
+    Ensures restoring to the right point and getting the right result later.
+    """
+
+    h, rxd, data, save_path = neuron_instance
+
+    soma = h.Section(name="soma")
+    soma.insert(h.hh)
+    soma.nseg = 51
+    cyt = rxd.Region(h.allsec(), name="cyt")
+    c = rxd.Species(cyt, name="c", d=1, initial=lambda node: 1 if node.x < 0.5 else 0)
+    c2 = rxd.Species(cyt, name="c2", d=0.6, initial=lambda node: 1 if node.x > 0.5 else 0)
+    r = rxd.Rate(c, -c * (1 - c) * (0.3 - c))
+    r2 = rxd.Reaction(c + c2 > c2, 1)
+
+    h.finitialize(-65)
+    soma(0).v = -30
+
+    while h.t < 5:
+        h.fadvance()
+
+    def get_state():
+        return (soma(0.5).v, c.nodes(soma(0.5)).concentration[0], c2.nodes(soma(0.5)).concentration[0])
+
+    s1 = get_state()
+    s = h.SaveState()
+    s.save()
+
+    while h.t < 10:
+        h.fadvance()
+
+    s2 = get_state()
+    s.restore()
+
+    assert(get_state() == s1)
+    assert(get_state() != s2)
+
+    while h.t < 10:
+        h.fadvance()
+
+    assert(get_state() != s1)
+    assert(get_state() == s2)

--- a/test/rxd/test_savestate.py
+++ b/test/rxd/test_savestate.py
@@ -2,6 +2,10 @@ def test_savestate(neuron_instance):
     """Test rxd SaveState
     
     Ensures restoring to the right point and getting the right result later.
+
+    Note: getting the right result later was a problem in a prior version of
+    NEURON, so the continuation test is important. The issue was that somehow
+    restoring from a SaveState broke the rxd connection to the integrator.
     """
 
     h, rxd, data, save_path = neuron_instance

--- a/test/rxd/test_savestate.py
+++ b/test/rxd/test_savestate.py
@@ -1,6 +1,6 @@
 def test_savestate(neuron_instance):
     """Test rxd SaveState
-    
+
     Ensures restoring to the right point and getting the right result later.
 
     Note: getting the right result later was a problem in a prior version of
@@ -15,7 +15,9 @@ def test_savestate(neuron_instance):
     soma.nseg = 51
     cyt = rxd.Region(h.allsec(), name="cyt")
     c = rxd.Species(cyt, name="c", d=1, initial=lambda node: 1 if node.x < 0.5 else 0)
-    c2 = rxd.Species(cyt, name="c2", d=0.6, initial=lambda node: 1 if node.x > 0.5 else 0)
+    c2 = rxd.Species(
+        cyt, name="c2", d=0.6, initial=lambda node: 1 if node.x > 0.5 else 0
+    )
     r = rxd.Rate(c, -c * (1 - c) * (0.3 - c))
     r2 = rxd.Reaction(c + c2 > c2, 1)
 
@@ -26,7 +28,11 @@ def test_savestate(neuron_instance):
         h.fadvance()
 
     def get_state():
-        return (soma(0.5).v, c.nodes(soma(0.5)).concentration[0], c2.nodes(soma(0.5)).concentration[0])
+        return (
+            soma(0.5).v,
+            c.nodes(soma(0.5)).concentration[0],
+            c2.nodes(soma(0.5)).concentration[0],
+        )
 
     s1 = get_state()
     s = h.SaveState()
@@ -38,11 +44,11 @@ def test_savestate(neuron_instance):
     s2 = get_state()
     s.restore()
 
-    assert(get_state() == s1)
-    assert(get_state() != s2)
+    assert get_state() == s1
+    assert get_state() != s2
 
     while h.t < 10:
         h.fadvance()
 
-    assert(get_state() != s1)
-    assert(get_state() == s2)
+    assert get_state() != s1
+    assert get_state() == s2


### PR DESCRIPTION
Adds the function `register_savestate(id_, store, restore)` to the `neuron` module top-level namespace that can be used to register SaveState extensions. `store` returns a bytestring and `restore` takes a bytestring. The `id_` is used to map extension data to the right restore function. Only extensions having non-empty stored data need to be available to restore the SaveState data.

If no extension types generate state data to store, then a version 6.0 SaveState file is generated, which is backwards compatible with prior versions of NEURON. Otherwise, a version 7.0 file is generated, which is the same as 6.0 except for the version flag and the presence of state data.

The reaction-diffusion (rxd) mechanisms use this extension mechanism to allow `h.SaveState` to save and restore rxd state. For rxd, besides a version header and length, the rest of the data is stored gzip-compressed by `Species`. Additionally, new functions `rxd.save_state` and `rxd.restore_state` allow saving and restoring rxd state to/from bytestrings independently of the rest of the simulator's state, and each `rxd.Species` now has a `_state` property that can be used for reading/writing state with some error checking (e.g. size). Note: rxd only registers its savestate handlers when an `rxd.Species` is created.