### PR TITLE
nmodl "EXTERNAL array" should translate as "double array[];"

### DIFF
--- a/src/nmodl/nocpout.cpp
+++ b/src/nmodl/nocpout.cpp
@@ -393,7 +393,7 @@ void parout() {
                 continue;
             }
             if (s->subtype & ARRAY) {
-                Sprintf(buf, "extern double* %s;\n", s->name);
+                Sprintf(buf, "extern double %s[];\n", s->name);
             } else {
                 Sprintf(buf, "extern double %s;\n", s->name);
             }


### PR DESCRIPTION
 (instead of "double* array;")

Otherwise a segfault in the most common case of where the GLOBAL array is declared in another mod file.
