### PR TITLE
get `c91662.CNG.swc` from `neuronsimulator/resources`

### DIFF
--- a/docs/rxd-tutorials/basic-initialization.ipynb
+++ b/docs/rxd-tutorials/basic-initialization.ipynb
@@ -231,7 +231,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we use the morphology <a href=\"https://github.com/neuronsimulator/resources/blob/master/notebooks/rxd/c91662.CNG.swc\">c91662.CNG.swc</a> from NeuroMorpho.Org and initialize based on <i>path distance</i> from the soma."
+    "Here we use the morphology <a href=\"https://github.com/neuronsimulator/resources/blob/8b1290d5c8ab748dd6251be5bd46a4e3794d742f/notebooks/rxd/c91662.CNG.swc\">c91662.CNG.swc</a> obtained from NeuroMorpho.Org and initialize based on <i>path distance</i> from the soma."
    ]
   },
   {
@@ -240,7 +240,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget -N https://raw.githubusercontent.com/neuronsimulator/resources/master/notebooks/rxd/c91662.CNG.swc"
+    "!wget -N https://raw.githubusercontent.com/neuronsimulator/resources/8b1290d5c8ab748dd6251be5bd46a4e3794d742f/notebooks/rxd/c91662.CNG.swc"
    ]
   },
   {

--- a/docs/rxd-tutorials/basic-initialization.ipynb
+++ b/docs/rxd-tutorials/basic-initialization.ipynb
@@ -231,7 +231,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we use the morphology <a href=\"http://neuromorpho.org/dableFiles/amaral/CNG%20version/c91662.CNG.swc\">c91662.CNG.swc</a> from NeuroMorpho.Org and initialize based on <i>path distance</i> from the soma."
+    "Here we use the morphology <a href=\"https://github.com/neuronsimulator/resources/blob/master/notebooks/rxd/c91662.CNG.swc\">c91662.CNG.swc</a> from NeuroMorpho.Org and initialize based on <i>path distance</i> from the soma."
    ]
   },
   {
@@ -240,7 +240,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget --no-check-certificate --ciphers DEFAULT:@SECLEVEL=1 https://neuromorpho.org/dableFiles/amaral/CNG%20version/c91662.CNG.swc"
+    "!wget -N https://raw.githubusercontent.com/neuronsimulator/resources/master/notebooks/rxd/c91662.CNG.swc"
    ]
   },
   {

--- a/docs/rxd-tutorials/extracellular.ipynb
+++ b/docs/rxd-tutorials/extracellular.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "<ul>\n",
     "\t<li>steady_k.mod</a></li>\n",
-    "\t<li><a href=\"https://github.com/neuronsimulator/resources/blob/master/notebooks/rxd/c91662.CNG.swc\">c91662.CNG.swc</a></li>\n",
+    "\t<li><a href=\"https://github.com/neuronsimulator/resources/blob/8b1290d5c8ab748dd6251be5bd46a4e3794d742f/notebooks/rxd/c91662.CNG.swc\">c91662.CNG.swc</a></li>\n",
     "</ul>\n",
     "\n",
     "<p>The first is simple mechanism written for this tutorial that releases potassium at a constant rate per surface area. The second is a morphology from NeuroMorpho.Org.</p>\n"
@@ -70,7 +70,7 @@
     "from urllib.request import urlretrieve\n",
     "\n",
     "urlretrieve(\n",
-    "    \"https://raw.githubusercontent.com/neuronsimulator/resources/master/notebooks/rxd/c91662.CNG.swc\",\n",
+    "    \"https://raw.githubusercontent.com/neuronsimulator/resources/8b1290d5c8ab748dd6251be5bd46a4e3794d742f/notebooks/rxd/c91662.CNG.swc\",\n",
     "    \"c91662.swc\",\n",
     ")"
    ]

--- a/docs/rxd-tutorials/extracellular.ipynb
+++ b/docs/rxd-tutorials/extracellular.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "<ul>\n",
     "\t<li>steady_k.mod</a></li>\n",
-    "\t<li><a href=\"http://neuromorpho.org/dableFiles/amaral/CNG%20version/c91662.CNG.swc\">c91662.CNG.swc</a></li>\n",
+    "\t<li><a href=\"https://github.com/neuronsimulator/resources/blob/master/notebooks/rxd/c91662.CNG.swc\">c91662.CNG.swc</a></li>\n",
     "</ul>\n",
     "\n",
     "<p>The first is simple mechanism written for this tutorial that releases potassium at a constant rate per surface area. The second is a morphology from NeuroMorpho.Org.</p>\n"
@@ -68,18 +68,9 @@
    "source": [
     "# Download morphology\n",
     "from urllib.request import urlretrieve\n",
-    "import ssl\n",
     "\n",
-    "\n",
-    "def make_context():\n",
-    "    ctx = ssl._create_unverified_context()\n",
-    "    ctx.set_ciphers(\"DEFAULT:@SECLEVEL=1\")\n",
-    "    return ctx\n",
-    "\n",
-    "\n",
-    "ssl._create_default_https_context = make_context\n",
     "urlretrieve(\n",
-    "    \"http://neuromorpho.org/dableFiles/amaral/CNG%20version/c91662.CNG.swc\",\n",
+    "    \"https://raw.githubusercontent.com/neuronsimulator/resources/master/notebooks/rxd/c91662.CNG.swc\",\n",
     "    \"c91662.swc\",\n",
     ")"
    ]


### PR DESCRIPTION
* introduce `neuronsimulator/resources` 
* get rid of extra code required for certificate handling

Closes #1789 