### PR TITLE
Fail to make test/pynrn/test_netpar.py fail.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -179,7 +179,7 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
     add_test(
       NAME parallel_netpar
       COMMAND
-        ${CMAKE_COMMAND} -E env PYTHONPATH=$PYTHONPATH:${PROJECT_SOURCE_DIR}/test/pynrn ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_OVERSUBSCRIBE}
+        ${CMAKE_COMMAND} -E env ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_OVERSUBSCRIBE}
         ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/bin/nrniv ${MPIEXEC_POSTFLAGS} -mpi -python
         ${PROJECT_SOURCE_DIR}/test/pynrn/test_netpar.py)
     list(APPEND TESTS parallel_tests parallel_netpar)

--- a/test/pynrn/test_netpar.py
+++ b/test/pynrn/test_netpar.py
@@ -1,14 +1,24 @@
 # Error tests for netpar.cpp
 # Some minor coverage increase for netpar.cpp when nhost > 1
+import os, sys, traceback
 
-from neuron import h
+try:
+    from neuron import h
 
-pc = h.ParallelContext()
+    pc = h.ParallelContext()
 
-from neuron.expect_hocerr import expect_err
-from test_hoc_po import Ring
+    from neuron.expect_hocerr import expect_err
 
-cvode = h.CVode()
+    # Prepend the directory of this script to the search path.
+    sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+
+    from test_hoc_po import Ring
+
+    cvode = h.CVode()
+except:
+    traceback.print_exc()
+    # make the ctest test fail
+    sys.exit(24)
 
 
 def run(tstop):
@@ -116,6 +126,11 @@ def test_1():
 
 
 if __name__ == "__main__":
-    test_1()
-    pc.barrier()
+    try:
+        test_1()
+        pc.barrier()
+    except:
+        traceback.print_exc()
+        # make the ctest test fail
+        sys.exit(42)
     h.quit()


### PR DESCRIPTION
The `PYTHONPATH=$PYTHONPATH:${PROJECT_SOURCE_DIR}/test/pynrn` construction in the test configuration does not work, because the test command is not executed in a shell.

Presumably this didn't matter on systems where required dependencies were found in generic/system paths, but it caused `import numpy` to fail if `numpy` needed to be found via `PYTHONPATH` (this happens in the BB5-based CI of CoreNEURON, for example).

Unfortunately this error was not obvious, because NEURON does not return an error code when it executes a Python script that throws an exception: https://github.com/neuronsimulator/nrn/issues/335.

This PR uses the same messy prescription as is used in other tests to transform Python exceptions into non-zero exit codes, which at least made the test fail when `numpy` could not be imported.

With all of these changes I still see
```
25: numprocs=2
25: NEURON -- VERSION 8.0a-732-gc4b4bd6ef+ olupton/c++14 (c4b4bd6ef+) 2022-01-19
25: Duke, Yale, and the BlueBrain Project -- Copyright 1984-2021
25: See http://neuron.yale.edu/neuron/credits
25:
25: send NetParEvent 0 t=1 tt-t=1
25: send NetParEvent 0 t=1 tt-t=1
25: send NetParEvent 0 t=2 tt-t=1
25: send NetParEvent 0 t=2 tt-t=1
25: send NetCon[0] src=<test_hoc_po.PyCell object at 0x2aeabff6a100>.axon target=ExpSyn[1] 2.94244066831006
25: send NetCon[0] src=<test_hoc_po.PyCell object at 0x2aaab1c28100>.axon target=ExpSyn[1] 2.94244066831006
25: send NetParEvent 0 t=3 tt-t=1
25: send NetParEvent 0 t=3 tt-t=1
25: send NetParEvent 0 t=4 tt-t=1
25: send NetParEvent 0 t=4 tt-t=1
25: 0 /gpfs/bbp.cscs.ch/home/olupton/nrn/build_ollinmodl_gpu_omp/bin/nrniv: ParallelContext.spike_compress cannot be used with cvode active
25: 0  near line 0
25: 0
25:  ^
1/1 Test #25: parallel_netpar ..................   Passed    1.97 sec
```
which looks like another error-that-does-not-cause-a-failure, but I am less sure what to do with this one.

This was introduced in https://github.com/neuronsimulator/nrn/pull/1568.

cc: @nrnhines 