### PR TITLE
Improve documentation targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,14 @@ include(BuildOptionDefaults)
 # =============================================================================
 # Build options (boolean)
 # =============================================================================
+option(NRN_ENABLE_DOCS "Build documentation" ${NRN_ENABLE_DOCS_DEFAULT})
+# This is useful for readthedocs-style builds and the documentation CI, where the actual
+# installation of NEURON comes from an installed binary wheel.
+option(
+  NRN_ENABLE_DOCS_WITH_EXTERNAL_INSTALLATION
+  "Build documentation without building NEURON. It will be assumed that import neuron works, nrnivmodl is in PATH, etc."
+  ${NRN_ENABLE_DOCS_WITH_EXTERNAL_INSTALLATION_DEFAULT})
+mark_as_advanced(NRN_ENABLE_DOCS_WITH_EXTERNAL_INSTALLATION)
 option(NRN_ENABLE_SHARED "Build shared libraries (otherwise static library)"
        ${NRN_ENABLE_SHARED_DEFAULT})
 option(NRN_ENABLE_INTERVIEWS "Enable GUI with INTERVIEWS" ${NRN_ENABLE_INTERVIEWS_DEFAULT})
@@ -239,79 +247,6 @@ if(NRN_ENABLE_RX3D)
 endif()
 if(MINGW)
   find_package(Termcap REQUIRED)
-endif()
-
-# =============================================================================
-# Setup Doxygen documentation
-# =============================================================================
-find_package(Doxygen QUIET)
-if(DOXYGEN_FOUND)
-  # generate Doxyfile with correct source paths
-  configure_file(${PROJECT_SOURCE_DIR}/docs/Doxyfile.in ${PROJECT_BINARY_DIR}/Doxyfile)
-  add_custom_target(
-    doxygen
-    COMMAND ${DOXYGEN_EXECUTABLE} ${PROJECT_BINARY_DIR}/Doxyfile
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-    COMMENT "Generating API documentation with Doxygen"
-    VERBATIM)
-endif()
-
-# =============================================================================
-# Setup Sphinx documentation
-# =============================================================================
-find_package(Sphinx QUIET)
-if(SPHINX_FOUND)
-  # Target to execute && convert notebooks to html. Note that neuron must be available for python
-  # import. See docs/README.md.
-  add_custom_target(
-    notebooks
-    COMMAND ${CMAKE_COMMAND} -E env NEURON_MODULE_OPTIONS="-nogui" bash
-            ${PROJECT_SOURCE_DIR}/docs/notebooks.sh
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/docs)
-
-  # Executing notebooks will add outputs in-place. We don't want those committed to the repo. This
-  # commands cleans them out.
-  add_custom_target(
-    notebooks-clean
-    COMMAND bash ${PROJECT_SOURCE_DIR}/docs/notebooks.sh --clean
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/docs)
-
-  set(SPHINX_SOURCE ${PROJECT_SOURCE_DIR}/docs)
-  set(SPHINX_BUILD ${PROJECT_SOURCE_DIR}/docs/_build)
-
-  add_custom_target(
-    sphinx
-    COMMAND ${SPHINX_EXECUTABLE} -b html ${SPHINX_SOURCE} ${SPHINX_BUILD}
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/docs
-    COMMENT "Generating documentation with Sphinx")
-endif()
-
-# =============================================================================
-# Build full docs
-# =============================================================================
-find_program(JUPYTER_EXE jupyter QUIET)
-
-if(DOXYGEN_FOUND
-   AND SPHINX_FOUND
-   AND JUPYTER_EXE)
-  add_custom_target(
-    docs
-    COMMAND ${CMAKE_COMMAND} --build . --target doxygen
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-    COMMAND ${CMAKE_COMMAND} --build . --target notebooks
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/docs
-    COMMAND ${CMAKE_COMMAND} --build . --target sphinx
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-    COMMAND ${CMAKE_COMMAND} --build . --target notebooks-clean
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-    COMMAND echo "The HTML docs are at file://${PROJECT_SOURCE_DIR}/docs/_build/index.html"
-    COMMENT "Generating full documentation")
-else()
-  add_custom_target(
-    docs
-    VERBATIM
-    COMMAND echo "Please install docs requirements (see docs/README.md)!"
-    COMMENT "Documentation generation not possible!")
 endif()
 
 # =============================================================================
