### PR TITLE
updates for arm64 wheels

### DIFF
--- a/docs/install/python_wheels.md
+++ b/docs/install/python_wheels.md
@@ -111,11 +111,13 @@ git clone ssh://bbpcode.epfl.ch/user/kumbhar/mpt-headers
 ## macOS wheels
 
 Note that for macOS there is no docker image needed, but all required dependencies must exist.
-In order to have the wheels working on multiple macOS target versions, special consideration must be made for `MACOSX_DEPLOYMENT_TARGET`, which has to be set to `10.9`.
+In order to have the wheels working on multiple macOS target versions, special consideration must be made for `MACOSX_DEPLOYMENT_TARGET`.
 
 
 Taking Azure macOS `x86_64` wheels for example, `readline` was built with `MACOSX_DEPLOYMENT_TARGET=10.9` and stored as secure file on Azure.
-For `arm64`, the wheels currently need to be built manually, using `universal2` Python installers. Note that last and final official release for Python 3.8 has `MACOSX_DEPLOYMENT_TARGET=11.0`.   
+For `arm64` we need to set `MACOSX_DEPLOYMENT_TARGET=11.0`. The wheels currently need to be built manually, using `universal2` Python installers. 
+For upcoming `universal2` wheels (targeting both `x86_64` and `arm64`) we will consider leveling everything to `MACOSX_DEPLOYMENT_TARGET=11.0`.
+
 
 You can use [packaging/python/build_static_readline_osx.bash](../../packaging/python/build_static_readline_osx.bash) to build a static readline library.
 You can have a look at the script for requirements and usage. 
@@ -170,6 +172,11 @@ bash packaging/python/test_wheels.sh python3.8 wheelhouse/NEURON-7.8.0.236-cp38-
 # Or, you can provide the pypi url
 bash packaging/python/test_wheels.sh python3.8 "-i https://test.pypi.org/simple/NEURON==7.8.11.2"
 ```
+
+### MacOS considerations
+
+On MacOS, launching `nrniv -python` or `special -python` can fail to load `neuron` module due to security restrictions. 
+For this specific purpose, please `export SKIP_EMBEDED_PYTHON_TEST=true` before launching the tests.
 
 ### Testing on BB5
 On BB5, we can test CPU wheels with:

--- a/packaging/python/build_static_readline_osx.bash
+++ b/packaging/python/build_static_readline_osx.bash
@@ -21,8 +21,13 @@ if [[ ! -d "$NRNWHEEL_DIR" || ! -x "$NRNWHEEL_DIR" ]]; then
     exit 1
 fi
 
-# 10.9 regardless of x86_64/arm64/universal2. if you want 11 for universal2 python3.8, see nrn PR #1649 comments
-export MACOSX_DEPLOYMENT_TARGET=10.9
+# Set MACOSX_DEPLOYMENT_TARGET based on wheel arch.
+# For upcoming `universal2` wheels we will consider leveling everything to 11.0.
+if [[ `uname -m` == 'arm64' ]]; then
+	export MACOSX_DEPLOYMENT_TARGET=11.0  # for arm64 we need 11.0
+else
+	export MACOSX_DEPLOYMENT_TARGET=10.9  # for x86_64
+fi
 
 (wget http://ftpmirror.gnu.org/ncurses/ncurses-6.2.tar.gz \
     && tar -xvzf ncurses-6.2.tar.gz \

--- a/packaging/python/test_wheels.sh
+++ b/packaging/python/test_wheels.sh
@@ -200,15 +200,16 @@ run_parallel_test() {
 
       brew unlink openmpi
       brew link mpich
+      BREW_PREFIX=$(brew --prefix)
 
       # TODO : latest mpich has issuee on Azure OSX
       if [[ "$CI_OS_NAME" == "osx" ]]; then
-          run_mpi_test "/usr/local/opt/mpich/bin/mpirun" "MPICH" ""
+          run_mpi_test "${BREW_PREFIX}/opt/mpich/bin/mpirun" "MPICH" ""
       fi
 
       brew unlink mpich
       brew link openmpi
-      run_mpi_test "/usr/local/opt/open-mpi/bin/mpirun" "OpenMPI" ""
+      run_mpi_test "${BREW_PREFIX}/opt/open-mpi/bin/mpirun" "OpenMPI" ""
 
     # CI Linux or Azure Linux
     elif [[ "$CI_OS_NAME" == "linux" || "$AGENT_OS" == "Linux" ]]; then


### PR DESCRIPTION
* test_wheels now supports arm64 brew
* update build_static_readline_osx for `arm64`
* modify README accordingly
* describe SKIP_EMBEDED_PYTHON_TEST