### PR TITLE
Set LIBSONATA_ZERO_BASED_GIDS in external tests

### DIFF
--- a/test/external/ringtest/CMakeLists.txt
+++ b/test/external/ringtest/CMakeLists.txt
@@ -51,11 +51,11 @@ foreach(processor cpu gpu)
     "#!/bin/bash\n"
     "set -e\n"
     "OMP_NUM_THREADS=1 ${ringtest_special_str} -tstop 0 -coreneuron -dumpmodel\n"
-    "OMP_NUM_THREADS=1 ${ringtest_special_core_str} --mpi -d coredat/ -e 10 --checkpoint part0"
+    "OMP_NUM_THREADS=1 LIBSONATA_ZERO_BASED_GIDS=1 ${ringtest_special_core_str} --mpi -d coredat/ -e 10 --checkpoint part0"
     " --outpath part0\n"
-    "OMP_NUM_THREADS=1 ${ringtest_special_core_str} --mpi -d coredat/ -e 40 --checkpoint part1"
+    "OMP_NUM_THREADS=1 LIBSONATA_ZERO_BASED_GIDS=1 ${ringtest_special_core_str} --mpi -d coredat/ -e 40 --checkpoint part1"
     " --restore part0 --outpath part1\n"
-    "OMP_NUM_THREADS=1 ${ringtest_special_core_str} --mpi -d coredat/ -e 100 --checkpoint part2"
+    "OMP_NUM_THREADS=1 LIBSONATA_ZERO_BASED_GIDS=1 ${ringtest_special_core_str} --mpi -d coredat/ -e 100 --checkpoint part2"
     " --restore part1 --outpath part2\n"
     "cat part0/out.dat > out.dat\n"
     "cat part1/out.dat >> out.dat\n"
@@ -81,7 +81,7 @@ foreach(processor cpu gpu)
     CONFLICTS mpi_dynamic
     PROCESSORS ${ringtest_mpi_ranks}
     PRECOMMAND OMP_NUM_THREADS=1 ${ringtest_special} -tstop 0 -coreneuron -dumpmodel
-    COMMAND OMP_NUM_THREADS=1 ${ringtest_special_core} --mpi -d coredat/ -e 100 ${special_gpu_arg}
+    COMMAND OMP_NUM_THREADS=1 LIBSONATA_ZERO_BASED_GIDS=1 ${ringtest_special_core} --mpi -d coredat/ -e 100 ${special_gpu_arg}
     OUTPUT asciispikes::out.dat)
 
   # Following suggestion on #1552, run a test with more threads than datasets.

--- a/test/external/testcorenrn/CMakeLists.txt
+++ b/test/external/testcorenrn/CMakeLists.txt
@@ -72,6 +72,15 @@ foreach(test ${spike_comparison_tests})
       OMP_NUM_THREADS=1 HOC_LIBRARY_PATH=. ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} ${num_ranks}
       ${MPIEXEC_OVERSUBSCRIBE} ${MPIEXEC_PREFLAGS} special ${MPIEXEC_POSTFLAGS} -mpi -c
       arg_tstop=100 test${test}.hoc)
+
+  # bbcore test generated gids starting at zero, we need to enable this feature in libsonata
+  # otherwise an assert fail inside libsonata-report
+  if(NOT "${test}" STREQUAL "vecevent")
+      set(SONATA_GIDS_ZERO "LIBSONATA_ZERO_BASED_GIDS=1")
+  else()
+      set(SONATA_GIDS_ZERO "")
+  endif()
+
   # Set up tests that run the simulation using CoreNEURON. In principle we run all combinations of
   # [online, offline]*[CPU, GPU], but some of these may be disabled.
   foreach(processor gpu cpu)
@@ -80,6 +89,7 @@ foreach(test ${spike_comparison_tests})
       # Set up a test that runs the simulation using CoreNEURON's online mode
       if(NOT "${test}" STREQUAL "patstim")
         # Exclude the patstim test from running via CoreNEURON online mode