@@ -569,6 +504,113 @@ endif()
 
 if(MINGW)
   add_subdirectory(src/mswin)
+endif()
+
+# =============================================================================
+# Collect the environment variables that are needed to execute NEURON from the build directory. This
+# is used when configuring tests, and when building documentation targets. TODO: be more careful
+# about trailing colons?
+# =============================================================================
+set(NRN_RUN_FROM_BUILD_DIR_ENV
+    "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}"
+    "NEURONHOME=${PROJECT_BINARY_DIR}/share/nrn" "NRNHOME=${PROJECT_BINARY_DIR}"
+    "PATH=${PROJECT_BINARY_DIR}/bin:$ENV{PATH}")
+if(NRN_ENABLE_CORENEURON AND NOT coreneuron_FOUND)
+  # CoreNEURON is enabled *and* is being built internally
+  list(APPEND NRN_RUN_FROM_BUILD_DIR_ENV "CORENRNHOME=${PROJECT_BINARY_DIR}")
+endif()
+if(NRN_ENABLE_PYTHON)
+  list(APPEND NRN_RUN_FROM_BUILD_DIR_ENV
+       PYTHONPATH=${PROJECT_BINARY_DIR}/lib/python:${PROJECT_SOURCE_DIR}/test/rxd:$ENV{PYTHONPATH})
+endif()
+
+if(NRN_ENABLE_DOCS)
+  # Do we need to set extra environment variables to find NEURON?
+  set(NRN_DOCS_COMMAND_PREFIX ${CMAKE_COMMAND} -E env)
+  if(NOT NRN_ENABLE_DOCS_WITH_EXTERNAL_INSTALLATION)
+    list(APPEND NRN_DOCS_COMMAND_PREFIX ${NRN_RUN_FROM_BUILD_DIR_ENV})
+  endif()
+
+  # Make sure all dependencies are available
+  find_package(Doxygen REQUIRED)
+  find_program(FFMPEG_EXECUTABLE ffmpeg REQUIRED)
+  find_program(JUPYTER_EXECUTABLE jupyter REQUIRED)
+  find_program(PANDOC_EXECUTABLE pandoc REQUIRED)
+  find_package(Sphinx REQUIRED)
+  set(docs_requirements_file "${PROJECT_SOURCE_DIR}/docs/docs_requirements.txt")
+  file(STRINGS "${docs_requirements_file}" docs_requirements)
+  # Make sure CMake reruns if docs_requirements.txt changeds.
+  set_property(GLOBAL APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${docs_requirements_file}")
+  foreach(docs_requirement ${docs_requirements})
+    if(${skip_next})
+      set(skip_next FALSE)
+      continue()
+    endif()
+    # This is needed for ipython, which is pip installable but not importable.
+    if("${docs_requirement}" STREQUAL "# do not check import of next line")
+      set(skip_next TRUE)
+    elseif("${docs_requirement}" MATCHES "^([a-zA-Z_][a-zA-Z0-9]*)")
+      nrn_find_python_module(${CMAKE_MATCH_0} REQUIRED)
+    endif()
+  endforeach()
+
+  # =============================================================================
+  # Setup Doxygen documentation
+  # =============================================================================
+  # generate Doxyfile with correct source paths
+  configure_file(${PROJECT_SOURCE_DIR}/docs/Doxyfile.in ${PROJECT_BINARY_DIR}/Doxyfile)
+  add_custom_target(
+    doxygen
+    COMMAND ${NRN_DOCS_COMMAND_PREFIX} ${DOXYGEN_EXECUTABLE} ${PROJECT_BINARY_DIR}/Doxyfile
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    COMMENT "Generating API documentation with Doxygen"
+    VERBATIM)
+
+  # =============================================================================
+  # Setup Sphinx documentation
+  # =============================================================================
+
+  # Target to execute && convert notebooks to html. Note that neuron must be available for python
+  # import, so we use NRN_RUN_FROM_BUILD_DIR_ENV. See docs/README.md.
+  add_custom_target(
+    notebooks
+    COMMAND ${NRN_DOCS_COMMAND_PREFIX} NEURON_MODULE_OPTIONS="-nogui" bash
+            ${PROJECT_SOURCE_DIR}/docs/notebooks.sh
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/docs)
+  if(NRN_ENABLE_DOCS_WITH_EXTERNAL_INSTALLATION)
+    message(STATUS "**Not** making the notebooks target depend on the rest of the NEURON build.")
+    message(STATUS "Documentation building will probably fail if you haven't installed NEURON.")
+  else()
+    # We need NEURON to execute the notebooks. If we're building documentation as part of a normal
+    # build, this means we need to schedule the documenation targets sufficiently late in the build.
+    add_dependencies(notebooks hoc_module rxdmath)
+  endif()
+
+  add_custom_target(
+    sphinx
+    COMMAND ${NRN_DOCS_COMMAND_PREFIX} ${SPHINX_EXECUTABLE} -b html "${PROJECT_SOURCE_DIR}/docs"
+            "${PROJECT_SOURCE_DIR}/docs/_build"
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/docs
+    COMMENT "Generating documentation with Sphinx")
+
+  # Executing notebooks will add outputs in-place. We don't want those committed to the repo. This
+  # commands cleans them out.
+  add_custom_target(
+    notebooks-clean
+    COMMAND ${NRN_DOCS_COMMAND_PREFIX} bash ${PROJECT_SOURCE_DIR}/docs/notebooks.sh --clean
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/docs)
+
+  # =============================================================================
+  # Build full docs
+  # =============================================================================
+  add_custom_target(
+    docs
+    COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR} --target doxygen
+    COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR} --target notebooks
+    COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR} --target sphinx
+    COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR} --target notebooks-clean
+    COMMAND echo "The HTML docs are at file://${PROJECT_SOURCE_DIR}/docs/_build/index.html"
+    COMMENT "Generating full documentation")
 endif()
 
 # =============================================================================

