### PR TITLE
Disable PR builds on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,11 @@ workflows:
   build-workflow:
     jobs:
       - manylinux2014-aarch64:
+          filters:
+            branches:
+              only:
+                - /release\/.*/
+                - /circleci\/.*/
           matrix:
             parameters:
               NRN_PYTHON_VERSION: ["310"]


### PR DESCRIPTION
* Due to limited build credits (and 💵), do not build all PRs on CircleCI
* When branch is `release/*` or `circleci/*` then only PR build will be triggered
* NOTE: nightly build of master and Neuron-nightly wheel upload is still there.
   So we will find regressions via this.
 