### PR TITLE
docs: fix to anchor point in hoc rxd

### DIFF
--- a/docs/hoc/modelspec/programmatic/rxd.rst
+++ b/docs/hoc/modelspec/programmatic/rxd.rst
@@ -236,6 +236,7 @@ they are just fixed values.
 
 
 .. _hoc_rxd_what:
+
 Defining reactions
 ------------------
 


### PR DESCRIPTION
There needs to be a blank line after defining an anchor point or it won't work