### PR TITLE
macos 12.3: applescript can only open a terminal explicitly

### DIFF
--- a/src/mac/prototype_applescript_cmake.txt
+++ b/src/mac/prototype_applescript_cmake.txt
@@ -43,7 +43,7 @@ on mylaunch(farg)
 		close access thefile
 		
 		set termfile to appdir & "bin:" & "macnrn.term"
-		open file termfile
+		tell application "Terminal" to open file termfile
 		
 	end tell
 	


### PR DESCRIPTION
As of macos 12.3, the mac icon launch was broken with the error
```
The application "Terminal" can't be opened.
-1703
```
Need to open nrnmac.term explicitly with the Terminal.
Closes #1708