### PR TITLE
nrnrandom.h: declare nrn*random* to mechanisms.

### DIFF
--- a/cmake/NeuronFileLists.cmake
+++ b/cmake/NeuronFileLists.cmake
@@ -16,6 +16,7 @@ set(HEADER_FILES_TO_INSTALL
     ivstream.h
     md1redef.h
     md2redef.h
+    mech_api.h
     membdef.h
     membfunc.h
     multicore.h
@@ -33,6 +34,7 @@ set(HEADER_FILES_TO_INSTALL
     nrnoc_ml.h
     nrnmpi.h
     nrnmpidec.h
+    nrnrandom.h
     nrnran123.h
     nrnredef.h
     oc_ansi.h

--- a/src/nmodl/cout.cpp
+++ b/src/nmodl/cout.cpp
@@ -273,7 +273,7 @@ void c_out() {
     P("#include \"common.h\"\n#include \"softbus.h\"\n");
     P("#include \"sbtypes.h\"\n#include \"Solver.h\"\n");
 #else
-    P("#include <stdio.h>\n#include <math.h>\n#include \"scoplib.h\"\n");
+    P("#include <stdio.h>\n#include <math.h>\n#include \"mech_api.h\"\n");
     P("#undef PI\n");
 #endif
     printlist(defs_list);
@@ -589,7 +589,7 @@ void c_out_vectorize() {
     Fflush(fcout);
     /* things which must go first and most declarations */
     P("/* VECTORIZED */\n");
-    P("#include <stdio.h>\n#include <math.h>\n#include \"scoplib.h\"\n");
+    P("#include <stdio.h>\n#include <math.h>\n#include \"mech_api.h\"\n");
     P("#undef PI\n");
     printlist(defs_list);
     printlist(firstlist);

--- a/src/nmodl/noccout.cpp
+++ b/src/nmodl/noccout.cpp
@@ -130,7 +130,7 @@ void c_out() {
     P("#include \"common.h\"\n#include \"softbus.h\"\n");
     P("#include \"sbtypes.h\"\n#include \"Solver.h\"\n");
 #else
-    P("#include <stdio.h>\n#include <stdlib.h>\n#include <math.h>\n#include \"scoplib.h\"\n");
+    P("#include <stdio.h>\n#include <stdlib.h>\n#include <math.h>\n#include \"mech_api.h\"\n");
     P("#undef PI\n");
     P("#define nil 0\n");
     P("#include \"md1redef.h\"\n");
@@ -650,7 +650,7 @@ void c_out_vectorize() {
 
     /* things which must go first and most declarations */
     P("/* VECTORIZED */\n#define NRN_VECTORIZED 1\n");
-    P("#include <stdio.h>\n#include <stdlib.h>\n#include <math.h>\n#include \"scoplib.h\"\n");
+    P("#include <stdio.h>\n#include <stdlib.h>\n#include <math.h>\n#include \"mech_api.h\"\n");
     P("#undef PI\n");
     P("#define nil 0\n");
     P("#include \"md1redef.h\"\n");

--- a/src/nrnoc/netstim.mod
+++ b/src/nrnoc/netstim.mod
@@ -113,18 +113,6 @@ FUNCTION invl(mean (ms)) (ms) {
 		invl = (1. - noise)*mean + noise*mean*erand()
 	}
 }
-VERBATIM
-#include "nrnran123.h"
-
-#if !NRNBBCORE
-/* backward compatibility */
-double nrn_random_pick(void* r);
-void* nrn_random_arg(int argpos);
-int nrn_random_isran123(void* r, uint32_t* id1, uint32_t* id2, uint32_t* id3);
-int nrn_random123_setseq(void* r, uint32_t seq, char which);
-int nrn_random123_getseq(void* r, uint32_t* seq, char* which);
-#endif
-ENDVERBATIM
 
 FUNCTION erand() {
 VERBATIM

--- a/src/oc/mech_api.h
+++ b/src/oc/mech_api.h
@@ -1,0 +1,14 @@
+#pragma once
+/** @brief Header file included in translated mechanism.
+ *
+ *  This ensures that all functions that are tacitly part of the NEURON API
+ *  usable from .mod files have definitions that are visible when the translated
+ *  versions of those .mod files are compiled.
+ *
+ *  @todo Functions defined in nrniv_mf.h are also used by .mod files, but that
+ *        header has to be sandwiched between md1redef.h and md2redef.h, which
+ *        we leave to nocmodl.
+ */
+#include "nrnrandom.h"
+#include "nrnran123.h"
+#include "scoplib.h"

--- a/src/oc/nrnrandom.h
+++ b/src/oc/nrnrandom.h
@@ -24,4 +24,8 @@ double nrn_random_pick(void* r);
 void nrn_random_reset(void* r);
 int nrn_random123_getseq(void* r, uint32_t* seq, char* which);
 int nrn_random123_setseq(void* r, uint32_t seq, char which);
-void nrn_set_random_sequence(void* r, long seq);
+
+/** Note that in addition to having void* in place of Rand*, this has int in
+ *  place of long.
+ */
+void nrn_set_random_sequence(void* r, int seq);

--- a/src/oc/nrnrandom.h
+++ b/src/oc/nrnrandom.h
@@ -1,0 +1,18 @@
+#pragma once
+#ifdef __cplusplus
+#error "This version of nrnrandom.h should never be compiled as C++."
+#endif
+#include <stdint.h>
+
+/** These declarations are wrong, in the sense that they are inconsistent with
+ *  the definitions in ivocrand.cpp. This is an intentional, but possibly
+ *  unwise, decision.
+ */
+long nrn_get_random_sequence(void* r);
+void* nrn_random_arg(int);
+int nrn_random_isran123(void* r, uint32_t* id1, uint32_t* id2, uint32_t* id3);
+double nrn_random_pick(void* r);
+void nrn_random_reset(void* r);
+int nrn_random123_getseq(void* r, uint32_t* seq, char* which);
+int nrn_random123_setseq(void* r, uint32_t seq, char which);
+void nrn_set_random_sequence(void* r, long seq);

--- a/src/oc/nrnrandom.h
+++ b/src/oc/nrnrandom.h
@@ -4,6 +4,15 @@
 #endif
 #include <stdint.h>
 
+/** Ideally the prototypes below would take Rand* in place of void*, but this
+ *  would break several existing models. We do, however, want to declare the
+ *  Rand type, as this makes it possible to write (for example)
+ *  nrn_random_pick((Rand*)some_rand) now, which will be required to suppress
+ *  deprecation warnings in NEURON 9+ where nrn_random_pick(void*) is a
+ *  [[deprecated]] overload and the non-deprecated version takes Rand*.
+ */
+typedef struct Rand Rand;
+
 /** These declarations are wrong, in the sense that they are inconsistent with
  *  the definitions in ivocrand.cpp. This is an intentional, but possibly
  *  unwise, decision.


### PR DESCRIPTION
In this commit the declared prototypes take `void*`, which does not correspond to the definitions in `ivocrand.cpp`.
Additionally, `nrn_set_random_sequence` is declared to take an `int` second argument, despite its definition expecting a `long`.

The logic behind this change is that the declarations which are added to `nrnrandom.h` correspond to those that commonly occur in MOD files, even though they are not quite correct. In principle this means that adding these declarations to the headers that are implicitly included in translated MOD files will not introduce compilation failures in these models, because they are the same as the declarations included in the MOD files themselves.
- https://github.com/neuronsimulator/nrn/pull/1755#issuecomment-1084492976 is a counterexample, as there a naming clash in the MOD file means that the declaration in the MOD file is "even more wrong"

The declarations added in this PR correspond to the `[[deprecated]]` overloads of these methods that are included in https://github.com/neuronsimulator/nrn/pull/1597. The motivation for this change is that it makes it easier to update external models to be forward-compatible with https://github.com/neuronsimulator/nrn/pull/1597 ("NEURON 9") -- by removing declarations and adding casts -- while remaining compatible with `master` before that PR is merged (but after **this** PR is merged, "NEURON 8.2").