### PR TITLE
Disallow STATE variables being GLOBAL

### DIFF
--- a/src/nmodl/modl.cpp
+++ b/src/nmodl/modl.cpp
@@ -191,6 +191,7 @@ no longer adequate for saying we can not */
 	}
 #endif
 	chk_thread_safe();
+	chk_global_state();
 	parout();		/* print .var file.
 				 * Also #defines which used to be in defs.h
 				 * are printed into .c file at beginning.

--- a/src/nmodl/nmodlfunc.h
+++ b/src/nmodl/nmodlfunc.h
@@ -89,6 +89,7 @@ void net_receive(Item* qarg, Item* qp1, Item* qp2, Item* qstmt, Item* qend);
 void net_init(Item* qinit, Item* qp2);
 void fornetcon(Item* keyword, Item* par1, Item* args, Item* par2, Item* stmt, Item* qend);
 void chk_thread_safe();
+void chk_global_state();
 void threadsafe_seen(Item* q1, Item* q2);
 void explicit_decl(int level, Item* q);
 void parm_array_install(Symbol* n, char* num, char* units, char* limits, int index);

--- a/src/nmodl/nocpout.cpp
+++ b/src/nmodl/nocpout.cpp
@@ -2719,6 +2719,18 @@ void chk_thread_safe() {
 }
 
 
+void chk_global_state() {
+    int i;
+    Item *q;
+    SYMLISTITER {
+        Symbol* s = SYM(q);
+        if (s->nrntype & NRNGLOBAL && s->subtype & STAT) {
+            diag(s->name, " is as a STATE variable and hence cannot be declared as GLOBAL");
+        }
+    }
+}
+
+
 void threadsafe_seen(Item* q1, Item* q2) {
 	Item* q;
 	assert_threadsafe = 1;


### PR DESCRIPTION
 * state variables can not be global, see
   https://github.com/neuronsimulator/nrn/pull/1479#issuecomment-1072982558
 * before code generation iterate through all
   symbols and error if there is any state variable
   declared as global.