### PR TITLE
Fix Python3.6 compatibility with test_pointer.py

### DIFF
--- a/test/coreneuron/test_pointer.py
+++ b/test/coreneuron/test_pointer.py
@@ -1,5 +1,6 @@
 from neuron import h
 import subprocess
+from subprocess import PIPE
 
 pc = h.ParallelContext()
 cvode = h.CVode()
@@ -133,7 +134,7 @@ class Model:
 def srun(cmd):
     print("--------------------")
     print(cmd)
-    r = subprocess.run(cmd, shell=True, capture_output=True)
+    r = subprocess.run(cmd, shell=True, stdout=PIPE, stderr=PIPE)
     if r.returncode != 0:
         print(r)
     r.check_returncode()


### PR DESCRIPTION
 - subprocess.run doesn't have `capture_output` arg in Python 3.6
 - use alternative mentioned in https://stackoverflow.com/questions/53209127/subprocess-unexpected-keyword-argument-capture-output

Fixes the build errors in the nightly CI: https://github.com/neuronsimulator/nrn-build-ci/actions/runs/1966655638