### PR TITLE
nrn_add_test_*: improve consistency/docs/speed.

### DIFF
--- a/.cmake-format.changes.yaml
+++ b/.cmake-format.changes.yaml
@@ -3,26 +3,27 @@ additional_commands:
     pargs: 0
     kwargs:
       NAME: 1
-      SUBMODULE: '?'
-      MODFILE_PATTERNS: '*'
-      SCRIPT_PATTERNS: '*'
-      OUTPUT: '*'
+      MODFILE_PATTERNS: '+'
+      NRNIVMODL_ARGS: '+'
+      OUTPUT: '+'
+      SCRIPT_PATTERNS: '+'
+      SUBMODULE: '1'
   nrn_add_test:
     pargs: 0
     kwargs:
       GROUP: 1
       NAME: 1
-      SUBMODULE: '?'
-      MODFILE_PATTERNS: '*'
-      PRECOMMAND: '+'
       COMMAND: '+'
-      SCRIPT_PATTERNS: '*'
-      REQUIRES: '*'
-      CONFLICTS: '*'
+      CONFLICTS: '+'
+      PRECOMMAND: '+'
+      PROCESSORS: 1
+      REQUIRES: '+'
+      MODFILE_PATTERNS: '*'
+      NRNIVMODL_ARGS: '*'
       OUTPUT: '*'
-      PROCESSORS: '?'
+      SCRIPT_PATTERNS: '*'
       SIM_DIRECTORY: '?'
-      NRNIVMODL_ARGS: '+'
+      SUBMODULE: '?'
   nrn_add_test_group_comparison:
     pargs: 0
     kwargs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,6 +485,8 @@ if(NRN_ENABLE_CORENEURON)
     # variable in this scope. If CoreNEURON is installed externally then this
     # is exported into coreneuron-config.cmake.
     get_property(CORENEURON_LIB_LINK_FLAGS GLOBAL PROPERTY CORENEURON_LIB_LINK_FLAGS)
+    # NEURON tests that link against CoreNEURON need to depend on it.
+    set(CORENEURON_TARGET_TO_DEPEND coreneuron)
   endif()
 endif()
 

--- a/cmake/NeuronTestHelper.cmake
+++ b/cmake/NeuronTestHelper.cmake
@@ -249,7 +249,9 @@ function(nrn_add_test)
   # NEURON and CoreNEURON versions of a test will share the same hash, which is
   # probably fine, but also means that any NEURON-only tests will be compiled
   # for CoreNEURON too.
+  set(nrnivmodl_dependencies)
   if(NRN_ENABLE_CORENEURON)
+    list(APPEND nrnivmodl_dependencies ${CORENEURON_TARGET_TO_DEPEND})
     list(APPEND nrnivmodl_command -coreneuron)
     list(APPEND hash_components -coreneuron)
   endif()
@@ -302,12 +304,9 @@ function(nrn_add_test)
     # translated to CMake, so it can be called natively here and the `nrnivmodl` executable would be
     # a wrapper that invokes CMake?
     set(output_binaries "${special}")
-    set(nrnivmodl_dependencies nrniv_lib)
+    list(APPEND nrnivmodl_dependencies nrniv_lib)
     if(requires_coreneuron)
-      # See above; if the condition is changed to NRN_ENABLE_CORENEURON there it should be changed
-      # here too.
       list(APPEND output_binaries "${special}-core")
