### PR TITLE
Improve Python error handling.

### DIFF
--- a/src/ivoc/ivocmain.cpp
+++ b/src/ivoc/ivocmain.cpp
@@ -163,7 +163,7 @@ static OptionDesc options[] = {
 #if defined(USE_PYTHON)
 	int nrn_nopython;
 	extern int use_python_interpreter;
-	extern void (*p_nrnpython_start)(int);
+	extern int (*p_nrnpython_start)(int);
 	char* nrnpy_pyexe;
 #endif
 
@@ -856,7 +856,11 @@ PR_PROFILE
 #if defined(USE_PYTHON)
 	if (use_python_interpreter) {
 		// process the .py files and an interactive interpreter
-		if (p_nrnpython_start) {(*p_nrnpython_start)(2);}
+		if (p_nrnpython_start && (*p_nrnpython_start)(2) != 0) {
+			// We encountered an error when processing the -c argument or Python
+			// script given on the commandline.
+			exit_status = 1;
+		}
 	}
 	if (p_nrnpython_start) { (*p_nrnpython_start)(0); }
 #endif

--- a/src/nrniv/nrnpy.cpp
+++ b/src/nrniv/nrnpy.cpp
@@ -18,7 +18,7 @@ extern int nrnpy_nositeflag;
 extern char* nrnpy_pyexe;
 extern int nrn_is_python_extension;
 int* nrnpy_site_problem_p;
-extern void (*p_nrnpython_start)(int);
+extern int (*p_nrnpython_start)(int);
 void nrnpython();
 static void (*p_nrnpython_real)();
 static void (*p_nrnpython_reg_real)();
@@ -66,7 +66,7 @@ static void* python_already_loaded();
 static void* load_python();
 static void load_nrnpython(int, const char*);
 #else //!defined(NRNPYTHON_DYNAMICLOAD)
-extern "C" void nrnpython_start(int);
+extern "C" int nrnpython_start(int);
 extern "C" void nrnpython_reg_real();
 extern "C" void nrnpython_real();
 #endif //defined(NRNPYTHON_DYNAMICLOAD)
@@ -398,7 +398,7 @@ static void load_nrnpython(int pyver10, const char* pylib) {
         return;
     }
 #endif
-	p_nrnpython_start = (void(*)(int))load_sym(handle, "nrnpython_start");
+	p_nrnpython_start = (int(*)(int))load_sym(handle, "nrnpython_start");
 	p_nrnpython_real = (void(*)())load_sym(handle, "nrnpython_real");
 	p_nrnpython_reg_real = (void(*)())load_sym(handle, "nrnpython_reg_real");
 }

--- a/src/nrnpython/nrnpython.cpp
+++ b/src/nrnpython/nrnpython.cpp
@@ -13,7 +13,7 @@
 
 #include <hocstr.h>
 extern "C" void nrnpython_real();
-extern "C" void nrnpython_start(int);
+extern "C" int nrnpython_start(int);
 extern int hoc_get_line();
 extern HocStr* hoc_cbufstr;
 extern int nrnpy_nositeflag;
@@ -63,6 +63,9 @@ void nrnpy_augment_path() {
   }
 }
 
