### PR TITLE
address numpy deprecation warning

### DIFF
--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -777,7 +777,7 @@ def numpy_from_pointer(cpointer, size):
     buf_from_mem.restype = ctypes.py_object
     buf_from_mem.argtypes = (ctypes.c_void_p, ctypes.c_int, ctypes.c_int)
     cbuffer = buf_from_mem(cpointer, size * numpy.dtype(float).itemsize, 0x200)
-    return numpy.ndarray((size,), numpy.float, cbuffer, order="C")
+    return numpy.ndarray((size,), float, cbuffer, order="C")
 
 
 try:

--- a/share/lib/python/neuron/nonvint_block_supervisor.py
+++ b/share/lib/python/neuron/nonvint_block_supervisor.py
@@ -128,7 +128,7 @@ def numpy_from_pointer(cpointer, size):
     buf_from_mem.restype = ctypes.py_object
     buf_from_mem.argtypes = (ctypes.c_void_p, ctypes.c_int, ctypes.c_int)
     cbuffer = buf_from_mem(cpointer, size * _float_size, 0x200)
-    return numpy.ndarray((size,), numpy.float, cbuffer, order="C")
+    return numpy.ndarray((size,), float, cbuffer, order="C")
 
 
 def nonvint_block(method, size, pd1, pd2, tid):

--- a/share/lib/python/neuron/rxd/rxd.py
+++ b/share/lib/python/neuron/rxd/rxd.py
@@ -117,7 +117,7 @@ ics_register_reaction.argtypes = [
     _int_ptr,
     numpy.ctypeslib.ndpointer(dtype=numpy.uint64),
     ctypes.c_int,
-    numpy.ctypeslib.ndpointer(dtype=numpy.float),
+    numpy.ctypeslib.ndpointer(dtype=float),
 ]
 
 ecs_register_reaction = nrn_dll_sym("ecs_register_reaction")
@@ -137,10 +137,10 @@ set_hybrid_data.argtypes = [
     numpy.ctypeslib.ndpointer(dtype=numpy.int64),
     numpy.ctypeslib.ndpointer(dtype=numpy.int64),
     numpy.ctypeslib.ndpointer(dtype=numpy.int64),
-    numpy.ctypeslib.ndpointer(dtype=numpy.float_),
-    numpy.ctypeslib.ndpointer(dtype=numpy.float_),
-    numpy.ctypeslib.ndpointer(dtype=numpy.float_),
-    numpy.ctypeslib.ndpointer(dtype=numpy.float_),
+    numpy.ctypeslib.ndpointer(dtype=float),
+    numpy.ctypeslib.ndpointer(dtype=float),
+    numpy.ctypeslib.ndpointer(dtype=float),
+    numpy.ctypeslib.ndpointer(dtype=float),
 ]
 
 # ics_register_reaction = nrn_dll_sym('ics_register_reaction')
@@ -647,7 +647,7 @@ def _update_node_data(force=False, newspecies=False):
 def _matrix_to_rxd_sparse(m):
     """precondition: assumes m a numpy array"""
     nonzero_i, nonzero_j = list(zip(*list(m.keys())))
-    nonzero_values = numpy.ascontiguousarray(list(m.values()), dtype=numpy.float64)
+    nonzero_values = numpy.ascontiguousarray(list(m.values()), dtype=float)
 
     # number of rows
     n = m.shape[1]
@@ -673,7 +673,6 @@ def _setup_matrices():
 
         n = len(_node_get_states())
 
-        
         volumes = node._get_data()[0]
         zero_volume_indices = (numpy.where(volumes == 0)[0]).astype(numpy.int_)
         if species._has_1d:
@@ -724,8 +723,6 @@ def _setup_matrices():
                 #        _linmodadd_c[i, i] = 1
 
                 # _cvode_object.re_init()
-
-
 
         # Hybrid logic
         if species._has_1d and species._has_3d:
@@ -886,10 +883,10 @@ def _setup_matrices():
             hybrid_grid_ids = numpy.asarray(hybrid_grid_ids, dtype=numpy.int64)
 
             hybrid_indices3d = numpy.asarray(hybrid_indices3d, dtype=numpy.int64)