--- a/cmake/BuildOptionDefaults.cmake
+++ b/cmake/BuildOptionDefaults.cmake
@@ -3,6 +3,8 @@
 # The <optionname>_DEFAULT values should only be changed in this file
 # and not on the command line.
 # ~~~
+set(NRN_ENABLE_DOCS_DEFAULT OFF)
+set(NRN_ENABLE_DOCS_WITH_EXTERNAL_INSTALLATION_DEFAULT OFF)
 set(NRN_ENABLE_SHARED_DEFAULT ON)
 set(NRN_ENABLE_INTERVIEWS_DEFAULT ON)
 set(NRN_ENABLE_MECH_DLL_STYLE_DEFAULT ON)

--- a/cmake/NeuronTestHelper.cmake
+++ b/cmake/NeuronTestHelper.cmake
@@ -145,10 +145,13 @@ function(nrn_add_test)
     message(WARNING "nrn_add_test: unknown arguments: ${NRN_ADD_TEST_UNPARSED_ARGUMENTS}")
   endif()
 
-  if(NOT DEFINED NRN_TEST_ENV)
+  if(NOT DEFINED NRN_RUN_FROM_BUILD_DIR_ENV)
     # To avoid duplication we take this value from the {nrn}/test/CMakeLists.txt file by assuming
     # this variable name.
