### PR TITLE
Prefer ctypes.PyDLL

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,9 +15,7 @@ on:
       - release/**
 
 env:
-  # Python 3.10 fails executing jupyter notebooks. Don't need 3.10 for building docs anyway.
-  # see https://github.com/neuronsimulator/nrn/issues/1612
-  DEFAULT_PY_VERSION: '3.8'
+  DEFAULT_PY_VERSION: '3.10'
 
 jobs:
   documentation:

--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -632,15 +632,15 @@ def nrn_dll(printpath=False):
         be used with care.
     """
     import ctypes
-    import os
-    import platform
     import glob
+    import os
+    import sys
 
     try:
         # extended? if there is a __file__, then use that
         if printpath:
             print("hoc.__file__ %s" % _original_hoc_file)
-        the_dll = ctypes.cdll[_original_hoc_file]
+        the_dll = ctypes.pydll[_original_hoc_file]
         return the_dll
     except:
         pass
@@ -657,7 +657,7 @@ def nrn_dll(printpath=False):
         dlls = glob.glob(base_path + "*.*")
         for dll in dlls:
             try:
-                the_dll = ctypes.cdll[dll]
+                the_dll = ctypes.pydll[dll]
                 if printpath:
                     print(dll)
                 return the_dll
@@ -672,7 +672,7 @@ def nrn_dll(printpath=False):
         dlls = glob.glob(base_path + "*" + extension)
         for dll in dlls:
             try:
-                the_dll = ctypes.cdll[dll]
+                the_dll = ctypes.pydll[dll]
                 if printpath:
                     print(dll)
                 success = True

--- a/src/neuronmusic/nrnmusic.h
+++ b/src/neuronmusic/nrnmusic.h
@@ -3,7 +3,7 @@
 #if defined(NO_PYTHON_H)
 typedef struct _object PyObject;
 #else
-#include <Python.h>
+#include <nrnwrap_Python.h>
 #endif
 #include <music.hh>
 

--- a/src/nrnpython/nrnpython.h
+++ b/src/nrnpython/nrnpython.h
@@ -17,10 +17,6 @@
 #if defined(USE_PYTHON)
 #undef _POSIX_C_SOURCE
 #undef _XOPEN_SOURCE
-#if defined(__MINGW32__)
-//at least a problem with g++6.3.0
-#define _hypot hypot
-#endif
 #include <nrnwrap_Python.h>
 
 #endif /*USE_PYTHON*/

--- a/src/nrnpython/nrnwrap_Python.h
+++ b/src/nrnpython/nrnwrap_Python.h
@@ -1,7 +1,4 @@
-#ifndef nrnwrap_Python_h
-#define nrnwrap_Python_h
-/* avoid "redefined" warnings due to inconsistent configure HAVE_xxx */
-
+#pragma once
 #undef HAVE_PUTENV
 #undef HAVE_FTIME
 #undef HAVE_PROTOTYPES
@@ -9,6 +6,9 @@
 #undef _hypot
 #define _hypot hypot
 #endif
+// https://docs.python.org/3/c-api/intro.html#include-files states: It is
+// recommended to always define PY_SSIZE_T_CLEAN before including Python.h.
+#ifndef PY_SSIZE_T_CLEAN
+#define PY_SSIZE_T_CLEAN
+#endif
 #include <Python.h>
-
-#endif /* nrnwrap_Python_h */


### PR DESCRIPTION
This means that the global interpreter lock is implicitly retained when entering the methods that are called via `nrn_dll_sym`, which means that Python C API methods can safely be used.

This fixes building the documentation with Python 3.9 and 3.10, but this is not really documentation specific. There just happen to be some patterns that exist inside IPython notebooks in the documentation and not elsewhere in the test suite.

Closes #1612.