-            rates = numpy.asarray(rates, dtype=numpy.float_)
-            volumes1d = numpy.asarray(volumes1d, dtype=numpy.float_)
-            volumes3d = numpy.asarray(volumes3d, dtype=numpy.float_)
-            dxs = numpy.asarray(grids_dx, dtype=numpy.float_)
+            rates = numpy.asarray(rates, dtype=float)
+            volumes1d = numpy.asarray(volumes1d, dtype=float)
+            volumes3d = numpy.asarray(volumes3d, dtype=float)
+            dxs = numpy.asarray(grids_dx, dtype=float)
             set_hybrid_data(
                 num_1d_indices_per_grid,
                 num_3d_indices_per_grid,

--- a/share/lib/python/neuron/rxd/species.py
+++ b/share/lib/python/neuron/rxd/species.py
@@ -122,7 +122,7 @@ _ics_set_grid_currents.argtypes = [
     ctypes.c_int,
     ctypes.c_int,
     ctypes.py_object,
-    numpy.ctypeslib.ndpointer(dtype=numpy.float_),
+    numpy.ctypeslib.ndpointer(dtype=float),
 ]
 
 
@@ -856,7 +856,7 @@ class _IntracellularSpecies(_SpeciesMathable):
     def create_alphas(self):
         self._isalive()
         alphas = [vol / self._dx ** 3 for vol in self._region._vol]
-        return numpy.asarray(alphas, dtype=numpy.float)
+        return numpy.asarray(alphas, dtype=float)
 
     def _import_concentration(self):
         self._isalive()
@@ -955,9 +955,7 @@ class _IntracellularSpecies(_SpeciesMathable):
                     scale_factors = [
                         sign * area * scale * scale_factor for area in node_area
                     ]
-                    self._scale_factors = numpy.asarray(
-                        scale_factors, dtype=numpy.float_
-                    )
+                    self._scale_factors = numpy.asarray(scale_factors, dtype=float)
                     _ics_set_grid_currents(
                         grid_list_start,
                         self._grid_id,
@@ -1056,9 +1054,7 @@ class _IntracellularSpecies(_SpeciesMathable):
         dc = None
         dgrid = None
         if callable(d) or (hasattr(d, "__len__") and callable(d[0])):
-            dgrid = numpy.ndarray(
-                (3, self._nodes_length), dtype=numpy.float64, order="C"
-            )
+            dgrid = numpy.ndarray((3, self._nodes_length), dtype=float, order="C")
             if hasattr(d, "__len__"):
                 if len(d) == 3:
                     for dr in range(3):
@@ -1103,15 +1099,15 @@ class _IntracellularSpecies(_SpeciesMathable):
                     )
         elif hasattr(d, "__len__"):
             if len(d) == 3:
-                dc = numpy.array(d, dtype=numpy.float64)
+                dc = numpy.array(d, dtype=float)
             elif len(d) == 1:
-                dc = numpy.array(d[0] * numpy.ones(3), dtype=numpy.float64)
+                dc = numpy.array(d[0] * numpy.ones(3), dtype=float)
             else:
                 raise RxDException(
                     "Intracellular diffusion coefficient may be a scalar or a tuple of length 3 for anisotropic diffusion, it can also be a function for inhomogeneous diffusion (or tuple of 3 functions) with arguments x, y, z location or node with optional argument for direction"
                 )
         else:
-            dc = numpy.array(d * numpy.ones(3), dtype=numpy.float64)
+            dc = numpy.array(d * numpy.ones(3), dtype=float)
         return (dc, dgrid)
 
     @property


### PR DESCRIPTION
Running an rxd simulation with recent versions of numpy led to warnings like

```
__init__.py:735: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here. 
 Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations 
   return numpy.ndarray((size,), numpy.float, cbuffer, order='C')
```

This change set standardizes the pure-Python (but not Cython) library to always use `float` instead of `numpy.float`, `numpy.float_`, or `numpy.float64`. Cython is different because our Cython code doesn't ever use any of those, but it does have a `numpy.float_t` that's used for defining data types but isn't actually defined in `numpy`.

This was used by `rxd` in a number of places, by the `neuron.numpy_from_pointer` function which makes `Vector.as_numpy` work, and by `nonvint_block_supervisor.numpy_from_pointer`. (The latter is a copy of the function from `neuron` and these should be merged but that's a code cleanup that goes beyond simply addressing the deprecation warning.)