### PR TITLE
NeuronTestHelper: CORENEURON option, reorganise.

### DIFF
--- a/.cmake-format.changes.yaml
+++ b/.cmake-format.changes.yaml
@@ -2,6 +2,7 @@ additional_commands:
   nrn_add_test_group:
     pargs: 0
     kwargs:
+      CORENEURON: 0
       NAME: 1
       MODFILE_PATTERNS: '+'
       NRNIVMODL_ARGS: '+'
@@ -19,12 +20,9 @@ additional_commands:
       PRECOMMAND: '+'
       PROCESSORS: 1
       REQUIRES: '+'
-      MODFILE_PATTERNS: '*'
-      NRNIVMODL_ARGS: '*'
       OUTPUT: '*'
       SCRIPT_PATTERNS: '*'
       SIM_DIRECTORY: '?'
-      SUBMODULE: '?'
   nrn_add_test_group_comparison:
     pargs: 0
     kwargs:

--- a/cmake/NeuronTestHelper.cmake
+++ b/cmake/NeuronTestHelper.cmake
@@ -4,6 +4,7 @@
 # of operation.
 #
 # 1. nrn_add_test_group(NAME name
+#                       [CORENEURON]
 #                       [MODFILE_PATTERNS mod/file/dir/*.mod ...]
 #                       [NRNIVMODL_ARGS arg1 ...]
 #                       [OUTPUT datatype::file.ext ...]
@@ -16,6 +17,10 @@
 #    consists of different configurations of running logically the same
 #    simulation. The outputs of the different configurations will be compared.
 #
+#    CORENEURON       - if this is passed, the mechanisms will be compiled for
+#                       CoreNEURON if CoreNEURON is enabled. You should pass
+#                       this if any test in the group is going to include
+#                       `coreneuron` in its REQUIRES clause.
 #    MODFILE_PATTERNS - a list of patterns that will be matched against the
 #                       submodule directory tree to find the modfiles that must
 #                       be compiled (using nrnivmodl) to run the test. The special
@@ -37,11 +42,10 @@
 #                       assumptions about directory layout.
 #    SUBMODULE        - the name of the git submodule containing test data.
 #
-#    The MODFILE_PATTERNS, NRNIVMODL_ARGS, OUTPUT, SCRIPT_PATTERNS,
-#    SIM_DIRECTORY and SUBMODULE arguments are default values that will be
-#    inherited tests that are added to this group using nrn_add_test.
-#    They can be overriden for specific tests by passing the same keyword
-#    arguments to nrn_add_test.
+#    The OUTPUT, SCRIPT_PATTERNS and SIM_DIRECTORY arguments are default values
+#    that will be inherited by tests that are added to this group using
+#    nrn_add_test. They can be overriden for specific tests by passing the same
+#    keyword arguments to nrn_add_test.
 #
 # 2. nrn_add_test(GROUP group_name
 #                 NAME test_name
@@ -50,12 +54,9 @@
 #                 [PRECOMMAND command ...]
 #                 [PROCESSORS required_processors]
 #                 [REQUIRES feature1 ...]
-#                 [MODFILE_PATTERNS mod/file/dir/*.mod ...]
-#                 [NRNIVMODL_ARGS arg1 ...]
 #                 [OUTPUT datatype::file.ext ...]
 #                 [SCRIPT_PATTERNS "*.py" ...]
 #                 [SIM_DIRECTORY sim_dir]
-#                 [SUBMODULE some/submodule]
 #                )
 #
 #    Create a new integration test inside the given group, which must have
@@ -87,11 +88,14 @@
 # Load the cpp_cc_build_time_copy helper function.
 include("${CODING_CONV_CMAKE}/build-time-copy.cmake")
 function(nrn_add_test_group)
-  # NAME is used as a key, everything else is a default that can be overriden in subsequent calls to
-  # nrn_add_test
+  # NAME is used as a key, [CORENEURON, MODFILE_PATTERNS, NRNIVMODL_ARGS and SUBMODULE] are used to
+  # set up a custom target that runs nrnivmod, everything else is a default that can be overriden in
+  # subsequent calls to nrn_add_test that actually set up CTest tests.
+  set(options CORENEURON)
   set(oneValueArgs NAME SUBMODULE)
   set(multiValueArgs MODFILE_PATTERNS NRNIVMODL_ARGS OUTPUT SCRIPT_PATTERNS SIM_DIRECTORY)
