### PR TITLE
Update GPU wheels to use NVHPC 22.1 and CUDA 11.5.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,7 +122,7 @@ jobs:
         -e NRN_RELEASE_UPLOAD \
         -e NEURON_WHEEL_VERSION \
         -e NRN_BUILD_FOR_UPLOAD=1 \
-        'neuronsimulator/neuron_wheel_gpu' \
+        'neuronsimulator/neuron_wheel_gpu:nvhpc-22.1-cuda-11.5' \
         packaging/python/build_wheels.bash linux $(python.version) coreneuron-gpu
     displayName: 'Building ManyLinux Wheel'
 

--- a/packaging/python/Dockerfile_gpu
+++ b/packaging/python/Dockerfile_gpu
@@ -1,21 +1,15 @@
 FROM neuronsimulator/neuron_wheel
-LABEL authors="Pramod Kumbhar, Fernando Pereira, Alexandru Savulescu"
+LABEL authors="Pramod Kumbhar, Olli Lupton, Fernando Pereira, Alexandru Savulescu"
 
 WORKDIR /root
 
-# download nvhpc 21.2 rpms. Note that newer versions until at least 21.7 has various
-# bugs and hence we are sticking to 21.2 until we verify latest release.
-# see https://github.com/BlueBrain/CoreNeuron/issues/605
-RUN wget --no-verbose \
-      https://developer.download.nvidia.com/hpc-sdk/21.2/nvhpc-21-2-21.2-1.x86_64.rpm \
-      https://developer.download.nvidia.com/hpc-sdk/21.2/nvhpc-2021-21.2-1.x86_64.rpm \
-      https://developer.download.nvidia.com/hpc-sdk/21.2/nvhpc-21-2-cuda-multi-21.2-1.x86_64.rpm \
-    && yum install -y *.rpm \
-    && rm *.rpm && yum clean all
+# Install NVHPC from NVIDIA's repository.
+RUN yum-config-manager --add-repo https://developer.download.nvidia.com/hpc-sdk/rhel/nvhpc.repo \
+    && yum install -y nvhpc-22-1 nvhpc-2022-22.1 \
+    && yum clean all
 
 # setup nvhpc environment for building wheel and interactive usage
 RUN yum install -y environment-modules && yum clean all \
     && echo "module use /opt/nvidia/hpc_sdk/modulefiles" >> ~/.bashrc \
-    && echo "export CORENRN_CUDA_HOME=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/cuda/11.0" >> ~/.bashrc \
-    && /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/bin/makelocalrc -x \
-        -gcc `which gcc` -gpp `which g++` -g77 `which gfortran` # -cuda 11.0 option is valid for >=21.7
+    && /opt/nvidia/hpc_sdk/Linux_x86_64/22.1/compilers/bin/makelocalrc -x \
+        -gcc `which gcc` -gpp `which g++` -g77 `which gfortran` -cuda 11.5

--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -83,8 +83,6 @@ build_wheel_linux() {
         source ~/.bashrc
         module load nvhpc
         unset CC CXX
-        # preferred cuda version e.g. 11.0
-        export PATH=${CORENRN_CUDA_HOME}/bin:$PATH
     fi
 
     CMAKE_DEFS="NRN_MPI_DYNAMIC=$3"

--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -74,6 +74,11 @@ build_wheel_linux() {
     echo " - Building..."
     rm -rf dist build
 
+    CMAKE_DEFS="NRN_MPI_DYNAMIC=$3"
+    if [ "$USE_STATIC_READLINE" == "1" ]; then
+      CMAKE_DEFS="$CMAKE_DEFS,NRN_WHEEL_STATIC_READLINE=ON"
+    fi
+
     if [ "$2" == "coreneuron" ]; then
         setup_args="--enable-coreneuron"
     elif [ "$2" == "coreneuron-gpu" ]; then
@@ -83,12 +88,12 @@ build_wheel_linux() {
         source ~/.bashrc
         module load nvhpc
         unset CC CXX
+        # the default is currently 70;80, partly because NVHPC does not
+        # support OpenMP target offload with 60. Wheels use mod2c and
+        # OpenACC for now, so we can be a little more generic.
+        CMAKE_DEFS="${CMAKE_DEFS},CMAKE_CUDA_ARCHITECTURES=60;70;80"
     fi
 
-    CMAKE_DEFS="NRN_MPI_DYNAMIC=$3"
-    if [ "$USE_STATIC_READLINE" == "1" ]; then
-      CMAKE_DEFS="$CMAKE_DEFS,NRN_WHEEL_STATIC_READLINE=ON"
-    fi
     python setup.py build_ext --cmake-prefix="/nrnwheel/ncurses;/nrnwheel/readline" --cmake-defs="$CMAKE_DEFS" $setup_args bdist_wheel
 
     # For CI runs we skip wheelhouse repairs


### PR DESCRIPTION
I tend to think it is better to keep the explicit tag in the Azure CI configuration; we could even re-tag the current `latest` version as `nvhpc-21.2-cuda-11.0` and then remove `latest`.