### PR TITLE
oc_ansi.h: add some definitions used in mods (ModedlDB & BBP)

### DIFF
--- a/src/nrniv/bgpdmasetup.cpp
+++ b/src/nrniv/bgpdmasetup.cpp
@@ -141,7 +141,7 @@ all2allv_int lists space=3088 total=37351312 time=4.4708e-05
 */
 #define all2allv_perf 0
 extern "C" {
-extern unsigned long long nrn_mallinfo(int);
+extern size_t nrn_mallinfo(int);
 }  // extern "C"
 // input s, scnt, sdispl ; output, newly allocated r, rcnt, rdispl
 static void

--- a/src/nrniv/bgpdmasetup.cpp
+++ b/src/nrniv/bgpdmasetup.cpp
@@ -8,6 +8,8 @@ we construct a gid target host list on host gid%nhost and copy that list to
 the source host owning the gid.
 */
 
+#include "oc_ansi.h"
+
 #if 0
 void celldebug(const char* p, Gid2PreSyn& map) {
 	FILE* f;
@@ -140,9 +142,6 @@ all2allv_int gidout space=528 total=37379376 time=1.641e-05
 all2allv_int lists space=3088 total=37351312 time=4.4708e-05
 */
 #define all2allv_perf 0
-extern "C" {
-extern size_t nrn_mallinfo(int);
-}  // extern "C"
 // input s, scnt, sdispl ; output, newly allocated r, rcnt, rdispl
 static void
 all2allv_int(int* s, int* scnt, int* sdispl, int*& r, int*& rcnt, int*& rdispl, const char* dmes) {

--- a/src/oc/oc_ansi.h
+++ b/src/oc/oc_ansi.h
@@ -277,7 +277,7 @@ extern int hoc_is_tempobj_arg(int narg);
 extern FILE* hoc_obj_file_arg(int i);
 extern void hoc_reg_nmodl_text(int type, const char* txt);
 extern void hoc_reg_nmodl_filename(int type, const char* filename);
-extern unsigned long long nrn_mallinfo(int item);
+extern size_t nrn_mallinfo(int item);
 extern int nrn_mlh_gsort(double* vec, int* base_ptr, int total_elems, int (*cmp)(double, double));
 extern void state_discontinuity(int i, double* pd, double d);
 

--- a/src/oc/oc_ansi.h
+++ b/src/oc/oc_ansi.h
@@ -281,7 +281,6 @@ extern size_t nrn_mallinfo(int item);
 extern int nrn_mlh_gsort(double* vec, int* base_ptr, int total_elems, int (*cmp)(double, double));
 extern void state_discontinuity(int i, double* pd, double d);
 
-extern Symbol* hoc_get_symbol(const char* var);
 extern double nrn_event_queue_stats(double* stats);
 extern double* nrn_recalc_ptr(double*);
 extern void nrn_register_recalc_ptr_callback(Pfrv f);

--- a/src/oc/oc_ansi.h
+++ b/src/oc/oc_ansi.h
@@ -272,6 +272,29 @@ extern int nrn_is_cable(void);
 extern int nrn_isdouble(double*, double, double);
 extern void* nrn_opaque_obj2pyobj(Object*);  // PyObject reference not incremented
 
+extern double hoc_Exp(double);
+extern int hoc_is_tempobj_arg(int narg);
+extern FILE* hoc_obj_file_arg(int i);
+extern void hoc_reg_nmodl_text(int type, const char* txt);
+extern void hoc_reg_nmodl_filename(int type, const char* filename);
+extern unsigned long long nrn_mallinfo(int item);
+extern int nrn_mlh_gsort(double* vec, int* base_ptr, int total_elems, int (*cmp)(double, double));
+extern void state_discontinuity(int i, double* pd, double d);
+
+extern Symbol* hoc_get_symbol(const char* var);
+extern double nrn_event_queue_stats(double* stats);
+extern double* nrn_recalc_ptr(double*);
+extern void nrn_register_recalc_ptr_callback(Pfrv f);
+
+//BlueBrain
+extern void* bbss_buffer_counts( int*, int**, int**, int* );
+extern void bbss_save_global( void*, char*, int );
+extern void bbss_restore_global( void*, char*, int );
+extern void bbss_save( void*, int, char*, int );
+extern void bbss_restore( void*, int, int, char*, int );
+extern void bbss_save_done( void* );
+extern void bbss_restore_done( void* );
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/oc/oc_ansi.h
+++ b/src/oc/oc_ansi.h
@@ -286,14 +286,14 @@ extern double nrn_event_queue_stats(double* stats);
 extern double* nrn_recalc_ptr(double*);
 extern void nrn_register_recalc_ptr_callback(Pfrv f);
 
-//BlueBrain
-extern void* bbss_buffer_counts( int*, int**, int**, int* );
-extern void bbss_save_global( void*, char*, int );
-extern void bbss_restore_global( void*, char*, int );
-extern void bbss_save( void*, int, char*, int );
-extern void bbss_restore( void*, int, int, char*, int );
-extern void bbss_save_done( void* );
-extern void bbss_restore_done( void* );
+// BlueBrain
+extern void* bbss_buffer_counts(int*, int**, int**, int*);
+extern void bbss_save_global(void*, char*, int);
+extern void bbss_restore_global(void*, char*, int);
+extern void bbss_save(void*, int, char*, int);
+extern void bbss_restore(void*, int, int, char*, int);
+extern void bbss_save_done(void*);
+extern void bbss_restore_done(void*);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
In the context of C/C++ MOD compatibility across different versions, the aim is to have as much as possible all NRN "API" in headers so to as not having to declare them in the  VERBATIM blocks. 

Also #1805 changed `nrn_mallinfo` signature to return `std::size_t`