+
         nrn_add_test(
           GROUP testcorenrn_${test}
           NAME coreneuron_${processor}_online${psolve_test_mode_suffix}
@@ -87,10 +97,11 @@ foreach(test ${spike_comparison_tests})
           CONFLICTS ${test_${test}_coreneuron_${processor}_conflicts}
           PROCESSORS ${num_ranks}
           COMMAND
-            OMP_NUM_THREADS=1 HOC_LIBRARY_PATH=. ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG}
-            ${num_ranks} ${MPIEXEC_OVERSUBSCRIBE} ${MPIEXEC_PREFLAGS} special ${MPIEXEC_POSTFLAGS}
-            -mpi -c arg_tstop=100 -c arg_coreneuron=1 -c arg_psolve_test_mode=${psolve_test_mode}
-            ${${processor}_args_online} test${test}.hoc)
+            OMP_NUM_THREADS=1 HOC_LIBRARY_PATH=. ${SONATA_GIDS_ZERO} ${MPIEXEC_NAME}
+            ${MPIEXEC_NUMPROC_FLAG} ${num_ranks} ${MPIEXEC_OVERSUBSCRIBE} ${MPIEXEC_PREFLAGS}
+            special ${MPIEXEC_POSTFLAGS} -mpi -c arg_tstop=100 -c arg_coreneuron=1
+            -c arg_psolve_test_mode=${psolve_test_mode} ${${processor}_args_online}
+            test${test}.hoc)
       endif()
     endforeach()
     # This is a workaround to reduce the number of MPI ranks in the GPU version of the patstim test
@@ -121,11 +132,11 @@ foreach(test ${spike_comparison_tests})
         "sed -n 2,1001p patstim.spk >> patstim.1.spk\n"
         "echo 1000 > patstim.2.spk\n"
         "sed -n 1002,2001p patstim.spk >> patstim.2.spk\n"
-        "OMP_NUM_THREADS=1 ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} ${local_mpi_ranks}"
+        "OMP_NUM_THREADS=1 ${SONATA_GIDS_ZERO} ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} ${local_mpi_ranks}"
         " ${MPIEXEC_OVERSUBSCRIBE} ${MPIEXEC_PREFLAGS} special-core ${MPIEXEC_POSTFLAGS}"
         " -d coredat --mpi -e 49 --pattern patstim.1.spk ${${processor}_args_offline}"
         " --checkpoint checkpoint -o part1\n"
-        "OMP_NUM_THREADS=1 ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} ${local_mpi_ranks}"
+        "OMP_NUM_THREADS=1 ${SONATA_GIDS_ZERO} ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} ${local_mpi_ranks}"
         " ${MPIEXEC_OVERSUBSCRIBE} ${MPIEXEC_PREFLAGS} special-core ${MPIEXEC_POSTFLAGS}"
         " -d coredat --mpi -e 100 --pattern patstim.2.spk ${${processor}_args_offline}"
         " --restore checkpoint -o part2\n"
@@ -161,7 +172,7 @@ foreach(test ${spike_comparison_tests})
                  arg_dump_coreneuron_model=1
                  test${test}.hoc
       COMMAND
-        OMP_NUM_THREADS=1 ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} ${local_mpi_ranks}
+        OMP_NUM_THREADS=1 ${SONATA_GIDS_ZERO} ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} ${local_mpi_ranks}
         ${MPIEXEC_OVERSUBSCRIBE} ${MPIEXEC_PREFLAGS} special-core ${MPIEXEC_POSTFLAGS} -d coredat
         --mpi -e 100 ${extra_args} ${${processor}_args_offline}
       OUTPUT asciispikes::out.dat)

--- a/test/external/testcorenrn/CMakeLists.txt
+++ b/test/external/testcorenrn/CMakeLists.txt
@@ -89,7 +89,6 @@ foreach(test ${spike_comparison_tests})
       # Set up a test that runs the simulation using CoreNEURON's online mode
       if(NOT "${test}" STREQUAL "patstim")
         # Exclude the patstim test from running via CoreNEURON online mode
