### PR TITLE
Allow multiple BEFORE/AFTER blocks of same type in a mod file.

### DIFF
--- a/docs/install/python_wheels.md
+++ b/docs/install/python_wheels.md
@@ -221,17 +221,17 @@ After creating the tag on the `release/x.y` or on the `master` branch, perform t
 4) We need to define three variables:
    * `NRN_NIGHTLY_UPLOAD` : `false`
    * `NRN_RELEASE_UPLOAD` : `false`
-   * `NEURON_NIGHTLY_TAG` : null (leave empty)
-   
+   * `NEURON_NIGHTLY_TAG` : undefined (leave empty)
+
    Do so by clicking `Add variable`, input the variable name and optionally the value and then click `Create`.
 5) Click on `Run`
 
 ![](images/azure-release-no-upload.png)
 
 With above, wheel will be created like release from the provided tag but they won't be uploaded to the pypi.org ( as we have set  `NRN_RELEASE_UPLOAD=false`). These wheels now you can download from artifacts section and perform thorough testing. Once you are happy with the testing result, set `NRN_RELEASE_UPLOAD` to `true` and trigger the pipeline same way:
-   * `NRN_NIGHTLY_UPLOAD` : `false`
+   * `NRN_NIGHTLY_UPLOAD` : `true`
    * `NRN_RELEASE_UPLOAD` : `false`
-   * `NEURON_NIGHTLY_TAG` : null (leave empty)
+   * `NEURON_NIGHTLY_TAG` : undefined (leave empty)
 
 ![](images/azure-release.png)
 

--- a/src/nrncvode/netcvode.cpp
+++ b/src/nrncvode/netcvode.cpp
@@ -1314,6 +1314,7 @@ void NetCvode::use_daspk(bool b) {
 	}
 }
 
+// Append new BAMechList item to arg
 BAMechList::BAMechList(BAMechList** first) { // preserve the list order
 	next = nil;
 	BAMechList* last;

--- a/src/nrnoc/init.cpp
+++ b/src/nrnoc/init.cpp
@@ -947,8 +947,15 @@ printf("before-after processing type %d for %s not implemented\n", type, memb_fu
 	bam = (BAMech*)emalloc(sizeof(BAMech));
 	bam->f = f;
 	bam->type = mt;
-	bam->next = bamech_[type];
-	bamech_[type] = bam;
+	bam->next = nullptr;
+	// keep in call order
+	if (!bamech_[type]) {
+		bamech_[type] = bam;
+	}else{
+		BAMech* last;
+		for (last = bamech_[type]; last->next; last = last->next) {}
+		last->next = bam;
+	}
 }
 
 extern "C" void _cvode_abstol(Symbol** s, double* tol, int i)

--- a/src/nrnoc/multicore.cpp
+++ b/src/nrnoc/multicore.cpp
@@ -826,14 +826,14 @@ hoc_execerror(memb_func[i].sym->name, "is not thread safe");
 			bamap[ii] = (BAMech*)0;
 		}
 		for (bam = bamech_[i]; bam; bam = bam->next) {
-			// First only. In case multiple bam with same mech type.
-			// Will get others, if any, below with bam->next, etc.
+			//Save first before-after block only.  In case of multiple
+			//before-after blocks with the same mech type, we will get
+			//subsequent ones using linked list below. 
 			if (!bamap[bam->type]) {
 				bamap[bam->type] = bam;
 			}
 		}
-		/* Unnecessary, but keep in order wrt tml */
-		// But necessary to keep in order wrt multiple BAMech with same mech type
+		// necessary to keep in order wrt multiple BAMech with same mech type
 		ptbl = _nt->tbl + i;
 		for (tml = _nt->tml; tml; tml = tml->next) {
 			if (bamap[tml->index]) {

--- a/src/nrnoc/multicore.cpp
+++ b/src/nrnoc/multicore.cpp
@@ -826,19 +826,27 @@ hoc_execerror(memb_func[i].sym->name, "is not thread safe");
 			bamap[ii] = (BAMech*)0;
 		}
 		for (bam = bamech_[i]; bam; bam = bam->next) {
-			bamap[bam->type] = bam;
+			// First only. In case multiple bam with same mech type.
+			// Will get others, if any, below with bam->next, etc.
+			if (!bamap[bam->type]) {
+				bamap[bam->type] = bam;
+			}
 		}
-		/* unnecessary but keep in order anyway */
+		/* Unnecessary, but keep in order wrt tml */
+		// But necessary to keep in order wrt multiple BAMech with same mech type
 		ptbl = _nt->tbl + i;
 		for (tml = _nt->tml; tml; tml = tml->next) {
 			if (bamap[tml->index]) {
-				Memb_list* ml = tml->ml;
+			    int mtype = tml->index;
+			    Memb_list* ml = tml->ml;
+			    for (bam = bamap[mtype]; bam && bam->type == mtype; bam = bam->next) {
 				tbl = (NrnThreadBAList*)emalloc(sizeof(NrnThreadBAList));
-				tbl->next = (NrnThreadBAList*)0;
-				tbl->bam = bamap[tml->index];
-				tbl->ml = ml;
 				*ptbl = tbl;
+				tbl->next = (NrnThreadBAList*)0;
+				tbl->bam = bam;
+				tbl->ml = ml;
 				ptbl = &(tbl->next);
+			    }
 			}
 		}
 	}

--- a/test/coreneuron/mod/axial.inc
+++ b/test/coreneuron/mod/axial.inc
@@ -40,13 +40,8 @@ AFTER SOLVE {
     }
 }
 
-COMMENT
-Need to explictly duplicate in axial.mod and axial_pp.mod since
-a test of coreneuron checkpoint requires calculating iaSum and
-nmodl does not currently allow multiple BEFORE STEP in same mod file
 BEFORE STEP {
     if (ri > 0) {
         pim = pim - ia : child contributions
     }
 }
-ENDCOMMENT

--- a/test/coreneuron/mod/axial.mod
+++ b/test/coreneuron/mod/axial.mod
@@ -3,12 +3,3 @@ NEURON {
 }
 
 INCLUDE "axial.inc"
-
-: get rid of following when nmodl allows multiple BEFORE STEP in same
-:mod file
-BEFORE STEP {
-    if (ri > 0) {
-        pim = pim - ia : child contributions
-    }
-}
-

--- a/test/coreneuron/mod/axial_pp.mod
+++ b/test/coreneuron/mod/axial_pp.mod
@@ -21,7 +21,6 @@ INITIAL {
 
 BEFORE STEP {
   if (ri > 0) {
-    pim = pim - ia : child contributions
     iaSum = iaSum + fabs(ia)
   }
 }


### PR DESCRIPTION
Same extension as BlueBrain/CoreNeuron#790

Includes modified coreneuron_modtests::test_pointer_py_cpu

- [x] Merge CoreNEURON PR and update submodule before merge