-  cmake_parse_arguments(NRN_ADD_TEST_GROUP "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  cmake_parse_arguments(NRN_ADD_TEST_GROUP "${options}" "${oneValueArgs}" "${multiValueArgs}"
+                        ${ARGN})
   if(DEFINED NRN_ADD_TEST_GROUP_MISSING_VALUES)
     message(
       WARNING
@@ -103,12 +107,6 @@ function(nrn_add_test_group)
 
   # Store the default values for this test group in parent-scope variables based on the group name
   set(prefix NRN_TEST_GROUP_${NRN_ADD_TEST_GROUP_NAME})
-  set(${prefix}_DEFAULT_MODFILE_PATTERNS
-      "${NRN_ADD_TEST_GROUP_MODFILE_PATTERNS}"
-      PARENT_SCOPE)
-  set(${prefix}_DEFAULT_NRNIVMODL_ARGS
-      "${NRN_ADD_TEST_GROUP_NRNIVMODL_ARGS}"
-      PARENT_SCOPE)
   set(${prefix}_DEFAULT_OUTPUT
       "${NRN_ADD_TEST_GROUP_OUTPUT}"
       PARENT_SCOPE)
@@ -118,21 +116,124 @@ function(nrn_add_test_group)
   set(${prefix}_DEFAULT_SIM_DIRECTORY
       "${NRN_ADD_TEST_GROUP_SIM_DIRECTORY}"
       PARENT_SCOPE)
-  set(${prefix}_DEFAULT_SUBMODULE
-      "${NRN_ADD_TEST_GROUP_SUBMODULE}"
+  # Set up a target that runs nrnivmodl for this group of tests. First, make sure the specified
+  # submodule is initialised. If there is no submodule, everything is relative to the root nrn/
+  # directory.
+  if(NOT ${NRN_ADD_TEST_GROUP_SUBMODULE} STREQUAL "")
+    cpp_cc_git_submodule(${NRN_ADD_TEST_GROUP_SUBMODULE} QUIET)
+    # Construct the name of the source tree directory where the submodule has been checked out.
+    set(test_source_directory "${PROJECT_SOURCE_DIR}/external/${NRN_ADD_TEST_GROUP_SUBMODULE}")
+  else()
+    set(test_source_directory "${PROJECT_SOURCE_DIR}")
+  endif()
+  set(${prefix}_TEST_SOURCE_DIRECTORY
+      "${test_source_directory}"
       PARENT_SCOPE)
+  if(NOT DEFINED NRN_RUN_FROM_BUILD_DIR_ENV)
+    # To avoid duplication we take this value from the {nrn}/test/CMakeLists.txt file by assuming
+    # this variable name.
+    message(WARNING "nrn_add_test: NRN_RUN_FROM_BUILD_DIR_ENV was not defined;"
+                    " building test files may not work")
+  endif()
+  if(NOT "${NRN_ADD_TEST_GROUP_MODFILE_PATTERNS}" STREQUAL "NONE")
+    # Add a rule to build the modfiles for this test group. Multiple groups may ask for exactly the
+    # same thing (testcorenrn), so it's worth deduplicating.
+    set(hash_components ${NRN_ADD_TEST_GROUP_NRNIVMODL_ARGS})
+    set(nrnivmodl_command cmake -E env ${NRN_RUN_FROM_BUILD_DIR_ENV}
+                          ${CMAKE_BINARY_DIR}/bin/nrnivmodl ${NRN_ADD_TEST_GROUP_NRNIVMODL_ARGS})
+    # The user decides whether or not this test group should have its MOD files compiled for
+    # CoreNEURON.
+    set(nrnivmodl_dependencies)
+    if(NRN_ADD_TEST_GROUP_CORENEURON AND NRN_ENABLE_CORENEURON)
+      list(APPEND hash_components -coreneuron)
+      list(APPEND nrnivmodl_dependencies ${CORENEURON_TARGET_TO_DEPEND})
+      list(APPEND nrnivmodl_command -coreneuron)
+    endif()
+    list(APPEND nrnivmodl_command .)
+    # Collect the list of modfiles that need to be compiled.
+    set(modfiles)
+    foreach(modfile_pattern ${NRN_ADD_TEST_GROUP_MODFILE_PATTERNS})
+      file(GLOB pattern_modfiles "${test_source_directory}/${modfile_pattern}")
+      list(APPEND modfiles ${pattern_modfiles})
+    endforeach()
+    if("${modfiles}" STREQUAL "")
+      message(WARNING "Didn't find any modfiles in ${test_source_directory} "
+                      "using ${NRN_ADD_TEST_GROUP_MODFILE_PATTERNS}")
+    endif()
+    list(SORT modfiles)
+    foreach(modfile ${modfiles})
+      # ${modfile} is an absolute path starting with ${PROJECT_SOURCE_DIR}, let's only add the part
+      # below this common prefix to the hash
+      string(LENGTH "${PROJECT_SOURCE_DIR}/" prefix_length)
+      string(SUBSTRING "${modfile}" ${prefix_length} -1 relative_modfile)
+      list(APPEND hash_components "${relative_modfile}")
+    endforeach()
+    # Get a hash that forms the working directory for nrnivmodl.
+    string(SHA256 nrnivmodl_command_hash "${hash_components}")
+    # Construct the name of a target that refers to the compiled special binaries
+    set(binary_target_name "NRN_TEST_nrnivmodl_${nrnivmodl_command_hash}")
+    set(nrnivmodl_directory "${PROJECT_BINARY_DIR}/test/nrnivmodl/${nrnivmodl_command_hash}")
+    # Short-circuit if the target has already been created.
+    if(NOT TARGET "${binary_target_name}")
+      # Copy modfiles from source -> build tree.
+      foreach(modfile ${modfiles})
+        # Construct the build tree path of the modfile.
+        get_filename_component(modfile_name "${modfile}" NAME)
+        set(modfile_build_path "${nrnivmodl_directory}/${modfile_name}")
+        # Add a build rule that copies this modfile from the source tree to the build tree.
+        cpp_cc_build_time_copy(
+          INPUT "${modfile}"
+          OUTPUT "${modfile_build_path}"
+          NO_TARGET)
+        # Store a list of the modfile paths in the build tree so we can declare nrnivmodl's
+        # dependency on these.
+        list(APPEND modfile_build_paths "${modfile_build_path}")
+      endforeach()
+      # Construct the names of the important output files
+      set(special "${nrnivmodl_directory}/${CMAKE_HOST_SYSTEM_PROCESSOR}/special")
+      # Add the custom command to generate the binaries. Get nrnivmodl from the build directory. At
+      # the moment it seems that `nrnivmodl` is generated at configure time, so there is no target
+      # to depend on and it should always be available, but it will try and link against libnrniv.so
+      # and libcoreneuron.so so we must depend on those. TODO: could the logic of `nrnivmodl` be
+      # translated to CMake, so it can be called natively here and the `nrnivmodl` executable would
+      # be a wrapper that invokes CMake?
+      set(output_binaries "${special}")
+      list(APPEND nrnivmodl_dependencies nrniv_lib)
+      if(NRN_ADD_TEST_GROUP_CORENEURON)
+        list(APPEND output_binaries "${special}-core")
+        if((NOT coreneuron_FOUND) AND (NOT DEFINED CORENEURON_BUILTIN_MODFILES))
+          message(WARNING "nrn_add_test_group couldn't find the names of the builtin "
+                          "CoreNEURON modfiles that nrnivmodl-core implicitly depends "
+                          "on *and* CoreNEURON is being built internally")
+        endif()
+        list(APPEND nrnivmodl_dependencies ${CORENEURON_BUILTIN_MODFILES})
+      endif()
+      add_custom_command(
+        OUTPUT ${output_binaries}
+        DEPENDS ${nrnivmodl_dependencies} ${modfile_build_paths}
+        COMMAND ${nrnivmodl_command}
+        COMMENT "Building special[-core] for test group ${NRN_ADD_TEST_GROUP_NAME}"
+        WORKING_DIRECTORY "${nrnivmodl_directory}")
+      # Add a target that depends on the binaries that will always be built.
+      add_custom_target(${binary_target_name} DEPENDS ${output_binaries})
+    endif()
+    set(${prefix}_NRNIVMODL_DIRECTORY
+        "${nrnivmodl_directory}"
+        PARENT_SCOPE)
+    set(${prefix}_NRNIVMODL_TARGET_NAME
+        "${binary_target_name}"
+        PARENT_SCOPE)
+  endif()
 endfunction()
 
 function(nrn_add_test)
   # Parse the function arguments
-  set(oneValueArgs GROUP NAME PROCESSORS SUBMODULE)
+  set(oneValueArgs GROUP NAME PROCESSORS)
   set(multiValueArgs
       COMMAND
       CONFLICTS
       PRECOMMAND
       REQUIRES
-      MODFILE_PATTERNS
-      NRNIVMODL_ARGS
       OUTPUT
       SCRIPT_PATTERNS
       SIM_DIRECTORY)
@@ -144,16 +245,6 @@ function(nrn_add_test)
   if(DEFINED NRN_ADD_TEST_UNPARSED_ARGUMENTS)
     message(WARNING "nrn_add_test: unknown arguments: ${NRN_ADD_TEST_UNPARSED_ARGUMENTS}")
   endif()
-
-  if(NOT DEFINED NRN_RUN_FROM_BUILD_DIR_ENV)
-    # To avoid duplication we take this value from the {nrn}/test/CMakeLists.txt file by assuming
-    # this variable name.
-    message(
-      WARNING
-        "nrn_add_test: NRN_RUN_FROM_BUILD_DIR_ENV was not defined; building test files may not work"
-    )
-  endif()
-
   # Check if the REQUIRES and/or CONFLICTS arguments mean we should disable this test.
   set(feature_cpu_enabled ON)
   set(feature_mpi_enabled ${NRN_ENABLE_MPI})
@@ -195,24 +286,22 @@ function(nrn_add_test)
       return()
     endif()
   endforeach()
-
   # Get the prefix under which we stored information about this test group
   set(prefix NRN_TEST_GROUP_${NRN_ADD_TEST_GROUP})
-
-  # Get the submodule etc. variables that have global defaults but which can be overriden locally
-  set(modfile_patterns "${${prefix}_DEFAULT_MODFILE_PATTERNS}")
-  set(nrnivmodl_args "${${prefix}_DEFAULT_NRNIVMODL_ARGS}")
+  # Name of the target created by nrn_add_test_group that we should depend on. This might not exist
+  # if the test group does not have any MOD files of its own.
+  set(binary_target_name "${${prefix}_NRNIVMODL_TARGET_NAME}")
+  if(TARGET "${binary_target_name}")
+    # Directory where nrn_add_test_group ran nrnivmodl. If the target exists, this will be created.
+    set(nrnivmodl_directory "${${prefix}_NRNIVMODL_DIRECTORY}")
+  endif()
+  # Path to the test repository.
+  set(test_source_directory "${${prefix}_TEST_SOURCE_DIRECTORY}")
+  # Get the variables that have global defaults but which can be overriden locally
   set(output_files "${${prefix}_DEFAULT_OUTPUT}")
   set(script_patterns "${${prefix}_DEFAULT_SCRIPT_PATTERNS}")
   set(sim_directory "${${prefix}_DEFAULT_SIM_DIRECTORY}")
-  set(submodule "${${prefix}_DEFAULT_SUBMODULE}")
   # Override them locally if appropriate
-  if(DEFINED NRN_ADD_TEST_MODFILE_PATTERNS)
-    set(modfile_patterns "${NRN_ADD_TEST_MODFILE_PATTERNS}")
-  endif()
-  if(DEFINED NRN_ADD_TEST_NRNIVMODL_ARGS)
-    set(nrnivmodl_args "${NRN_ADD_TEST_NRNIVMODL_ARGS}")
-  endif()
   if(DEFINED NRN_ADD_TEST_OUTPUT)
     set(output_files "${NRN_ADD_TEST_OUTPUT}")
   endif()
@@ -222,117 +311,18 @@ function(nrn_add_test)
   if(DEFINED NRN_ADD_TEST_SIM_DIRECTORY)
     set(sim_directory "${NRN_ADD_TEST_SIM_DIRECTORY}")
   endif()
-  if(DEFINED NRN_ADD_TEST_SUBMODULE)
-    set(submodule "${NRN_ADD_TEST_SUBMODULE}")
-  endif()
-  # First, make sure the specified submodule is initialised. If there is no submodule, everything is
-  # relative to the root nrn/ directory.
-  if(NOT ${submodule} STREQUAL "")
-    cpp_cc_git_submodule(${submodule} QUIET)
-    # Construct the name of the source tree directory where the submodule has been checked out.
-    set(test_source_directory "${PROJECT_SOURCE_DIR}/external/${submodule}")
-  else()
-    set(test_source_directory "${PROJECT_SOURCE_DIR}")
-  endif()
-  # Construct the name of a working directory in the build tree for this group of tests
-  set(group_working_directory "${PROJECT_BINARY_DIR}/test/${NRN_ADD_TEST_GROUP}")
   # Finally a working directory for this specific test within the group
-  set(working_directory "${group_working_directory}/${NRN_ADD_TEST_NAME}")
+  set(working_directory "${PROJECT_BINARY_DIR}/test/${NRN_ADD_TEST_GROUP}/${NRN_ADD_TEST_NAME}")
   file(MAKE_DIRECTORY "${working_directory}")
   if(NOT ${sim_directory} STREQUAL "")
     set(simulation_directory ${working_directory}/${sim_directory})
   else()
     set(simulation_directory ${working_directory})
   endif()
-  if(NOT "${modfile_patterns}" STREQUAL "NONE")
-    # Add a rule to build the modfiles for this test. The assumption is that it is likely that most
-    # members of the group will ask for exactly the same thing, so it's worth de-duplicating.
-    set(nrnivmodl_command cmake -E env ${NRN_RUN_FROM_BUILD_DIR_ENV}
-                          ${CMAKE_BINARY_DIR}/bin/nrnivmodl ${nrnivmodl_args})
-    set(hash_components nrnivmodl ${nrnivmodl_args})
-    # This condition used to be `requires_coreneuron`. This tends to mean that NEURON and CoreNEURON
-    # versions of a test will share the same hash, which is probably fine, but also means that any
-    # NEURON-only tests will be compiled for CoreNEURON too.
-    set(nrnivmodl_dependencies)
-    if(NRN_ENABLE_CORENEURON)
-      list(APPEND nrnivmodl_dependencies ${CORENEURON_TARGET_TO_DEPEND})
-      list(APPEND nrnivmodl_command -coreneuron)
-      list(APPEND hash_components -coreneuron)
-    endif()
-    list(APPEND nrnivmodl_command .)
-    # Collect the list of modfiles that need to be compiled.
-    set(modfiles)
-    foreach(modfile_pattern ${modfile_patterns})
-      file(GLOB pattern_modfiles "${test_source_directory}/${modfile_pattern}")
-      list(APPEND modfiles ${pattern_modfiles})
-    endforeach()
-    if("${modfiles}" STREQUAL "")
-      message(
-        WARNING "Didn't find any modfiles in ${test_source_directory} using ${modfile_patterns}")
-    endif()
-    list(SORT modfiles)
-    foreach(modfile ${modfiles})
-      # ${modfile} is an absolute path starting with ${PROJECT_SOURCE_DIR}, let's only add the part
-      # below this common prefix to the hash
-      string(LENGTH "${PROJECT_SOURCE_DIR}/" prefix_length)
-      string(SUBSTRING "${modfile}" ${prefix_length} -1 relative_modfile)
-      list(APPEND hash_components "${relative_modfile}")
-    endforeach()
-    # Get a hash of the nrnivmodl arguments and use that to make a unique working directory
-    string(SHA256 nrnivmodl_command_hash "${hash_components}")
-    # Construct the name of a target that refers to the compiled special binaries
-    set(binary_target_name "NRN_TEST_nrnivmodl_${nrnivmodl_command_hash}")
-    set(nrnivmodl_working_directory
-        "${PROJECT_BINARY_DIR}/test/nrnivmodl/${nrnivmodl_command_hash}")
-    # Short-circuit in case we set up these rules already
-    if(NOT TARGET ${binary_target_name})
-      # Copy modfiles from source -> build tree.
-      foreach(modfile ${modfiles})
-        # Construct the build tree path of the modfile.
-        get_filename_component(modfile_name "${modfile}" NAME)
-        set(modfile_build_path "${nrnivmodl_working_directory}/${modfile_name}")
-        # Add a build rule that copies this modfile from the source tree to the build tree.
-        cpp_cc_build_time_copy(
-          INPUT "${modfile}"
-          OUTPUT "${modfile_build_path}"
-          NO_TARGET)
-        # Store a list of the modfile paths in the build tree so we can declare nrnivmodl's
-        # dependency on these.
-        list(APPEND modfile_build_paths "${modfile_build_path}")
-      endforeach()
-      # Construct the names of the important output files
-      set(special "${nrnivmodl_working_directory}/${CMAKE_HOST_SYSTEM_PROCESSOR}/special")
-      # Add the custom command to generate the binaries. Get nrnivmodl from the build directory. At
-      # the moment it seems that `nrnivmodl` is generated at configure time, so there is no target
-      # to depend on and it should always be available, but it will try and link against libnrniv.so
-      # and libcoreneuron.so so we must depend on those. TODO: could the logic of `nrnivmodl` be
-      # translated to CMake, so it can be called natively here and the `nrnivmodl` executable would
-      # be a wrapper that invokes CMake?
-      set(output_binaries "${special}")
-      list(APPEND nrnivmodl_dependencies nrniv_lib)
-      if(requires_coreneuron)
-        list(APPEND output_binaries "${special}-core")
-        if((NOT coreneuron_FOUND) AND (NOT DEFINED CORENEURON_BUILTIN_MODFILES))
-          message(
-            WARNING
-              "nrn_add_test couldn't find the names of the builtin CoreNEURON modfiles that nrnivmodl-core implicitly depends on *and* CoreNEURON is being built internally"
-          )
-        endif()
-        list(APPEND nrnivmodl_dependencies ${CORENEURON_BUILTIN_MODFILES})
-      endif()
-      add_custom_command(
-        OUTPUT ${output_binaries}
-        DEPENDS ${nrnivmodl_dependencies} ${modfile_build_paths}
-        COMMAND ${nrnivmodl_command}
-        COMMENT "Building special[-core] for test ${NRN_ADD_TEST_GROUP}::${NRN_ADD_TEST_NAME}"
-        WORKING_DIRECTORY ${nrnivmodl_working_directory})
-      # Add a target that depends on the binaries that will always be built.
-      add_custom_target(${binary_target_name} ALL DEPENDS ${output_binaries})
-    endif()
+  if(DEFINED nrnivmodl_directory)
     execute_process(
       COMMAND
-        ${CMAKE_COMMAND} -E create_symlink
-        "${nrnivmodl_working_directory}/${CMAKE_HOST_SYSTEM_PROCESSOR}"
+        ${CMAKE_COMMAND} -E create_symlink "${nrnivmodl_directory}/${CMAKE_HOST_SYSTEM_PROCESSOR}"
         "${working_directory}/${CMAKE_HOST_SYSTEM_PROCESSOR}")
   endif()
   # Set up the actual test. First, collect the script files that need to be copied into the test-
@@ -355,12 +345,15 @@ function(nrn_add_test)
       list(APPEND all_copied_script_files "${working_directory}/${script_file}")
     endforeach()
   endforeach()
-
   # Construct the name of the test and store it in a parent-scope list to be used when setting up
   # the comparison job
   set(test_name "${NRN_ADD_TEST_GROUP}::${NRN_ADD_TEST_NAME}")
   add_custom_target(copy-scripts-${NRN_ADD_TEST_GROUP}-${NRN_ADD_TEST_NAME} ALL
                     DEPENDS ${all_copied_script_files})
+  # Depend on the target that runs nrnivmodl, if it exists. Otherwise it will not be run.
+  if(TARGET ${binary_target_name})
+    add_dependencies(copy-scripts-${NRN_ADD_TEST_GROUP}-${NRN_ADD_TEST_NAME} ${binary_target_name})
+  endif()
   set(group_members "${${prefix}_TESTS}")
   list(APPEND group_members "${test_name}")
   set(${prefix}_TESTS
@@ -392,20 +385,24 @@ function(nrn_add_test)
   endif()
   set(test_env "${NRN_RUN_FROM_BUILD_DIR_ENV}")
   if(requires_coreneuron)
-    if(DEFINED nrnivmodl_working_directory)
-      set(test_env
-          "${test_env};CORENEURONLIB=${nrnivmodl_working_directory}/${CMAKE_HOST_SYSTEM_PROCESSOR}/libcorenrnmech${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    if(DEFINED nrnivmodl_directory)
+      list(
+        APPEND
+        test_env
+        "CORENEURONLIB=${nrnivmodl_directory}/${CMAKE_HOST_SYSTEM_PROCESSOR}/libcorenrnmech${CMAKE_SHARED_LIBRARY_SUFFIX}"
       )
     else()
-      set(test_env
-          "${test_env};CORENEURONLIB=${CMAKE_BINARY_DIR}/bin/${CMAKE_HOST_SYSTEM_PROCESSOR}/libcorenrnmech${CMAKE_SHARED_LIBRARY_SUFFIX}"
+      list(
+        APPEND
+        test_env
+        "CORENEURONLIB=${CMAKE_BINARY_DIR}/bin/${CMAKE_HOST_SYSTEM_PROCESSOR}/libcorenrnmech${CMAKE_SHARED_LIBRARY_SUFFIX}"
       )
     endif()
   endif()
-  if(DEFINED nrnivmodl_working_directory)
-    set(path_additions "${nrnivmodl_working_directory}/${CMAKE_HOST_SYSTEM_PROCESSOR}:")
+  if(DEFINED nrnivmodl_directory)
+    set(path_additions "${nrnivmodl_directory}/${CMAKE_HOST_SYSTEM_PROCESSOR}:")
   endif()
-  set(test_env "${test_env};PATH=${path_additions}${CMAKE_BINARY_DIR}/bin:$ENV{PATH}")
+  list(APPEND test_env "PATH=${path_additions}${CMAKE_BINARY_DIR}/bin:$ENV{PATH}")
   set_tests_properties(${test_names} PROPERTIES ENVIRONMENT "${test_env}")
 
   # Construct an expression containing the names of the test output files that will be passed to the

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -141,13 +141,12 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
     unset(PYTEST_COVERAGE_ARGS)
   endif()
   # TODO: consider allowing the group-related parts to be dropped here
-  nrn_add_test_group(NAME pynrn_tests)
+  nrn_add_test_group(NAME pynrn MODFILE_PATTERNS test/pynrn/*.mod)
   nrn_add_test(
-    GROUP pynrn_tests
+    GROUP pynrn
     NAME basic_tests
     COMMAND COVERAGE_FILE=.coverage.basic_tests ${PYTHON_EXECUTABLE} -m pytest
             ${PYTEST_COVERAGE_ARGS} ./test/pynrn
-    MODFILE_PATTERNS test/pynrn/*.mod
     SCRIPT_PATTERNS test/pynrn/*.py)
 
   if(NRN_ENABLE_RX3D)
@@ -252,6 +251,7 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
   # builds (in near future we want to support only internal builds anyway)
   if(NOT nrn_using_ext_corenrn)
     nrn_add_test_group(
+      CORENEURON
       NAME coreneuron_standalone
       SCRIPT_PATTERNS test/coreneuron/test_psolve.py
       MODFILE_PATTERNS NONE)
@@ -266,6 +266,7 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
   endif()
 
   nrn_add_test_group(
+    CORENEURON
     NAME coreneuron_modtests
     # This get used in 4 tests so make it the default and override in other tests.
     SCRIPT_PATTERNS test/coreneuron/test_spikes.py

--- a/test/external/channel-benchmark/CMakeLists.txt
+++ b/test/external/channel-benchmark/CMakeLists.txt
@@ -19,6 +19,7 @@ set(channel_benchmark_gpu_args -c arg_coreneuron_gpu=1) # TODO: test --cell-perm
 set(channel_benchmark_filemode_args -c arg_coreneuron_filemode=1)
 foreach(model hippo sscx)
   nrn_add_test_group(
+    CORENEURON
     NAME channel_benchmark_${model}
     SUBMODULE tests/channel-benchmark
     OUTPUT asciispikes::out.dat

--- a/test/external/olfactory-bulb-3d/CMakeLists.txt
+++ b/test/external/olfactory-bulb-3d/CMakeLists.txt
@@ -13,6 +13,7 @@ set(olfactory_bulb_3d_neuron_prefix
     ${MPIEXEC_POSTFLAGS})
 
 nrn_add_test_group(
+  CORENEURON
   NAME olfactory-bulb-3d
   SUBMODULE tests/olfactory-bulb-3d
   OUTPUT asciispikes::olfactory_bulb.spikes.dat.000

--- a/test/external/reduced_dentate/CMakeLists.txt
+++ b/test/external/reduced_dentate/CMakeLists.txt
@@ -1,5 +1,6 @@
 include(NeuronTestHelper)
 nrn_add_test_group(
+  CORENEURON
   NAME reduced_dentate
   SUBMODULE tests/reduced_dentate
   OUTPUT "asciispikes::results/dentatenet_spikeout_*.dat"

--- a/test/external/ringtest/CMakeLists.txt
+++ b/test/external/ringtest/CMakeLists.txt
@@ -2,6 +2,7 @@
 include(NeuronTestHelper)
 # Step 1 -- define a group of configurations
 nrn_add_test_group(
+  CORENEURON
   NAME external_ringtest
   SUBMODULE tests/ringtest # git submodule where the relevant tests are defined
   MODFILE_PATTERNS "mod/*.mod"

--- a/test/external/testcorenrn/CMakeLists.txt
+++ b/test/external/testcorenrn/CMakeLists.txt
@@ -13,7 +13,7 @@ set(spike_comparison_tests
 set(modfiles mod/Gfluct3.mod mod/hhderiv.mod mod/hhwatch.mod mod/nacum.mod mod/vecevent.mod)
 if(NOT CORENRN_ENABLE_NMODL OR NOT CORENRN_ENABLE_GPU)
   # These .mod files cannot be compiled with NMODL + OpenACC/GPU because of
-  # https://github.com/BlueBrain/nmodl/issues/311
+  # https://github.com/BlueBrain/nmodl/issues/311 <-- this is apparently fixed?
   list(APPEND modfiles mod/hhkin.mod)
   # These tests depend on the modfiles on the line above.
   list(APPEND spike_comparison_tests conc kin)
@@ -64,6 +64,7 @@ foreach(test ${spike_comparison_tests})
     set(num_ranks 1)
   endif()
   nrn_add_test_group(
+    CORENEURON
     NAME testcorenrn_${test}
     SUBMODULE tests/testcorenrn
     MODFILE_PATTERNS ${modfiles}
@@ -187,6 +188,7 @@ foreach(test ${direct_tests})
     set(num_ranks 1)
   endif()
   nrn_add_test_group(
+    CORENEURON
     NAME testcorenrn_${test}
     SUBMODULE tests/testcorenrn
     MODFILE_PATTERNS ${modfiles}

--- a/test/external/testcorenrn/CMakeLists.txt
+++ b/test/external/testcorenrn/CMakeLists.txt
@@ -3,21 +3,17 @@ include(NeuronTestHelper)
 set(direct_tests netstimdirect)
 set(spike_comparison_tests
     bbcore
+    conc
     deriv
     gf
+    kin
     patstim
     vecplay
     vecevent
     watch)
 
-set(modfiles mod/Gfluct3.mod mod/hhderiv.mod mod/hhwatch.mod mod/nacum.mod mod/vecevent.mod)
-if(NOT CORENRN_ENABLE_NMODL OR NOT CORENRN_ENABLE_GPU)
-  # These .mod files cannot be compiled with NMODL + OpenACC/GPU because of
-  # https://github.com/BlueBrain/nmodl/issues/311 <-- this is apparently fixed?
-  list(APPEND modfiles mod/hhkin.mod)
-  # These tests depend on the modfiles on the line above.
-  list(APPEND spike_comparison_tests conc kin)
-endif()
+set(modfiles mod/Gfluct3.mod mod/hhderiv.mod mod/hhkin.mod mod/hhwatch.mod mod/nacum.mod
+             mod/vecevent.mod)
 
 # Set the number of MPI ranks to use for each test. Assume 1 if not explicitly specified.
 set(mpi_ranks_gf 2)

--- a/test/external/tqperf/CMakeLists.txt
+++ b/test/external/tqperf/CMakeLists.txt
@@ -1,8 +1,10 @@
 include(NeuronTestHelper)
 nrn_add_test_group(
+  CORENEURON
   NAME tqperf
   SUBMODULE tests/tqperf
   MODFILE_PATTERNS "mod/*.mod" "modx/*.mod"
+  NRNIVMODL_ARGS -incflags "-I${OPENSSL_INCLUDE_DIR}" -loadflags "${OPENSSL_CRYPTO_LIBRARY}"
   SCRIPT_PATTERNS "test1.py" "*.hoc")
 if("tqperf-heavy" IN_LIST NRN_ENABLE_MODEL_TESTS)
   set(tqperf_mpi_ranks 16)
@@ -15,6 +17,5 @@ nrn_add_test(
   CONFLICTS nmodl # https://github.com/BlueBrain/nmodl/issues/794
   REQUIRES mpi python coreneuron
   PROCESSORS ${tqperf_mpi_ranks}
-  NRNIVMODL_ARGS -incflags "-I${OPENSSL_INCLUDE_DIR}" -loadflags "${OPENSSL_CRYPTO_LIBRARY}"
   COMMAND ${MPIEXEC_NAME} ${MPIEXEC_NUMPROC_FLAG} ${tqperf_mpi_ranks} ${MPIEXEC_OVERSUBSCRIBE}
           ${MPIEXEC_PREFLAGS} special ${MPIEXEC_POSTFLAGS} -mpi -python test1.py)


### PR DESCRIPTION
- Create `nrnivmodl` targets in `nrn_add_test_group` and add a `CORENEURON` option to that command. This means that we do not have to compile *all* MOD files for CoreNEURON if CoreNEURON is enabled in the build.
- Drop `MODFILE_PATTERNS`, `NRNIVMODL_ARGS` and `SUBMODULE` arguments to `nrn_add_test` that were not being used.
- The same de-duplication is done as before, so there is no change to the number of `nrnivmodl` invocations, but some targets no longer pass `-coreneuron` to `nrnivmodl`.

Motivated because I realised that the test framework was requiring that even MOD files for NEURON-only tests were compilable for CoreNEURON. This also speeds things up a little, as we skip some `nrnivmodl-core` invocations.

Also remove some test exclusions in `testcorenrn` because the referenced issue (https://github.com/BlueBrain/nmodl/issues/311) was closed. Hopefully they will work now; https://bbpgitlab.epfl.ch/hpc/coreneuron/-/pipelines/46658 should confirm.