### PR TITLE
Cherry pick from `master` to `release/8.1`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,112 @@
+# NEURON 8.1
+
+## 8.1.0
+_Release Date_ : 25-03-2022
+
+### What's New
+
+* Python wheels
+  * Support for ARM (Aarch64) Platform wheels via CircleCI - Python 3.6 to 3.10 (#1676)
+  * Apple M1 Platform wheels - Python 3.8 to 3.10 (#1649)
+  * NVIDIA GPU enabled wheels
+    * First iteration released under a separate package: `neuron-gpu`
+      * Must use NVHPC 21.1 SDK when you compile your MOD files (#1657)
+  * Improved CoreNEURON support (#1705)
+    * Use vendor compilers like Intel, Cray or NVHPC for better performance when you compile MOD files using `nrnivmodl`.
+  * Support for HPE MPT MPI library (#1498)
+  * Linux wheels are now `manylinux2014` (#1365)
+* MacOS `universal2` package installer now available - Python 3.8 to 3.10
+* CoreNEURON
+  * Tight integration for both in-memory and as well as file transfer mode
+  * Extend CoreNEURON POINTER transfer to any RANGE variable in a NRN_THREAD (#1622)
+  * Support for BEFORE/AFTER constructs in MOD file (#1581)
+* RXD
+  * SaveState support added (#1586)
+  * Dynamic extracellular tortuosity and volume fraction (#1260)
+  * 3D support for importing multiple morphologies and for moving imported morphologies (#1147)
+
+* Dedicated CI repository [nrn-build-ci](https://github.com/neuronsimulator/nrn-build-ci) to check builds on different distributions. Check this if you have build issues.
+* Documentation
+  * Integrated various documentation & tutorials from neuron.yale.edu website to the readthedocs (#1674)
+  * Added training videos, guides and a list of NEURON publications
+  * CoreNEURON: usage, MOD files compatibility/migration, profiling and (GPU) performance benchmarking
+  * RxD programmer's reference expanded and rewritten (#1680)
+  * Propose changes directly from ReadTheDocs - click on `Edit on GitHub`
+
+### Breaking Changes
+* Models using `_NrnThread` in a VERBATIM block will fail now. Change it to `NrnThread`.[See #1609](https://github.com/neuronsimulator/nrn/pull/1609).
+* Minimum CMake version supported is now 3.15.0 (#1408)
+* Python2 and Python3.5 support dropped
+* Legacy internal `readline` source code is removed, must have Readline installed (#1371)
+* Python wheels are now manylinux2014 (#1365)
+
+### Deprecations
+* NEURON is being migrated to a C++ codebase and beginning with the next release `MOD` files will be converted to `C++` instead of `C`.
+  This might break compatibility with some legacy MOD files containing `VERBATIM` blocks.
+  We will update the NEURON documentation describing how one can make MOD files compatible with this change.
+* Python 3.6 Is End-of-Life - drop support after 8.1 release (#1651)
+
+### Bug Fixes
+* Can use ParallelContext.mpiabort_on_error(0) to say do not call to MPI_Abort on error (#1567)
+* OpenMPI initialisation crash: argv[argc] should be null. (#1682)
+* Avoid segfault if error during construction of POINT_PROCESS (#1627)
+* Fixes a 1D/3D voxelization problem where frusta are outside the 3D grid. (#1227)
+* Allow for two point (single section) SWC somas (#1144)
+* Fix for current response in 3D reaction-diffusion simulations (#1721)
+* `rxdmath.abs` no longer raises an exception (#1545)
+* Fixes for 3D reaction-diffusion grid alignment edge cases (#1471, #1227)
+* Update coreneuron : gpu bugfix for the BBP models (#1374)
+* Fix UndefinedBehaviourSanitizer errors. (#1518)
+* import3d_gui bugfix for HOC classes and top-level (#1159)
+
+### Improvements / Other Changes
+* Documentation
+  * sphinx jupyter notebooks integration via `nbsphinx` (#1684)
+  * Update CoreNEURON documentation. (#1650)
+  * Building python wheels & managing NEURON Docker Images (#1469)
+  * Short tutorial on using the profiler interface (#1453)
+  * docs: Updated several rxd tutorials (#1061)
+  * docs: WSL & Linux Python Wheel (#1496)
+  * Update GPU profiling documentation (#1538)
+* Testing and coverage
+  * Integration of tqperf model for CI and CoreNEURON testing (#1556)
+  * Add olfactory bulb mode as external test (#1541)
+  * Add reduced dentate model tests (#1515)
+  * Add BBP channel-benchmark to CTest suite. (#1439)
+  * Make neuronsimulator/nrntest part of the CI (#1429)
+* Refactorings
+  * Move codebase to CPP  (#763)
+  * Remove all code related to NRN_REALTIME and NRN_DAQ  (#1401)
+  * Drop legacy hash implementations: nrnhash (#1403)
+  * Remove absolute paths from generated code for ccache builds (#1574)
+  * Using std::unordered_map as Gid2PreSyn/Int2TarList (#1568)
+  * nrnivmodl succeeds when there are no mod files (#1583)
+  * Fix UndefinedBehaviourSanitizer errors. (#1518)
+  * Remove copy of readline (#1396)
+  * Remove multisend specific for BlueGene (DMA) (#1294)
+* Improvements
+  * Possible to prefer python from $PATH when building from source with CMake #1659
+  * User can use MPI_LIB_NRN_PATH to provide MPI library on linux platform (#1172)
+  * MPI Multisend available in NEURON by default (#1537)
+  * modlunit: Add CHARGE keyword and map it to VALENCE. (#1508)
+  * Allow user to specify dialog popup location. (#1487)
+  * Allow python section.disconnect(). (#1451)
+  * Implement BBSaveState for Python cells (#1355)
+  * macos build_wheels: add /usr/x11 to CMAKE_PREFIX_PATH (#1565)
+  * Add NRN_NMODL_CXX_FLAGS to facilitate cross compilation (#1174)
+* RXD
+  * Faster convergence rate for surface voxel partial volume estimation (#1555)
+  * Internal API for saving/restoring 3D voxelization (#1476)
+  * Prevent RxD keeping objects alive (#1270, #1103, #1072)
+  * Improved assignment of 3D voxels to segments (#1149)
+  
+### Upgrade Steps
+* Linux wheels are now `manylinux2014`: upgrade your `pip`
+* Legacy internal `readline` source code is removed: install `readline` on your system
+* Python2 and Python3.5 support dropped: migrate to Python 3.7+ (3.6 is deprecated)
+
+For the complete list of features and bug fixes, see `Commits going into 8.1.0` in [GitHub Issue #1719](https://github.com/neuronsimulator/nrn/issues/1719)
+
 # NEURON 8.0
 
 ## 8.0.2

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -10,3 +10,5 @@ plotnine
 numpy
 plotly
 nbsphinx
+# 3.1.0 is buggy
+jinja2!=3.1.0


### PR DESCRIPTION
* NEURON 8.1.0 Changelog (#1724)


Anything else? 
```bash
bb-c02gx3mmq6lt:nrn savulesc$ git log --pretty=format:"%h: %s" --since="2020-12-18"  release/8.1..master
513d45c52: drop Python 3.6 support (#1733)
4d294685e: NEURON 8.1.0 Changelog (#1724)
d141b7425: ban jinja2@3.1.0 as it's buggy (#1731)
6d82be01d: docs: NetStim random guide; also fix to toctree (#1727)
d0f38d582: UndefinedBehaviourSanitizer fixes (#1479)
6f666ac60: Disallow STATE variables being GLOBAL (#1723)
```