-      list(APPEND nrnivmodl_dependencies coreneuron)
       if((NOT coreneuron_FOUND) AND (NOT DEFINED CORENEURON_BUILTIN_MODFILES))
         message(
           WARNING

--- a/cmake/NeuronTestHelper.cmake
+++ b/cmake/NeuronTestHelper.cmake
@@ -4,19 +4,22 @@
 # of operation.
 #
 # 1. nrn_add_test_group(NAME name
-#                       SUBMODULE some/submodule
-#                       MODFILE_PATTERNS mod/file/dir/*.mod other/file.mod
-#                       OUTPUT datatype::file.ext otherdatatype::otherfile.ext
-#                       SCRIPT_PATTERNS "*.py")
+#                       [MODFILE_PATTERNS mod/file/dir/*.mod ...]
+#                       [NRNIVMODL_ARGS arg1 ...]
+#                       [OUTPUT datatype::file.ext ...]
+#                       [SCRIPT_PATTERNS "*.py" ...]
+#                       [SIM_DIRECTORY sim_dir]
+#                       [SUBMODULE some/submodule]
+#                      )
 #
 #    Create a new group of integration tests with the given name. The group
 #    consists of different configurations of running logically the same
 #    simulation. The outputs of the different configurations will be compared.
 #
-#    SUBMODULE        - the name of the git submodule containing test data.
 #    MODFILE_PATTERNS - a list of patterns that will be matched against the
 #                       submodule directory tree to find the modfiles that must
 #                       be compiled (using nrnivmodl) to run the test.
+#    NRNIVMODL_ARGS   - extra arguments that will be passed to nrnivmodl.
 #    OUTPUT           - zero or more expressions of the form `datatype::path`
 #                       describing the output data produced by a test. The
 #                       data type must be supported by the comparison script
@@ -27,39 +30,51 @@
 #                       submodule directory, matching scripts that must be
 #                       copied from the submodule to the working directory in
 #                       which the test is run.
+#    SIM_DIRECTORY    - extra directory name under which the test will be run,
+#                       this is useful for some models whose scripts make
+#                       assumptions about directory layout.
+#    SUBMODULE        - the name of the git submodule containing test data.
 #
-#    The SUBMODULE, MODFILE_PATTERNS, OUTPUT and SCRIPT_PATTERNS arguments are
-#    default values that will be inherited tests that are added to this group
-#    using nrn_add_test. They can be overriden for specific tests by passing
-#    the same keyword arguments to nrn_add_test.
+#    The MODFILE_PATTERNS, NRNIVMODL_ARGS, OUTPUT, SCRIPT_PATTERNS,
+#    SIM_DIRECTORY and SUBMODULE arguments are default values that will be
+#    inherited tests that are added to this group using nrn_add_test.
+#    They can be overriden for specific tests by passing the same keyword
+#    arguments to nrn_add_test.
 #
 # 2. nrn_add_test(GROUP group_name
 #                 NAME test_name
 #                 COMMAND command [arg ...]
-#                 [REQUIRES feature1 ...]
 #                 [CONFLICTS feature1 ...]
-#                 [SUBMODULE some/submodule]
-#                 [MODFILE_PATTERNS mod_file_pattern ...]
-#                 [OUTPUT datatype::file.ext otherdatatype::otherfile.ext ...]
+#                 [PRECOMMAND command ...]
+#                 [PROCESSORS required_processors]
+#                 [REQUIRES feature1 ...]
+#                 [MODFILE_PATTERNS mod/file/dir/*.mod ...]
+#                 [NRNIVMODL_ARGS arg1 ...]
+#                 [OUTPUT datatype::file.ext ...]
 #                 [SCRIPT_PATTERNS "*.py" ...]
 #                 [SIM_DIRECTORY sim_dir]
-#                 [NRNIVMODL_ARGS arg1 ...])
+#                 [SUBMODULE some/submodule]
+#                )
 #
 #    Create a new integration test inside the given group, which must have
 #    previously been created using nrn_add_test_group. The COMMAND option is
 #    the test expression, which is run in an environment whose PATH includes
-#    the `special` binary built from the specified modfiles. The SUBMODULE,
-#    MODFILE_PATTERNS, OUTPUT and SCRIPT_PATTERNS arguments are optional and
-#    can be used to override the defaults defined when nrn_add_test_group is
-#    called. The REQUIRES and CONFLICTS arguments allow a test to be disabled
-#    if certain features are, or are not, available. Eight features are currently
-#    supported: coreneuron, cpu, gpu, mod_compatibility, mpi, mpi_dynamic, nmodl and python.
-#    The SIM_DIRECTORY argument is used to override the default directory in which
-#    the simulation is run. The NRNIVMODL_ARGS argument allows extra arguments
-#    to be passed to nrnivmodl.
+#    the `special` binary built from the specified modfiles.
+#    The REQUIRES and CONFLICTS arguments allow a test to be disabled if
+#    certain features are, or are not, available. Eight features are currently
+#    supported: coreneuron, cpu, gpu, mod_compatibility, mpi, mpi_dynamic,
+#    nmodl and python. The PRECOMMAND argument is an optional command that will
+#    be executed before COMMAND and in the same directory. It can be used to
+#    prepare input data for simulations. The PROCESSORS argument specifies the
+#    number of processors used by the test. This is passed to CTest and allows
+#    invocations such as `ctest -j 16` to avoid overcommitting resources by
+#    running too many tests with internal parallelism.
+#    The remaining arguments can documented in nrn_add_test_group. The default
+#    values specified there can be overriden on a test-by-test basis by passing
+#    the same arguments here.
 #
 # 3. nrn_add_test_group_comparison(GROUP group_name
-#                                  REFERENCE_OUTPUT datatype::file.ext [...])
+#                                  [REFERENCE_OUTPUT datatype::file.ext ...])
 #
 #    Add a test job that runs after all the tests in this group (as defined by
 #    prior calls to nrn_add_test) and compares their output data. The optional
@@ -73,7 +88,7 @@ function(nrn_add_test_group)
   # NAME is used as a key, everything else is a default that can be overriden in subsequent calls to
   # nrn_add_test
   set(oneValueArgs NAME SUBMODULE)
-  set(multiValueArgs OUTPUT SCRIPT_PATTERNS MODFILE_PATTERNS)
+  set(multiValueArgs MODFILE_PATTERNS NRNIVMODL_ARGS OUTPUT SCRIPT_PATTERNS SIM_DIRECTORY)
   cmake_parse_arguments(NRN_ADD_TEST_GROUP "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
   if(DEFINED NRN_ADD_TEST_GROUP_MISSING_VALUES)
     message(
@@ -86,33 +101,39 @@ function(nrn_add_test_group)
 
   # Store the default values for this test group in parent-scope variables based on the group name
   set(prefix NRN_TEST_GROUP_${NRN_ADD_TEST_GROUP_NAME})
+  set(${prefix}_DEFAULT_MODFILE_PATTERNS
+      "${NRN_ADD_TEST_GROUP_MODFILE_PATTERNS}"
+      PARENT_SCOPE)
+  set(${prefix}_DEFAULT_NRNIVMODL_ARGS
+      "${NRN_ADD_TEST_GROUP_NRNIVMODL_ARGS}"
+      PARENT_SCOPE)
   set(${prefix}_DEFAULT_OUTPUT
       "${NRN_ADD_TEST_GROUP_OUTPUT}"
-      PARENT_SCOPE)
-  set(${prefix}_DEFAULT_SUBMODULE
-      "${NRN_ADD_TEST_GROUP_SUBMODULE}"
       PARENT_SCOPE)
   set(${prefix}_DEFAULT_SCRIPT_PATTERNS
       "${NRN_ADD_TEST_GROUP_SCRIPT_PATTERNS}"
       PARENT_SCOPE)
-  set(${prefix}_DEFAULT_MODFILE_PATTERNS
-      "${NRN_ADD_TEST_GROUP_MODFILE_PATTERNS}"
+  set(${prefix}_DEFAULT_SIM_DIRECTORY
+      "${NRN_ADD_TEST_GROUP_SIM_DIRECTORY}"
+      PARENT_SCOPE)
+  set(${prefix}_DEFAULT_SUBMODULE
+      "${NRN_ADD_TEST_GROUP_SUBMODULE}"
       PARENT_SCOPE)
 endfunction()
 
 function(nrn_add_test)
   # Parse the function arguments
-  set(oneValueArgs GROUP NAME SUBMODULE PROCESSORS)
+  set(oneValueArgs GROUP NAME PROCESSORS SUBMODULE)
   set(multiValueArgs
       COMMAND
+      CONFLICTS
+      PRECOMMAND
+      REQUIRES
+      MODFILE_PATTERNS
+      NRNIVMODL_ARGS
       OUTPUT
       SCRIPT_PATTERNS
-      REQUIRES
-      CONFLICTS
-      MODFILE_PATTERNS
-      PRECOMMAND
-      SIM_DIRECTORY
-      NRNIVMODL_ARGS)
+      SIM_DIRECTORY)
   cmake_parse_arguments(NRN_ADD_TEST "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
   if(DEFINED NRN_ADD_TEST_MISSING_VALUES)
     message(
@@ -139,7 +160,6 @@ function(nrn_add_test)
   else()
     set(feature_mod_compatibility_enabled OFF)
   endif()
-  # TODO: Do these work if CoreNEURON is installed externally?
   set(feature_gpu_enabled ${CORENRN_ENABLE_GPU})
   set(feature_nmodl_enabled ${CORENRN_ENABLE_NMODL})
   # Check REQUIRES
@@ -175,30 +195,37 @@ function(nrn_add_test)
   set(prefix NRN_TEST_GROUP_${NRN_ADD_TEST_GROUP})
 
   # Get the submodule etc. variables that have global defaults but which can be overriden locally
-  set(output_files "${${prefix}_DEFAULT_OUTPUT}")
-  set(git_submodule "${${prefix}_DEFAULT_SUBMODULE}")
-  set(script_patterns "${${prefix}_DEFAULT_SCRIPT_PATTERNS}")
   set(modfile_patterns "${${prefix}_DEFAULT_MODFILE_PATTERNS}")
+  set(nrnivmodl_args "${${prefix}_DEFAULT_NRNIVMODL_ARGS}")
+  set(output_files "${${prefix}_DEFAULT_OUTPUT}")
+  set(script_patterns "${${prefix}_DEFAULT_SCRIPT_PATTERNS}")
+  set(sim_directory "${${prefix}_DEFAULT_SIM_DIRECTORY}")
+  set(submodule "${${prefix}_DEFAULT_SUBMODULE}")
   # Override them locally if appropriate
+  if(DEFINED NRN_ADD_TEST_MODFILE_PATTERNS)
+    set(modfile_patterns "${NRN_ADD_TEST_MODFILE_PATTERNS}")
+  endif()
+  if(DEFINED NRN_ADD_TEST_NRNIVMODL_ARGS)
+    set(nrnivmodl_args "${NRN_ADD_TEST_NRNIVMODL_ARGS}")
+  endif()
   if(DEFINED NRN_ADD_TEST_OUTPUT)
     set(output_files "${NRN_ADD_TEST_OUTPUT}")
-  endif()
-  if(DEFINED NRN_ADD_TEST_SUBMODULE)
-    set(git_submodule "${NRN_ADD_TEST_SUBMODULE}")
   endif()
   if(DEFINED NRN_ADD_TEST_SCRIPT_PATTERNS)
     set(script_patterns "${NRN_ADD_TEST_SCRIPT_PATTERNS}")
   endif()
-  if(DEFINED NRN_ADD_TEST_MODFILE_PATTERNS)
-    set(modfile_patterns "${NRN_ADD_TEST_MODFILE_PATTERNS}")
+  if(DEFINED NRN_ADD_TEST_SCRIPT_PATTERNS)
+    set(sim_directory "${NRN_ADD_TEST_SIM_DIRECTORY}")
   endif()
-
+  if(DEFINED NRN_ADD_TEST_SUBMODULE)
+    set(submodule "${NRN_ADD_TEST_SUBMODULE}")
+  endif()
   # First, make sure the specified submodule is initialised. If there is no submodule, everything is
   # relative to the root nrn/ directory.
-  if(NOT ${git_submodule} STREQUAL "")
-    cpp_cc_git_submodule(${git_submodule} QUIET)
+  if(NOT ${submodule} STREQUAL "")
+    cpp_cc_git_submodule(${submodule} QUIET)
     # Construct the name of the source tree directory where the submodule has been checked out.
-    set(test_source_directory "${PROJECT_SOURCE_DIR}/external/${git_submodule}")
+    set(test_source_directory "${PROJECT_SOURCE_DIR}/external/${submodule}")
   else()
     set(test_source_directory "${PROJECT_SOURCE_DIR}")
   endif()
@@ -206,8 +233,8 @@ function(nrn_add_test)
   set(group_working_directory "${PROJECT_BINARY_DIR}/test/${NRN_ADD_TEST_GROUP}")
   # Finally a working directory for this specific test within the group
   set(working_directory "${group_working_directory}/${NRN_ADD_TEST_NAME}")
-  if(DEFINED NRN_ADD_TEST_SIM_DIRECTORY)
-    set(simulation_directory ${working_directory}/${NRN_ADD_TEST_SIM_DIRECTORY})
+  if(NOT ${sim_directory} STREQUAL "")
+    set(simulation_directory ${working_directory}/${sim_directory})
   else()
     set(simulation_directory ${working_directory})
   endif()
@@ -215,11 +242,14 @@ function(nrn_add_test)
   # Add a rule to build the modfiles for this test. The assumption is that it is likely that most
   # members of the group will ask for exactly the same thing, so it's worth de-duplicating. TODO:
   # allow extra arguments to be inserted here
-  set(nrnivmodl_command cmake -E env ${NRN_TEST_ENV} ${CMAKE_BINARY_DIR}/bin/nrnivmodl ${NRN_ADD_TEST_NRNIVMODL_ARGS})
-  set(hash_components nrnivmodl ${NRN_ADD_TEST_NRNIVMODL_ARGS})
-  if(requires_coreneuron)
-    # TODO: consider replacing the condition here with NRN_ENABLE_CORENEURON; this would tend to
-    # reduce the number of times we call nrnivmodl.
+  set(nrnivmodl_command cmake -E env ${NRN_TEST_ENV} ${CMAKE_BINARY_DIR}/bin/nrnivmodl
+                        ${nrnivmodl_args})
+  set(hash_components nrnivmodl ${nrnivmodl_args})
+  # This condition used to be `requires_coreneuron`. This tends to mean that
+  # NEURON and CoreNEURON versions of a test will share the same hash, which is
+  # probably fine, but also means that any NEURON-only tests will be compiled
+  # for CoreNEURON too.
+  if(NRN_ENABLE_CORENEURON)
     list(APPEND nrnivmodl_command -coreneuron)
     list(APPEND hash_components -coreneuron)
   endif()

--- a/test/external/olfactory-bulb-3d/CMakeLists.txt
+++ b/test/external/olfactory-bulb-3d/CMakeLists.txt
@@ -1,12 +1,12 @@
 include(NeuronTestHelper)
 set(prefix "sim") # everything is under this prefix in the repository
-set(olfcatory_bulb_3d_sim_time 50)
-set(olfcatory_bulb_3d_mpi_ranks 4)
-set(olfcatory_bulb_3d_neuron_prefix
+set(olfactory_bulb_3d_sim_time 50)
+set(olfactory_bulb_3d_mpi_ranks 4)
+set(olfactory_bulb_3d_neuron_prefix
     OMP_NUM_THREADS=1
     ${MPIEXEC_NAME}
     ${MPIEXEC_NUMPROC_FLAG}
-    ${olfcatory_bulb_3d_mpi_ranks}
+    ${olfactory_bulb_3d_mpi_ranks}
     ${MPIEXEC_OVERSUBSCRIBE}
     ${MPIEXEC_PREFLAGS}
     special
@@ -23,37 +23,35 @@ nrn_add_test(
   GROUP olfactory-bulb-3d
   NAME neuron
   REQUIRES mpi python
-  PROCESSORS ${olfcatory_bulb_3d_mpi_ranks}
-             SIM_DIRECTORY
-             "sim"
+  PROCESSORS ${olfactory_bulb_3d_mpi_ranks}
+  SIM_DIRECTORY ${prefix}
   PRECOMMAND sed -i "s/runsim.build_part_model(.*/runsim.build_part_model([5], [])/g" bulb3dtest.py
-  COMMAND ${olfcatory_bulb_3d_neuron_prefix} ${olfactory_bulb_3d_neuron_args} --tstop
-          ${olfcatory_bulb_3d_sim_time})
+  COMMAND ${olfactory_bulb_3d_neuron_prefix} ${olfactory_bulb_3d_neuron_args} --tstop
+          ${olfactory_bulb_3d_sim_time})
 foreach(processor gpu cpu)
   foreach(mode online)
     if(${processor} STREQUAL "gpu")
-      set(olfcatory_bulb_3d_gpu_args "--gpu")
+      set(olfactory_bulb_3d_gpu_args "--gpu")
     else()
-      set(olfcatory_bulb_3d_gpu_args "")
+      set(olfactory_bulb_3d_gpu_args "")
     endif()
     if(${mode} STREQUAL "online")
-      set(olfcatory_bulb_3d_filemode "")
+      set(olfactory_bulb_3d_filemode "")
     else()
-      set(olfcatory_bulb_3d_filemode "--filemode")
+      set(olfactory_bulb_3d_filemode "--filemode")
     endif()
     nrn_add_test(
       GROUP olfactory-bulb-3d
       NAME coreneuron_${processor}_${mode}
       REQUIRES coreneuron python ${processor}
-      PROCESSORS ${olfcatory_bulb_3d_mpi_ranks}
-                 SIM_DIRECTORY
-                 "sim"
+      PROCESSORS ${olfactory_bulb_3d_mpi_ranks}
+      SIM_DIRECTORY ${prefix}
       PRECOMMAND sed -i "s/runsim.build_part_model(.*/runsim.build_part_model([5], [])/g"
                  bulb3dtest.py
       COMMAND
-        ${olfcatory_bulb_3d_neuron_prefix} ${olfactory_bulb_3d_neuron_args} --tstop
-        ${olfcatory_bulb_3d_sim_time} --coreneuron ${olfcatory_bulb_3d_gpu_args}
-        ${olfcatory_bulb_3d_filemode})
+        ${olfactory_bulb_3d_neuron_prefix} ${olfactory_bulb_3d_neuron_args} --tstop
+        ${olfactory_bulb_3d_sim_time} --coreneuron ${olfactory_bulb_3d_gpu_args}
+        ${olfactory_bulb_3d_filemode})
   endforeach()
 endforeach()
 nrn_add_test_group_comparison(GROUP olfactory-bulb-3d)

--- a/test/external/tqperf/CMakeLists.txt
+++ b/test/external/tqperf/CMakeLists.txt
@@ -16,6 +16,5 @@ nrn_add_test(
   REQUIRES mpi python coreneuron
   PROCESSORS ${tqperf_mpi_ranks}
   NRNIVMODL_ARGS -loadflags -lcrypto
-  COMMAND
-    ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} ${tqperf_mpi_ranks}
-    ${MPIEXEC_OVERSUBSCRIBE} ${MPIEXEC_PREFLAGS} special ${MPIEXEC_POSTFLAGS} -mpi -python test1.py)
+  COMMAND ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} ${tqperf_mpi_ranks} ${MPIEXEC_OVERSUBSCRIBE}
+          ${MPIEXEC_PREFLAGS} special ${MPIEXEC_POSTFLAGS} -mpi -python test1.py)


### PR DESCRIPTION
Another spinout from #1597, aiming to manage the diff size there.

* Change strategy: pass -coreneuron if CoreNEURON is enabled in the
  build, not because someone REQUIRES coreneuron. This means the NEURON
  and CoreNEURON versions of a test will get the same hash, so there are
  fewer builds in total.
* Be more consistent about which arguments can have default values set
  in nrn_add_test_group that are inherited by nrn_add_test.
* Update documentation, reduce duplication a little bit.
* Update cmake-format YAML configuration for how to use these methods.
* Run cmake-format on files using these methods.
* Fix typo: olfcatory -> olfactory.