-    message(WARNING "nrn_add_test: NRN_TEST_ENV was not defined; building test files may not work")
+    message(
+      WARNING
+        "nrn_add_test: NRN_RUN_FROM_BUILD_DIR_ENV was not defined; building test files may not work"
+    )
   endif()
 
   # Check if the REQUIRES and/or CONFLICTS arguments mean we should disable this test.
@@ -244,8 +247,8 @@ function(nrn_add_test)
   if(NOT "${modfile_patterns}" STREQUAL "NONE")
     # Add a rule to build the modfiles for this test. The assumption is that it is likely that most
     # members of the group will ask for exactly the same thing, so it's worth de-duplicating.
-    set(nrnivmodl_command cmake -E env ${NRN_TEST_ENV} ${CMAKE_BINARY_DIR}/bin/nrnivmodl
-                          ${nrnivmodl_args})
+    set(nrnivmodl_command cmake -E env ${NRN_RUN_FROM_BUILD_DIR_ENV}
+                          ${CMAKE_BINARY_DIR}/bin/nrnivmodl ${nrnivmodl_args})
     set(hash_components nrnivmodl ${nrnivmodl_args})
     # This condition used to be `requires_coreneuron`. This tends to mean that NEURON and CoreNEURON
     # versions of a test will share the same hash, which is probably fine, but also means that any
@@ -387,7 +390,7 @@ function(nrn_add_test)
   if(DEFINED NRN_ADD_TEST_PROCESSORS)
     set_tests_properties(${test_names} PROPERTIES PROCESSORS ${NRN_ADD_TEST_PROCESSORS})
   endif()
-  set(test_env "${NRN_TEST_ENV}")
+  set(test_env "${NRN_RUN_FROM_BUILD_DIR_ENV}")
   if(requires_coreneuron)
     if(DEFINED nrnivmodl_working_directory)
       set(test_env

--- a/docs/cmake_doc/options.rst
+++ b/docs/cmake_doc/options.rst
@@ -107,7 +107,7 @@ CMAKE_BUILD_TYPE:STRING=RelWithDebInfo
 
 Ninja
 -----
-  Use the Ninja build system ('make' is the default 'CMake' build system).
+  Use the Ninja build system (``make`` is the default CMake build system).
 
   .. code-block:: shell
 
@@ -354,6 +354,41 @@ CMAKE_C_COMPILER:FILEPATH=/usr/bin/cc
 CMAKE_CXX_COMPILER:FILEPATH=/usr/bin/c++
 ----------------------------------------
   C plus plus compiler
+
+NRN_ENABLE_DOCS:BOOL=OFF
+------------------------
+  Enable documentation targets in the build.
+  This also makes all documentation dependencies into hard requirements, so
+  CMake will report an error if anything is missing.
+  There are five documentation targets:
+    * ``doxygen`` generates Doxygen documentation from the NEURON source code.
+    * ``notebooks`` executes the various Jupyter notebooks that are included in
+      the documentation, so they contain both code and results, instead of just
+      code. These are run in situ in the source tree, so if you run this target
+      manually then make sure not to accidentally commit the results to git.
+    * ``sphinx`` generates Sphinx documentation. This logically depends on
+      ``notebooks``, as it generates HTML from the executed notebooks, but this
+      dependency is not declared in the build system.
+    * ``notebooks-clean`` removes the execution results from the Jupyter
+      notebooks, leaving them in a clean state. This logically depends on
+      ``sphinx``, as the execution results need to be converted to HTML before
+      they are discarded, but this dependency is not declared in the build
+      system.
+    * ``docs`` is shorthand for building ``doxygen``, ``notebooks``, ``sphinx``
+      and ``notebooks-clean`` in that order.
+
+  .. warning::
+    Executing the notebooks requires a functional NEURON installation.
+    There are two possibilities here:
+      * The default, which is sensible for local development, is that the
+        ``notebooks`` target uses NEURON from the current CMake build directory.
+        This implies that building the documentation builds NEURON too.
+      * The alternative, which is enabled by setting
+        ``-DNRN_ENABLE_DOCS_WITH_EXTERNAL_INSTALLATION=ON``, is that ``notebooks``
+        does not depend on any other NEURON build targets. In this case you must
+        provide an installation of NEURON by some other means. It will be assumed
+        that commands like ``nrnivmodl`` work and that ``import neuron`` works
+        in Python.
 
 NRN_NMODL_CXX_FLAGS:STRING=""
 -----------------------------

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -5,6 +5,7 @@ nbconvert
 recommonmark
 matplotlib
 bokeh
+# do not check import of next line
 ipython
 plotnine
 numpy

--- a/docs/notebooks.sh
+++ b/docs/notebooks.sh
@@ -30,7 +30,7 @@ else
   for i in ${notebook_dirs[@]} ; do
     convert_notebooks "$i"
   done
-  echo "Done. NOTE: remember to run target ``notebooks-clean`` before a PR."
+  echo 'Done. NOTE: remember to run target `notebooks-clean` before a PR. The `docs` target does this automatically.'
 fi
 
 

--- a/setup.py
+++ b/setup.py
@@ -200,6 +200,9 @@ class CMakeAugmentedBuilder(build_ext):
         # RTD neds quick config
         if self.docs and os.environ.get("READTHEDOCS"):
             cmake_args = ["-DNRN_ENABLE_MPI=OFF", "-DNRN_ENABLE_INTERVIEWS=OFF"]
+        if self.docs:
+            cmake_args.append("-DNRN_ENABLE_DOCS=ON")
+            cmake_args.append("-DNRN_ENABLE_DOCS_WITH_EXTERNAL_INSTALLATION=ON")
         if self.cmake_prefix:
             cmake_args.append("-DCMAKE_PREFIX_PATH=" + self.cmake_prefix)
         if self.cmake_defs:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,22 +33,6 @@ if(NOT TARGET hoc_module)
             ${PROJECT_BINARY_DIR}/share/nrn/lib)
 endif()
 
