### PR TITLE
nrnivmodl: pass -incflags to CoreNEURON.

### DIFF
--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -52,7 +52,7 @@ fi
 LinkCoreNEURON=false
 UserINCFLAGS=""
 UserLDFLAGS=""
-UserCOREFLAGS=""
+UserCOREFLAGS=()
 
 # - options come first but can be in any order.
 while test -n "$1" ; do
@@ -65,13 +65,15 @@ while test -n "$1" ; do
     -incflags)
         # extra include flags and paths (NEURON only)
         UserINCFLAGS="$2"
+        # extra include flags and paths for CoreNEURON
+        UserCOREFLAGS+=(-i "${2}")
         shift
         shift;;
     -loadflags)
         # extra link flags, paths, libraries (NEURON only)
         UserLDFLAGS="$2"
         # extra lin flags, paths. libraries (CoreNEURON)
-        UserCOREFLAGS="$UserCOREFLAGS -l $2"
+        UserCOREFLAGS+=(-l "${2}")
         shift
         shift;;
     -*)
@@ -294,7 +296,7 @@ if [ "$LinkCoreNEURON" = true ] ; then
       j=`escape_spaces "$j"`
       args="$args $j"
     done
-    "${cnrn_prefix}/bin/nrnivmodl-core" $UserCOREFLAGS $args
+    "${cnrn_prefix}/bin/nrnivmodl-core" "${UserCOREFLAGS[@]}" $args
     cd $MODSUBDIR
   else
     printf "ERROR : CoreNEURON support is not enabled!\n"

--- a/test/external/tqperf/CMakeLists.txt
+++ b/test/external/tqperf/CMakeLists.txt
@@ -15,6 +15,6 @@ nrn_add_test(
   CONFLICTS nmodl # https://github.com/BlueBrain/nmodl/issues/794
   REQUIRES mpi python coreneuron
   PROCESSORS ${tqperf_mpi_ranks}
-  NRNIVMODL_ARGS -loadflags -lcrypto
+  NRNIVMODL_ARGS -incflags "-I${OPENSSL_INCLUDE_DIR}" -loadflags "${OPENSSL_CRYPTO_LIBRARY}"
   COMMAND ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} ${tqperf_mpi_ranks} ${MPIEXEC_OVERSUBSCRIBE}
           ${MPIEXEC_PREFLAGS} special ${MPIEXEC_POSTFLAGS} -mpi -python test1.py)


### PR DESCRIPTION
Enables passing OpenSSL include path when building the `tqperf` test, which otherwise failed on some macOS systems.
The new bash-array-based handling of `UserCOREFLAGS` should fix passing multiple include flags using `-incflags "-Ifoo -Ibar"`.