### PR TITLE
Avoid segfault if error during construction of POINT_PROCESS

### DIFF
--- a/src/nrnoc/point.cpp
+++ b/src/nrnoc/point.cpp
@@ -76,9 +76,12 @@ Object* nrn_new_pointprocess(Symbol* sym)
 
 extern "C" void destroy_point_process(void* v)
 {
+    // might be NULL if error handling because of error in construction
+    if (v) {
 	Point_process* pp = (Point_process*)v;
 	free_one_point(pp);
 	free(pp);
+    }
 }
 
 void nrn_loc_point_process(int pointtype, Point_process* pnt, Section* sec, Node* node)

--- a/test/pynrn/test_basic.py
+++ b/test/pynrn/test_basic.py
@@ -370,6 +370,15 @@ def test_py_alltoall_dict_err():
     expect_hocerr(pc.py_alltoall, src, ("hocobj_call error",))
 
 
+def test_nosection():
+    expect_err("h.IClamp(.5)")
+    expect_err("h.IClamp(5)")
+    s = h.Section()
+    expect_err("h.IClamp(5)")
+    del s
+    locals()
+
+
 if __name__ == "__main__":
     set_quiet(False)
     test_soma()
@@ -378,3 +387,4 @@ if __name__ == "__main__":
     test_disconnect()
     h.topology()
     h.allobjects()
+    test_nosection()


### PR DESCRIPTION
Includes test that the error is recoverable. Errors happen if there is no section or if the position parameter is out of range.

Closes #1625