-# Note that DYLD_LIBRARY_PATH is not required and interfere with dlopen
-set(TEST_ENV NEURONHOME=${PROJECT_BINARY_DIR}/share/nrn NRNHOME=${PROJECT_BINARY_DIR}
-             LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH})
-if(NOT coreneuron_FOUND)
-  # CoreNEURON is being built internally
-  list(APPEND TEST_ENV "CORENRNHOME=${PROJECT_BINARY_DIR}")
-endif()
-if(NRN_ENABLE_PYTHON)
-  list(APPEND TEST_ENV
-       PYTHONPATH=${PROJECT_BINARY_DIR}/lib/python:${PROJECT_SOURCE_DIR}/test/rxd:$ENV{PYTHONPATH})
-endif()
-# Give the environment string a more descriptive name that can be used in NeuronTestHelper.cmake
-set(NRN_TEST_ENV "${TEST_ENV}")
-
-set(TESTS "")
-
 # =============================================================================
 # Use add_test method and set environment for testneuron (NEURONHOME env variable needs to be set to
 # run testneuron and other tests based on nrniv)
@@ -441,46 +425,27 @@ endif()
 # ============================================
 # Test modlunit
 # ============================================
+function(add_modlunit_test mod_file)
+  get_filename_component(mod_file_basename "${mod_file}" NAME_WE)
+  add_test(
+    NAME modlunit_${mod_file_basename}
+    COMMAND modlunit "${mod_file}"
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+  list(APPEND TESTS modlunit_${mod_file_basename})
+  set(TESTS
+      "${TESTS}"
+      PARENT_SCOPE)
+endfunction()
+add_modlunit_test("${PROJECT_SOURCE_DIR}/test/pynrn/unitstest.mod")
+add_modlunit_test("${PROJECT_SOURCE_DIR}/src/nrnoc/hh.mod")
+add_modlunit_test("${PROJECT_SOURCE_DIR}/src/nrnoc/stim.mod")
+add_modlunit_test("${PROJECT_SOURCE_DIR}/src/nrnoc/pattern.mod")
+set_property(TEST modlunit_pattern PROPERTY WILL_FAIL ON)
 
-# Strategy. Create a bash script that runs modlunit on a list of mod file expecting success and a
-# list expecting failure. Then run the script with a custom target.
-
-file(
-  WRITE ${PROJECT_BINARY_DIR}/run_modlunit.bash
-  "\
-#!bash\n\
-set -e\n\
-M=${PROJECT_BINARY_DIR}/bin/modlunit
-for i in $1 ; do\n\
-  echo \"expect accept $i\"\n\
-  $M $i\n\
-done\n\
-for i in $2 ; do\n\
-  echo \"expect reject $i\"\n\
-  if $M $i ; then\n\
-    exit 1\n\
-  fi\n\
-done\n\
-exit 0\n\
-")
-
-set(MODFILES_ACCEPT ${PROJECT_SOURCE_DIR}/test/pynrn/unitstest.mod
-                    ${PROJECT_SOURCE_DIR}/src/nrnoc/hh.mod ${PROJECT_SOURCE_DIR}/src/nrnoc/stim.mod)
-set(MODFILES_REJECT ${PROJECT_SOURCE_DIR}/src/nrnoc/pattern.mod)
-
-add_custom_target(
-  modlunit_test ALL
-  COMMAND ${CMAKE_COMMAND} -E env ${TEST_ENV} $ENV{SHELL} ${PROJECT_BINARY_DIR}/run_modlunit.bash
-          \"${MODFILES_ACCEPT}\" \"${MODFILES_REJECT}\"
-  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-  DEPENDS ${PROJECT_BINARY_DIR}/bin/modlunit)
-
-# list(APPEND TESTS modlunit_test)
-
-set_tests_properties(${TESTS} PROPERTIES ENVIRONMENT "${TEST_ENV}")
+set_tests_properties(${TESTS} PROPERTIES ENVIRONMENT "${NRN_RUN_FROM_BUILD_DIR_ENV}")
 # If profiling is enabled, run ringtest with profiler
 if(NRN_ENABLE_PROFILING)
-  set(TEST_PROFILING_ENV ${TEST_ENV})
+  set(TEST_PROFILING_ENV ${NRN_RUN_FROM_BUILD_DIR_ENV})
   list(APPEND TEST_PROFILING_ENV "CALI_CONFIG=runtime-report,calc.inclusive")
   set_tests_properties(ringtest PROPERTIES ENVIRONMENT "${TEST_PROFILING_ENV}")
 endif()

--- a/test/external/nrntest/CMakeLists.txt
+++ b/test/external/nrntest/CMakeLists.txt
@@ -1,10 +1,8 @@
-list(APPEND TEST_ENV
-     PATH=${PROJECT_BINARY_DIR}/bin:${PROJECT_SOURCE_DIR}/external/nrntest:$ENV{PATH})
 add_test(
   external_nrntest
   ${CMAKE_COMMAND}
   -E
   env
-  ${TEST_ENV}
+  ${NRN_RUN_FROM_BUILD_DIR_ENV}
   MPIEXEC_OVERSUBSCRIBE=${MPIEXEC_OVERSUBSCRIBE}
   ${PROJECT_SOURCE_DIR}/external/tests/nrntest/runtests)


### PR DESCRIPTION
- Now they set the required environment variables so that they can be
  built without special environment manipulations.
- Add NRN_ENABLE_DOCS option, if it's enabled then check that
  dependencies are available as part of the CMake configuration step.
- Somewhat unrelated: make the modlunit tests into CTest tests.

Closes #1652, closes #1677.

TODO:
- [x] Check if this allows some CI configuration to be simplified.
- [x] Test ReadTheDocs -> https://nrn.readthedocs.io/en/olupton-docs