### PR TITLE
Avoid long lines in neuron.h.

### DIFF
--- a/src/nrnoc/neuron.h
+++ b/src/nrnoc/neuron.h
@@ -11,12 +11,12 @@ extern int neuron2nemo(), nemo2neuron();
 
 extern void node_data(), disconnect();
 extern void batch_run(), batch_save();
-extern void pt3dclear(), pt3dadd(), n3d(), x3d(), y3d(), z3d(), arc3d(), diam3d();
-extern void pt3dinsert(), pt3dremove(), pt3dchange();
+extern void pt3dadd(), n3d(), x3d(), y3d(), z3d(), arc3d(), diam3d();
+extern void pt3dclear(), pt3dinsert(), pt3dremove(), pt3dchange();
 extern void define_shape(), pt3dconst(), pt3dstyle();
 extern void spine3d(), setSpineArea(), getSpineArea();
-extern void area(), ri();
-extern void initnrn(), nrnhoc_topology(), fadvance(), distance(), finitialize();
+extern void area(), ri(), distance();
+extern void initnrn(), nrnhoc_topology(), fadvance(), finitialize();
 extern void fstim(), fstimi();
 extern void ion_style(), ion_register(), ion_charge(), nernst(), ghk();
 extern void section_owner(); /* returns object that created section */
@@ -30,7 +30,8 @@ extern void fcurrent(), fmatrix(), frecord_init();
 extern void issection(), ismembrane(), sectionname(), psection();
 extern void pop_section(), push_section(), section_exists();
 extern void delete_section();
-extern int secondorder, diam_changed, nrn_shape_changed_, nrn_netrec_state_adjust, nrn_sparse_partrans;
+extern int secondorder, diam_changed, nrn_shape_changed_;
+extern int nrn_netrec_state_adjust, nrn_sparse_partrans;
 extern double clamp_resist;
 extern double celsius;
 extern int stoprun;


### PR DESCRIPTION
Otherwise clang-format will break lines and mk_hocusr_h.py will
not properly transform to hocusr.h

This prepares for #1645