+/** @brief Execute a Python script.
+ *  @return 0 on failure, 1 on success.
+ */
 int nrnpy_pyrun(const char* fname) {
 #ifdef MINGW
   // perhaps this should be the generic implementation
@@ -79,11 +82,11 @@ int nrnpy_pyrun(const char* fname) {
 #else // MINGW not defined
   FILE* fp = fopen(fname, "r");
   if (fp) {
-    PyRun_AnyFile(fp, fname);
+    int const code = PyRun_AnyFile(fp, fname);
     fclose(fp);
-    return 1;
+    return !code;
   } else {
-    fprintf(stderr, "Could not open %s\n", fname);
+    std::cerr << "Could not open " << fname << std::endl;
     return 0;
   }
 #endif // MINGW not defined
@@ -125,7 +128,16 @@ static wchar_t* mywstrdup(char* s) {
   return ws;
 }
 
-extern "C" void nrnpython_start(int b) {
+/** @brief Start the Python interpreter.
+ *  @arg b Mode of operation, can be 0 (finalize), 1 (initialize), 2 (execute
+ *         commands/scripts) or possibly 3 (?).
+ *  @return 0 on success, non-zero on error
+ *
+ *  There is an internal state variable that stores whether or not Python has
+ *  been initialized. Mode 1 only has an effect if Python is not initialized,
+ *  while the other modes only take effect if Python is already initialized.
+ */
+extern "C" int nrnpython_start(int b) {
 #if USE_PYTHON
   static int started = 0;
   //printf("nrnpython_start %d started=%d\n", b, started);
@@ -175,20 +187,30 @@ extern "C" void nrnpython_start(int b) {
     PyOS_ReadlineFunctionPointer = nrnpython_getline;
 #endif
     // Is there a -c "command" or file.py arg.
+    bool python_error_encountered{false};
     for (i = 1; i < nrn_global_argc; ++i) {
       char* arg = nrn_global_argv[i];
       if (strcmp(arg, "-c") == 0 && i + 1 < nrn_global_argc) {
-        PyRun_SimpleString(nrn_global_argv[i + 1]);
+        if(PyRun_SimpleString(nrn_global_argv[i + 1])) {
+          python_error_encountered = true;
+        }
         break;
       } else if (strlen(arg) > 3 && strcmp(arg + strlen(arg) - 3, ".py") == 0) {
-        nrnpy_pyrun(arg);
+        if(!nrnpy_pyrun(arg)) {
+          python_error_encountered = true;
+        }
         break;
       }
     }
-    // In any case start interactive.
-    //		PyRun_InteractiveLoop(fopen("/dev/tty", "r"), "/dev/tty");
-    PyRun_InteractiveLoop(hoc_fin, "stdin");
+    // When running in non-interactive/batch mode then python_error_encountered
+    // imply NEURON exits with a nonzero code. In interactive mode, we can start
+    // a Python interpreter.
+    if(nrn_istty_) {
+      PyRun_InteractiveLoop(hoc_fin, "stdin");
+    }
+    return python_error_encountered;
   }
+  // olupton 2022-01-20: is this code ever reached?
   if (b == 3 && started) {
 #if HAVE_IV
     if (Session::instance()) {
@@ -198,6 +220,7 @@ extern "C" void nrnpython_start(int b) {
 #endif
   }
 #endif
+  return 0;
 }
 
 extern "C" void nrnpython_real() {

--- a/src/nrnpython/nrnpython.cpp
+++ b/src/nrnpython/nrnpython.cpp
@@ -129,8 +129,8 @@ static wchar_t* mywstrdup(char* s) {
 }
 
 /** @brief Start the Python interpreter.
- *  @arg b Mode of operation, can be 0 (finalize), 1 (initialize), 2 (execute
- *         commands/scripts) or possibly 3 (?).
+ *  @arg b Mode of operation, can be 0 (finalize), 1 (initialize),
+ *         or 2 (execute commands/scripts)
  *  @return 0 on success, non-zero on error
  *
  *  There is an internal state variable that stores whether or not Python has
@@ -202,22 +202,13 @@ extern "C" int nrnpython_start(int b) {
         break;
       }
     }
-    // When running in non-interactive/batch mode then python_error_encountered
-    // imply NEURON exits with a nonzero code. In interactive mode, we can start
-    // a Python interpreter.
+    // python_error_encountered dictates whether NEURON will exit with a nonzero
+    // code. In noninteractive/batch mode that happens immediately, in
+    // interactive mode then we start a Python interpreter first.
     if(nrn_istty_) {
       PyRun_InteractiveLoop(hoc_fin, "stdin");
     }
     return python_error_encountered;
-  }
-  // olupton 2022-01-20: is this code ever reached?
-  if (b == 3 && started) {
-#if HAVE_IV
-    if (Session::instance()) {
-      Session::instance()->quit();
-      rl_stuff_char(EOF);
-    }
-#endif
   }
 #endif
   return 0;

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -32,7 +32,7 @@ char** nrn_global_argv;
 
 #if defined(USE_PYTHON)
 int use_python_interpreter = 0;
-void (*p_nrnpython_start)(int);
+int (*p_nrnpython_start)(int);
 void (*p_nrnpython_finalize)();
 #endif
 int nrn_inpython_;

--- a/src/parallel/bbsclimpi.cpp
+++ b/src/parallel/bbsclimpi.cpp
@@ -18,7 +18,7 @@ extern void nrnmpi_int_broadcast(int*, int, int);
 #define debug 0
 
 #if defined(USE_PYTHON)
-extern void (*p_nrnpython_start)(int);
+extern int (*p_nrnpython_start)(int);
 #endif
 
 #if defined(HAVE_STL)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -179,7 +179,7 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
     add_test(
       NAME parallel_netpar
       COMMAND
-        ${CMAKE_COMMAND} -E env PYTHONPATH=$PYTHONPATH:${PROJECT_SOURCE_DIR}/test/pynrn ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_OVERSUBSCRIBE}
+        ${CMAKE_COMMAND} -E env ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_OVERSUBSCRIBE}
         ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/bin/nrniv ${MPIEXEC_POSTFLAGS} -mpi -python
         ${PROJECT_SOURCE_DIR}/test/pynrn/test_netpar.py)
     list(APPEND TESTS parallel_tests parallel_netpar)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -360,9 +360,10 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
         NAME inputpresyn_py_${processor}
         REQUIRES coreneuron ${processor}
         PROCESSORS 2
-        COMMAND ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS}
-                special ${MPIEXEC_POSTFLAGS} -mpi -python
-                ${PROJECT_SOURCE_DIR}/test/coreneuron/test_inputpresyn.py)
+        COMMAND
+          ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} special
+          ${MPIEXEC_POSTFLAGS} -mpi -python
+          ${PROJECT_SOURCE_DIR}/test/coreneuron/test_inputpresyn.py)
     endif()
   endforeach()
 endif()

--- a/test/coreneuron/test_datareturn.py
+++ b/test/coreneuron/test_datareturn.py
@@ -3,7 +3,7 @@ import distutils.util
 import itertools
 import os
 
-from neuron import h
+from neuron import h, gui
 
 pc = h.ParallelContext()
 h.dt = 1.0 / 32

--- a/test/coreneuron/test_datareturn.py
+++ b/test/coreneuron/test_datareturn.py
@@ -2,10 +2,8 @@
 import distutils.util
 import itertools
 import os
-import sys
-import traceback
 
-from neuron import h, gui
+from neuron import h
 
 pc = h.ParallelContext()
 h.dt = 1.0 / 32
@@ -219,10 +217,5 @@ def test_datareturn():
 
 if __name__ == "__main__":
     show = False
-    try:
-        test_datareturn()
-    except:
-        traceback.print_exc()
-        # Make the CTest test fail
-        sys.exit(42)
+    test_datareturn()
     h.quit()

--- a/test/coreneuron/test_direct.py
+++ b/test/coreneuron/test_direct.py
@@ -1,9 +1,7 @@
 import distutils.util
 import os
-import sys
-import traceback
 
-from neuron import h, gui
+from neuron import h
 
 
 def test_direct_memory_transfer():
@@ -90,10 +88,5 @@ def test_direct_memory_transfer():
 
 
 if __name__ == "__main__":
-    try:
-        test_direct_memory_transfer()
-    except:
-        traceback.print_exc()
-        # Make the CTest test fail
-        sys.exit(42)
+    test_direct_memory_transfer()
     h.quit()

--- a/test/coreneuron/test_direct.py
+++ b/test/coreneuron/test_direct.py
@@ -1,7 +1,7 @@
 import distutils.util
 import os
 
-from neuron import h
+from neuron import h, gui
 
 
 def test_direct_memory_transfer():

--- a/test/coreneuron/test_fornetcon.py
+++ b/test/coreneuron/test_fornetcon.py
@@ -3,8 +3,6 @@
 # in random order.
 import distutils.util
 import os
-import sys
-import traceback
 
 from neuron import h
 
@@ -111,13 +109,5 @@ def test_fornetcon():
 
 
 if __name__ == "__main__":
-    try:
-        test_fornetcon()
-    except:
-        traceback.print_exc()
-        # Make the CTest test fail
-        sys.exit(42)
-    # This test is not actually executed on GPU, but it has this logic anyway
-    # for consistency with the other .py tests in this folder when
-    # https://github.com/BlueBrain/CoreNeuron/issues/512 is resolved.
+    test_fornetcon()
     h.quit()

--- a/test/coreneuron/test_netmove.py
+++ b/test/coreneuron/test_netmove.py
@@ -2,8 +2,6 @@
 # mixed up with other instances.
 import distutils.util
 import os
-import sys
-import traceback
 
 from neuron import h
 
@@ -117,18 +115,13 @@ def test_netmove():
 
 
 if __name__ == "__main__":
-    try:
-        from neuron import gui
+    from neuron import gui
 
-        stdlist = test_netmove()
-        g = h.Graph()
-        print("n_netsend  n_netmove")
-        for result in stdlist:
-            print(result[0], result[1])
-            result[2].line(g)
-        g.exec_menu("View = plot")
-    except:
-        traceback.print_exc()
-        # Make the CTest test fail
-        sys.exit(42)
+    stdlist = test_netmove()
+    g = h.Graph()
+    print("n_netsend  n_netmove")
+    for result in stdlist:
+        print(result[0], result[1])
+        result[2].line(g)
+    g.exec_menu("View = plot")
     h.quit()

--- a/test/coreneuron/test_psolve.py
+++ b/test/coreneuron/test_psolve.py
@@ -1,7 +1,7 @@
 import distutils.util
 import os
 
-from neuron import h
+from neuron import h, gui
 
 pc = h.ParallelContext()
 

--- a/test/coreneuron/test_psolve.py
+++ b/test/coreneuron/test_psolve.py
@@ -1,9 +1,7 @@
 import distutils.util
 import os
-import sys
-import traceback
 
-from neuron import h, gui
+from neuron import h
 
 pc = h.ParallelContext()
 
@@ -117,13 +115,8 @@ def test_NetStim_noise():
 
 
 if __name__ == "__main__":
-    try:
-        test_psolve()
-        test_NetStim_noise()
-        for i in range(0):
-            test_NetStim_noise()  # for checking memory leak
-    except:
-        traceback.print_exc()
-        # Make the CTest test fail
-        sys.exit(42)
+    test_psolve()
+    test_NetStim_noise()
+    for i in range(0):
+        test_NetStim_noise()  # for checking memory leak
     h.quit()

--- a/test/coreneuron/test_spikes.py
+++ b/test/coreneuron/test_spikes.py
@@ -1,6 +1,5 @@
 import distutils.util
 import os
-import sys
 
 # Hacky, but it's non-trivial to pass commandline arguments to pytest tests.
 enable_gpu = bool(
@@ -31,10 +30,6 @@ elif nrnmpi_init_option:
 # otherwise serial execution
 else:
     from neuron import h, gui
-
-import pytest
-import sys
-import traceback
 
 
 def test_spikes(
@@ -142,12 +137,7 @@ def test_spikes(
 
 
 if __name__ == "__main__":
-    try:
-        h = test_spikes()
-    except:
-        traceback.print_exc()
-        # Make the CTest test fail
-        sys.exit(42)
+    h = test_spikes()
     if mpi4py_option or nrnmpi_init_option:
         pc = h.ParallelContext()
         pc.barrier()

--- a/test/coreneuron/test_units.py
+++ b/test/coreneuron/test_units.py
@@ -1,7 +1,5 @@
 import distutils.util
 import os
-import sys
-import traceback
 
 from neuron import h
 
@@ -37,10 +35,5 @@ def test_units():
 
 
 if __name__ == "__main__":
-    try:
-        model = test_units()
-    except:
-        traceback.print_exc()
-        # Make the CTest test fail
-        sys.exit(42)
+    test_units()
     h.quit()

--- a/test/coreneuron/test_watchrange.py
+++ b/test/coreneuron/test_watchrange.py
@@ -2,8 +2,6 @@
 # mixed up with other instances.
 import distutils.util
 import os
-import sys
-import traceback
 
 from neuron import h
 
@@ -147,18 +145,11 @@ def test_watchrange():
 
 
 if __name__ == "__main__":
-    try:
-        from neuron import gui
-
-        stdlist, tvec = test_watchrange()
-        g = h.Graph()
-        print("n_high  n_mid  n_low")
-        for i, result in enumerate(stdlist):
-            print(result[0], result[1], result[2])
-            result[4].line(g, tvec, i, 2)
-        g.exec_menu("View = plot")
-    except:
-        traceback.print_exc()
-        # Make the CTest test fail
-        sys.exit(42)
+    stdlist, tvec = test_watchrange()
+    g = h.Graph()
+    print("n_high  n_mid  n_low")
+    for i, result in enumerate(stdlist):
+        print(result[0], result[1], result[2])
+        result[4].line(g, tvec, i, 2)
+    g.exec_menu("View = plot")
     h.quit()

--- a/test/coreneuron/test_watchrange.py
+++ b/test/coreneuron/test_watchrange.py
@@ -145,6 +145,8 @@ def test_watchrange():
 
 
 if __name__ == "__main__":
+    from neuron import gui
+
     stdlist, tvec = test_watchrange()
     g = h.Graph()
     print("n_high  n_mid  n_low")

--- a/test/pynrn/test_fast_imem.py
+++ b/test/pynrn/test_fast_imem.py
@@ -3,8 +3,6 @@
 # sprinkled on zero and non-zero area nodes.
 import distutils.util
 import os
-import sys
-import traceback
 
 from neuron import h
 
@@ -361,12 +359,7 @@ def test_fastimem_corenrn():
 
 
 if __name__ == "__main__":
-    try:
-        test_allseg_unique_iter()
-        test_fastimem()
-        test_fastimem_corenrn()
-    except:
-        traceback.print_exc()
-        # Make the CTest test fail
-        sys.exit(42)
+    test_allseg_unique_iter()
+    test_fastimem()
+    test_fastimem_corenrn()
     h.quit()

--- a/test/pynrn/test_netpar.py
+++ b/test/pynrn/test_netpar.py
@@ -1,6 +1,12 @@
 # Error tests for netpar.cpp
 # Some minor coverage increase for netpar.cpp when nhost > 1
 
+# Prepend the location of the current script to the search path, so we can
+# import from test_hoc_po.
+import os, sys
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+
 from neuron import h
 
 pc = h.ParallelContext()


### PR DESCRIPTION
## Context
Many test scripts, such as
https://github.com/neuronsimulator/nrn/blob/a9e1f89a52eab42fde8bb6a6fa6956419ea1b12e/test/coreneuron/test_direct.py#L93-L98
have copy-pasted logic to exit NEURON with a non-zero code if a Python error is encountered.
This is ugly and error prone, and when we forget to include this pattern then we end up with tests that produce errors but are flagged as having passed. See https://github.com/neuronsimulator/nrn/pull/1593 for a recent example.

## Changeset
This PR tracks errors in Python execution and ensures that Python errors that are not caught within the Python world will eventually result in a non-zero exit code from `special` (`nrniv`).

It also removes the `sys` and `traceback`-based logic that was used in several Python tests.

Finally, it changes the `PYTHONPATH` logic for the `parallel_netpar` test. See: https://github.com/neuronsimulator/nrn/pull/1593.

## Examples
```
special -python path/to/script.py
special -python -c 'foo()'
```
both record whether or not Python execution succeeded.

If the command is run interactively (or `-isatty` is passed) then the existing behaviour, where an interactive Python shell is launched, is preserved. The error code from the original Python code will be returned after the interactive shell exits.

If the command is not run interactively (or `-notatty` is passed) then `special` will exit immediately with a non-zero exit code in case of an error in the Python code.

## Limitations
This has no effect on error handling in HOC scripts, so it is not a full solution to https://github.com/neuronsimulator/nrn/issues/335.

## Notes
~~This PR does not include any fixes from https://github.com/neuronsimulator/nrn/pull/1593, so it is expected that that test will initially fail on systems where `numpy` cannot be found in a **default** path.~~

In my local build, the `parallel_netpar` test shows
```
25/163 Test: parallel_netpar
Command: "/gpfs/bbp.cscs.ch/ssd/apps/bsd/2022-01-10/stage_externals/install_gcc-11.2.0-skylake/cmake-3.21.4-cdyb7k/bin/cmake" "-E" "env" "mpiexec" "-n" "2" "/gpfs/bbp.cscs.ch/home/olupton/nrn/build_ollinmodl_gpu_omp/bin/nrniv" "-mpi" "-python" "/gpfs/bbp.cscs.ch/home/olupton/nrn/test/pynrn/test_netpar.py"
Directory: /gpfs/bbp.cscs.ch/home/olupton/nrn/build_ollinmodl_gpu_omp/test
"parallel_netpar" start time: Jan 20 10:33 CET
Output:
----------------------------------------------------------
numprocs=2
NEURON -- VERSION 8.0a-733-g96d081cae+ olupton/python-error-handling (96d081cae+) 2022-01-20
Duke, Yale, and the BlueBrain Project -- Copyright 1984-2021
See http://neuron.yale.edu/neuron/credits

send NetParEvent 0 t=1 tt-t=1
send NetParEvent 0 t=1 tt-t=1
send NetParEvent 0 t=2 tt-t=1
send NetParEvent 0 t=2 tt-t=1
send NetCon[0] src=<test_hoc_po.PyCell object at 0x2aeabff630d0>.axon target=ExpSyn[1] 2.94244066831006
send NetCon[0] src=<test_hoc_po.PyCell object at 0x2aaab1c210d0>.axon target=ExpSyn[1] 2.94244066831006
send NetParEvent 0 t=3 tt-t=1
send NetParEvent 0 t=3 tt-t=1
send NetParEvent 0 t=4 tt-t=1
send NetParEvent 0 t=4 tt-t=1
0 /gpfs/bbp.cscs.ch/home/olupton/nrn/build_ollinmodl_gpu_omp/bin/nrniv: ParallelContext.spike_compress cannot be used with cvode active
0  near line 0
0
 ^
<end of output>
Test time =   2.01 sec
----------------------------------------------------------
Test Passed.
"parallel_netpar" end time: Jan 20 10:33 CET
"parallel_netpar" time elapsed: 00:00:02
----------------------------------------------------------
```
which looks like it should potentially be a failure.