### PR TITLE
Bug fix: wheel exe wrapper was not checking 'neuron' but only `neuron-nightly*` package

### DIFF
--- a/share/lib/python/scripts/_binwrapper.py
+++ b/share/lib/python/scripts/_binwrapper.py
@@ -55,6 +55,8 @@ def _config_exe(exe_name):
     elif "neuron-nightly" in working_set.by_key:
        print("INFO : Using neuron-nightly Package (Developer Version)")
        package_name = "neuron-nightly"
+    elif "neuron" in working_set.by_key:
+       package_name = "neuron"
     else:
        raise RuntimeError("NEURON package not found! Verify PYTHONPATH")
 


### PR DESCRIPTION
As part of #1452, we changed exe wrapper for GPU but
introduced a bug where `neuron` package name was not checked