-
         nrn_add_test(
           GROUP testcorenrn_${test}
           NAME coreneuron_${processor}_online${psolve_test_mode_suffix}

--- a/test/external/testcorenrn/CMakeLists.txt
+++ b/test/external/testcorenrn/CMakeLists.txt
@@ -50,10 +50,10 @@ function(set_psolve_test_mode_suffix psolve_test_mode)
 endfunction()
 
 # Libsonata-report automatically converts 1-based GIDs to 0-based by subtracting 1 from them.
-# If there is already a GID 0 in the reports, libsonata-report assertion for 1-based GIDs is going to fail.
+# If there is already a GID 0 in the reports, libsonata-report throws.
 # Since some of the NEURON integration tests create 0-based GID cells we set the environment variable
 # LIBSONATA_ZERO_BASED_GIDS to 1 to avoid libsonata-reports's automatic conversion of 1-based GIDs to
-# 0-based that would trigger the assertion to fail.
+# 0-based that would trigger the throw.
 set(SONATA_GIDS_ZERO "LIBSONATA_ZERO_BASED_GIDS=1")
 
 # Run tests that require separate runs of NEURON and CoreNEURON to compare their spikes only

--- a/test/external/testcorenrn/CMakeLists.txt
+++ b/test/external/testcorenrn/CMakeLists.txt
@@ -49,6 +49,10 @@ function(set_psolve_test_mode_suffix psolve_test_mode)
       PARENT_SCOPE)
 endfunction()
 
+# bbcore test generated gids starting at zero, we need to enable this feature in libsonata
+# otherwise an assert fail inside libsonata-report
+set(SONATA_GIDS_ZERO "LIBSONATA_ZERO_BASED_GIDS=1")
+
 # Run tests that require separate runs of NEURON and CoreNEURON to compare their spikes only
 foreach(test ${spike_comparison_tests})
   if(DEFINED mpi_ranks_${test})
@@ -72,14 +76,6 @@ foreach(test ${spike_comparison_tests})
       OMP_NUM_THREADS=1 HOC_LIBRARY_PATH=. ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} ${num_ranks}
       ${MPIEXEC_OVERSUBSCRIBE} ${MPIEXEC_PREFLAGS} special ${MPIEXEC_POSTFLAGS} -mpi -c
       arg_tstop=100 test${test}.hoc)
-
-  # bbcore test generated gids starting at zero, we need to enable this feature in libsonata
-  # otherwise an assert fail inside libsonata-report
-  if(NOT "${test}" STREQUAL "vecevent")
-      set(SONATA_GIDS_ZERO "LIBSONATA_ZERO_BASED_GIDS=1")
-  else()
-      set(SONATA_GIDS_ZERO "")
-  endif()
 
   # Set up tests that run the simulation using CoreNEURON. In principle we run all combinations of
   # [online, offline]*[CPU, GPU], but some of these may be disabled.

--- a/test/external/testcorenrn/CMakeLists.txt
+++ b/test/external/testcorenrn/CMakeLists.txt
@@ -49,8 +49,11 @@ function(set_psolve_test_mode_suffix psolve_test_mode)
       PARENT_SCOPE)
 endfunction()
 
-# bbcore test generated gids starting at zero, we need to enable this feature in libsonata
-# otherwise an assert fail inside libsonata-report
+# Libsonata-report automatically converts 1-based GIDs to 0-based by subtracting 1 from them.
+# If there is already a GID 0 in the reports, libsonata-report assertion for 1-based GIDs is going to fail.
+# Since some of the NEURON integration tests create 0-based GID cells we set the environment variable
+# LIBSONATA_ZERO_BASED_GIDS to 1 to avoid libsonata-reports's automatic conversion of 1-based GIDs to
+# 0-based that would trigger the assertion to fail.
 set(SONATA_GIDS_ZERO "LIBSONATA_ZERO_BASED_GIDS=1")
 
 # Run tests that require separate runs of NEURON and CoreNEURON to compare their spikes only


### PR DESCRIPTION
Some external tests automatically generate gids that start at 0 instead of 1.
When enabling libsonata-report this is a problem because it checks that gids are != 0 and translate them.
This patch tells libsonata-report which tests are already starting to 0 so it does not fail.