### PR TITLE
publications using NEURON; progress toward #1728

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ explore the `source code for over 750 NEURON models on ModelDB <https://senselab
    videos/index
    guide/index
    publications
+   publications-using-neuron
    
 
 

--- a/docs/publications-using-neuron.rst
+++ b/docs/publications-using-neuron.rst
@@ -1,0 +1,13703 @@
+.. generated from HTML via
+.. pandoc publications-using-neuron.html -f html -t rst -o publications-using-neuron.rst 
+
+.. _publications_using_neuron:
+
+Publications using NEURON
+=========================
+
+Each item in this list is a publication about work that actually used
+NEURON. With rare exceptions abstracts have been omitted. Please help
+us keep this list complete and accurate by addressing questions,
+corrections, additions, or comments to **ted dot carnevale at yale
+dot edu**
+
+----
+
+Total of **2672** items verified as of *February 15, 2022*.
+
+----
+
+Abbasi, S., Abbasi, A. and Sarbaz, Y.. Introducing treatment
+strategy for cerebellar ataxia in mutant med mice: combination of
+acetazolamide and 4-aminopyridine. *Computer Methods and Programs
+in Biomedicine* 113:697-704, 10.1016/j.cmpb.2013.11.008, 2014.
+
+Abbasi, S., Abbasi, A., Sarbaz, Y. and Janahmadi, M.. Power
+spectral density analysis of Purkinje cell tonic and burst firing
+patterns from a rat model of ataxia and riluzole treated. *Basic
+and Clinical Neuroscience* 8:61-68, 10.15412/J.BCN.03080108, 2017.
+
+Abbasi, S., Abbasi, A., Sarbaz, Y. and Shahabi, P.. Contribution
+of somatic and dendritic SK channels in the firing rate of deep
+cerebellar nuclei: implication in cerebellar ataxia. *Basic and
+Clinical Neuroscience* 7:57-62, 2016.
+
+Abdelaal, A. Y., Mousa, M. H., Gamal, M., Khalil, M. I.,
+Elbasiouny, S. M. and Eldawlatly, S.. A classification approach to
+recognize the firing of spinal motoneurons in amyotrophic lateral
+sclerosis. *Annual International Conference of the IEEE
+Engineering in Medicine and Biology Society* 2020:3680-3683,
+10.1109/EMBC44109.2020.9176551, 2020.
+
+Aberra, A. S., Peterchev, A. V. and Grill, W. M.. Biophysically
+realistic neuron models for simulation of cortical stimulation.
+*Journal of Neural Engineering* 15:066023,
+10.1088/1741-2552/aadbb1, 2018.
+
+Aberra, A. S., Wang, B., Grill, W. M. and Peterchev, A. V..
+Simulation of transcranial magnetic stimulation in head model with
+morphologically-realistic cortical neurons. *Brain Stimulation*
+13:175-189, 10.1016/j.brs.2019.10.002, 2020.
+
+Abrahamsson, T., Cathala, L., Matsui, K., Shigemoto, R. and
+Digregorio, D. A.. Thin dendrites of cerebellar interneurons
+confer sublinear synaptic integration and a gradient of short-term
+plasticity. *Neuron* 73:1159-1172, 10.1016/j.neuron.2012.01.027,
+2012.
+
+Acciarito, S., Cardarilli, G. C., Cristini, A., Di Nunzio, L.,
+Fazzolari, R., Khanal, G. M., Re, M. and Susi, G.. Hardware design
+of LIF with Latency neuron model with memristive STDP synapses.
+*Integration-the VLSI Journal* 59:81-89,
+10.1016/j.vlsi.2017.05.006, 2017.
+
+Acker, C. D. and Antic, S. D.. Quantitative assessment of the
+distributions of membrane conductances involved in action
+potential backpropagation along basal dendrites. *Journal of
+Neurophysiology* 101:1524-1541, 2009.
+
+Acker, C. D., Hoyos, E. and Loew, L. M.. EPSPs measured in
+proximal dendritic spines of cortical pyramidal neurons. *eNeuro*
+3:ENEURO.0050-15.2016, 10.1523/ENEURO.0050-15.2016, 2016.
+
+Ackermann, D. M., Bhadra, N., Gerges, M. and Thomas, P. J..
+Dynamics and sensitivity analysis of high-frequency conduction
+block. *Journal of Neural Engineering* 8:065007,
+10.1088/1741-2560/8/6/065007, 2011.
+
+Ackermann, Jr., D. M., Foldes, E. L., Bhadra, N. and Kilgore, K.
+L.. Effect of bipolar cuff electrode design on block thresholds in
+high-frequency electrical neural conduction block. *IEEE
+Transactions on Neural Systems and Rehabilitation Engineering*
+17:469-477, 10.1109/TNSRE.2009.2034069, 2009.
+
+Adesnik, H. and Scanziani, M.. Lateral competition for cortical
+space by layer-specific horizontal circuits. *Nature* 464:1155-60,
+10.1038/nature08935, 2010.
+
+Adonias, G. L., Duffy, C., Barros, M. T., McCoy, C. E. and
+Balasubramaniam, S.. Analysis of the information capacity of
+neuronal molecular communications under demyelination and
+remyelination. *IEEE Transactions on Neural Systems and
+Rehabilitation Engineering* 29:2765-2774,
+10.1109/TNSRE.2021.3137350, 2021.
+
+Adonias, G. L., Siljak, H., Barros, M. T., Marchetti, N., White,
+M. and Balasubramaniam, S.. Reconfigurable filtering of
+neuro-spike communications using synthetically engineered logic
+circuits. *Frontiers In Computational Neuroscience* 14:556628,
+10.3389/fncom.2020.556628, 2020a.
+
+Adonias, G. L., Yastrebova, A., Barros, M. T., Koucheryavy, Y.,
+Cleary, F. and Balasubramaniam, S.. Utilizing neurons for digital
+logic circuits: a molecular communications analysis. *IEEE
+Transactions on NanoBioscience* 19:224-236,
+10.1109/TNB.2020.2975942, 2020b.
+
+Aghvami, S. S., Müller, M., Araabi, B. N. and Egger, V..
+Coincidence detection within the excitable rat olfactory bulb
+granule cell spines. *Journal of Neuroscience* 39:584-595,
+10.1523/JNEUROSCI.1798-18.2018, 2019.
+
+Aguiar, P., Sousa, M. and Lima, D.. NMDA channels together with
+L-type calcium currents and calcium-activated nonspecific cationic
+currents are sufficient to generate windup in WDR neurons.
+*Journal of Neurophysiology* 104:1155-1166, 10.1152/jn.00834.2009,
+2010.
+
+Aguiar, P. and Willshaw, D.. Hippocampal mossy fibre boutons as
+dynamical synapses. *Neurocomputing* 58-60:699-703, 2004.
+
+Ahlfors, S. P. and Wreh, 2nd, C.. Modeling the effect of dendritic
+input location on MEG and EEG source dipoles. *Medical and
+Biological Engineering and Computing* 53:879-887,
+10.1007/s11517-015-1296-5, 2015.
+
+Ahmed, B., Anderson, J. C., Douglas, R. J., Martin, K. A. C. and
+Whitteridge, D.. Estimates of the net excitatory currents evoked
+by visual stimulation of identified neurons in cat visual cortex.
+*Cerebral Cortex* 8:462-476, 1998.
+
+Ait Ouares, K., Filipis, L., Tzilivaki, A., Poirazi, P. and
+Canepari, M.. Two distinct sets of Ca2+ and K+ channels are
+activated at different membrane potentials by the climbing fiber
+synaptic potential in Purkinje neuron dendrites. *Journal of
+Neuroscience* 39:1969-1981, 10.1523/JNEUROSCI.2155-18.2018, 2019.
+
+Akbari, A., Moradi, K., Hadaeghi, F., Gharibzadeh, S. and
+Emkanjoo, Z.. Is "capacitive coupling" purely excitatory in the
+cardiac tissue?. *Frontiers in Physiology* 5:77,
+10.3389/fphys.2014.00077, 2014.
+
+Akemann, W. and Knöpfel, T.. Interaction of Kv3 potassium channels
+and resurgent sodium current influences the rate of spontaneous
+firing of Purkinje neurons. *Journal of Neuroscience*
+26:4602-4612, 2006.
+
+Akemann, W., Lundby, A., Mutoh, H. and Knöpfel, T.. Effect of
+voltage sensitive fluorescent proteins on neuronal excitability.
+*Biophysical Journal* 96:3959-3976, 2009.
+
+Akiyama, H., Shimizu, Y., Miyakawa, H. and Inoue, M..
+Extracellular DC electric fields induce nonuniform membrane
+polarization in rat hippocampal CA1 pyramidal neurons. *Brain
+Research* 1383:22-35, 10.1016/j.brainres.2011.01.097, 2011.
+
+Alessi, C., Raspanti, A. and Magistretti, J.. Two distinct types
+of depolarizing afterpotentials are differentially expressed in
+stellate and pyramidal-like neurons of entorhinal-cortex layer
+II.. *Hippocampus* 26:380-404, 10.1002/hipo.22529, 2016.
+
+Alfonsa, H., Merricks, E. M., Codadu, N. K., Cunningham, M. O.,
+Deisseroth, K., Racca, C. and Trevelyan, A. J.. The contribution
+of raised intraneuronal chloride to epileptic network activity.
+*Journal of Neuroscience* 35:7715-7726,
+10.1523/JNEUROSCI.4105-14.2015, 2015.
+
+Allain, A.-E., Cazenave, W., Delpy, A., Exertier, P., Barthe, C.,
+Meyrand, P., Cattaert, D. and Branchereau, P.. Nonsynaptic glycine
+release is involved in the early KCC2 expression. *Developmental
+Neurobiology* 76:764-779, 10.1002/dneu.22358, 2016.
+
+Allam, S. L., Ghaderi, V. S., Bouteiller, J.-M. C., Legendre, A.,
+Ambert, N., Greget, R., Bischoff, S., Baudry, M. and Berger, T.
+W.. A computational model to investigate astrocytic glutamate
+uptake influence on synaptic transmission and neuronal spiking.
+*Frontiers in Computational Neuroscience* 6:70,
+10.3389/fncom.2012.00070, 2012.
+
+Alle, H. and Geiger, J. R. P.. Combined analog and action
+potential coding in hippocampal mossy fibers. *Science*
+311:1290-1293, 2006.
+
+Alle, H. and Geiger, J. R. P.. GABAergic spill-over transmission
+onto hippocampal mossy fiber boutons. *Journal of Neuroscience*
+27:942-950, 2007.
+
+Alle, H., Roth, A. and Geiger, J. R. P.. Energy-efficient action
+potentials in hippocampal mossy fibers. *Science* 325:1405-1408,
+10.1126/science.1174331, 2009.
+
+Allen, J. M. and Elbasiouny, S. M.. The effects of model
+composition design choices on high-fidelity simulations of
+motoneuron recruitment and firing behaviors. *Journal of Neural
+Engineering* 15:036024, 10.1088/1741-2552/aa9db5, 2018.
+
+Allken, V., Chepkoech, J.-L., Einevoll, G. T. and Halnes, G.. The
+subcellular distribution of T-type Ca2+ channels in interneurons
+of the lateral geniculate nucleus. *PLoS ONE* 9:e107780,
+10.1371/journal.pone.0107780, 2014.
+
+Almog, M., Barkai, T., Lampert, A. and Korngreen, A..
+Voltage-gated sodium channels in neocortical pyramidal neurons
+display Cole-Moore activation kinetics. *Frontiers in Cellular
+Neuroscience* 12:187, 10.3389/fncel.2018.00187, 2018.
+
+Almog, M. and Korngreen, A.. A quantitative description of
+dendritic conductances and its application to dendritic excitation
+in layer 5 pyramidal neurons. *Journal of Neuroscience*
+34:182-196, 10.1523/JNEUROSCI.2896-13.2014, 2014.
+
+Alturki, A., Feng, F., Nair, A., Guntu, V. and Nair, S. S..
+Distinct current modules shape cellular dynamics in model neurons.
+*Neuroscience* 334:309-331, 10.1016/j.neuroscience.2016.08.016,
+2016.
+
+Alvarez, F. P. and Destexhe, A.. Simulating cortical network
+activity states constrained by intracellular recordings.
+*Neurocomputing* 58:285-290, 2004.
+
+Al-Yaari, M., Yamada, R. and Kuba, H.. Excitatory-inhibitory
+synaptic coupling in avian nucleus magnocellularis. *Journal of
+Neuroscience* 40:619-631, 10.1523/JNEUROSCI.1124-19.2019, 2020.
+
+Amarillo, Y., Tissone, A. I., Mato, G. and Nadal, M. S.. Inward
+rectifier potassium current IKir promotes intrinsic pacemaker
+activity of thalamocortical neurons. *Journal of Neurophysiology*
+119:2358-2372, 10.1152/jn.00867.2017, 2018.
+
+Amarillo, Y., Zagha, E., Mato, G., Rudy, B. and Nadal, M. S.. The
+interplay of seven subthreshold conductances controls the resting
+membrane potential and the oscillatory behavior of thalamocortical
+neurons. *Journal of Neurophysiology* 112:393-410,
+10.1152/jn.00647.2013, 2014.
+
+Amatrudo, J. M., Weaver, C. M., Crimins, J. L., Hof, P. R.,
+Rosene, D. L. and Luebke, J. I.. Influence of highly distinctive
+structural properties on the excitability of pyramidal neurons in
+monkey visual and prefrontal cortices. *Journal of Neuroscience*
+32:13644-13660, 10.1523/JNEUROSCI.2581-12.2012, 2012.
+
+Ambros-Ingerson, J., Grover, L. M. and Holmes, W. R.. A
+classification method to distinguish cell-specific responses
+elicited by current pulses in hippocampal CA1 pyramidal cells.
+*Neural Computation* 20:1512-1536, 2008.
+
+Ambros-Ingerson, J. and Holmes, W. R.. Analysis and comparison of
+morphological reconstructions of hippocampal field CA1 pyramidal
+cells. *Hippocampus* 15:302-315, 2005.
+
+Amir, R. and Devor, M.. Electrical excitability of the soma of
+sensory neurons is required for spike invasion of the soma, but
+not for through-conduction. *Biophysical Journal* 84:2181-2191,
+2003a.
+
+Amir, R. and Devor, M.. Extra spike formation in sensory neurons
+and the disruption of afferent spike patterning. *Biophysical
+Journal* 84:2700-2708, 2003b.
+
+Amir, R., Kocsis, J. D. and Devor, M.. Multiple interacting sites
+of ectopic spike electrogenesis in primary sensory neurons.
+*Journal of Neuroscience* 25:2576-2585, 2005.
+
+Amir, R., Liu, C.-N., Kocsis, J. D. and Devor, M.. Oscillatory
+mechanism in primary sensory neurones. *Brain* 125:421-435, 2002a.
+
+Amir, R., Michaelis, M. and Devor, M.. Burst discharge in primary
+sensory neurons: triggered by subthreshold oscillations,
+maintained by depolarizing afterpotentials. *Journal of
+Neuroscience* 22:1187-1198, 2002b.
+
+Amos, G. J., Jacobson, I., Duker, G. and Carlsson, L.. Block of
+HERG-carried K+ currents by the new repolarization delaying agent
+H 345/52. *Journal of Cardiovascular Electrophysiology*
+14:651-658, 2003.
+
+Amsalem, O., Eyal, G., Rogozinski, N., Gevaert, M., Kumbhar, P.,
+Schürmann, F. and Segev, I.. An efficient analytical reduction of
+detailed nonlinear neuron models. *Nature Communications* 11:288,
+10.1038/s41467-019-13932-6, 2020.
+
+Amsalem, O., Van Geit, W., Muller, E., Markram, H. and Segev, I..
+From neuron biophysics to orientation selectivity in electrically
+coupled networks of neocortical L2/3 large basket cells. *Cerebral
+Cortex* 26:3655-3668, 10.1093/cercor/bhw166, 2016.
+
+An, L., Tang, Y., Wang, Q., Pei, Q., Wei, R., Duan, H. and Liu, J.
+K.. Coding capacity of purkinje cells with different schemes of
+morphological reduction. *Frontiers In Computational Neuroscience*
+13:29, 10.3389/fncom.2019.00029, 2019.
+
+Anastassiou, C. A., Montgomery, S. M., Barahona, M., Buzsáki, G.
+and Koch, C.. The effect of spatially inhomogeneous extracellular
+electric fields on neurons. *Journal of Neuroscience*
+30:1925-1936, 10.1523/JNEUROSCI.3635-09.2010, 2010.
+
+Anaya, C. J., Zander, H. J., Graham, R. D., Sankarasubramanian, V.
+and Lempka, S. F.. Evoked potentials recorded from the spinal cord
+during neurostimulation for pain: a computational modeling study.
+*Neuromodulation* 23:64-73, 10.1111/ner.12965, 2020.
+
+Anderson, D. N., Anderson, C., Lanka, N., Sharma, R., Butson, C.
+R., Baker, B. W. and Dorval, A. D.. The μDBS: multiresolution,
+directional deep brain stimulation for improved targeting of small
+diameter fibers. *Frontiers in Neuroscience* 13:1152,
+10.3389/fnins.2019.01152, 2019a.
+
+Anderson, D. N., Duffley, G., Vorwerk, J., Dorval, A. D. and
+Butson, C. R.. Anodic stimulation misunderstood: preferential
+activation of fiber orientations with anodic waveforms in deep
+brain stimulation. *Journal of Neural Engineering* 16:016026,
+10.1088/1741-2552/aae590, 2019b.
+
+Anderson, D. N., Osting, B., Vorwerk, J., Dorval, A. D. and
+Butson, C. R.. Optimized programming algorithm for cylindrical and
+directional deep brain stimulation electrodes. *Journal of Neural
+Engineering* 15:026005, 10.1088/1741-2552/aaa14b, 2018a.
+
+Anderson, J. C., Binzegger, T., Kahana, O., Segev, I. and Martin,
+K. A. C.. Dendritic asymmetry cannot account for directional
+responses of neurons in visual cortex. *Nature Neuroscience*
+2:820-824, 1999.
+
+Anderson, R. W., Farokhniaee, A., Gunalan, K., Howell, B. and
+McIntyre, C. C.. Action potential initiation, propagation, and
+cortical invasion in the hyperdirect pathway during subthalamic
+deep brain stimulation. *Brain Stimulation* 11:1140-1150,
+10.1016/j.brs.2018.05.008, 2018b.
+
+Andrade, A., Hope, J., Allen, A., Yorgan, V., Lipscombe, D. and
+Pan, J. Q.. A rare schizophrenia risk variant of CACNA1I disrupts
+CaV3.3 channel activity. *Scientific Reports* 6:34233,
+10.1038/srep34233, 2016.
+
+Andree, A., Li, N., Butenko, K., Kober, M., Chen, J. Z., Higuchi,
+T., Fauser, M., Storch, A., Ip, C. W., Kühn, A. A., Horn, A. and
+van Rienen, U.. Deep brain stimulation electrode modeling in rats.
+*Experimental Neurology* 350:113978,
+10.1016/j.expneurol.2022.113978, 2022.
+
+Andreozzi, E., Carannante, I., D'Addio, G., Cesarelli, M. and
+Balbi, P.. Phenomenological models of Nav1.5. A side by side,
+procedural, hands-on comparison between Hodgkin-Huxley and kinetic
+formalisms.. *Scientific Reports* 9:17493,
+10.1038/s41598-019-53662-9, 2019.
+
+Androuin, A., Potier, B., Nägerl, U. V., Cattaert, D., Danglot,
+L., Thierry, M., Youssef, I., Triller, A., Duyckaerts, C.,
+Hachimi, K. H. E., Dutar, P., Delatour, B. and Marty, S.. Evidence
+for altered dendritic spine compartmentalization in Alzheimer's
+disease and functional effects in a mouse model. *Acta
+Neuropathologica* 135:839-854, 10.1007/s00401-018-1847-6, 2018.
+
+Angelo, K., London, M., Christensen, S. R. and Häusser, M.. Local
+and global effects of I-h distribution in dendrites of mammalian
+neurons. *Journal of Neuroscience* 27:8643-8653, 2007.
+
+Angulo, S. L., Henzi, T., Neymotin, S. A., Suarez, M. D., Lytton,
+W. W., Schwaller, B. and Moreno, H.. Amyloid pathology-produced
+unexpected modifications of calcium homeostasis in hippocampal
+subicular dendrites. *Alzheimer's and Dementia* 16:251-261,
+10.1016/j.jalz.2019.07.017, 2020.
+
+Angulo, S. L., Orman, R., Neymotin, S. A., Liu, L., Buitrago, L.,
+Cepeda-Prado, E., Stefanov, D., Lytton, W. W., Stewart, M., Small,
+S. A., Duff, K. E. and Moreno, H.. Tau and amyloid-related
+pathologies in the entorhinal cortex have divergent effects in the
+hippocampal circuit. *Neurobiology of Disease* 108:261-276,
+10.1016/j.nbd.2017.08.015, 2017.
+
+Anirudhan, A. and Narayanan, R.. Analogous synaptic plasticity
+profiles emerge from disparate channel combinations. *Journal of
+Neuroscience* 35:4691-4705, 10.1523/JNEUROSCI.4223-14.2015, 2015.
+
+Ankri, L., Ezra-Tsur, E., Maimon, S. R., Kaushansky, N. and
+Rivlin-Etzion, M.. Antagonistic center-surround mechanisms for
+direction selectivity in the retina. *Cell Reports* 31:107608,
+10.1016/j.celrep.2020.107608, 2020.
+
+Antunes, G., Faria da Silva, S. F. and Simoes de Souza, F. M..
+Mirror neurons modeled through spike-timing-dependent plasticity
+are affected by channelopathies associated with autism spectrum
+disorder. *International Journal of Neural Systems* 28:1750058,
+10.1142/S0129065717500587, 2018.
+
+Anwar, H., Hepburn, I., Nedelescu, H., Chen, W. and De Schutter,
+E.. Stochastic calcium mechanisms cause dendritic calcium spike
+variability. *Journal of Neuroscience* 33:15848-15867,
+10.1523/JNEUROSCI.1722-13.2013, 2013.
+
+Anwar, H., Hong, S. and De Schutter, E.. Controlling
+Ca2+-activated K+ channels with models of Ca2+ buffering in
+Purkinje cells. *Cerebellum* 11:681-693,
+10.1007/s12311-010-0224-3, 2012.
+
+Anwar, H., Roome, C. J., Nedelescu, H., Chen, W., Kuhn, B. and De
+Schutter, E.. Dendritic diameters affect the spatial variability
+of intracellular calcium dynamics in computer models. *Frontiers
+in Cellular Neuroscience* 8:168, 10.3389/fncel.2014.00168, 2014.
+
+Apollo, N., Grayden, D. B., Burkitt, A. N., Meffin, H. and
+Kameneva, T.. Modeling intrinsic electrophysiology of AII amacrine
+cells: preliminary results [Online]. *IEEE Engineering in Medicine
+and Biology Society Proceedings* 2013:6551-6554,
+10.1109/EMBC.2013.6611056, 2013.
+
+Apostolides, P. F., Milstein, A. D., Grienberger, C., Bittner, K.
+C. and Magee, J. C.. Axonal filtering allows reliable output
+during dendritic plateau-driven complex spiking in Ca1 neurons.
+*Neuron* 89:770-783, 10.1016/j.neuron.2015.12.040, 2016.
+
+Appukuttan, S., Brain, K. L. and Manchanda, R.. A computational
+model of urinary bladder smooth muscle syncytium: validation and
+investigation of electrical properties. *Journal of Computational
+Neuroscience* 38:167-187, 10.1007/s10827-014-0532-6, 2015a.
+
+Appukuttan, S., Brain, K. L. and Manchanda, R.. Modeling
+extracellular fields for a three-dimensional network of cells
+using NEURON. *Journal of Neuroscience Methods* 290:27-38,
+10.1016/j.jneumeth.2017.07.005, 2017a.
+
+Appukuttan, S., Brain, K. L. and Manchanda, R.. Effect of
+variations in gap junctional coupling on the frequency of
+oscillatory action potentials in a smooth muscle syncytium.
+*Frontiers in Physiology* 12:655225, 10.3389/fphys.2021.655225,
+2021.
+
+Appukuttan, S., Padmakumar, M., Brain, K. L. and Manchanda, R.. A
+method for the analysis of AP foot convexity: insights into smooth
+muscle biophysics. *Frontiers in Bioengineering and Biotechnology*
+5:64, 10.3389/fbioe.2017.00064, 2017b.
+
+Appukuttan, S., Padmakumar, M., Young, J. S., Brain, K. L. and
+Manchanda, R.. Investigation of the syncytial nature of detrusor
+smooth muscle as a determinant of action potential shape.
+*Frontiers in Physiology* 9:1300, 10.3389/fphys.2018.01300, 2018.
+
+Appukuttan, S., Sathe, R. and Manchanda, R.. Modular approach to
+modeling homotypic and heterotypic gap junctions [Online]. *2015
+IEEE 5th International Conference on Computational Advances in Bio
+and Medical Sciences*, 10.1109/iccabs.2015.7344707, 2015b.
+
+Appukuttan, S., Sathe, R. and Manchanda, R.. Influence of gap
+junction subtypes on passive and active electrical properties of
+syncytial tissues [Online]. *2016 International Conference on
+Systems in Medicine and Biology*, 10.1109/icsmb.2016.7915104,
+2016.
+
+Aradi, I. and Erdi, P.. Multicompartmental modeling of neural
+circuits in the olfactory bulb. *International Journal of Neural
+Systems* 7:519-527, 1996a.
+
+Aradi, I. and Erdi, P.. Multicompartmental modeling of the
+olfactory bulb. *Cybernetics and Systems* 27:605-615, 1996b.
+
+Aradi, I. and Erdi, P.. Signal generation and propagation in the
+olfactory bulb: multicompartmental modeling. *Computers and
+Mathematics with Applications* 32:1-27, 1996c.
+
+Aradi, I. and Erdi, P.. Simulation of the whole olfactory bulb
+based on detailed single cell models. *Neurobiology* 4:251-252,
+1996d.
+
+Aradi, I. and Maccaferri, G.. Cell type-specific synaptic dynamics
+of synchronized bursting in the juvenile CA3 rat hippocampus.
+*Journal of Neuroscience* 24:9681-9692, 2004.
+
+Aradi, I., Santhakumar, V., Chen, K. and Soltesz, I.. Postsynaptic
+effects of GABAergic synaptic diversity: regulation of neuronal
+excitability by changes in IPSC variance. *Neuropharmacology*
+43:511-522, 2002.
+
+Aradi, I., Santhakumar, V. and Soltesz, I.. Impact of
+heterogeneous perisomatic IPSC populations on pyramidal cell
+firing rates. *Journal of Neurophysiology* 91:2849-2858, 2004.
+
+Aradi, I. and Soltesz, I.. Modulation of network behaviour by
+changes in variance in interneuronal properties. *Journal of
+Physiology* 538:227-251, 2002.
+
+Arai, I., Tanaka, M. and Tachibana, M.. Active roles of
+electrically coupled bipolar cell network in the adult retina.
+*Journal of Neuroscience* 30:9260-9270,
+10.1523/JNEUROSCI.1590-10.2010, 2010.
+
+Araya, R., Vogels, T. P. and Yuste, R.. Activity-dependent
+dendritic spine neck changes are correlated with synaptic
+strength. *Proceedings of the National Academy of Sciences of the
+United States of America* 111:E2895-E2904,
+10.1073/pnas.1321869111, 2014.
+
+Archie, K. A. and Mel, B. W.. A model for intradendritic
+computation of binocular disparity. *Nature Neuroscience* 3:54-63,
+2000.
+
+Arias, E. R., Valle-Leija, P., Morales, M. A. and Cifuentes, F..
+Differential contribution of BDNF and NGF to long-term
+potentiation in the superior cervical ganglion of the rat.
+*Neuropharmacology* 81:206-214, 10.1016/j.neuropharm.2014.02.001,
+2014.
+
+Ariav, G., Polsky, A. and Schiller, J.. Submillisecond precision
+of the input-output transformation function mediated by fast
+sodium dendritic spikes in basal dendrites of CA1 pyramidal
+neurons. *Journal of Neuroscience* 23:7750-7758, 2003.
+
+Arkhipov, A., Gouwens, N. W., Billeh, Y. N., Gratiy, S., Iyer, R.,
+Wei, Z., Xu, Z., Abbasi-Asl, R., Berg, J., Buice, M., Cain, N., da
+Costa, N., de Vries, S., Denman, D., Durand, S., Feng, D., Jarsky,
+T., Lecoq, J., Lee, B., Li, L., Mihalas, S., Ocker, G. K., Olsen,
+S. R., Reid, R. C., Soler-Llavina, G., Sorensen, S. A., Wang, Q.,
+Waters, J., Scanziani, M. and Koch, C.. Visual physiology of the
+layer 4 cortical circuit in silico. *PLoS Computational Biology*
+14:e1006535, 10.1371/journal.pcbi.1006535, 2018.
+
+Arleo, A., Nieus, T., Bezzi, M., D'Errico, A., D'Angelo, E. and
+Coenen, O. J.-M. D.. How synaptic release probability shapes
+neuronal transmission: information-theoretic analysis in a
+cerebellar granule cell. *Neural Computation* 22:2031-2058,
+10.1162/NECO_a_00006-Arleo, 2010.
+
+Arruda, D., Publio, R. and Roque, A. C.. The periglomerular cell
+of the olfactory bulb and its role in controlling mitral cell
+spiking: a computational model. *PLoS ONE* 8:e56148,
+10.1371/journal.pone.0056148, 2013.
+
+Arsiero, M., Lüscher, H.-R., Lundstrom, B. N. and Giugliano, M..
+The impact of input fluctuations on the frequency-current
+relationships of layer 5 pyramidal neurons in the rat medial
+prefrontal cortex. *Journal of Neuroscience* 27:3274-3284, 2007.
+
+Aruljothi, S., Mandge, D. and Manchanda, R.. A biophysical model
+of heat sensitivity in nociceptive C-fiber neurons [Online]. *2017
+8th International IEEE/EMBS Conference on Neural Engineering*,
+10.1109/ner.2017.8008422, 2017.
+
+Ascoli, G. A., Gasparini, S., Medinilla, V. and Migliore, M..
+Local control of postinhibitory rebound spiking in CA1 pyramidal
+neuron dendrites. *Journal of Neuroscience* 30:6434-6442,
+10.1523/JNEUROSCI.4066-09.2010, 2010.
+
+Ashhad, S. and Feldman, J. L.. Emergent elements of inspiratory
+rhythmogenesis: network synchronization and synchrony propagation.
+*Neuron* 106:482-497.e4, 10.1016/j.neuron.2020.02.005, 2020.
+
+Ashhad, S. and Narayanan, R.. Quantitative interactions between
+the A-type K+ current and inositol trisphosphate receptors
+regulate intraneuronal Ca2+ waves and synaptic plasticity.
+*Journal of Physiology* 591:1645-1669,
+10.1113/jphysiol.2012.245688, 2013.
+
+Ashhad, S. and Narayanan, R.. Active dendrites regulate the impact
+of gliotransmission on rat hippocampal pyramidal neurons..
+*Proceedings of the National Academy of Sciences of the United
+States of America* 113:E3280-E3289, 10.1073/pnas.1522180113, 2016.
+
+Aspart, F., Ladenbauer, J. and Obermayer, K.. Extending
+integrate-and-fire model neurons to account for the effects of
+weak electric fields and input filtering mediated by the dendrite.
+*PLoS Computational Biology* 12:e1005206,
+10.1371/journal.pcbi.1005206, 2016.
+
+Aspart, F., Remme, M. W. H. and Obermayer, K.. Differential
+polarization of cortical pyramidal neuron dendrites through weak
+extracellular fields. *PLoS Computational Biology* 14:e1006124,
+10.1371/journal.pcbi.1006124, 2018.
+
+Athilingam, J. C., Ben-Shalom, R., Keeshen, C. M., Sohal, V. S.
+and Bender, K. J.. Serotonin enhances excitability and gamma
+frequency temporal integration in mouse prefrontal fast-spiking
+interneurons. *eLife* 610.7554/eLife.31991, 2017.
+
+Aubie, B., Sayegh, R. and Faure, P. A.. Duration tuning across
+vertebrates. *Journal of Neuroscience* 32:6373-6390,
+10.1523/JNEUROSCI.5624-11.2012, 2012.
+
+Augustin, H., Zylbertal, A. and Partridge, L.. A computational
+model of the escape response latency in the giant fiber system of
+Drosophila melanogaster. *eNeuro* 6:ENEURO.0423-18.2019,
+10.1523/ENEURO.0423-18.2019, 2019.
+
+Avella Gonzalez, O. J., van Aerde, K. I., van Elburg, R. A. J.,
+Poil, S.-S., Mansvelder, H. D., Linkenkaer-Hansen, K., van Pelt,
+J. and van Ooyen, A.. External drive to inhibitory cells induces
+alternating episodes of high- and low-amplitude oscillations.
+*PLoS Computational Biology* 8:e1002666,
+10.1371/journal.pcbi.1002666, 2012.
+
+Avella Gonzalez, O. J., van Aerde, K. I., Mansvelder, H. D., van
+Pelt, J. and van Ooyen, A.. Inter-network interactions: impact of
+connections between oscillatory neuronal networks on oscillation
+frequency and pattern. *PLoS ONE* 9:e100899,
+10.1371/journal.pone.0100899, 2014.
+
+Avella Gonzalez, O. J., Mansvelder, H. D., van Pelt, J. and van
+Ooyen, A.. H-channels affect frequency, power and amplitude
+fluctuations of neuronal network oscillations. *Frontiers in
+Computational Neuroscience* 9:141, 10.3389/fncom.2015.00141, 2015.
+
+Aviner, B., Gradwohl, G., Moore, H. J. and Grossman, Y..
+Modulation of presynaptic Ca(2+) currents in frog motor nerve
+terminals by high pressure.. *European Journal of Neuroscience*
+38:2716-2729, 10.1111/ejn.12267, 2013.
+
+Azouz, R.. Dynamic spatiotemporal synaptic integration in cortical
+neurons: neuronal gain, revisited. *Journal of Neurophysiology*
+94:2785-2796, 2005.
+
+Azouz, R. and Gray, C. M.. Dynamic spike threshold reveals a
+mechanism for synaptic coincidence detection in cortical neurons
+in vivo. *Proceedings of the National Academy of Sciences of the
+United States of America* 97:8110-8115, 2000.
+
+Azouz, R. and Gray, C. M.. Adaptive coincidence detection and
+dynamic gain control in visual cortical neurons in vivo. *Neuron*
+37:513-523, 2003.
+
+Azouz, R. and Gray, C. M.. Stimulus-selective spiking is driven by
+the relative timing of synchronous excitation and disinhibition in
+cat striate neurons in vivo. *European Journal of Neuroscience*
+28:1286-1300, 2008.
+
+Baccus, S. A.. Synaptic facilitation by reflected action
+potentials: enhancement of transmission when nerve impulses
+reverse direction at axon branch points. *Proceedings of the
+National Academy of Sciences of the United States of America*
+95:8345-8350, 1998.
+
+Baccus, S. A., Sahley, C. L. and Muller, K. J.. Multiple sites of
+action potential initiation increase neuronal firing rate.
+*Journal of Neurophysiology* 86:1226-1236, 2001.
+
+Badoual, M., Rudolph, M., Piwkowska, Z., Destexhe, A. and Bal, T..
+High discharge variability in neurons driven by current noise.
+*Neurocomputing* 65:493-498, 2005.
+
+Badoual, M., Zou, Q., Davison, A. P., Rudolph, M., Bal, T.,
+Fregnac, Y. and Destexhe, A.. Biophysical and phenomenological
+models of multiple spike interactions in spike-timing dependent
+plasticity. *International Journal of Neural Systems* 16:79-97,
+2006.
+
+BagheriMofidi, S. M., Pouladian, M., Jameie, S. B. and
+Tehrani-Fard, A. A.. Computational modeling of neuronal current
+MRI signals with rat somatosensory cortical neurons.
+*Interdisciplinary Sciences: Computational Life Sciences*
+8:253-262, 2016a.
+
+BagheriMofidi, S. M., Pouladian, M., Jameie, S. B. and
+Tehrani-Fard, A. A.. Estimation of phase signal change in neuronal
+current MRI for evoke response of tactile detection with realistic
+somatosensory laminar network model. *Australasian Physical and
+Engineering Sciences in Medicine* 39:717-726,
+10.1007/s13246-016-0467-5, 2016b.
+
+Bagnall, M. W., Hull, C., Bushong, E. A., Ellisman, M. H. and
+Scanziani, M.. Multiple clusters of release sites formed by
+individual thalamic afferents onto cortical interneurons ensure
+reliable transmission. *Neuron* 71:180-194,
+10.1016/j.neuron.2011.05.032, 2011.
+
+Bahl, A., Stemmler, M. B., Herz, A. V. M. and Roth, A.. Automated
+optimization of a reduced layer 5 pyramidal cell model based on
+experimental data. *Journal of Neuroscience Methods* 210:22-34,
+10.1016/j.jneumeth.2012.04.006, 2012.
+
+Bahmer, A. and Gupta, D. S.. Role of oscillations in auditory
+temporal processing: a general model for temporal processing of
+sensory information in the brain?. *Frontiers in Neuroscience*
+12:793, 10.3389/fnins.2018.00793, 2018.
+
+Bahmer, A. and Langner, G.. Parameters for a model of an
+oscillating neuronal network in the cochlear nucleus defined by
+genetic algorithms. *Biological Cybernetics* 102:81-93,
+10.1007/s00422-009-0353-2, 2010.
+
+Baker, J. L., Perez-Rosello, T., Migliore, M., Barrionuevo, G. and
+Ascoli, G. A.. A computer model of unitary responses from
+associational/commissural and perforant path synapses in
+hippocampal CA3 pyramidal cells. *Journal of Computational
+Neuroscience* 31:137-158, 10.1007/s10827-010-0304-x, 2011.
+
+Baker, J. L., Ryou, J.-W., Wei, X. F., Butson, C. R., Schiff, N.
+D. and Purpura, K. P.. Robust modulation of arousal regulation,
+performance, and frontostriatal activity through central thalamic
+deep brain stimulation in healthy nonhuman primates. *Journal of
+Neurophysiology* 116:2383-2404, 10.1152/jn.01129.2015, 2016.
+
+Balaguer, J.-M. and Capogrosso, M.. A computational model of the
+interaction between residual cortico-spinal inputs and spinal cord
+stimulation after paralysis [Online]. *Proceedings of the 10th
+International IEEE/EMBS Conference on Neural Engineering*
+:251-254, 10.1109/NER49283.2021.9441219, 2021.
+
+Balakrishnan, S. and Pearce, R. A.. Midazolam and atropine alter
+theta oscillations in the hippocampal CA1 region by modulating
+both the somatic and distal dendritic dipoles. *Hippocampus*
+24:1212-1231, 10.1002/hipo.22307, 2014.
+
+Balakrishnan, S. and Pearce, R. A.. Spatiotemporal characteristics
+and pharmacological modulation of multiple gamma oscillations in
+the CA1 region of the hippocampus. *Frontiers in Neural Circuits*
+8:150, 10.3389/fncir.2014.00150, 2015.
+
+Balbi, P., Martinoia, S., Colombo, R. and Massobrio, P.. Modelling
+recurrent discharge in the spinal α-motoneuron: reappraisal of the
+F wave. *Clinical Neurophysiology* 125:427-429,
+10.1016/j.clinph.2013.09.025, 2014.
+
+Balbi, P., Martinoia, S. and Massobrio, P.. Axon-somatic
+back-propagation in detailed models of spinal alpha motoneurons.
+*Frontiers in Computational Neuroscience* 9:15,
+10.3389/fncom.2015.00015, 2015.
+
+Balbi, P., Massobrio, P. and Hellgren Kotaleski, J.. A single
+Markov-type kinetic model accounting for the macroscopic currents
+of all human voltage-gated sodium channel isoforms. *PLoS
+Computational Biology* 13:e1005737, 10.1371/journal.pcbi.1005737,
+2017.
+
+Ball, J. M., Hummos, A. M. and Nair, S. S.. Role of sensory input
+distribution and intrinsic connectivity in lateral amygdala during
+auditory fear conditioning: a computational study. *Neuroscience*
+224:249-267, 10.1016/j.neuroscience.2012.08.030, 2012.
+
+Balmer, T. S., Borges-Merjane, C. and Trussell, L. O.. Incomplete
+removal of extracellular glutamate controls synaptic transmission
+and integration at a cerebellar synapse. *eLife*
+1010.7554/eLife.63819, 2021.
+
+Banerjee, A.. On the phase-space dynamics of systems of spiking
+neurons. I: Model and experiments. *Neural Computation*
+13:161-193, 2001.
+
+Banitt, Y., Martin, K. A. C. and Segev, I.. Depressed responses of
+facilitatory synapses. *Journal of Neurophysiology* 94:865-870,
+2005.
+
+Banitt, Y., Martin, K. A. C. and Segev, I.. A biologically
+realistic model of contrast invariant orientation tuning by
+thalamocortical synaptic depression. *Journal of Neuroscience*
+27:10230-10239, 2007.
+
+Bar Ilan, L., Gidon, A. and Segev, I.. Interregional synaptic
+competition in neurons with multiple STDP-inducing signals.
+*Journal of Neurophysiology* 105:989-998, 10.1152/jn.00612.2010,
+2011.
+
+Baranauskas, G., David, Y. and Fleidervish, I. A.. Spatial
+mismatch between the Na+ flux and spike initiation in axon initial
+segment. *Proceedings of the National Academy of Sciences of the
+United States of America* 110:4051-4056, 10.1073/pnas.1215125110,
+2013.
+
+Baranauskas, G. and Martina, M.. Sodium currents activate without
+a Hodgkin and Huxley-type delay in central mammalian neurons.
+*Journal of Neuroscience* 26:671-684, 2006.
+
+Baranauskas, G., Mukovskiy, A., Wolf, F. and Volgushev, M.. The
+determinants of the onset dynamics of action potentials in a
+computational model. *Neuroscience* 167:1070-1090,
+10.1016/j.neuroscience.2010.02.072, 2010.
+
+Barbieri, R., Bertelli, S., Pusch, M. and Gavazzo, P.. Late sodium
+current blocker GS967 inhibits persistent currents induced by
+familial hemiplegic migraine type 3 mutations of the SCN1A gene.
+*Journal of Headache and Pain* 20:107, 10.1186/s10194-019-1056-2,
+2019.
+
+Barela, A. J., Waddy, S. P., Lickfett, J. G., Hunter, J., Anido,
+A., Helmers, S. L., Goldin, A. L. and Escayg, A.. An epilepsy
+mutation in the sodium channel SCN1A that decreases channel
+excitability. *Journal of Neuroscience* 26:2714-2723, 2006.
+
+Barkai, O., Butterman, R., Katz, B., Lev, S. and Binshtok, A. M..
+The input-output relation of primary nociceptive neurons is
+determined by the morphology of the peripheral nociceptive
+terminals. *Journal of Neuroscience* 40:9346-9363,
+10.1523/JNEUROSCI.1546-20.2020, 2020.
+
+Barkai, O., Goldstein, R. H., Caspi, Y., Katz, B., Lev, S. and
+Binshtok, A. M.. The role of Kv7/M potassium channels in
+controlling ectopic firing in nociceptors. *Frontiers in Molecular
+Neuroscience* 10:181, 10.3389/fnmol.2017.00181, 2017.
+
+Barlow, B. M., Joos, B., Trinh, A. K. and Longtin, A.. Cooling
+reverses pathological bifurcations to spontaneous firing caused by
+mild traumatic injury. *Chaos* 28:106328, 10.1063/1.5040288, 2018.
+
+Barriga-Rivera, A., Guo, T., Yang, C.-Y., Abed, A. A., Dokos, S.,
+Lovell, N. H., Morley, J. W. and Suaning, G. J.. High-amplitude
+electrical stimulation can reduce elicited neuronal activity in
+visual prosthesis. *Scientific Reports* 7:42682,
+10.1038/srep42682, 2017.
+
+Barros-Zulaica, N., Rahmon, J., Chindemi, G., Perin, R., Markram,
+H., Muller, E. and Ramaswamy, S.. Estimating the
+readily-releasable vesicle pool size at synaptic connections in
+the neocortex. *Frontiers in Synaptic Neuroscience* 11:29,
+10.3389/fnsyn.2019.00029, 2019.
+
+Barry, J. F., Turner, M. J., Schloss, J. M., Glenn, D. R., Song,
+Y., Lukin, M. D., Park, H. and Walsworth, R. L.. Optical magnetic
+detection of single-neuron action potentials using quantum defects
+in diamond. *Proceedings of the National Academy of Sciences of
+the United States of America* 113:14133-14138,
+10.1073/pnas.1601513113, 2016.
+
+Bartos, M., Vida, I., Frotscher, M., Geiger, J. R. P. and Jonas,
+P.. Rapid signaling at inhibitory synapses in a dentate gyrus
+interneuron network. *Journal of Neuroscience* 21:2687-2698, 2001.
+
+Bartos, M., Vida, I., Frotscher, M., Meyer, A., Monyer, H.,
+Geiger, J. R. P. and Jonas, P.. Fast synaptic inhibition promotes
+synchronized gamma oscillations in hippocampal interneuron
+networks. *Proceedings of the National Academy of Sciences of the
+United States of America* 99:13222-13227, 2002.
+
+Bar-Yehuda, D. and Korngreen, A.. Space-clamp problems when
+voltage clamping neurons expressing voltage-gated conductances.
+*Journal of Neurophysiology* 99:1127-1136, 2008.
+
+Basak, R. and Narayanan, R.. Active dendrites regulate the
+spatiotemporal spread of signaling microdomains. *PLoS
+Computational Biology* 14:e1006485, 10.1371/journal.pcbi.1006485,
+2018a.
+
+Basak, R. and Narayanan, R.. Spatially dispersed synapses yield
+sharply-tuned place cell responses through dendritic spike
+initiation. *Journal of Physiology* 596:4173-4205,
+10.1113/JP275310, 2018b.
+
+Basak, R. and Narayanan, R.. Robust emergence of sharply tuned
+place-cell responses in hippocampal neurons with structural and
+biophysical heterogeneities. *Brain Structure and Function*
+225:567-590, 10.1007/s00429-019-02018-0, 2020.
+
+Basalyga, G., Gleiser, P. M. and Wennekers, T.. Emergence of
+small-world structure in networks of spiking neurons through STDP
+plasticity. *Advances in Experimental Medicine and Biology*
+718:33-39, 10.1007/978-1-4614-0164-3_4, 2011.
+
+Basalyga, G., Montemurro, M. A. and Wennekers, T.. Information
+coding in a laminar computational model of cat primary visual
+cortex. *Journal of Computational Neuroscience* 34:273-283,
+10.1007/s10827-012-0420-x, 2013.
+
+Basu, J., Srinivas, K. V., Cheung, S. K., Taniguchi, H., Huang, Z.
+J. and Siegelbaum, S. A.. A cortico-hippocampal learning rule
+shapes inhibitory microcircuit activity to enhance hippocampal
+information flow. *Neuron* 79:1208-1221,
+10.1016/j.neuron.2013.07.001, 2013.
+
+Bathellier, B., Margrie, T. W. and Larkum, M. E.. Properties of
+piriform cortex pyramidal cell dendrites: implications for
+olfactory circuit design. *Journal of Neuroscience*
+29:12641-12652, 2009.
+
+Battefeld, A., Popovic, M. A., de Vries, S. I. and Kole, M. H. P..
+High-frequency microdomain Ca2+ transients and waves during early
+myelin internode remodeling. *Cell Reports* 26:182-191.e5,
+10.1016/j.celrep.2018.12.039, 2019.
+
+Battefeld, A., Tran, B. T., Gavrilis, J., Cooper, E. C. and Kole,
+M. H. P.. Heteromeric Kv7.2/7.3 channels differentially regulate
+action potential initiation and conduction in neocortical
+myelinated axons. *Journal of Neuroscience* 34:3719-3732,
+10.1523/JNEUROSCI.4206-13.2014, 2014.
+
+Beaulieu-Laroche, L., Brown, N. J., Hansen, M., Toloza, E. H. S.,
+Sharma, J., Williams, Z. M., Frosch, M. P., Cosgrove, G. R., Cash,
+S. S. and Harnett, M. T.. Allometric rules for mammalian cortical
+layer 5 neuron biophysics. *Nature* 600:274-278,
+10.1038/s41586-021-04072-3, 2021.
+
+Beaulieu-Laroche, L., Toloza, E. H. S., van der Goes, M.-S.,
+Lafourcade, M., Barnagian, D., Williams, Z. M., Eskandar, E. N.,
+Frosch, M. P., Cash, S. S. and Harnett, M. T.. Enhanced dendritic
+compartmentalization in human cortical neurons. *Cell*
+175:643-651.e14, 10.1016/j.cell.2018.08.045, 2018.
+
+Bédard, C., Béhuret, S., Deleuze, C., Bal, T. and Destexhe, A..
+Oversampling method to extract excitatory and inhibitory
+conductances from single-trial membrane potential recordings.
+*Journal of Neuroscience Methods* 210:3-14,
+10.1016/j.jneumeth.2011.09.010, 2012.
+
+Bédard, C. and Destexhe, A.. A modified cable formalism for
+modeling neuronal membranes at high frequencies. *Biophysical
+Journal* 94:1133-1143, 2008.
+
+Bédard, C., Kröger, H. and Destexhe, A.. Modeling extracellular
+field potentials and the frequency-filtering properties of
+extracellular space. *Biophysical Journal* 86:1829-1842, 2004.
+
+Bédard, C., Rodrigues, S., Roy, N., Contreras, D. and Destexhe,
+A.. Evidence for frequency-dependent extracellular impedance from
+the transfer function between extracellular and intracellular
+potentials. *Journal of Computational Neuroscience* 29:389-403,
+10.1007/s10827-010-0250-7, 2010.
+
+Begum, R., Bakiri, Y., Volynski, K. E. and Kullmann, D. M.. Action
+potential broadening in a presynaptic channelopathy. *Nature
+Communications* 7:12102, 10.1038/ncomms12102, 2016.
+
+Behabadi, B. F. and Mel, B. W.. J4 at sweet 16: A new wrinkle?.
+*Neural Computation* 19:2865-2870, 2007.
+
+Behabadi, B. F. and Mel, B. W.. Mechanisms underlying subunit
+independence in pyramidal neuron dendrites. *Proceedings of the
+National Academy of Sciences of the United States of America*
+111:498-503, 10.1073/pnas.1217645111, 2014.
+
+Behabadi, B. F., Polsky, A., Jadi, M., Schiller, J. and Mel, B.
+W.. Location-dependent excitatory synaptic interactions in
+pyramidal neuron dendrites. *PLoS Computational Biology*
+8:e1002599, 10.1371/journal.pcbi.1002599, 2012.
+
+Béhuret, S., Deleuze, C. and Bal, T.. Corticothalamic synaptic
+noise as a mechanism for selective attention in thalamic neurons.
+*Frontiers in Neural Circuits* 9:80, 10.3389/fncir.2015.00080,
+2015.
+
+Béhuret, S., Deleuze, C., Gomez, L., Frégnac, Y. and Bal, T..
+Cortically-controlled population stochastic facilitation as a
+plausible substrate for guiding sensory transfer across the
+thalamic gateway. *PLoS Computational Biology* 9:e1003401,
+10.1371/journal.pcbi.1003401, 2013.
+
+Beining, M., Mongiat, L. A., Schwarzacher, S. W., Cuntz, H. and
+Jedlicka, P.. T2N as a new tool for robust electrophysiological
+modeling demonstrated for mature and adult-born dentate granule
+cells. *eLife* 6:e26517, 10.7554/eLife.26517, 2017.
+
+Bekkers, J. M. and Stevens, C. F.. Cable properties of cultured
+hippocampal neurons determined from sucrose-evoked miniature
+EPSCs. *Journal of Neurophysiology* 75:1250-1255, 1996.
+
+Bekkouche, B., Shoemaker, P. A., Fabian, J., Rigosi, E.,
+Wiederman, S. D. and O'Carroll, D. C.. Multicompartment
+simulations of NMDA receptor based facilitation in an insect
+target tracking neuron. In: *Artificial Neural Networks and
+Machine Learning -- ICANN 2017*. Springer International
+Publishing, 2017, pp. 397-404.
+
+Bekkouche, B. M. B., Shoemaker, P. A., Fabian, J. M., Rigosi, E.,
+Wiederman, S. D. and O'Carroll, D. C.. Modeling nonlinear
+dendritic processing of facilitation in a dragonfly
+target-tracking neuron. *Frontiers in Neural Circuits* 15:684872,
+10.3389/fncir.2021.684872, 2021.
+
+Bekolay, T., Bergstra, J., Hunsberger, E., Dewolf, T., Stewart, T.
+C., Rasmussen, D., Choo, X., Voelker, A. R. and Eliasmith, C..
+Nengo: a Python tool for building large-scale functional brain
+models. *Frontiers in Neuroinformatics* 7:48,
+10.3389/fninf.2013.00048, 2014.
+
+Bell, A., Mainen, Z. F. and Sejnowski, T. J.. Balancing of
+conductances may explain irregularity of cortical spiking
+[Online]. *Proceedings of the Joint Symposium on Neural
+Computation, University of California, San Diego and California
+Institute of Technology* 4:1-5, 1994.
+
+Bell, A., Mainen, Z. F. and Sejnowski, T. J.. Technical Report
+INC-9502: "Balancing" of conductances may explain irregularity of
+cortical spiking. Institute for Neural Computation,
+10.1.1.50.5668, 1995.
+
+Bellinger, S. C., Miyazawa, G. and Steinmetz, P. N.. Submyelin
+potassium accumulation may functionally block subsets of local
+axons during deep brain stimulation: a modeling study. *Journal of
+Neural Engineering* 5:263-274, 2008.
+
+Bellinger, S. C., Rho, J. M. and Steinmetz, P. N.. Modeling action
+potential generation during single and dual electrode stimulation
+of CA3 axons in hippocampal slice. *Computers in Biology and
+Medicine* 40:487-497, 10.1016/j.compbiomed.2010.03.003, 2010.
+
+Benke, T. A., Lüthi, A., Palmer, M. J., Wikström, M. A., Anderson,
+W. W., Isaac, J. T. R. and Collingridge, G. L.. Mathematical
+modelling of non-stationary fluctuation analysis for studying
+channel properties of synaptic AMPA receptors. *Journal of
+Physiology* 537:407-420, 2001.
+
+Bennett, C. B. and Muschol, M.. Large neurohypophysial
+varicosities amplify action potentials: results from numerical
+simulations. *Endocrinology* 150:2829-2836, 2009.
+
+Ben-Shalom, R., Aviv, A., Razon, B. and Korngreen, A.. Optimizing
+ion channel models using a parallel genetic algorithm on graphical
+processors. *Journal of Neuroscience Methods* 206:183-194,
+10.1016/j.jneumeth.2012.02.024, 2012.
+
+Ben-Shalom, R., Keeshen, C. M., Berrios, K. N., An, J. Y.,
+Sanders, S. J. and Bender, K. J.. Opposing effects on NAV1.2
+function underlie differences between SCN2A variants observed in
+individuals with autism spectrum disorder or infantile seizures.
+*Biological Psychiatry* 82:224-232,
+10.1016/j.biopsych.2017.01.009, 2017.
+
+Ben-Shalom, R., Ladd, A., Artherya, N. S., Cross, C., Kim, K. G.,
+Sanghevi, H., Korngreen, A., Bouchard, K. E. and Bender, K. J..
+NeuroGPU: accelerating multi-compartment, biophysically detailed
+neuron simulations on GPUs. *Journal of Neuroscience Methods*
+366:109400, 10.1016/j.jneumeth.2021.109400, 2022.
+
+Ben-Shalom, R., Liberman, G. and Korngreen, A.. Accelerating
+compartmental modeling on a graphical processing unit. *Frontiers
+in Neuroinformatics* 7:4, 10.3389/fninf.2013.00004, 2013.
+
+Benucci, A., Verschure, P. F. M. J. and König, P.. Two-state
+membrane potential fluctuations driven by weak pairwise
+correlations. *Neural Computation* 16:2351-2378, 2004.
+
+Benucci, A., Verschure, P. F. M. J. and König, P.. Dynamical
+features of higher-order correlation events: impact on cortical
+cells. *Cognitive Neurodynamics* 1:53-69, 2007.
+
+Berecki, G., Bryson, A., Terhag, J., Maljevic, S., Gazina, E. V.,
+Hill, S. L. and Petrou, S.. SCN1A gain of function in early
+infantile encephalopathy. *Annals of Neurology* 85:514-525,
+10.1002/ana.25438, 2019.
+
+Berends, M., Maex, R. and De Schutter, E.. The effect of NMDA
+receptors on gain modulation. *Neural Computation* 17:2531-2547,
+2005.
+
+Bernander, Ö., Douglas, R. J., Martin, K. A. C. and Koch, C..
+Synaptic background activity influences spatiotemporal integration
+in single pyramidal cells. *Proceedings of the National Academy of
+Sciences of the United States of America* 88:11569-11573, 1991.
+
+Bernander, Ö., Koch, C. and Douglas, R. J.. Amplification and
+linearization of distal synaptic input to cortical pyramidal
+neurons. *Journal of Neurophysiology* 72:2743-2753, 1994.
+
+Bernasconi, C. A., Schindler, K. A., Stoop, R. and Douglas, R..
+Complex response to periodic inhibition in simple and detailed
+neuronal models. *Neural Computation* 11:67-74, 1999.
+
+Berzhanskaya, J., Chernyy, N., Gluckman, B. J., Schiff, S. J. and
+Ascoli, G. A.. Modulation of hippocampal rhythms by subthreshold
+electric fields and network topology. *Journal of Computational
+Neuroscience* 34:369-389, 10.1007/s10827-012-0426-4, 2013.
+
+Bessaih, T., Leresche, N. and Lambert, R. C.. T current
+potentiation increases the occurrence and temporal fidelity of
+synaptically evoked burst firing in sensory thalamic neurons.
+*Proceedings of the National Academy of Sciences of the United
+States of America* 105:11376-11381, 2008.
+
+Bezaire, M., Raikov, I., Burk, K., Armstrong, C. and Soltesz, I..
+SimTracker tool and code template to design, manage and analyze
+neural network model simulations in parallel NEURON. *bioRxiv*
+:081927, 2016a.
+
+Bezaire, M. J., Raikov, I., Burk, K., Vyas, D. and Soltesz, I..
+Interneuronal mechanisms of hippocampal theta oscillations in a
+full-scale model of the rodent CA1 circuit. *eLife* 5:e18566,
+10.7554/eLife.18566, 2016b.
+
+Bhadra, N. and Kilgore, K. L.. Direct current electrical
+conduction block of peripheral nerve. *IEEE Transactions on Neural
+Systems and Rehabilitation Engineering* 12:313-324, 2004.
+
+Bhadra, N., Lahowetz, E. A., Foldes, S. T. and Kilgore, K. L..
+Simulation of high-frequency sinusoidal electrical block of
+mammalian myelinated axons. *Journal of Computational
+Neuroscience* 22:313-326, 2007.
+
+Bhumbra, G. S., Bannatyne, B. A., Watanabe, M., Todd, A. J.,
+Maxwell, D. J. and Beato, M.. The recurrent case for the Renshaw
+cell. *Journal of Neuroscience* 34:12919-12932,
+10.1523/JNEUROSCI.0199-14.2014, 2014.
+
+Bialowas, A., Rama, S., Zbili, M., Marra, V.,
+Fronzaroli-Molinieres, L., Ankri, N., Carlier, E. and Debanne, D..
+Analog modulation of spike-evoked transmission in CA3 circuits is
+determined by axonal Kv1.1 channels in a time-dependent manner.
+*European Journal of Neuroscience* 41:293-304, 10.1111/ejn.12787,
+2015.
+
+Bianchi, D., De Michele, P., Marchetti, C., Tirozzi, B., Cuomo,
+S., Marie, H. and Migliore, M.. Effects of increasing
+CREB-dependent transcription on the storage and recall processes
+in a hippocampal CA1 microcircuit. *Hippocampus* 24:165-177,
+10.1002/hipo.22212, 2014.
+
+Bianchi, D., Marasco, A., Limongiello, A., Marchetti, C., Marie,
+H., Tirozzi, B. and Migliore, M.. On the mechanisms underlying the
+depolarization block in the spiking dynamics of CA1 pyramidal
+neurons. *Journal of Computational Neuroscience* 33:207-225,
+10.1007/s10827-012-0383-y, 2012.
+
+Bianchi, D., Migliore, R., Vitale, P., Garad, M., Pousinha, P. A.,
+Marie, H., Lessmann, V. and Migliore, M.. Membrane electrical
+properties of mouse hippocampal CA1 pyramidal neurons during
+strong inputs. *Biophysical Journal* 121:644-657,
+10.1016/j.bpj.2022.01.002, 2022.
+
+Biane, C., Rückerl, F., Abrahamsson, T., Saint-Cloment, C.,
+Mariani, J., Shigemoto, R., DiGregorio, D. A., Sherrard, R. M. and
+Cathala, L.. Developmental emergence of two-stage nonlinear
+synaptic integration in cerebellar interneurons. *eLife*
+1010.7554/eLife.65954, 2021.
+
+Bicknell, B. A. and Häusser, M.. A synaptic learning rule for
+exploiting nonlinear dendritic computation. *Neuron*
+109:4001-4017.e10, 10.1016/j.neuron.2021.09.044, 2021.
+
+Bieda, M. C. and Copenhagen, D. R.. Inhibition is not required for
+the production of transient spiking responses from retinal
+ganglion cells. *Visual Neuroscience* 17:243-254, 2000.
+
+Billeh, Y. N., Cai, B., Gratiy, S. L., Dai, K., Iyer, R., Gouwens,
+N. W., Abbasi-Asl, R., Jia, X., Siegle, J. H., Olsen, S. R., Koch,
+C., Mihalas, S. and Arkhipov, A.. Systematic integration of
+structural and functional data into multi-scale models of mouse
+primary visual cortex. *Neuron* 106:388-403.e18,
+10.1016/j.neuron.2020.01.040, 2020.
+
+Billings, G., Piasini, E., Lorincz, A., Nusser, Z. and Silver, R.
+A.. Network structure within the cerebellar input layer enables
+lossless sparse encoding. *Neuron* 83:960-974,
+10.1016/j.neuron.2014.07.020, 2014.
+
+Bingham, C. S., Bouteiller, J.-M. C., Song, D. and Berger, T. W..
+Graph-based models of cortical axons for the prediction of
+neuronal response to extracellular electrical stimulation. *IEEE
+Engineering in Medicine and Biology Society. Annual Conference*
+2018:1380-1383, 10.1109/EMBC.2018.8512503, 2018a.
+
+Bingham, C. S., Loizos, K., Yu, G., Gilbert, A., Bouteiller,
+J.-M., Song, D., Lazzi, G. and Berger, T. W.. A large-scale
+detailed neuronal model of electrical stimulation of the dentate
+gyrus and perforant path as a platform for electrode design and
+optimization. *IEEE Engineering in Medicine and Biology Society
+Annual Conference* 2016:2794-2797, 10.1109/EMBC.2016.7591310,
+2016.
+
+Bingham, C. S., Loizos, K., Yu, G. J., Gilbert, A., Bouteiller,
+J.-M. C., Song, D., Lazzi, G. and Berger, T. W.. Model-based
+analysis of electrode placement and pulse amplitude for
+hippocampal stimulation. *IEEE Transactions on Bio-Medical
+Engineering* 65:2278-2289, 10.1109/TBME.2018.2791860, 2018b.
+
+Bingham, C. S., Mergenthal, A., Bouteiller, J.-M. C., Song, D.,
+Lazzi, G. and Berger, T. W.. ROOTS: an algorithm to generate
+biologically realistic cortical axons and an application to
+electroceutical modeling. *Frontiers In Computational
+Neuroscience* 14:13, 10.3389/fncom.2020.00013, 2020a.
+
+Bingham, C. S., Paknahad, J., Girard, C. B. C., Loizos, K.,
+Bouteiller, J.-M. C., Song, D., Lazzi, G. and Berger, T. W..
+Admittance method for estimating local field potentials generated
+in a multi-scale neuron model of the hippocampus. *Frontiers in
+Computational Neuroscience* 14:72, 10.3389/fncom.2020.00072,
+2020b.
+
+Birdno, M. J., Cooper, S. E., Rezai, A. R. and Grill, W. M..
+Pulse-to-pulse changes in the frequency of deep brain stimulation
+affect tremor and modeled neuronal activity. *Journal of
+Neurophysiology* 98:1675-1684, 2007.
+
+Birdno, M. J., Kuncel, A. M., Dorval, A. D., Turner, D. A., Gross,
+R. E. and Grill, W. M.. Stimulus features underlying reduced
+tremor suppression with temporally patterned deep brain
+stimulation. *Journal of Neurophysiology* 107:364-383,
+10.1152/jn.00906.2010, 2012.
+
+Birdno, M. J., Tang, W., Dostrovsky, J. O., Hutchison, W. D. and
+Grill, W. M.. Response of human thalamic neurons to high-frequency
+stimulation. *PLoS ONE* 9:e96026, 10.1371/journal.pone.0096026,
+2014.
+
+Biró, Á. A., Brémaud, A., Falck, J. and Ruiz, A. J.. A-type K+
+channels impede supralinear summation of clustered glutamatergic
+inputs in layer 3 neocortical pyramidal neurons.
+*Neuropharmacology* 140:86-99, 10.1016/j.neuropharm.2018.07.005,
+2018.
+
+Bittner, K. C., Milstein, A. D., Grienberger, C., Romani, S. and
+Magee, J. C.. Behavioral time scale synaptic plasticity underlies
+CA1 place fields. *Science* 357:1033-1036,
+10.1126/science.aan3846, 2017.
+
+Blackman, A. V., Grabuschnig, S., Legenstein, R. and Sjöström, P.
+J.. A comparison of manual neuronal reconstruction from biocytin
+histology or 2-photon imaging: morphometry and computer modeling.
+*Frontiers in Neuroanatomy* 8:65, 10.3389/fnana.2014.00065, 2014.
+
+Blair, H. T.. A thalamocortical circuit for computing directional
+heading in the rat. In: *Advances in Neural Information Processing
+Systems*, edited by Touretzky, D. S., Mozer, M. C. and Hasselmo,
+M. E.. Cambridge, MA: Cambridge, MA, MIT Press, 1996, pp. 152-158.
+
+Blank, D. A. and Stoop, R.. Collective bursting in populations of
+intrinsically nonbursting neurons. *Zeitschrift für Naturforschung
+A* 54:617-627, 1999.
+
+Blank, D. A., Stoop, R., Kern, A. and Douglas, R. J.. Optimal
+recurrent excitation amplification in biophysically plausible
+neuron models [Online]. *Proceedings of the 2nd ICSD Symposium on
+Neural Computation* 2:463-469, 2000.
+
+Bloss, E. B., Cembrowski, M. S., Karsh, B., Colonell, J., Fetter,
+R. D. and Spruston, N.. Structured dendritic inhibition supports
+branch-selective integration in CA1 pyramidal cells. *Neuron*
+89:1016-1030, 10.1016/j.neuron.2016.01.029, 2016.
+
+Bloss, E. B., Cembrowski, M. S., Karsh, B., Colonell, J., Fetter,
+R. D. and Spruston, N.. Single excitatory axons form clustered
+synapses onto CA1 pyramidal cell dendrites. *Nature Neuroscience*
+21:353-363, 10.1038/s41593-018-0084-6, 2018.
+
+Bock, T., Honnuraiah, S. and Stuart, G. J.. Paradoxical excitatory
+impact of SK channels on dendritic excitability. *Journal of
+Neuroscience* 39:7826-7839, 10.1523/JNEUROSCI.0105-19.2019, 2019.
+
+Bock, T., Negrean, A. and Siegelbaum, S. A.. Somatic
+depolarization enhances hippocampal Ca1 dendritic spike
+propagation and distal input driven synaptic plasticity. *Journal
+of Neuroscience* 10.1523/JNEUROSCI.0780-21.2022, 2022.
+
+Bodda, S., Palathingal, R. K., Sankar, V., Nair, B. and Diwakar,
+S.. Modeling population network activity using LFPsim, spiking
+neurons and neural mass models [Online]. *2017 International
+Conference on Advances in Computing, Communications and
+Informatics*, 10.1109/icacci.2017.8125898, 2017.
+
+Bogaard, A., Parent, J., Zochowski, M. and Booth, V.. Interaction
+of cellular and network mechanisms in spatiotemporal pattern
+formation in neuronal networks. *Journal of Neuroscience*
+29:1677-1687, 2009.
+
+Bolduan, F., Grosser, S. and Vida, I.. Minimizing shrinkage of
+acute brain slices using metal spacers during histological
+embedding. *Brain Structure and Function* 225:2577-2589,
+10.1007/s00429-020-02141-3, 2020.
+
+Bonaiuto, J. J., Little, S., Neymotin, S. A., Jones, S. R.,
+Barnes, G. R. and Bestmann, S.. Laminar dynamics of high amplitude
+beta bursts in human motor cortex. *NeuroImage* 242:118479,
+10.1016/j.neuroimage.2021.118479, 2021.
+
+Booker, S. A., Gross, A., Althof, D., Shigemoto, R., Bettler, B.,
+Frotscher, M., Hearing, M., Wickman, K., Watanabe, M., Kulik, Á.
+and Vida, I.. Differential GABAB-receptor-mediated effects in
+perisomatic- and dendrite-targeting parvalbumin interneurons.
+*Journal of Neuroscience* 33:7961-7974,
+10.1523/JNEUROSCI.1186-12.2013, 2013.
+
+Booker, S. A., Simões de Oliveira, L., Anstey, N. J., Kozic, Z.,
+Dando, O. R., Jackson, A. D., Baxter, P. S., Isom, L. L., Sherman,
+D. L., Hardingham, G. E., Brophy, P. J., Wyllie, D. J. A. and
+Kind, P. C.. Input-output relationship of Ca1 pyramidal neurons
+reveals intact homeostatic mechanisms in a mouse model of fragile
+X syndrome. *Cell Reports* 32:107988,
+10.1016/j.celrep.2020.107988, 2020.
+
+Booth, V. and Poe, G. R.. Input source and strength influences
+overall firing phase of model hippocampal CA1 pyramidal cells
+during theta: Relevance to REM sleep reactivation and memory
+consolidation. *Hippocampus* 16:161-173, 2006.
+
+Borda Bossana, S., Verbist, C. and Giugliano, M.. Homogeneous and
+narrow bandwidth of spike initiation in rat L1 cortical
+interneurons. *Frontiers in Cellular Neuroscience* 14:118,
+10.3389/fncel.2020.00118, 2020.
+
+Borel, M., Guadagna, S., Jang, H. J., Kwag, J. and Paulsen, O..
+Frequency dependence of CA3 spike phase response arising from
+h-current properties. *Frontiers In Cellular Neuroscience*
+710.3389/fncel.2013.00263, 2013.
+
+Bos, R., Harris-Warrick, R. M., Brocard, C., Demianenko, L. E.,
+Manuel, M., Zytnicki, D., Korogod, S. M. and Brocard, F.. Kv1.2
+channels promote nonlinear spiking motoneurons for powering up
+locomotion. *Cell Reports* 22:3315-3327,
+10.1016/j.celrep.2018.02.093, 2018.
+
+Botta, P., Simões de Souza, F. M., Sangrey, T., De Schutter, E.
+and Valenzuela, C. F.. Alcohol excites cerebellar Golgi cells by
+inhibiting the Na+/K+ ATPase. *Neuropsychopharmacology*
+35:1984-1996, 10.1038/npp.2010.76, 2010.
+
+Botta, P., Simões de Souza, F. M., Sangrey, T., De Schutter, E.
+and Valenzuela, C. F.. Excitation of rat cerebellar Golgi cells by
+ethanol: further characterization of the mechanism. *Alcoholism,
+Clinical and Experimental Research* 36:616-624,
+10.1111/j.1530-0277.2011.01658.x, 2012.
+
+Bourbeau, D. J., Hokanson, J. A., Rubin, J. E. and Weber, D. J.. A
+computational model for estimating recruitment of primary afferent
+fibers by intraneural stimulation in the dorsal root ganglia.
+*Journal of Neural Engineering* 8:056009,
+10.1088/1741-2560/8/5/056009, 2011.
+
+Bouteiller, J.-M. C., Allam, S. L., Hu, E. Y., Greget, R., Ambert,
+N., Keller, A. F., Bischoff, S., Baudry, M. and Berger, T. W..
+Integrated multiscale modeling of the nervous system: predicting
+changes in hippocampal network activity by a positive AMPA
+receptor modulator. *IEEE Transactions on Biomedical Engineering*
+58:3008-3011, 10.1109/TBME.2011.2158605, 2011a.
+
+Bouteiller, J.-M. C., Allam, S. L., Hu, E. Y., Greget, R., Ambert,
+N., Keller, A. F., Pernot, F., Bischoff, S., Baudry, M. and
+Berger, T. W.. Modeling of the nervous system: from molecular
+dynamics and synaptic modulation to neuron spiking activity
+[Online]. *IEEE Engineering in Medicine and Biology Society
+Proceedings* 2011:445-448, 10.1109/IEMBS.2011.6090061, 2011b.
+
+Bouteiller, J.-M. C., Legendre, A., Allam, S. L., Ambert, N., Hu,
+E. Y., Greget, R., Keller, A. F., Pernot, F., Bischoff, S.,
+Baudry, M. and Berger, T. W.. Modeling of the nervous system: from
+modulation of glutamatergic and gabaergic molecular dynamics to
+neuron spiking activity [Online]. *IEEE Engineering in Medicine
+and Biology Society Proceedings* 2012:6612-6615,
+10.1109/EMBC.2012.6347510, 2012.
+
+Bower, K. L. and McIntyre, C. C.. Deep brain stimulation of
+terminating axons. *Brain Stimulation* 13:1863-1870,
+10.1016/j.brs.2020.09.001, 2020.
+
+Braganza, O., Mueller-Komorowska, D., Kelly, T. and Beck, H..
+Quantitative properties of a feedback circuit predict
+frequency-dependent pattern separation. *eLife*
+910.7554/eLife.53148, 2020.
+
+Branchereau, P., Cattaert, D., Delpy, A., Allain, A.-E., Martin,
+E. and Meyrand, P.. Depolarizing GABA/glycine synaptic events
+switch from excitation to inhibition during frequency increases.
+*Scientific Reports* 6:21753, 10.1038/srep21753, 2016.
+
+Branchereau, P., Martin, E., Allain, A.-E., Cazenave, W., Supiot,
+L., Hodeib, F., Laupénie, A., Dalvi, U., Zhu, H. and Cattaert, D..
+Relaxation of synaptic inhibitory events as a compensatory
+mechanism in fetal SOD spinal motor networks. *eLife* 8:e51402,
+10.7554/eLife.51402, 2019.
+
+Branco, T., Clark, B. A. and Häusser, M.. Dendritic discrimination
+of temporal input sequences in cortical neurons. *Science*
+329:1671-1675, 10.1126/science.1189664, 2010.
+
+Branco, T. and Häusser, M.. Synaptic integration gradients in
+single cortical pyramidal cell dendrites. *Neuron* 69:885-892,
+10.1016/j.neuron.2011.02.006, 2011.
+
+Branco, T., Tozer, A., Magnus, C. J., Sugino, K., Tanaka, S., Lee,
+A. K., Wood, J. N. and Sternson, S. M.. Near-perfect synaptic
+integration by Na(v)1.7 in hypothalamic neurons regulates body
+weight. *Cell* 165:1749-1761, 10.1016/j.cell.2016.05.019, 2016.
+
+Bras, H., Lahjouji, F., Korogod, S. M., Kulagina, I. B. and Barbe,
+A.. Heterogeneous synaptic covering and differential charge
+transfer sensitivity among the dendrites of a reconstructed
+abducens motor neurone: correlations between electron microscopic
+and compter simulation data. *Journal of Neurocytology* 32:5-24,
+2003.
+
+Brecht, M., Roth, A. and Sakmann, B.. Dynamic receptive fields of
+reconstructed pyramidal cells in layers 3 and 2 of rat
+somatosensory barrel cortex. *Journal of Physiology* 553:243-265,
+2003.
+
+Brecht, M. and Sakmann, B.. Dynamic representation of whisker
+deflection by synaptic potentials in spiny stellate and pyramidal
+cells in the barrels and septa of layer 4 rat somatosensory
+cortex. *Journal of Physiology* 543:49-70, 2002.
+
+Breen, B. J., Gerken, W. C. and Butera, R. J.. Hybrid
+integrate-and-fire model of a bursting neuron. *Neural
+Computation* 15:2843-2862, 2003.
+
+Brennan, E. K., Jedrasiak-Cape, I., Kailasa, S., Rice, S. P.,
+Sudhakar, S. K. and Ahmed, O. J.. Thalamus and claustrum control
+parallel layer 1 circuits in retrosplenial cortex. *eLife*
+1010.7554/eLife.62207, 2021.
+
+Brennan, E. K. W., Sudhakar, S. K., Jedrasiak-Cape, I., John, T.
+T. and Ahmed, O. J.. Hyperexcitable neurons enable precise and
+persistent information encoding in the superficial retrosplenial
+cortex. *Cell Reports* 30:1598-1612.e8,
+10.1016/j.celrep.2019.12.093, 2020.
+
+Breton-Provencher, V., Bakhshetyan, K., Hardy, D., Bammann, R. R.,
+Cavarretta, F., Snapyan, M., Côté, D., Migliore, M. and
+Saghatelyan, A.. Principal cell activity induces spine relocation
+of adult-born interneurons in the olfactory bulb. *Nature
+Communications* 7:12659, 10.1038/ncomms12659, 2016.
+
+Brette, R. and Gerstner, W.. Adaptive exponential
+integrate-and-fire model as an effective description of neuronal
+activity. *Journal of Neurophysiology* 94:3637-3642, 2005.
+
+Brette, R., Piwkowska, Z., Monier, C., González, J. F. G.,
+Frégnac, Y., Bal, T. and Destexhe, A.. Dynamic clamp with
+high-resistance electrodes using active electrode compensation in
+vitro and in vivo. In: *Dynamic-Clamp: From Principles to
+Applications*. New York, NY: Springer US, 2009, pp. 347-382.
+
+Brette, R., Piwkowska, Z., Monier, C., Rudolph-Lilith, M.,
+Fournier, J., Levy, M., Fregnac, Y., Bal, T. and Destexhe, A..
+High-resolution intracellular recordings using a real-time
+computational model of the electrode. *Neuron* 59:379-391, 2008.
+
+Brette, R., Piwkowska, Z., Rudolph, M., Bal, T. and Destexhe, A..
+A non-parametric electrode model for intracellular recording.
+*Neurocomputing* 70:1597-1601, 2007a.
+
+Brette, R., Rudolph, M., Carnevale, T., Hines, M., Beeman, D.,
+Bower, J. M., Diesmann, M., Goodman, P. H., Harris, F. C. J.,
+Zirpe, M., Natschläger, T., Pecevski, D., Ermentrout, B.,
+Djurfeldt, M., Lansner, A., Rochel, O., Vieville, T., Muller, E.,
+Davison, A., El Boustani, S. and Destexhe, A.. Simulation of
+networks of spiking neurons: a review of tools and strategies.
+*Journal of Computational Neuroscience* 23:349-398, 2007b.
+
+Briant, L. J. B., Paton, J. F. R., Pickering, A. E. and Champneys,
+A. R.. Modelling the vascular response to sympathetic
+postganglionic nerve activity. *Journal of Theoretical Biology*
+371:102-116, 10.1016/j.jtbi.2015.01.037, 2015.
+
+Briant, L. J. B., Reinbothe, T. M., Spiliotis, I., Miranda, C.,
+Rodriguez, B. and Rorsman, P.. δ-cells and β-cells are
+electrically coupled and regulate α-cell activity via
+somatostatin. *Journal of Physiology* 596:197-215,
+10.1113/JP274581, 2018.
+
+Briant, L. J. B., Stalbovskiy, A. O., Nolan, M. F., Champneys, A.
+R. and Pickering, A. E.. Increased intrinsic excitability of
+muscle vasoconstrictor preganglionic neurons may contribute to the
+elevated sympathetic activity in hypertensive rats. *Journal of
+Neurophysiology* 112:2756-2778, 10.1152/jn.00350.2014, 2014.
+
+Briska, A. M., Uhlrich, D. J. and Lytton, W. W.. Independent
+dendritic domains in the thalamic circuit. *Neurocomputing*
+32:299-305, 2000.
+
+Briska, A. M., Uhlrich, D. J. and Lytton, W. W.. Computer model of
+passive signal integration based on whole-cell in vitro studies of
+rat lateral geniculate nucleus. *European Journal of Neuroscience*
+17:1531-1541, 2003.
+
+Brody, M. and Korngreen, A.. Simulating the effects of short-term
+synaptic plasticity on postsynaptic dynamics in the globus
+pallidus. *Frontiers in Systems Neuroscience* 7:40,
+10.3389/fnsys.2013.00040, 2013.
+
+Broicher, T., Kanyshkova, T., Landgraf, P., Rankovic, V., Meuth,
+P., Meuth, S. G., Pape, H. C. and Budde, T.. Specific expression
+of low-voltage-activated calcium channel isoforms and splice
+variants in thalamic local circuit interneurons. *Molecular and
+Cellular Neuroscience* 36:132-145, 2007a.
+
+Broicher, T., Kanyshkova, T., Meuth, P., Pape, H. C. and Budde,
+T.. Correlation of T-channel coding gene expression, I-T, and the
+low threshold Ca2+ spike in the thalamus of a rat model of absence
+epilepsy. *Molecular and Cellular Neuroscience* 39:384-399, 2008.
+
+Broicher, T., Seidenbecher, T., Meuth, P., Munsch, T., Meuth, S.
+G., Kanyshkova, T., Pape, H. C. and Budde, T.. T-current related
+effects of antiepileptic drugs and a Ca2+ channel antagonist on
+thalamic relay and local circuit interneurons in a rat model of
+absence epilepsy. *Neuropharmacology* 53:431-446, 2007b.
+
+Broser, P. J., Schulte, R., Lang, S., Roth, A., Helmchen, F.,
+Waters, J., Sakmann, B. and Wittum, G.. Nonlinear anisotropic
+diffusion filtering of three-dimensional image data from
+two-photon microscopy. *Journal of Biomedical Optics* 9:1253-1264,
+2004.
+
+Brown, A. M., Evans, R. D., Smith, P. A., Rich, L. R. and Ransom,
+B. R.. Hypothermic neuroprotection during reperfusion following
+exposure to aglycemia in central white matter is mediated by
+acidification. *Physiological Reports* 7:e14007,
+10.14814/phy2.14007, 2019.
+
+Brown, D., Feng, J. and Feerick, S.. Variability of firing of
+Hodgkin-Huxley and FitzHugh-Nagumo neurons with stochastic
+synaptic input. *Physical Review Letters* 82:4731-4734, 1999.
+
+Brown, S.-A., Moraru, I. I., Schaff, J. C. and Loew, L. M..
+Virtual NEURON: a strategy for merged biochemical and
+electrophysiological modeling. *Journal of Computational
+Neuroscience* 31:385-400, 10.1007/s10827-011-0317-0, 2011.
+
+Brown, T. H., Mainen, Z. F., Zador, A. M. and Claiborne, B. J..
+Self-organization of Hebbian synapses in hippocampal neurons. In:
+*Advances in Neural Information Processing Systems*, edited by
+Lippmann, R. P., Moody, J. E. and Touretzky, D. J.. San Mateo, CA:
+San Mateo, CA, Morgan Kaufmann, 1991a, pp. 39-45.
+
+Brown, T. H., Zador, A. M., Mainen, Z. F. and Claiborne, B. J..
+Hebbian modifications in hippocampal neurons. In: *Long-term
+potentiation: A debate of current issues*, edited by Davis, J. and
+Baudry, M.. Cambridge, MA: Cambridge, MA, MIT Press, 1991b, pp.
+357-389.
+
+Brown, T. H., Zador, A. M., Mainen, Z. F. and Claiborne, B. J..
+Hebbian computations in hippocampal dendrites and spines. In:
+*Single Neuron Computation*, edited by McKenna, T., Davis, J. and
+Zornetzer, S. F.. San Diego: San Diego, Academic Press, 1992, pp.
+81-116.
+
+Brüderle, D., Petrovici, M. A., Vogginger, B., Ehrlich, M., Pfeil,
+T., Millner, S., Gruebl, A., Wendt, K., Mueller, E., Schwartz,
+M.-O., de Oliveira, D. H., Jeltsch, S., Fieres, J., Schilling, M.,
+Mueller, P., Breitwieser, O., Petkov, V., Muller, L., Davison, A.
+P., Krishnamurthy, P., Kremkow, J., Lundqvist, M., Muller, E.,
+Partzsch, J., Scholze, S., Zuehl, L., Mayr, C., Destexhe, A.,
+Diesmann, M., Potjans, T. C., Lansner, A., Schueffny, R.,
+Schemmel, J. and Meier, K.. A comprehensive workflow for
+general-purpose neural modeling with highly configurable
+neuromorphic hardware systems. *Biological Cybernetics*
+104:263-296, 10.1007/s00422-011-0435-9, 2011.
+
+Brunner, J., Ster, J., Van-Weert, S., Andrási, T., Neubrandt, M.,
+Corti, C., Corsi, M., Ferraguti, F., Gerber, U. and Szabadics, J..
+Selective silencing of individual dendritic branches by an
+mGlu2-activated potassium conductance in dentate gyrus granule
+cells. *Journal of Neuroscience* 33:7285-7298,
+10.1523/JNEUROSCI.4537-12.2013, 2013.
+
+Brunner, J. and Szabadics, J.. Analogue modulation of
+back-propagating action potentials enables dendritic hybrid
+signalling. *Nature Communications* 7:13033, 10.1038/ncomms13033,
+2016.
+
+Bryman, G. S., Liu, A. and Do, M. T. H.. Optimized signal flow
+through photoreceptors supports the high-acuity vision of
+primates. *Neuron* 108:335-348.e7, 10.1016/j.neuron.2020.07.035,
+2020.
+
+Bryson, A., Berkovic, S. F., Petrou, S. and Grayden, D. B.. State
+transitions through inhibitory interneurons in a cortical network
+model. *PLoS Computational Biology* 17:e1009521,
+10.1371/journal.pcbi.1009521, 2021.
+
+Bryson, A., Hatch, R. J., Zandt, B.-J., Rossert, C., Berkovic, S.
+F., Reid, C. A., Grayden, D. B., Hill, S. L. and Petrou, S..
+GABA-mediated tonic inhibition differentially modulates gain in
+functional subtypes of cortical interneurons. *Proceedings of the
+National Academy of Sciences* 117:3192-3202,
+10.1073/pnas.1906369117, 2020.
+
+Buccino, A. P. and Einevoll, G. T.. MEArec: a fast and
+customizable testbench simulator for ground-truth extracellular
+spiking activity. *Neuroinformatics* 19:185-204,
+10.1007/s12021-020-09467-7, 2021.
+
+Buccino, A. P., Hagen, E., Einevoll, G. T., Hafliger, P. D. and
+Cauwenbergh, G.. Independent component analysis for fully
+automated multi-electrode array spike sorting. *IEEE Engineering
+in Medicine and Biology Society. Annual Conference*
+2018:2627-2630, 10.1109/EMBC.2018.8512788, 2018a.
+
+Buccino, A. P., Hurwitz, C. L., Garcia, S., Magland, J., Siegle,
+J. H., Hurwitz, R. and Hennig, M. H.. SpikeInterface, a unified
+framework for spike sorting. *eLife* 910.7554/eLife.61834, 2020.
+
+Buccino, A. P., Kordovan, M., Ness, T. V., Merkt, B., Häfliger, P.
+D., Fyhn, M., Cauwenberghs, G., Rotter, S. and Einevoll, G. T..
+Combining biophysical modeling and deep learning for
+multielectrode array neuron localization and classification.
+*Journal of Neurophysiology* 120:1212-1232, 10.1152/jn.00210.2018,
+2018b.
+
+Buccino, A. P., Kuchta, M., Jæger, K. H., Ness, T. V., Berthet,
+P., Mardal, K.-A., Cauwenberghs, G. and Tveito, A.. How does the
+presence of neural probes affect extracellular potentials?.
+*Journal of Neural Engineering* 16:026030,
+10.1088/1741-2552/ab03a1, 2019.
+
+Buccino, A. P., Ness, T. V., Einevoll, G. T., Cauwenberghs, G. and
+Hafliger, P. D.. Localizing neuronal somata from multi-electrode
+array in-vivo recordings using deep learning. *IEEE Engineering in
+Medicine and Biology Society. Annual Conference* 2017:974-977,
+10.1109/EMBC.2017.8036988, 2017.
+
+Buccino, A. P., Ness, T. V., Einevoll, G. T., Cauwenberghs, G. and
+Hafliger, P. D.. A deep learning approach for the classification
+of neuronal cell types. *IEEE Engineering in Medicine and Biology
+Society. Annual Conference* 2018:999-1002,
+10.1109/EMBC.2018.8512498, 2018c.
+
+Buckingham, S. D. and Spencer, A. N.. Role of high-voltage
+activated potassium currents in high-frequency neuronal firing:
+evidence from a basal metazoan. *Journal of Neurophysiology*
+88:861-868, 2002.
+
+Buckingham, S. D. and Ali, D. W.. Computer simulations of
+high-pass filtering in zebrafish larval muscle fibres. *Journal of
+Experimental Biology* 208:3055-3063, 2005.
+
+Bucurenciu, I., Kulik, A., Schwaller, B., Frotscher, M. and Jonas,
+P.. Nanodomain coupling between Ca2+ channels and Ca2+ sensors
+promotes fast and efficient transmitter release at a cortical
+GABAergic synapse. *Neuron* 57:536-545,
+10.1016/j.neuron.2007.12.026, 2008.
+
+Budak, M., Grosh, K., Sasmal, A., Corfas, G., Zochowski, M. and
+Booth, V.. Contrasting mechanisms for hidden hearing loss:
+synaptopathy vs myelin defects. *PLoS Computational Biology*
+17:e1008499, 10.1371/journal.pcbi.1008499, 2021.
+
+Budd, J. M. L.. Theta oscillations by synaptic excitation in a
+neocortical circuit model. *Proceedings of the Royal Society B:
+Biological Sciences* 272:101-109, 2005.
+
+Budde, T., Coulon, P., Pawlowski, M., Meuth, P., Kanyshkova, T.,
+Japes, A., Meuth, S. G. and Pape, H. C.. Reciprocal modulation of
+I-h and I-TASK in thalamocortical relay neurons by halothane.
+*Pflügers Archiv-European Journal of Physiology* 456:1061-1073,
+2008.
+
+Buonomano, D. V.. Decoding temporal information: a model based on
+short-term synaptic plasticity. *Journal of Neuroscience*
+20:1129-1141, 2000.
+
+Buonomano, D. V.. A learning rule for the emergence of stable
+dynamics and timing in recurrent networks. *Journal of
+Neurophysiology* 94:2275-2283, 2005.
+
+Burton, S. D. and Urban, N. N.. Rapid feedforward inhibition and
+asynchronous excitation regulate granule cell activity in the
+mammalian main olfactory bulb. *Journal of Neuroscience*
+35:14103-14122, 10.1523/JNEUROSCI.0746-15.2015, 2015.
+
+Bús, B., Antal, K. and Emri, Z.. Intrathalamic connections shape
+spindle activity - a modelling study. *Acta Biologica Hungarica*
+69:16-28, 10.1556/018.68.2018.1.2, 2018.
+
+Bush, P. and Priebe, N.. GABAergic inhibitory control of the
+transient and sustained components of orientation selectivity in a
+model microcolumn in layer 4 of cat visual cortex. *Neural
+Computation* 10:855-867, 1998.
+
+Bush, P. C., Prince, D. A. and Miller, K. D.. Increased pyramidal
+excitability and NMDA conductance can explain posttraumatic
+epileptogenesis without disinhibition: a model. *Journal of
+Neurophysiology* 82:1748-1758, 1999.
+
+Bush, P. C. and Sejnowski, T. J.. Reduced compartmental models of
+neocortical pyramidal cells. *Journal of Neuroscience Methods*
+46:159-166, 1993.
+
+Bush, P. C. and Sejnowski, T. J.. Effects of inhibition and
+dendritic saturation in simulated neocortical pyramidal cells.
+*Journal of Neurophysiology* 71:2183-2193, 1994.
+
+Bush, P. and Sejnowski, T.. Inhibition synchronizes sparsely
+connected cortical neurons within and between columns in realistic
+network models. *Journal of Computational Neuroscience* 3:91-110,
+1996.
+
+Butenko, K., Bahls, C., Schröder, M., Köhling, R. and van Rienen,
+U.. OSS-DBS: open-source simulation platform for deep brain
+stimulation with a comprehensive automated modeling. *PLoS
+Computational Biology* 16:e1008023, 10.1371/journal.pcbi.1008023,
+2020.
+
+Butson, C. R., Maks, C. B. and McIntyre, C. C.. Sources and
+effects of electrode impedance during deep brain stimulation.
+*Clinical Neurophysiology* 117:447-454, 2006.
+
+Butson, C. R. and McIntyre, C. C.. Role of electrode design on the
+volume of tissue activated during deep brain stimulation. *Journal
+of Neural Engineering* 3:1-8, 2006.
+
+Butson, C. R., Cooper, S. E., Henderson, J. M. and McIntyre, C.
+C.. Patient-specific analysis of the volume of tissue activated
+during deep brain stimulation. *Neuroimage* 34:661-670, 2007.
+
+Butson, C. R. and McIntyre, C. C.. Tissue and electrode
+capacitance reduce neural activation volumes during deep brain
+stimulation. *Clinical Neurophysiology* 116:2490-2500, 2005.
+
+Butson, C. R. and McIntyre, C. C.. Differences among implanted
+pulse generator waveforms cause variations in the neural response
+to deep brain stimulation. *Clinical Neurophysiology*
+118:1889-1894, 2007.
+
+Butson, C. R. and McIntyre, C. C.. Current steering to control the
+volume of tissue activated during deep brain stimulation. *Brain
+Stimulation* 1:7-14, 2008.
+
+Butson, C. R., Miller, I. O., Normann, R. A. and Clark, G. A..
+Selective neural activation in a histologically derived model of
+peripheral nerve. *Journal of Neural Engineering* 8:036009,
+10.1088/1741-2560/8/3/036009, 2011.
+
+Byczkowicz, N., Eshra, A., Montanaro, J., Trevisiol, A.,
+Hirrlinger, J., Kole, M. H., Shigemoto, R. and Hallermann, S.. HCN
+channel-mediated neuromodulation can control action potential
+velocity and fidelity in central axons. *eLife* 8:e42766,
+10.7554/eLife.42766, 2019.
+
+Bywalez, W. G., Patirniche, D., Rupprecht, V., Stemmler, M., Herz,
+A. V. M., Pálfi, D., Rózsa, B. and Egger, V.. Local postsynaptic
+voltage-gated sodium channel activation in dendritic spines of
+olfactory bulb granule cells. *Neuron* 85:590-601,
+10.1016/j.neuron.2014.12.051, 2015.
+
+Cagnan, H., Meijer, H. G. E., van Gils, S. A., Krupa, M., Heida,
+T., Rudolph, M., Wadman, W. J. and Martens, H. C. F..
+Frequency-selectivity of a thalamocortical relay neuron during
+Parkinson's disease and deep brain stimulation: a computational
+study. *European Journal of Neuroscience* 30:1306-1317,
+10.1111/j.1460-9568.2009.06922.x, 2009.
+
+Cakir, A., Noble, J. H. and Labadie, R. F.. Auditory nerve fiber
+segmentation methods for neural activation modeling [Online].
+*Medical Imaging 2019: Image-Guided Procedures, Robotic
+Interventions, and Modeling*, 10.1117/12.2513006, 2019.
+
+Cali, C., Berger, T. K., Pignatelli, M., Carleton, A., Markram, H.
+and Giugliano, M.. Inferring connection proximity in networks of
+electrically coupled cells by subthreshold frequency response
+analysis. *Journal of Computational Neuroscience* 24:330-345,
+2008.
+
+Calin-Jageman, R. J. and Katz, P. S.. A distributed computing tool
+for generating neural simulation databases. *Neural Computation*
+18:2923-2927, 2006.
+
+Calin-Jageman, R. J., Tunstall, M. J., Mensh, B. D., Katz, P. S.
+and Frost, W. N.. Parameter space analysis suggests multi-site
+plasticity contributes to motor pattern initiation in Tritonia.
+*Journal of Neurophysiology* 98:2382-2398, 2007.
+
+Callaway, J. C., Lasser-Ross, N., Stuart, A. E. and Ross, W. N..
+Dynamics of intracellular free calcium-concentration in the
+presynaptic arbors of individual barnacle photoreceptors. *Journal
+of Neuroscience* 13:1157-1166, 1993.
+
+Cameron, D. A., Vafai, H. and White, J. A.. Analysis of dendritic
+arbors of native and regenerated ganglion cells in the goldfish
+retina. *Visual Neuroscience* 16:253-261, 1999.
+
+Camiré, O., Lazarevich, I., Gilbert, T. and Topolnik, L..
+Mechanisms of supralinear calcium integration in dendrites of
+hippocampal ca1 fast-spiking cells. *Frontiers in Synaptic
+Neuroscience* 10:47, 10.3389/fnsyn.2018.00047, 2018.
+
+Camuñas-Mesa, L. A. and Quiroga, R. Q.. A detailed and fast model
+of extracellular recordings. *Neural Computation* 25:1191-1212,
+10.1162/NECO_a_00433, 2013.
+
+Canakci, S., Toy, M. F., Inci, A. F., Liu, X. and Kuzum, D..
+Computational analysis of network activity and spatial reach of
+sharp wave-ripples. *PLoS ONE* 12:e0184542,
+10.1371/journal.pone.0184542, 2017.
+
+Canavier, C. C.. Sodium dynamics underlying burst firing and
+putative mechanisms for the regulation of the firing pattern in
+midbrain dopamine neurons: a computational approach. *Journal of
+Computational Neuroscience* 6:49-69, 1999.
+
+Cannon, R. C., O'Donnell, C. and Nolan, M. F.. Stochastic ion
+channel gating in dendritic neurons: morphology dependence and
+probabilistic synaptic activation of dendritic spikes. *PLoS
+Computational Biology* 6:e1000886, 10.1371/journal.pcbi.1000886,
+2010.
+
+Cao, X., Sui, X., Lyu, Q., Li, L. and Chai, X.. Effects of
+different three-dimensional electrodes on epiretinal electrical
+stimulation by modeling analysis. *Journal of NeuroEngineering and
+Rehabilitation* 12:73, 10.1186/s12984-015-0065-x, 2015.
+
+Capllonch-Juan, M., Koelbl, F. and Sepulveda, F.. Optimisation of
+the spatial discretisation of myelinated axon models [Online].
+*2016 8th Computer Science and Electronic Engineering*,
+10.1109/ceec.2016.7835916, 2016.
+
+Capllonch-Juan, M., Kolbl, F. and Sepulveda, F.. Unidirectional
+ephaptic stimulation between two myelinated axons [Online]. *2017
+39th Annual International Conference of the IEEE Engineering in
+Medicine and Biology Society*, 10.1109/embc.2017.8036804, 2017.
+
+Capllonch-Juan, M. and Sepulveda, F.. Conduction velocity effects
+due to ephaptic interactions between myelinated axons. In: *EMBEC
+& NBC 2017*, edited by Eskola, H., Väisänen, O., Viik, J. and
+Hyttinen, J.. Springer Singapore, 2017, pp. 659-662.
+
+Capllonch-Juan, M. and Sepulveda, F.. Evaluation of a resistor
+network for solving electrical problems on ohmic media [Online].
+*2019 11th Computer Science and Electronic Engineering (CEEC)*,
+10.1109/ceec47804.2019.8974323, 2019.
+
+Capllonch-Juan, M. and Sepulveda, F.. Modelling the effects of
+ephaptic coupling on selectivity and response patterns during
+artificial stimulation of peripheral nerves. *PLoS Computational
+Biology* 16:e1007826, 10.1371/journal.pcbi.1007826, 2020.
+
+Capogrosso, M., Gandar, J., Greiner, N., Moraud, E. M., Wenger,
+N., Shkorbatova, P., Musienko, P., Minev, I., Lacour, S. and
+Courtine, G.. Advantages of soft subdural implants for the
+delivery of electrochemical neuromodulation therapies to the
+spinal cord. *Journal of Neural Engineering* 15:026024,
+10.1088/1741-2552/aaa87a, 2018.
+
+Capogrosso, M., Wenger, N., Raspopovic, S., Musienko, P.,
+Beauparlant, J., Bassi Luciani, L., Courtine, G. and Micera, S.. A
+computational model for epidural electrical stimulation of spinal
+sensorimotor circuits. *Journal of Neuroscience* 33:19326-19340,
+10.1523/JNEUROSCI.1688-13.2013, 2013.
+
+Capurro, A., Diambra, L. and Malta, C. P.. Model for the heart
+beat-to-beat time series during meditation. *Physica A-Statistical
+Mechanics and its Applications* 327:168-173, 2003.
+
+Carbunaru, R. and Durand, D. M.. Axonal stimulation under MRI
+magnetic field z gradients: a modeling study. *Magnetic Resonance
+in Medicine* 38:750-758, 1997.
+
+Carlin, K. P., Jones, K. E., Jiang, Z., Jordan, L. M. and
+Brownstone, R. M.. Dendritic L-type calcium currents in mouse
+spinal motoneurons: implications for bistability. *European
+Journal of Neuroscience* 12:1635-1646, 2000.
+
+Carlin, K. P., Bui, T. V., Dai, Y. and Brownstone, R. M..
+Staircase currents in motoneurons: insight into the spatial
+arrangement of calcium channels in the dendritic tree. *Journal of
+Neuroscience* 29:5343-5353, 10.1523/JNEUROSCI.5458-08.2009, 2009.
+
+Carnevale, N. T. and Hines, M. L.. A functional basis for choosing
+compartment size in neuronal models [Online]. *Society for
+Neuroscience Abstracts* 31, 2001.
+
+Carnevale, N. T. and Hines, M. L.. *The NEURON Book*. Cambridge,
+UK: address, Cambridge University Press, 2006.
+
+Carnevale, N. T., Tsai, K. Y., Claiborne, B. J. and Brown, T. H..
+Qualitative electrotonic comparison of three classes of
+hippocampal neurons in the rat [Online]. *The Neurobiology of
+Computation: Proceedings of the Third Annual Computation and
+Neural Systems Conference* 3:67-72, 1995a.
+
+Carnevale, N. T., Tsai, K. Y., Claiborne, B. J. and Brown, T. H..
+The electrotonic transformation: a tool for relating neuronal form
+to function. In: *Advances in Neural Information Processing
+Systems*, edited by Tesauro, G., Touretzky, D. S. and Leen, T. K..
+Cambridge, MA: Cambridge, MA, MIT Press, 1995b, pp. 69-76.
+
+Carnevale, N. T., Tsai, K. Y., Claiborne, B. J. and Brown, T. H..
+Comparative electrotonic analysis of three classes of rat
+hippocampal neurons. *Journal of Neurophysiology* 78:703-720,
+1997.
+
+Carnevale, N. T., Tsai, K. Y. and Hines, M. L.. The Electrotonic
+Workbench [Online]. *Society for Neuroscience Abstracts* 22:1741,
+1996.
+
+Carr, D. B., Day, M., Cantrell, A. R., Held, J., Scheuer, T.,
+Catterall, W. A. and Surmeier, D. J.. Transmitter modulation of
+slow, activity-dependent alterations in sodium channel
+availability endows neurons with a novel form of cellular
+plasticity. *Neuron* 39:793-806, 2003.
+
+Carrillo, R. R., Ros, E., Tolu, S., Nieus, T. and D'Angelo, E..
+Event-driven simulation of cerebellar granule cells. *Biosystems*
+94:10-17, 2008.
+
+Cartmell, S. C., Tian, Q., Thio, B. J., Leuze, C., Ye, L.,
+Williams, N. R., Yang, G., Ben-Dor, G., Deisseroth, K., Grill, W.
+M., McNab, J. A. and Halpern, C. H.. Multimodal characterization
+of the human nucleus accumbens. *NeuroImage* 198:137-149,
+10.1016/j.neuroimage.2019.05.019, 2019.
+
+Carvalho, T. P. and Buonomano, D. V.. Differential effects of
+excitatory and inhibitory plasticity on synaptically driven
+neuronal input-output functions. *Neuron* 61:774-785, 2009.
+
+Casale, A. E. and McCormick, D. A.. Active action potential
+propagation but not initiation in thalamic interneuron dendrites.
+*Journal of Neuroscience* 31:18289-18302,
+10.1523/JNEUROSCI.4417-11.2011, 2011.
+
+Casaleggio, A., Hines, M. L. and Migliore, M.. Computational model
+of erratic arrhythmias in a cardiac cell network: the role of gap
+junctions. *PLoS ONE* 9:e100288, 10.1371/journal.pone.0100288,
+2014.
+
+Casali, S., Marenzi, E., Medini, C., Casellato, C. and D'Angelo,
+E.. Reconstruction and simulation of a scaffold model of the
+cerebellar network. *Frontiers In Neuroinformatics* 13:37,
+10.3389/fninf.2019.00037, 2019.
+
+Casali, S., Tognolina, M., Gandolfi, D., Mapelli, J. and D'Angelo,
+E.. Cellular-resolution mapping uncovers spatial adaptive
+filtering at the rat cerebellum input stage. *Communications
+Biology* 3:635, 10.1038/s42003-020-01360-y, 2020.
+
+Cases, M., Llobet, A., Terni, B., Gómez de Aranda, I., Blanch, M.,
+Doohan, B., Revill, A., Brown, A. M., Blasi, J. and Solsona, C..
+Acute effect of pore-forming Clostridium perfringens ε-toxin on
+compound action potentials of optic nerve of mouse. *eNeuro*
+4:ENEURO.0051-17.2017, 10.1523/ENEURO.0051-17.2017, 2017.
+
+Cassara, A. M., Hagberg, G. E., Bianciardi, M., Migliore, M. and
+Maraviglia, B.. Realistic simulations of neuronal activity: a
+contribution to the debate on direct detection of neuronal
+currents by MRI. *Neuroimage* 39:87-106, 2008.
+
+Cassara, A. M. and Maraviglia, B.. Microscopic investigation of
+the resonant mechanism for the implementation of nc-MRI at
+ultra-low field MRI. *Neuroimage* 41:1228-1241, 2008.
+
+Castelfranco, A. M. and Hartline, D. K.. Simulations of
+space-clamp errors in estimating parameters of voltage-gated
+conductances localized at different electrotonic distances.
+*Neurocomputing* 44:75-80, 2002.
+
+Castelfranco, A. M. and Hartline, D. K.. Corrections for
+space-clamp errors in measured parameters of voltage-dependent
+conductances in a cylindrical neurite. *Biological Cybernetics*
+90:280-290, 2004.
+
+Castelfranco, A. M. and Hartline, D. K.. The evolution of
+vertebrate and invertebrate myelin: a theoretical computational
+study. *Journal of Computational Neuroscience* 38:521-538,
+10.1007/s10827-015-0552-x, 2015.
+
+Cataldi, M., Lariccia, V., Marzaioli, V., Cavaccini, A., Curia,
+G., Viggiano, D., Canzoniero, L. M. T., di Renzo, G., Avoli, M.
+and Annunziato, L.. Zn2+ slows down Ca(V)3.3 gating kinetics:
+Implications for thalamocortical activity. *Journal of
+Neurophysiology* 98:2274-2284, 2007.
+
+Cathala, L., Brickley, S., Cull-Candy, S. and Farrant, M..
+Maturation of EPSCs and intrinsic membrane properties enhances
+precision at a cerebellar synapse. *Journal of Neuroscience*
+23:6074-6085, 2003.
+
+Cattani, A., Solinas, S. and Canuto, C.. A hybrid model for the
+computationally-efficient simulation of the cerebellar granular
+layer. *Frontiers in Computational Neuroscience* 10:30,
+10.3389/fncom.2016.00030, 2016.
+
+Cauller, L. J. and Connors, B. W.. Functions of very distal
+dendrites: experimental and computational studies of layer I
+synapses on neocortical pyramidal cells. In: *Single Neuron
+Computation*, edited by McKenna, T., Davis, J. and Zornetzer, S.
+F.. San Diego: San Diego, Academic Press, 1992, pp. 199-229.
+
+Cauller, L. J. and Connors, B. W.. Synaptic physiology of
+horizontal afferents to layer I in slices of rat SI neocortex.
+*Journal of Neuroscience* 14:751-762, 1994.
+
+Cavarretta, F., Burton, S. D., Igarashi, K. M., Shepherd, G. M.,
+Hines, M. L. and Migliore, M.. Parallel odor processing by mitral
+and middle tufted cells in the olfactory bulb. *Scientific
+Reports* 8:7625, 10.1038/s41598-018-25740-x, 2018.
+
+Cavarretta, F., Carnevale, N. T., Tegolo, D. and Migliore, M..
+Effects of low frequency electric fields on synaptic integration
+in hippocampal CA1 pyramidal neurons: implications for power line
+emissions. *Frontiers in Cellular Neuroscience* 8:310,
+10.3389/fncel.2014.00310, 2014.
+
+Cavarretta, F., Marasco, A., Hines, M. L., Shepherd, G. M. and
+Migliore, M.. Glomerular and mitral-granule cell microcircuits
+coordinate temporal and spatial information processing in the
+olfactory bulb. *Frontiers in Computational Neuroscience* 10:67,
+10.3389/fncom.2016.00067, 2016.
+
+Cazade, M., Bidaud, I., Lory, P. and Chemin, J..
+Activity-dependent regulation of T-type calcium channels by
+submembrane calcium ions. *eLife* 6:e22331, 10.7554/eLife.22331,
+2017.
+
+Cazé, R. D., Humphries, M. and Gutkin, B.. Passive dendrites
+enable single neurons to compute linearly non-separable functions.
+*PLoS Computational Biology* 9:e1002867,
+10.1371/journal.pcbi.1002867, 2013.
+
+Cazé, R. D., Jarvis, S., Foust, A. J. and Schultz, S. R..
+Dendrites enable a robust mechanism for neuronal stimulus
+selectivity. *Neural Computation* 29:2511-2527,
+10.1162/NECO_a_00989, 2017.
+
+Ceballos, C. C., Li, S., Roque, A. C., Tzounopoulos, T. and Leão,
+R. M.. Ih equalizes membrane input resistance in a heterogeneous
+population of fusiform neurons in the dorsal cochlear nucleus.
+*Frontiers in Cellular Neuroscience* 10:249,
+10.3389/fncel.2016.00249, 2016.
+
+Ceballos, C. C., Pena, R. F. O. and Roque, A. C.. Impact of the
+activation rate of the hyperpolarization-activated current Ih on
+the neuronal membrane time constant and synaptic potential
+duration. *European Physical Journal Special Topics*
+10.1140/epjs/s11734-021-00176-z, 2021.
+
+Ceballos, C. C., Roque, A. C. and Leão, R. M.. A negative slope
+conductance of the persistent sodium current prolongs subthreshold
+depolarizations. *Biophysical Journal* 113:2207-2217,
+10.1016/j.bpj.2017.06.047, 2017.
+
+Cellot, G., Maggi, L., Di Castro, M. A., Catalano, M., Migliore,
+R., Migliore, M., Scattoni, M. L., Calamandrei, G. and Cherubini,
+E.. Premature changes in neuronal excitability account for
+hippocampal network impairment and autistic-like behavior in
+neonatal BTBR T+tf/J mice. *Scientific Reports* 6:31696,
+10.1038/srep31696, 2016.
+
+Cembrowski, M. S., Logan, S. M., Tian, M., Jia, L., Li, W., Kath,
+W. L., Riecke, H. and Singer, J. H.. The mechanisms of repetitive
+spike generation in an axonless retinal interneuron. *Cell
+Reports* 1:155-166, 10.1016/j.celrep.2011.12.006, 2012.
+
+Cercós, M. G., De-Miguel, F. F. and Trueta, C.. Real-time
+measurements of synaptic autoinhibition produced by serotonin
+release in cultured leech neurons. *Journal of Neurophysiology*
+102:1075-1085, 2009.
+
+Cerina, M., Szkudlarek, H. J., Coulon, P., Meuth, P., Kanyshkova,
+T., Nguyen, X. V., Göbel, K., Seidenbecher, T., Meuth, S. G.,
+Pape, H.-C. and Budde, T.. Thalamic Kv 7 channels: pharmacological
+properties and activity control during noxious signal processing.
+*British Journal of Pharmacology* 172:3126-3140,
+10.1111/bph.13113, 2015.
+
+Cestèle, S., Labate, A., Rusconi, R., Tarantino, P., Mumoli, L.,
+Franceschetti, S., Annesi, G., Mantegazza, M. and Gambardella, A..
+Divergent effects of the T1174S SCN1A mutation associated with
+seizures and hemiplegic migraine. *Epilepsia* 54:927-935,
+10.1111/epi.12123, 2013a.
+
+Cestèle, S., Schiavon, E., Rusconi, R., Franceschetti, S. and
+Mantegazza, M.. Nonfunctional NaV1.1 familial hemiplegic migraine
+mutant transformed into gain of function by partial rescue of
+folding defects. *Proceedings of the National Academy of Sciences
+of the United States of America* 110:17546-17551,
+10.1073/pnas.1309827110, 2013b.
+
+Chadderdon, G. L., Mohan, A., Suter, B. A., Neymotin, S. A., Kerr,
+C. C., Francis, J. T., Shepherd, G. M. G. and Lytton, W. W.. Motor
+cortex microcircuit simulation based on brain activity mapping.
+*Neural Computation* 26:1239-1262, 10.1162/NECO_a_00602, 2014.
+
+Chadderdon, G. L., Neymotin, S. A., Kerr, C. C. and Lytton, W. W..
+Reinforcement learning of targeted movement in a spiking neuronal
+model of motor cortex. *PLoS ONE* 7:e47251,
+10.1371/journal.pone.0047251, 2012.
+
+Chakraborty, D., Truong, D. Q., Bikson, M. and Kaphzan, H..
+Neuromodulation of axon terminals. *Cerebral Cortex* 28:2786-2794,
+10.1093/cercor/bhx158, 2018.
+
+Chambers, J. D., Bethwaite, B., Diamond, N. T., Peachey, T.,
+Abramson, D., Petrou, S. and Thomas, E. A.. Parametric computation
+predicts a multiplicative interaction between synaptic strength
+parameters that control gamma oscillations. *Frontiers in
+Computational Neuroscience* 6:53, 10.3389/fncom.2012.00053, 2012.
+
+Chambers, J. D., Bornstein, J. C., Gwynne, R. M., Koussoulas, K.
+and Thomas, E. A.. A detailed, conductance-based computer model of
+intrinsic sensory neurons of the gastrointestinal tract. *American
+Journal of Physiology. Gastrointestinal and Liver Physiology*
+307:G517-G532, 10.1152/ajpgi.00228.2013, 2014.
+
+Chan, C. S., Guzman, J. N., Ilijic, E., Mercer, J. N., Rick, C.,
+Tkatch, T., Meredith, G. E. and Surmeier, D. J.. 'Rejuvenation'
+protects neurons in mouse models of Parkinson's disease. *Nature*
+447:1081-1086, 2007.
+
+Chan, C. S., Shigemoto, R., Mercer, J. N. and Surmeier, D. J..
+HCN2 and HCN1 channels govern the regularity of autonomous
+pacemaking and synaptic resetting in globus pallidus neurons.
+*Journal of Neuroscience* 24:9921-9932, 2004.
+
+Chan, C.-F., Kuo, T.-W., Weng, J.-Y., Lin, Y.-C., Chen, T.-Y.,
+Cheng, J.-K. and Lien, C.-C.. Ba2+- and bupivacaine-sensitive
+background K+ conductances mediate rapid EPSP attenuation in
+oligodendrocyte precursor cells. *Journal of Physiology*
+591:4843-4858, 10.1113/jphysiol.2013.257113, 2013.
+
+Chan, D. D. and Krauthamer, V.. Effects of high-rate stimulation
+in modeled axons and role of calculation time step interval on
+simulations. *International Journal of Medical Implants and
+Devices* 2:92-99, 2007.
+
+Chang, J. T. and Higley, M. J.. Potassium channels contribute to
+activity-dependent regulation of dendritic inhibition.
+*Physiological Reports* 6:e13747, 10.14814/phy2.13747, 2018.
+
+Chaturvedi, A., Butson, C. R., Lempka, S. F., Cooper, S. E. and
+McIntyre, C. C.. Patient-specific models of deep brain
+stimulation: influence of field model complexity on neural
+activation predictions. *Brain Stimulation* 3:65-67,
+10.1016/j.brs.2010.01.003, 2010.
+
+Chaturvedi, A., Foutz, T. J. and McIntyre, C. C.. Current steering
+to activate targeted neural pathways during deep brain stimulation
+of the subthalamic region. *Brain Stimulation* 5:369-377,
+10.1016/j.brs.2011.05.002, 2012.
+
+Chaturvedi, A., Lujan, J. L. and McIntyre, C. C.. Artificial
+neural network based characterization of the volume of tissue
+activated during deep brain stimulation. *Journal of Neural
+Engineering* 10:056023, 10.1088/1741-2560/10/5/056023, 2013.
+
+Chatzikalymniou, A. P., Gumus, M. and Skinner, F. K.. Linking
+minimal and detailed models of CA1 microcircuits reveals how theta
+rhythms emerge and their frequencies controlled. *Hippocampus*
+31:982-1002, 10.1002/hipo.23364, 2021.
+
+Chatzikalymniou, A. P. and Skinner, F. K.. Deciphering the
+contribution of oriens-lacunosum/moleculare (olm) cells to
+intrinsic θ rhythms using biophysical local field potential (LFP)
+models. *eNeuro* 510.1523/ENEURO.0146-18.2018, 2018.
+
+Chemin, J., Monteil, A., Bourinet, E., Nargeot, J. and Lory, P..
+Alternatively spliced a1G(CaV3.1) intracellular loops promote
+specific T-type Ca2+ channel gating properties. *Biophysical
+Journal* 80:1238-1250, 2001a.
+
+Chemin, J., Monteil, A., Perez-Reyes, E., Bourinet, E., Nargeot,
+J. and Lory, P.. Specific contribution of human T-type calcium
+channel isotypes (alpha(1G), alpha(1H) and alpha(1I)) to neuronal
+excitability. *Journal of Physiology* 540:3-14, 2002.
+
+Chemin, J., Monteil, A., Perez-Reyes, E., Nargeot, J. and Lory,
+P.. Direct inhibition of T-type calcium channels by the endogenous
+cannabinoid anandamide. *EMBO Journal* 20:7033-7040, 2001b.
+
+Chemin, J., Siquier-Pernet, K., Nicouleau, M., Barcia, G., Ahmad,
+A., Medina-Cano, D., Hanein, S., Altin, N., Hubert, L.,
+Bole-Feysot, C., Fourage, C., Nitschké, P., Thevenon, J., Rio, M.,
+Blanc, P., Vidal, C., Bahi-Buisson, N., Desguerre, I., Munnich,
+A., Lyonnet, S., Boddaert, N., Fassi, E., Shinawi, M., Zimmerman,
+H., Amiel, J., Faivre, L., Colleaux, L., Lory, P. and Cantagrel,
+V.. De novo mutation screening in childhood-onset cerebellar
+atrophy identifies gain-of-function mutations in the CACNA1G
+calcium channel gene. *Brain* 141:1998-2013, 10.1093/brain/awy145,
+2018.
+
+Chemla, S. and Chavane, F.. A biophysical cortical column model to
+study the multi-component origin of the VSDI signal. *Neuroimage*
+53:420-438, 10.1016/j.neuroimage.2010.06.026, 2010.
+
+Chemla, S. and Chavane, F.. Effects of GABAA kinetics on cortical
+population activity: computational studies and physiological
+confirmations. *Journal of Neurophysiology* 115:2867-2879,
+10.1152/jn.00352.2015, 2016.
+
+Chen, E., Stiefel, K. M., Sejnowski, T. J. and Bullock, T. H..
+Model of traveling waves in a coral nerve network. *Journal of
+Comparative Physiology. A, Neuroethology, Sensory, Neural, and
+Behavioral Physiology* 194:195-200, 2008.
+
+Chen, J.-Y.. A simulation study investigating the impact of
+dendritic morphology and synaptic topology on neuronal firing
+patterns. *Neural Computation* 22:1086-1111,
+10.1162/neco.2009.11-08-913, 2010.
+
+Chen, K., Aradi, I., Thon, N., Eghbal-Ahmadi, M., Baram, T. Z. and
+Soltesz, I.. Persistently modified h-channels after complex
+febrile seizures convert the seizure-induced enhancement of
+inhibition to hyperexcitability. *Nature Medicine* 7:331-337,
+2001a.
+
+Chen, K., Jiang, Y., Wu, Z., Zheng, N., Wang, H. and Hong, H..
+HTsort: Enabling Fast and Accurate Spike Sorting on
+Multi-Electrode Arrays.. *Frontiers in computational neuroscience*
+15:657151, 10.3389/fncom.2021.657151, 2021.
+
+Chen, N. S., Li, B., Murphy, T. H. and Raymond, L. A.. Site within
+N-methyl-D-aspartate receptor pore modulates channel gating.
+*Molecular Pharmacology* 65:157-164, 2004.
+
+Chen, N. S., Ren, J. H., Raymond, L. A. and Murphy, T. H.. Changes
+in agonist concentration dependence that are a function of
+duration of exposure suggest N-methyl-D-aspartate receptor
+nonsaturation during synaptic stimulation. *Molecular
+Pharmacology* 59:212-219, 2001b.
+
+Chen, P., Liu, X.-d., Zhang, W., Zhou, J., Wang, P., Yang, W. and
+Luo, J.. Modeling and simulation of ion channels and action
+potentials in taste receptor cells. *Science in China. Series C,
+Life Sciences* 52:1036-1047, 10.1007/s11427-009-0138-9, 2009a.
+
+Chen, P. H., Liu, X. D., Wang, B. Q., Cheng, G. and Wang, P.. A
+biomimetic taste receptor cell-based biosensor for
+electrophysiology recording and acidic sensation. *Sensors and
+Actuators B-Chemical* 139:576-583, 2009b.
+
+Chen, S., Wang, J., Zhou, L., George, M. S. and Siegelbaum, S. A..
+Voltage sensor movement and cAMP binding allosterically regulate
+an inherently voltage-independent closed-open transition in HCN
+channels. *Journal of General Physiology* 129:175-188, 2007.
+
+Chen, W. R., Shen, G. Y., Shepherd, G. M., Hines, M. L. and
+Midtgaard, J.. Multiple modes of action potential initiation and
+propagation in mitral cell primary dendrite. *Journal of
+Neurophysiology* 88:2755-2764, 2002.
+
+Chen, X., Shu, S., Schwartz, L. C., Sun, C., Kapur, J. and
+Bayliss, D. A.. Homeostatic regulation of synaptic excitability:
+tonic GABA(A) receptor currents replace I(h) in cortical pyramidal
+neurons of HCN1 knock-out mice. *Journal of Neuroscience*
+30:2611-2622, 10.1523/JNEUROSCI.3771-09.2010, 2010.
+
+Chen, X. D., Shu, S. F., Kennedy, D. P., Willcox, S. C. and
+Bayliss, D. A.. Subunit-specific effects of isoflurane on neuronal
+I-h in HCN1 knockout mice. *Journal of Neurophysiology*
+101:129-140, 2009c.
+
+Chen, Y. A., Yu, F. H., Surmeier, D. J., Scheuer, T. and
+Catterall, W. A.. Neuromodulation of Na+ channel slow inactivation
+via cAMP-dependent protein kinase and protein kinase C. *Neuron*
+49:409-420, 2006.
+
+Chéreau, R., Saraceno, G. E., Angibaud, J., Cattaert, D. and
+Nägerl, U. V.. Superresolution imaging reveals activity-dependent
+plasticity of axon morphology linked to changes in action
+potential conduction velocity. *Proceedings of the National
+Academy of Sciences of the United States of America*
+114:1401-1406, 10.1073/pnas.1607541114, 2017.
+
+Chiang, P.-H., Wu, P.-Y., Kuo, T.-W., Liu, Y.-C., Chan, C.-F.,
+Chien, T.-C., Cheng, J.-K., Huang, Y.-Y., Chiu, C.-D. and Lien,
+C.-C.. GABA is depolarizing in hippocampal dentate granule cells
+of the adolescent and adult rats. *Journal of Neuroscience*
+32:62-67, 10.1523/JNEUROSCI.3393-11.2012, 2012.
+
+Chimento, T. C., Doshay, D. G. and Ross, M. D.. Compartmental
+modeling of rat macular primary afferents from 3-dimensional
+reconstructions of transmission electron-micrographs of serial
+sections. *Journal of Neurophysiology* 71:1883-1896, 1994.
+
+Chimento, T. C. and Ross, M. D.. Evidence of a sensory processing
+unit in the mammalian macula. *Annals of the New York Academy of
+Sciences* 781:196-212, 1996.
+
+Chiovini, B., Turi, G. F., Katona, G., Kaszás, A., Pálfi, D.,
+Maák, P., Szalay, G., Szabó, M. F., Szabó, G., Szadai, Z., Káli,
+S. and Rózsa, B.. Dendritic spikes induce ripples in parvalbumin
+interneurons during hippocampal sharp waves. *Neuron* 82:908-924,
+10.1016/j.neuron.2014.04.004, 2014.
+
+Chitwood, R. A., Claiborne, B. J. and Jaffe, D. B.. Modeling the
+passive properties of nonpyramidal neurons in hippocampal area
+CA3. In: *Computational Neuroscience: Trends in Research, 1997*,
+edited by Bower, J. M.. New York: New York, Plenum Press, 1997,
+pp. 59-64.
+
+Chitwood, R. A., Hubbard, A. and Jaffe, D. B.. Passive
+electrotonic properties of rat hippocampal CA3 interneurones.
+*Journal of Physiology* 515:743-756, 1999.
+
+Chiu, C. Q., Lur, G., Morse, T. M., Carnevale, N. T.,
+Ellis-Davies, G. C. R. and Higley, M. J.. Compartmentalization of
+GABAergic inhibition by dendritic spines. *Science* 340:759-762,
+10.1126/science.1234274, 2013.
+
+Choi, J.-S. and Waxman, S. G.. Physiological interactions between
+Na(v)1.7 and Na(v)1.8 sodium channels: a computer simulation
+study.. *Journal of Neurophysiology* 106:3173-3184,
+10.1152/jn.00100.2011, 2011.
+
+Chono, K., Takagi, H., Koyama, S., Suzuki, H. and Ito, E.. A cell
+model study of calcium influx mechanism regulated by calcium
+dependent potassium channels in Purkinje cell dendrites. *Journal
+of Neuroscience Methods* 129:115-127, 2003.
+
+Chow, C. C. and White, J. A.. Spontaneous action potentials due to
+channel fluctuations. *Biophysical Journal* 71:3013-3021, 1996.
+
+Christensen, T. A., D'Alessandro, G., Lega, J. and Hildebrand, J.
+G.. Morphometric modeling of olfactory circuits in the insect
+antennal lobe: I simulations of spiking local interneurons.
+*Biosystems* 61:143-153, 2001.
+
+Chung, H., Im, C., Seo, H. and Jun, S. C.. Morphological influence
+and electric field direction’s influence on activation of cortical
+neurons in electrical brain stimulation: a computational study
+[Online]. *Proc. 42nd Annual Int. Conf. of the IEEE Engineering in
+Medicine Biology Society (EMBC)* :2938-2941,
+10.1109/EMBC44109.2020.9175250, 2020.
+
+Ciotti, F., Valle, G., Pedrocchi, A. and Raspopovic, S.. A
+computational model of the pudendal nerve for the bioelectronic
+treatment of sexual dysfunctions [Online]. *Proc. 10th Int.
+IEEE/EMBS Conf. Neural Engineering* :267-270,
+10.1109/NER49283.2021.9441309, 2021.
+
+Claiborne, B. J., Zador, A. M., Mainen, Z. F. and Brown, T. H..
+Computational models of hippocampal neurons. In: *Single Neuron
+Computation*, edited by McKenna, T., Davis, J. and Zornetzer, S.
+F.. San Diego: San Diego, Academic Press, 1992, pp. 61-79.
+
+Clark, B. A., Monsivais, P., Branco, T., London, M. and Häusser,
+M.. The site of action potential initiation in cerebellar Purkinje
+neurons. *Nature Neuroscience* 8:137-139, 2005.
+
+Clark, D. L., Johnson, K. A., Butson, C. R., Lebel, C., Gobbi, D.,
+Ramasubbu, R. and Kiss, Z. H. T.. Tract-based analysis of target
+engagement by subcallosal cingulate deep brain stimulation for
+treatment resistant depression. *Brain Stimulation* 13:1094-1101,
+10.1016/j.brs.2020.03.006, 2020.
+
+Clay, J. R., Paydarfar, D. and Forger, D. B.. A simple
+modification of the Hodgkin and Huxley equations explains type 3
+excitability in squid giant axons. *Journal of the Royal Society
+Interface* 5:1421-1428, 10.1098/rsif.2008.0166, 2008.
+
+Cleland, T. A. and Sethupathy, P.. Non-topographical contrast
+enhancement in the olfactory bulb. *BMC Neuroscience* 7:7,
+doi:10.1186/1471-2202-7-7, 2006.
+
+Clopath, C., Büsing, L., Vasilaki, E. and Gerstner, W..
+Connectivity reflects coding: a model of voltage-based STDP with
+homeostasis. *Nature Neuroscience* 13:344-352, 10.1038/nn.2479,
+2010.
+
+Cochran, A. L., Nieser, K. J., Forger, D. B., Zöllner, S. and
+McInnis, M. G.. Gene-set enrichment with mathematical biology
+(GEMB). *GigaScience* 910.1093/gigascience/giaa091, 2020.
+
+Coggan, J. S., Prescott, S. A., Bartol, T. M. and Sejnowski, T.
+J.. Imbalance of ionic conductances contributes to diverse
+symptoms of demyelination. *Proceedings of the National Academy of
+Sciences of the United States of America* 107:20602-20609,
+10.1073/pnas.1013798107, 2010.
+
+Coggan, J. S., Keller, D., Calì, C., Lehväslaiho, H., Markram, H.,
+Schürmann, F. and Magistretti, P. J.. Norepinephrine stimulates
+glycogenolysis in astrocytes to fuel neurons with lactate. *PLoS
+Computational Biology* 14:e1006392, 10.1371/journal.pcbi.1006392,
+2018.
+
+Coggan, J. S., Sejnowski, T. J. and Prescott, S. A.. Cooperativity
+between remote sites of ectopic spiking allows afterdischarge to
+be initiated and maintained at different locations. *Journal of
+Computational Neuroscience* 39:17-28, 10.1007/s10827-015-0562-8,
+2015.
+
+Cohen, A., Shappir, J., Yitzchaik, S. and Spira, M. E..
+Experimental and theoretical analysis of neuron-transistor hybrid
+electrical coupling: The relationships between the electro-anatomy
+of cultured Aplysia neurons and the recorded field potentials.
+*Biosensors and Bioelectronics* 22:656-663, 2006.
+
+Cohen, A., Shappir, J., Yitzchaik, S. and Spira, M. E.. Reversible
+transition of extracellular field potential recordings to
+intracellular recordings of action potentials generated by neurons
+grown on transistors. *Biosensors and Bioelectronics* 23:811-819,
+2008.
+
+Cohen, C. C. H., Popovic, M. A., Klooster, J., Weil, M.-T.,
+Möbius, W., Nave, K.-A. and Kole, M. H. P.. Saltatory conduction
+along myelinated axons involves a periaxonal nanocircuit. *Cell*
+180:311-322.e15, 10.1016/j.cell.2019.11.039, 2020.
+
+Cohen, M. X.. Fluctuations in oscillation frequency control spike
+timing and coordinate neural networks. *Journal of Neuroscience*
+34:8988-8998, 10.1523/JNEUROSCI.0261-14.2014, 2014.
+
+Coker, R. A., Zellmer, E. R. and Moran, D. W.. Micro-channel sieve
+electrode for concurrent bidirectional peripheral nerve interface.
+Part A: recording. *Journal of Neural Engineering* 16:026001,
+10.1088/1741-2552/aaefcf, 2019a.
+
+Coker, R. A., Zellmer, E. R. and Moran, D. W.. Micro-channel sieve
+electrode for concurrent bidirectional peripheral nerve interface.
+Part B: stimulation. *Journal of Neural Engineering* 16:026002,
+10.1088/1741-2552/aaefab, 2019b.
+
+Colbert, C. M. and Pan, E. H.. Ion channel properties underlying
+axonal action potential initiation in pyramidal neurons. *Nature
+Neuroscience* 5:533-538, 2002.
+
+Colburn, H. S., Chung, Y. J., Zhou, Y. and Brughera, A.. Models of
+brainstem responses to bilateral electrical stimulation. *Journal
+of the Association for Research in Otolaryngology* 10:91-110,
+2009.
+
+Combe, C. L., Canavier, C. C. and Gasparini, S.. Intrinsic
+mechanisms of frequency selectivity in the proximal dendrites of
+Ca1 pyramidal neurons. *Journal of Neuroscience* 38:8110-8127,
+10.1523/JNEUROSCI.0449-18.2018, 2018.
+
+Conde-Sousa, E. and Aguiar, P.. A working memory model for serial
+order that stores information in the intrinsic excitability
+properties of neurons. *Journal of Computational Neuroscience*
+35:187-199, 10.1007/s10827-013-0447-7, 2013.
+
+Connelly, W. M.. Autaptic connections and synaptic depression
+constrain and promote gamma oscillations. *PLoS ONE* 9:e89995,
+10.1371/journal.pone.0089995, 2014.
+
+Connelly, W. M., Crunelli, V. and Errington, A. C.. The Global
+Spike: conserved dendritic properties enable unique Ca2+ spike
+generation in low-threshold spiking neurons. *Journal of
+Neuroscience* 35:15505-15522, 10.1523/JNEUROSCI.2740-15.2015,
+2015.
+
+Connelly, W. M., Crunelli, V. and Errington, A. C.. Passive
+synaptic normalization and input synchrony-dependent amplification
+of cortical feedback in thalamocortical neuron dendrites. *Journal
+of Neuroscience* 36:3735-3754, 10.1523/JNEUROSCI.3836-15.2016,
+2016.
+
+Contreras, D., Destexhe, A. and Steriade, M.. Intracellular and
+computational characterization of the intracortical inhibitory
+control of synchronized thalamic inputs in vivo. *Journal of
+Neurophysiology* 78:335-350, 1997.
+
+Cook, D. L., Schwindt, P. C., Grande, L. A. and Spain, W. J..
+Synaptic depression in the localization of sound. *Nature*
+421:66-70, 2003.
+
+Cook, E. P. and Johnston, D.. Active dendrites reduce
+location-dependent variability of synaptic input trains. *Journal
+of Neurophysiology* 78:2116-2128, 1997.
+
+Cook, E. P. and Johnston, D.. Voltage-dependent properties of
+dendrites that eliminate location-dependent variability of
+synaptic input. *Journal of Neurophysiology* 81:535-543, 1999.
+
+Cook, E. P., Wilhelm, A. C., Guest, J. A., Liang, Y., Masse, N. Y.
+and Colbert, C. M.. The neuronal transfer function: contributions
+from voltage- and time-dependent mechanisms.. *Progress in Brain
+Research* 165:1-12, 10.1016/S0079-6123(06)65001-2, 2007.
+
+Coombes, S., Timofeeva, Y., Svensson, C.-M., Lord, G. J., Josic,
+K., Cox, S. J. and Colbert, C. M.. Branching dendrites with
+resonant membrane: a "sum-over-trips" approach. *Biological
+Cybernetics* 97:137-149, 2007.
+
+Cornford, J. H., Mercier, M. S., Leite, M., Magloire, V., Häusser,
+M. and Kullmann, D. M.. Dendritic NMDA receptors in parvalbumin
+neurons enable strong and stable neuronal assemblies. *eLife*
+8:e49872, 10.7554/eLife.49872, 2019.
+
+Corsi, P., Formento, E., Capogrosso, M. and Micera, S.. Role of
+renshaw cells in the mammalian locomotor circuit: a computational
+study [Online]. *Converging Clinical and Engineering Research on
+Neurorehabilitation III* :107-111, 2019.
+
+Coskren, P. J., Luebke, J. I., Kabaso, D., Wearne, S. L., Yadav,
+A., Rumbell, T., Hof, P. R. and Weaver, C. M.. Functional
+consequences of age-related morphologic changes to pyramidal
+neurons of the rhesus monkey prefrontal cortex. *Journal of
+Computational Neuroscience* 38:263-283, 10.1007/s10827-014-0541-5,
+2015.
+
+Couto, J. and Grill, W. M.. Kilohertz frequency deep brain
+stimulation is ineffective at regularizing the firing of model
+thalamic neurons. *Frontiers in Computational Neuroscience* 10:22,
+10.3389/fncom.2016.00022, 2016.
+
+Couto, J., Linaro, D., De Schutter, E. and Giugliano, M.. On the
+firing rate dependency of the phase response curve of rat Purkinje
+neurons in vitro. *PLoS Computational Biology* 11:e1004112,
+10.1371/journal.pcbi.1004112, 2015.
+
+Coventry, B. S., Parthasarathy, A., Sommer, A. L. and Bartlett, E.
+L.. Hierarchical winner-take-all particle swarm optimization
+social network for neural model fitting. *Journal of Computational
+Neuroscience* 42:71-85, 10.1007/s10827-016-0628-2, 2017.
+
+Crane, G. J., Hines, M. L. and Neild, T. O.. Simulating the spread
+of membrane potential changes in arteriolar networks.
+*Microcirculation* 8:33-43, 2001.
+
+Cremonesi, F., Hager, G., Wellein, G. and Schürmann, F.. Analytic
+performance modeling and analysis of detailed neuron simulations.
+*International Journal of High Performance Computing Applications*
+34:428-449, 10.1177/1094342020912528, 2020.
+
+Cremonesi, F. and Schürmann, F.. Understanding computational costs
+of cellular-level brain tissue simulations through analytical
+performance models. *Neuroinformatics* 10.1007/s12021-019-09451-w,
+2020.
+
+Criado, J., Garcia-Gasulla, M., Kumbhar, P., Awile, O.,
+Magkanaris, I. and Mantovani, F.. CoreNEURON: performance and
+energy efficiency evaluation on Intel and Arm CPUs [Online]. *2020
+IEEE International Conference on Cluster Computing (CLUSTER)*,
+10.1109/cluster49012.2020.00077, 2020.
+
+Crotty, P., Lasker, E. and Cheng, S.. Constraints on the
+synchronization of entorhinal cortex stellate cells. *Physical
+Review E* 86:011908, 10.1103/PhysRevE.86.011908, 2012.
+
+Crotty, P. and Levy, W. B.. Intersymbol interference in axonal
+transmission. *Neurocomputing* 69:1006-1009, 2006.
+
+Crotty, P. and Levy, W. B.. Effects of Na+ channel inactivation
+kinetics on metabolic energy costs of action potentials.
+*Neurocomputing* 70:1652-1656, 2007.
+
+Crotty, P. and Sangrey, T.. Optimization of battery strengths in
+the Hodgkin-Huxley model. *Neurocomputing* 74:3843-3854,
+10.1016/j.neucom.2011.07.021, 2011.
+
+Crotty, P., Sangrey, T. and Levy, W. B.. Metabolic energy cost of
+action potential velocity. *Journal of Neurophysiology*
+96:1237-1246, 2006.
+
+Cruz, G. E., Sahley, C. L. and Muller, K. J.. Neuronal competition
+for action potential initiation sites in a circuit controlling
+simple learning. *Neuroscience* 148:65-81, 2007.
+
+Cruz, J. S., Kushmerick, C., Moreira-Lobo, D. C. and Oliveira, F.
+A.. Thiamine deficiency in vitro accelerates A-type potassium
+current inactivation in cerebellar granule neurons. *Neuroscience*
+221:108-114, 10.1016/j.neuroscience.2012.06.053, 2012.
+
+Csernai, M., Borbély, S., Kocsis, K., Burka, D., Fekete, Z.,
+Balogh, V., Káli, S., Emri, Z. and Barthó, P.. Dynamics of sleep
+oscillations is coupled to brain temperature on multiple scales.
+*Journal of Physiology* 597:4069-4086, 10.1113/JP277664, 2019.
+
+Cserpán, D., Meszéna, D., Wittner, L., Tóth, K., Ulbert, I.,
+Somogyvári, Z. and Wójcik, D. K.. Revealing the distribution of
+transmembrane currents along the dendritic tree of a neuron from
+extracellular recordings. *eLife* 62017.
+
+Cudmore, R. H., Fronzaroli-Molinieres, L., Giraud, P. and Debanne,
+D.. Spike-time precision and network synchrony are controlled by
+the homeostatic regulation of the D-type potassium current.
+*Journal of Neuroscience* 30:12885-12895,
+10.1523/JNEUROSCI.0740-10.2010, 2010.
+
+Culmone, V. and Migliore, M.. Progressive effect of beta amyloid
+peptides accumulation on CA1 pyramidal neurons: a model study
+suggesting possible treatments. *Frontiers in Computational
+Neuroscience* 6:52, 10.3389/fncom.2012.00052, 2012.
+
+Cuntz, H., Bird, A. D., Mittag, M., Beining, M., Schneider, M.,
+Mediavilla, L., Hoffmann, F. Z., Deller, T. and Jedlicka, P.. A
+general principle of dendritic constancy: a neuron's size- and
+shape-invariant excitability. *Neuron* 109:3647-3662.e7,
+10.1016/j.neuron.2021.08.028, 2021.
+
+Cuntz, H., Borst, A. and Segev, I.. Optimization principles of
+dendritic structure. *Theoretical Biology and Medical Modelling*
+4:21, 10.1186/1742-4682-4-21, 2007a.
+
+Cuntz, H., Haag, J. and Borst, A.. Neural image processing by
+dendritic networks. *Proceedings of the National Academy of
+Sciences of the United States of America* 100:11082-11085, 2003.
+
+Cuntz, H., Haag, J., Forstner, F., Segev, I. and Borst, A.. Robust
+coding of flow-field parameters by axo-axonal gap junctions
+between fly visual interneurons. *Proceedings of the National
+Academy of Sciences of the United States of America*
+104:10229-10233, 2007b.
+
+Currin, C. B., Trevelyan, A. J., Akerman, C. J. and Raimondo, J.
+V.. Chloride dynamics alter the input-output properties of
+neurons. *PLoS Computational Biology* 16:e1007932,
+10.1371/journal.pcbi.1007932, 2020.
+
+Curti, S., Gomez, L., Budelli, R. and Pereda, A. E.. Subthreshold
+sodium current underlies essential functional specializations at
+primary auditory afferents. *Journal of Neurophysiology*
+99:1683-1699, 2008.
+
+Cutsuridis, V.. Improving the recall performance of a brain
+mimetic microcircuit model. *Cognitive Computation* 11:644-655,
+10.1007/s12559-019-09658-8, 2019.
+
+Cutsuridis, V., Cobb, S. and Graham, B. P.. Encoding and retrieval
+in a model of the hippocampal CA1 microcircuit. *Hippocampus*
+20:423-446, 10.1002/hipo.20661, 2010.
+
+Cutsuridis, V. and Poirazi, P.. A computational study on how theta
+modulated inhibition can account for the long temporal windows in
+the entorhinal-hippocampal loop. *Neurobiology of Learning and
+Memory* 120:69-83, 10.1016/j.nlm.2015.02.002, 2015.
+
+D'Angelo, E.. The critical role of Golgi cells in regulating
+spatio-temporal integration and plasticity at the cerebellum input
+stage. *Frontiers in Neuroscience* 2:35-46, 2008.
+
+D’Angelo, E., Nieus, T., Bezzi, M., Arleo, A. and Coenen, O.-M.
+D.. Modeling synaptic transmission and quantifying information
+transfer in the granular layer of the cerebellum. In:
+*Computational Intelligence and Bioinspired Systems*, edited by
+Cabestany, J., Prieto, A. and Sandoval, F.. Springer Berlin
+Heidelberg, 2005, pp. 107-114.
+
+D'Angelo, E., Nieus, T., Maffei, A., Armano, S., Rossi, P.,
+Taglietti, V., Fontana, A. and Naldi, G.. Theta-frequency bursting
+and resonance in cerebellar granule cells: experimental evidence
+and modeling of a slow K+-dependent mechanism. *Journal of
+Neuroscience* 21:759-770, 2001.
+
+Dai, K., Gratiy, S. L., Billeh, Y. N., Xu, R., Cai, B., Cain, N.,
+Rimehaug, A. E., Stasik, A. J., Einevoll, G. T., Mihalas, S.,
+Koch, C. and Arkhipov, A.. Brain Modeling ToolKit: an open source
+software suite for multiscale modeling of brain circuits. *PLoS
+Computational Biology* 16:e1008386, 10.1371/journal.pcbi.1008386,
+2020a.
+
+Dai, K., Hernando, J., Billeh, Y. N., Gratiy, S. L., Planas, J.,
+Davison, A. P., Dura-Bernal, S., Gleeson, P., Devresse, A.,
+Dichter, B. K., Gevaert, M., King, J. G., Van Geit, W. A. H.,
+Povolotsky, A. V., Muller, E., Courcol, J.-D. and Arkhipov, A..
+The SONATA data format for efficient description of large-scale
+network models. *PLoS Computational Biology* 16:e1007696,
+10.1371/journal.pcbi.1007696, 2020b.
+
+D'Amico, M., Garcia-Gasulla, M., López, V., Jokanovic, A.,
+Sirvent, R. and Corbalan, J.. DROM [Online]. *Proceedings of the
+47th International Conference on Parallel Processing Companion*,
+10.1145/3229710.3229752, 2018.
+
+Dan, O., Hopp, E., Borst, A. and Segev, I.. Non-uniform weighting
+of local motion inputs underlies dendritic computation in the fly
+visual system. *Scientific Reports* 8:5787,
+10.1038/s41598-018-23998-9, 2018.
+
+Daneshi Kohan, E., Lashkari, B. S. and Sparrey, C. J.. The effects
+of paranodal myelin damage on action potential depend on axonal
+structure. *Medical and Biological Engineering and Computing*
+56:395-411, 10.1007/s11517-017-1691-1, 2018.
+
+Das, A. and Narayanan, R.. Active dendrites regulate spectral
+selectivity in location-dependent spike initiation dynamics of
+hippocampal model neurons. *Journal of Neuroscience* 34:1195-1211,
+10.1523/JNEUROSCI.3203-13.2014, 2014.
+
+Das, A. and Narayanan, R.. Active dendrites mediate stratified
+gamma-range coincidence detection in hippocampal model neurons.
+*Journal of Physiology* 593:3549-3576, 10.1113/JP270688, 2015.
+
+Dasgupta, D. and Sikdar, S. K.. Calcium permeable AMPA
+receptor-dependent long lasting plasticity of intrinsic
+excitability in fast spiking interneurons of the dentate gyrus
+decreases inhibition in the granule cell layer. *Hippocampus*
+25:269-285, 10.1002/hipo.22371, 2015.
+
+Datunashvili, M., Chaudhary, R., Zobeiri, M., Lüttjohann, A.,
+Mergia, E., Baumann, A., Balfanz, S., Budde, B., van Luijtelaar,
+G., Pape, H.-C., Koesling, D. and Budde, T.. Modulation of
+hyperpolarization-activated inward current and thalamic activity
+modes by different cyclic nucleotides. *Frontiers in Cellular
+Neuroscience* 12:369, 10.3389/fncel.2018.00369, 2018.
+
+Daur, N., Zhang, Y., Nadim, F. and Bucher, D.. Mutual suppression
+of proximal and distal axonal spike initiation determines the
+output patterns of a motor neuron. *Frontiers In Cellular
+Neuroscience* 13:477, 10.3389/fncel.2019.00477, 2019.
+
+Dave, V., Mahapatra, C. and Manchanda, R.. A mathematical model of
+the calcium transient in urinary bladder smooth muscle cells.
+*Annual International Conference of the IEEE Engineering in
+Medicine and Biology Society* 2015:5359-5362,
+10.1109/EMBC.2015.7319602, 2015.
+
+Dave, V. and Manchanda, R.. A computational model of the Ca2+
+transients and influence of buffering in guinea pig urinary
+bladder smooth muscle cells. *Journal of Bioinformatics and
+Computational Biology* 15:1750011, 10.1142/S0219720017500111,
+2017.
+
+David, F., Linster, C. and Cleland, T. A.. Lateral dendritic shunt
+inhibition can regularize mitral cell spike patterning. *Journal
+of Computational Neuroscience* 25:25-38, 2008.
+
+David, Y., Cacheaux, L. P., Ivens, S., Lapilover, E., Heinemann,
+U., Kaufer, D. and Friedman, A.. Astrocytic dysfunction in
+epileptogenesis: consequence of altered potassium and glutamate
+homeostasis?. *Journal of Neuroscience* 29:10588-10599, 2009.
+
+Davids, M., Guérin, B., Malzacher, M., Schad, L. R. and Wald, L.
+L.. Predicting magnetostimulation thresholds in the peripheral
+nervous system using realistic body models. *Scientific Reports*
+7:5316, 10.1038/s41598-017-05493-9, 2017.
+
+Davids, M., Guérin, B., Vom Endt, A., Schad, L. R. and Wald, L.
+L.. Prediction of peripheral nerve stimulation thresholds of MRI
+gradient coils using coupled electromagnetic and neurodynamic
+simulations. *Magnetic Resonance in Medicine* 81:686-701,
+10.1002/mrm.27382, 2019.
+
+Davis, O., Merrison-Hort, R., Soffe, S. R. and Borisyuk, R..
+Studying the role of axon fasciculation during development in a
+computational model of the Xenopus tadpole spinal cord.
+*Scientific Reports* 7:13551, 10.1038/s41598-017-13804-3, 2017.
+
+Davison, A.. Biologically-detailed network modelling. In:
+*Computational Neuroscience*, edited by Feng, J.. London: London,
+Chapman & Hall/CRC Press, 2004, pp. 287-304.
+
+Davison, A. P., Feng, J. and Brown, D.. A reduced compartmental
+model of the mitral cell for use in network models of the
+olfactory bulb. *Brain Research Bulletin* 51:393-399, 2000.
+
+Davison, A. P., Feng, J. F. and Brown, D.. Dendrodendritic
+inhibition and simulated odor responses in a detailed olfactory
+bulb network model. *Journal of Neurophysiology* 90:1921-1935,
+2003.
+
+Davison, A. P. and Fregnac, Y.. Learning cross-modal spatial
+transformations through spike timing-dependent plasticity.
+*Journal of Neuroscience* 26:5604-5615, 2006.
+
+Davison, A. P., Brüderle, D., Eppler, J., Kremkow, J., Muller, E.,
+Pecevski, D., Perrinet, L. and Yger, P.. PyNN: a common interface
+for neuronal network simulators. *Front Neuroinform* 2:11,
+10.3389/neuro.11.011.2008, 2008.
+
+Davison, A. P., Hines, M. L. and Muller, E.. Trends in programming
+languages for neuroscience simulations. *Frontiers in
+Neuroscience* 3:374-380, 10.3389/neuro.01.036.2009, 2009.
+
+Davoine, F. and Curti, S.. Response to coincident inputs in
+electrically coupled primary afferents is heterogeneous and is
+enhanced by H-current (IH) modulation. *Journal of
+Neurophysiology* 122:151-175, 10.1152/jn.00029.2019, 2019.
+
+Day, M., Carr, D. B., Ulrich, S., Ilijic, E., Tkatch, T. and
+Surmeier, D. J.. Dendritic excitability of mouse frontal cortex
+pyramidal neurons is shaped by the interaction among HCN, Kir2,
+and Kleak channels. *Journal of Neuroscience* 25:8776-8787, 2005.
+
+Day, M., Wokosin, D., Plotkin, J. L., Tian, X. Y. and Surmeier, D.
+J.. Differential excitability and modulation of striatal medium
+spiny neuron dendrites. *Journal of Neuroscience* 28:11603-11614,
+2008.
+
+De La Pava Panche, I., Gómez-Orozco, V., Álvarez-López, M. A.,
+Henao-Gallo, Ó. A., Daza-Santacoloma, G. and Orozco-Gutiérrez, Á.
+Á.. Accelerating the computation of the volume of tissue activated
+during deep brain stimulation using Gaussian processes. *Revista
+Facultad de Ingeniería Universidad de Antioquia* 84:17-26, 2017.
+
+Debay, D., Wolfart, J., Le Franc, Y., Le Masson, G. and Bal, T..
+Exploring spike transfer through the thalamus using hybrid
+artificial-biological neuronal networks. *Journal of Physiology,
+Paris* 98:540-558, 2004.
+
+Degro, C. E., Kulik, A., Booker, S. A. and Vida, I.. Compartmental
+distribution of GABAB receptor-mediated currents along the
+somatodendritic axis of hippocampal principal cells.. *Frontiers
+in Synaptic Neuroscience* 7:6, 10.3389/fnsyn.2015.00006, 2015.
+
+Deister, C. A., Chan, C. S., Surmeier, D. J. and Wilson, C. J..
+Calcium-activated SK channels influence voltage-gated ion channels
+to determine the precision of firing in globus pallidus neurons.
+*Journal of Neuroscience* 29:8452-8461, 2009.
+
+Deitcher, Y., Eyal, G., Kanari, L., Verhoog, M. B., Atenekeng
+Kahou, G. A., Mansvelder, H. D., de Kock, C. P. J. and Segev, I..
+Comprehensive morpho-electrotonic analysis shows 2 distinct
+classes of L2 and L3 pyramidal neurons in human temporal cortex.
+*Cerebral Cortex* 27:5398-5414, 10.1093/cercor/bhx226, 2017.
+
+Dekker, D. M. T., Briaire, J. J. and Frijns, J. H. M.. The impact
+of internodal segmentation in biophysical nerve fiber models.
+*Journal of Computational Neuroscience* 37:307-315,
+10.1007/s10827-014-0503-y, 2014.
+
+Delaney, A. J., Sedlak, P. L., Autuori, E., Power, J. M. and Sah,
+P.. Synaptic NMDA receptors in basolateral amygdala principal
+neurons are triheteromeric proteins: physiological role of GluN2B
+subunits. *Journal of Neurophysiology* 109:1391-1402,
+10.1152/jn.00176.2012, 2013.
+
+Delattre, V., Keller, D., Perich, M., Markram, H. and Muller, E.
+B.. Network-timing-dependent plasticity. *Frontiers in Cellular
+Neuroscience* 9:220, 10.3389/fncel.2015.00220, 2015.
+
+Deleuze, C., David, F., Béhuret, S., Sadoc, G., Shin, H.-S.,
+Uebele, V. N., Renger, J. J., Lambert, R. C., Leresche, N. and
+Bal, T.. T-type calcium channels consolidate tonic action
+potential output of thalamic neurons to neocortex. *Journal of
+Neuroscience* 32:12228-12236, 10.1523/JNEUROSCI.1362-12.2012,
+2012.
+
+Delgado, J. Y., Gomez-Gonzalez, J. F. and Desai, N. S.. Pyramidal
+neuron conductance state gates spike-timing-dependent plasticity.
+*Journal of Neuroscience* 30:15713-15725,
+10.1523/JNEUROSCI.3068-10.2010, 2010.
+
+Delorme, A.. Early cortical orientation selectivity: how fast
+inhibition decodes the order of spike latencies. *Journal of
+Computational Neuroscience* 15:357-365, 2003.
+
+Delvendahl, I., Straub, I. and Hallermann, S.. Dendritic
+patch-clamp recordings from cerebellar granule cells demonstrate
+electrotonic compactness. *Frontiers in Cellular Neuroscience*
+9:93, 10.3389/fncel.2015.00093, 2015.
+
+DeMaegd, M. L. and Stein, W.. Temperature-robust activity patterns
+arise from coordinated axonal Sodium channel properties. *PLoS
+Computational Biology* 16:e1008057, 10.1371/journal.pcbi.1008057,
+2020.
+
+DeMaegd, M. L. and Stein, W.. Neuropeptide modulation increases
+dendritic electrical spread to restore neuronal activity disrupted
+by temperature. *Journal of Neuroscience* 41:7607-7622,
+10.1523/JNEUROSCI.0101-21.2021, 2021.
+
+Dembitskaya, Y., Wu, Y.-W. and Semyanov, A.. Tonic GABAA
+conductance favors spike-timing-dependent over theta-burst-induced
+long-term potentiation in the hippocampus. *Journal of
+Neuroscience* 10.1523/JNEUROSCI.2118-19.2020, 2020.
+
+Demianenko, L. E., PoddubnayaI, E. P., MakedonskyI, A., Kulagina,
+B. and Korogod, S. M.. Hypothermic suppression of epileptiform
+bursting activity of a hyppocampal granule neuron possessing
+thermosensitive TRP channels (a model study: biophysical and
+clinical aspects). *Neurophysiology* 49:8-18,
+10.1007/s11062-017-9624-z, 2017.
+
+Desjardins, A. E., Li, Y. X., Reinker, S., Miura, R. M. and
+Neuman, R. S.. The influences of I-h on temporal summation in
+hippocampal CA1 pyramidal neurons: a modeling study. *Journal of
+Computational Neuroscience* 15:131-142, 2003.
+
+Destexhe, A.. Conductance-based integrate-and-fire models. *Neural
+Computation* 9:503-514, 1997.
+
+Destexhe, A.. Spike-and-wave oscillations based on the properties
+of GABA-B receptors. *Journal of Neuroscience* 18:9099-9111, 1998.
+
+Destexhe, A.. Can GABAA conductances explain the fast oscillation
+frequency of absence seizures in rodents?. *European Journal of
+Neuroscience* 11:2175-2181, 1999.
+
+Destexhe, A.. Modelling corticothalamic feedback and the gating of
+the thalamus by the cerebral cortex. *Journal of Physiology,
+Paris* 94:391-410, 2000.
+
+Destexhe, A.. Simplified models of neocortical pyramidal cells
+preserving somatodendritic voltage attenuation. *Neurocomputing*
+38-40:167-173, 2001.
+
+Destexhe, A.. Self-sustained asynchronous irregular states and
+Up-Down states in thalamic, cortical and thalamocortical networks
+of nonlinear integrate-and-fire neurons. *Journal of Computational
+Neuroscience* 27:493-506, 10.1007/s10827-009-0164-4, 2009.
+
+Destexhe, A. and Babloyantz, A.. A model of the inward current Ih
+and its possible role in thalamocortical oscillations.
+*Neuroreport* 4:223-226, 1993.
+
+Destexhe, A., Babloyantz, A. and Sejnowski, T. J.. Ionic
+mechanisms for intrinsic slow oscillations in thalamic relay
+neurons. *Biophysical Journal* 65:1538-1552, 1993a.
+
+Destexhe, A., Badoual, M., Piwkowska, Z., Bal, T. and Rudolph, M..
+A novel method for characterizing synaptic noise in cortical
+neurons. *Neurocomputing* 58-60:191-196, 2004.
+
+Destexhe, A., Bal, T., McCormick, D. A. and Sejnowski, T. J..
+Ionic mechanisms underlying synchronized oscillations and
+propagating waves in a model of ferret thalamic slices. *Journal
+of Neurophysiology* 76:2049-2070, 1996a.
+
+Destexhe, A. and Contreras, D.. Neuronal computations with
+stochastic network states. *Science* 314:85-90, 2006.
+
+Destexhe, A., Contreras, D., Sejnowski, T. J. and Steriade, M.. A
+model of spindle rhythmicity in the isolated thalamic reticular
+nucleus. *Journal of Neurophysiology* 72:803-818, 1994a.
+
+Destexhe, A., Contreras, D., Sejnowski, T. J. and Steriade, M..
+Modeling the control of reticular thalamic oscillations by
+neuromodulators. *Neuroreport* 5:2217-2220, 1994b.
+
+Destexhe, A., Contreras, D. and Steriade, M.. Mechanisms
+underlying the synchronizing action of corticothalamic feedback
+through inhibition of thalamic relay cells. *Journal of
+Neurophysiology* 79:999-1016, 1998a.
+
+Destexhe, A., Contreras, D. and Steriade, M.. Cortically-induced
+coherence of a thalamic-generated oscillation. *Neuroscience*
+92:427-443, 1999.
+
+Destexhe, A., Contreras, D. and Steriade, M.. LTS cells in
+cerebral cortex and their role in generating spike-and-wave
+oscillations. *Neurocomputing* 38:555-563, 2001a.
+
+Destexhe, A., Contreras, D., Steriade, M., Sejnowski, T. J. and
+Huguenard, J.. Computational models constrained by voltage-clamp
+data for investigating dendritic currents. In: *Computational
+Neuroscience*, edited by Bower, J.. New York: New York, Academic
+Press, 1996b, pp. .
+
+Destexhe, A., Contreras, D., Steriade, M., Sejnowski, T. J. and
+Huguenard, J. R.. In vivo, in vitro, and computational analysis of
+dendritic calcium currents in thalamic reticular neurons. *Journal
+of Neuroscience* 16:169-185, 1996c.
+
+Destexhe, A. and Huguenard, J. R.. Nonlinear thermodynamic models
+of voltage-dependent currents. *Journal of Computational
+Neuroscience* 9:259-270, 2000.
+
+Destexhe, A. and Huguenard, J. R.. Which formalism to use for
+modeling voltage-dependent conductances?. In: *Computational
+Neuroscience*, edited by De Schutter, E.. Boca Raton, FL: Boca
+Raton, FL, CRC Press, 2001, pp. 129-157.
+
+Destexhe, A., Lang, E. and Paré, D.. Somato-dendritic interactions
+underlying action potential generation in neocortical pyramidal
+cells in vivo. In: *Computational Neuroscience: Trends in
+Research, 1998*, edited by Bower, J. M.. New York: New York,
+Plenum Press, 1998b, pp. 167-172.
+
+Destexhe, A., Mainen, Z. F. and Sejnowski, T. J.. An efficient
+method for computing synaptic conductances based on a kinetic
+model of receptor binding. *Neural Computation* 6:14-18, 1994c.
+
+Destexhe, A., Mainen, Z. F. and Sejnowski, T. J.. Synthesis of
+models for excitable membranes, synaptic transmission, and
+neuromodulation using a common kinetic formalism. *Journal of
+Computational Neuroscience* 1:195-231, 1994d.
+
+Destexhe, A., Mainen, Z. F. and Sejnowski, T. J.. Fast kinetic
+models for simulating AMPA, NMDA, GABA(A) and GABA(B) receptors.
+In: *The Neurobiology of Computation*, edited by Bower, J..
+Norwell, MA: Norwell, MA, Kluwer, 1995a, pp. 9-14.
+
+Destexhe, A., Mainen, Z. F. and Sejnowski, T. J.. Synaptic
+currents, neuromodulation and kinetic models. In: *The Handbook of
+Brain Theory and Neural Networks*, edited by Arbib, M. A..
+Cambridge, MA: Cambridge, MA, MIT Press, 1995b, pp. 956-959.
+
+Destexhe, A., Mainen, Z. F. and Sejnowski, T. J.. Kinetic models
+of synaptic transmission. In: *Methods in Neuronal Modeling*,
+edited by Koch, C. and Segev, I.. Cambridge, MA: Cambridge, MA,
+MIT Press, 1998c, pp. 1-25.
+
+Destexhe, A., Mainen, Z. F. and Sejnowski, T. J.. Synaptic
+interactions. In: *The Handbook of Brain Theory and Neural
+Networks*, edited by Arbib, M. A.. Cambridge, MA: Cambridge, MA,
+MIT Press, 2002, pp. 1126-1130.
+
+Destexhe, A. and Marder, E.. Plasticity in single neuron and
+circuit computations. *Nature* 431:789-795, 2004.
+
+Destexhe, A., McCormick, D. A. and Sejnowski, T. J.. A model for
+8-10 Hz spindling in interconnected thalamic relay and reticularis
+neurons. *Biophysical Journal* 65:2473-2477, 1993b.
+
+Destexhe, A., Neubig, M., Ulrich, D. and Huguenard, J.. Dendritic
+low-threshold calcium currents in thalamic relay cells. *Journal
+of Neuroscience* 18:3574-3588, 1998d.
+
+Destexhe, A. and Paré, D.. Impact of network activity on the
+integrative properties of neocortical pyramidal neurons in vivo.
+*Journal of Neurophysiology* 81:1531-1547, 1999.
+
+Destexhe, A. and Paré, D.. A combined computational and
+intracellular study of correlated synaptic bombardment in
+neocortical pyramidal neurons in vivo. *Neurocomputing*
+32:113-119, 2000.
+
+Destexhe, A. and Rudolph, M.. Location independence and fast
+conduction of synaptic inputs in neocortical neurons in vivo.
+*Neurocomputing* 52-54:233-238, 2003.
+
+Destexhe, A. and Rudolph, M.. Extracting information from the
+power spectrum of synaptic noise. *Journal of Computational
+Neuroscience* 17:327-345, 2004.
+
+Destexhe, A. and Rudolph, M.. Extracting information from the
+power spectrum of voltage noise. *Neurocomputing* 65:901-906,
+2005.
+
+Destexhe, A., Rudolph, M., Fellous, J.-M. and Sejnowski, T. J..
+Fluctuating synaptic conductances recreate in vivo-like activity
+in neocortical neurons. *Neuroscience* 107:13-24, 2001b.
+
+Destexhe, A., Rudolph, M. and Paré, D.. The high-conductance state
+of neocortical neurons in vivo. *Nature Reviews Neuroscience*
+4:739-751, 2003.
+
+Destexhe, A. and Rudolph-Lilith, M.. *Neuronal Noise*. Springer,
+2012.
+
+Destexhe, A. and Sejnowski, T. J.. G-protein activation kinetics
+and spillover of g-aminobutyric acid may account for differences
+between inhibitory responses in the hippocampus and thalamus.
+*Proceedings of the National Academy of Sciences of the United
+States of America* 92:9515-9519, 1995.
+
+Destexhe, A. and Sejnowski, T. J.. Synchronized oscillations in
+thalamic networks: insights from modeling studies. In: *Thalamus*,
+edited by Steriade, M., Jones, E. G. and McCormick, D. A..
+Amsterdam: Amsterdam, Elsevier, 1997, pp. 331-371.
+
+Destexhe, A. and Sejnowski, T. J.. *Thalamocortical Assemblies*.
+New York: address, Oxford University Press, 2001.
+
+Destexhe, A. and Sejnowski, T. J.. Sleep oscillations. In: *The
+Handbook of Brain Theory and Neural Networks*, edited by Arbib, M.
+A.. Cambridge, MA: Cambridge, MA, MIT Press, 2002a, pp. 1049-1053.
+
+Destexhe, A. and Sejnowski, T. J.. The initiation of bursts in
+thalamic neurons and the cortical control of thalamic sensitivity.
+*Philosophical Transactions of the Royal Society B: Biological
+Sciences* 357:1649-1657, 2002b.
+
+Destexhe, A. and Sejnowski, T. J.. Interactions between membrane
+conductances underlying thalamocortical slow-wave oscillations.
+*Physiological Reviews* 83:1401-1453, 2003.
+
+Devaux, J. and Gow, A.. Tight junctions potentiate the insulative
+properties of small CNS myelinated axons. *Journal of Cell
+Biology* 183:909-921, 2008.
+
+Devor, A. and Yarom, Y.. Electrotonic coupling in the inferior
+olivary nucleus revealed by simultaneous double patch recordings.
+*Journal of Neurophysiology* 87:3048-3058, 2002.
+
+Dewell, R. B. and Gabbiani, F.. Biophysics of object segmentation
+in a collision-detecting neuron. *eLife* 7:e34238,
+10.7554/eLife.34238, 2018a.
+
+Dewell, R. B. and Gabbiani, F.. M current regulates firing mode
+and spike reliability in a collision-detecting neuron. *Journal of
+Neurophysiology* 120:1753-1764, 10.1152/jn.00363.2018, 2018b.
+
+Dewell, R. B. and Gabbiani, F.. Active membrane conductances and
+morphology of a collision detection neuron broaden its impedance
+profile and improve discrimination of input synchrony. *Journal of
+Neurophysiology* 122:691-706, 10.1152/jn.00048.2019, 2019.
+
+Deyo, S. N. and Lytton, W. W.. Inhibition can disrupt
+hypersynchrony in model neuronal networks. *Progress in
+Neuro-Psychopharmacology and Biological Psychiatry* 21:735-750,
+1997.
+
+Dhupia, N., Rathour, R. K. and Narayanan, R.. Dendritic atrophy
+constricts functional maps in resonance and impedance properties
+of hippocampal model neurons. *Frontiers in Cellular Neuroscience*
+8:456, 10.3389/fncel.2014.00456, 2015.
+
+Diaz, M. R., Wadleigh, A., Kumar, S., De Schutter, E. and
+Valenzuela, C. F.. Na+/K+-ATPase inhibition partially mimics the
+ethanol-induced increase of the Golgi cell-dependent component of
+the tonic GABAergic current in rat cerebellar granule cells..
+*PLoS ONE* 8:e55673, 10.1371/journal.pone.0055673, 2013.
+
+Diba, K., Koch, C. and Segev, I.. Spike propagation in dendrites
+with stochastic ion channels. *Journal of Computational
+Neuroscience* 20:77-84, 2006.
+
+Diba, K., Lester, H. A. and Koch, C.. Intrinsic noise in cultured
+hippocampal neurons: Experiment and modeling. *Journal of
+Neuroscience* 24:9723-9733, 2004.
+
+Dietz, M., Wang, L., Greenberg, D. and McAlpine, D.. Sensitivity
+to interaural time differences conveyed in the stimulus envelope:
+estimating inputs of binaural neurons through the temporal
+analysis of spike trains. *Journal of the Association for Research
+in Otolaryngology: JARO* 17:313-330, 10.1007/s10162-016-0573-9,
+2016.
+
+DiGregorio, D. A., Nusser, Z. and Silver, R. A.. Spillover of
+glutamate onto synaptic AMPA receptors enhances fast transmission
+at a cerebellar synapse. *Neuron* 35:521-533, 2002.
+
+van Dijk, K. J., Verhagen, R., Bour, L. J., Heida, C. and Veltink,
+P. H.. Avoiding internal capsule stimulation with a new
+eight-channel steering deep brain stimulation lead.
+*Neuromodulation* 21:553-561, 10.1111/ner.12702, 2018.
+
+van Dijk, K. J., Verhagen, R., Chaturvedi, A., McIntyre, C. C.,
+Bour, L. J., Heida, C. and Veltink, P. H.. A novel lead design
+enables selective deep brain stimulation of neural populations in
+the subthalamic region. *Journal of Neural Engineering* 12:046003,
+10.1088/1741-2560/12/4/046003, 2015.
+
+Dityatev, A. E., Chmykhova, N. M., Dityateva, G. V., Babalian, A.
+L., Kleinle, J. and Clamann, H. P.. Structural and physiological
+properties of connections between individual reticulospinal axons
+and lumbar motoneurons of the frog. *Journal of Comparative
+Neurology* 430:433-447, 2001.
+
+Diwakar, S.. Computational modeling of neuronal dysfunction at
+molecular level validates the role of single neurons in circuit
+functions in cerebellum granular layer. In: *Validating
+Neuro-computational Models of Neurological and Psychiatric
+Disorders*, edited by SenBhattacharya, B. and Chowdhury, F. N.. ,
+2015, pp. 189-220.
+
+Diwakar, S., Lombardo, P., Solinas, S., Naldi, G. and D'Angelo,
+E.. Local field potential modeling predicts dense activation in
+cerebellar granule cells clusters under LTP and LTD control. *PLoS
+ONE* 6:e21928, 10.1371/journal.pone.0021928, 2011.
+
+Diwakar, S., Magistretti, J., Goldfarb, M., Naldi, G. and
+D'Angelo, E.. Axonal Na+ channels ensure fast spike activation and
+back-propagation in cerebellar granule cells. *Journal of
+Neurophysiology* 101:519-532, 2009.
+
+Djurisic, M., Antic, S., Chen, W. R. and Zecevic, D.. Voltage
+imaging from dendrites of mitral cells: EPSP attenuation and spike
+trigger zones. *Journal of Neuroscience* 24:6703-6714, 2004.
+
+Djurisic, M., Popovic, M., Carnevale, N. and Zecevic, D..
+Functional structure of the mitral cell dendritic tuft in the rat
+olfactory bulb. *Journal of Neuroscience* 28:4057-4068, 2008.
+
+Doiron, B., Longtin, A., Berman, N. and Maler, L.. Subtractive and
+divisive inhibition: effect of voltage-dependent inhibitory
+conductances and noise. *Neural Computation* 13:227-248, 2001a.
+
+Doiron, B., Longtin, A., Turner, R. W. and Maler, L.. Model of
+gamma frequency burst discharge generated by conditional
+backpropagation. *Journal of Neurophysiology* 86:1523-1545, 2001b.
+
+Doiron, B., Noonan, L., Lemon, N. and Turner, R. W.. Persistent
+Na+ current modifies burst discharge by regulating conditional
+backpropagation of dendritic spikes. *Journal of Neurophysiology*
+89:324-337, 2003.
+
+Doischer, D., Hosp, J. A., Yanagawa, Y., Obata, K., Jonas, P.,
+Vida, I. and Bartos, M.. Postnatal differentiation of basket cells
+from slow to fast signaling devices. *Journal of Neuroscience*
+28:12956-12968, 2008.
+
+Domanski, A. P. F., Booker, S. A., Wyllie, D. J. A., Isaac, J. T.
+R. and Kind, P. C.. Cellular and synaptic phenotypes lead to
+disrupted information processing in Fmr1-KO mouse layer 4 barrel
+cortex. *Nature Communications* 10:4814,
+10.1038/s41467-019-12736-y, 2019.
+
+Donley, D. W., Chen, Z., Bergin, D., Schulz, D. J. and Nair, S.
+S.. Multi-platform simulations facilitate interdisciplinary
+instruction in undergraduate neuroscience [Online]. *Proc. 10th
+Int. IEEE/EMBS Conf. Neural Engineering* :738-741,
+10.1109/NER49283.2021.9441407, 2021.
+
+Donnelly, D. F.. Spontaneous action potential generation due to
+persistent sodium channel currents in simulated carotid body
+afferent fibers. *Journal of Applied Physiology* 104:1394-1401,
+2008.
+
+Doron, M., Chindemi, G., Muller, E., Markram, H. and Segev, I..
+Timed synaptic inhibition shapes NMDA spikes, influencing local
+dendritic processing and global I/O properties of cortical
+neurons. *Cell Reports* 21:1550-1561,
+10.1016/j.celrep.2017.10.035, 2017.
+
+van Dorp, S. and De Zeeuw, C. I.. Variable timing of synaptic
+transmission in cerebellar unipolar brush cells. *Proceedings of
+the National Academy of Sciences of the United States of America*
+111:5403-5408, 10.1073/pnas.1314219111, 2014.
+
+Dougalis, A. G., Matthews, G. A. C., Liss, B. and Ungless, M. A..
+Ionic currents influencing spontaneous firing and pacemaker
+frequency in dopamine neurons of the ventrolateral periaqueductal
+gray and dorsal raphe nucleus (vlPAG/DRN): A voltage-clamp and
+computational modelling study. *Journal of Computational
+Neuroscience* 42:275-305, 10.1007/s10827-017-0641-0, 2017.
+
+Dougherty, K. A., Islam, T. and Johnston, D.. Intrinsic
+excitability of CA1 pyramidal neurones from the rat dorsal and
+ventral hippocampus. *Journal of Physiology* 590:5707-5722,
+10.1113/jphysiol.2012.242693, 2012.
+
+Dover, K., Marra, C., Solinas, S., Popovic, M., Subramaniyam, S.,
+Zecevic, D., D'Angelo, E. and Goldfarb, M.. FHF-independent
+conduction of action potentials along the leak-resistant
+cerebellar granule cell axon. *Nature Communications* 7:12895,
+10.1038/ncomms12895, 2016.
+
+Dover, K., Solinas, S., D'Angelo, E. and Goldfarb, M.. Long-term
+inactivation particle for voltage-gated sodium channels. *Journal
+of Physiology* 588:3695-3711, 10.1113/jphysiol.2010.192559, 2010.
+
+Doyon, N., Prescott, S. A., Castonguay, A., Godin, A. G., Kröger,
+H. and De Koninck, Y.. Efficacy of synaptic inhibition depends on
+multiple, dynamically interacting mechanisms implicated in
+chloride homeostasis. *PLoS Computational Biology* 7:e1002149,
+10.1371/journal.pcbi.1002149, 2011.
+
+Drion, G., Franci, A., Seutin, V. and Sepulchre, R.. A novel phase
+portrait for neuronal excitability. *PLoS ONE* 7:e41806,
+10.1371/journal.pone.0041806, 2012.
+
+Drion, G., Massotte, L., Sepulchre, R. and Seutin, V.. How
+modeling can reconcile apparently discrepant experimental results:
+the case of pacemaking in dopaminergic neurons. *PLoS
+Computational Biology* 7:e1002050, 10.1371/journal.pcbi.1002050,
+2011.
+
+Druckmann, S., Banitt, Y., Gidon, A., Schürmann, F., Markram, H.
+and Segev, I.. A novel multiple objective optimization framework
+for constraining conductance-based neuron models by experimental
+data.. *Frontiers in Neuroscience* 1:7-18,
+10.3389/neuro.01.1.1.001.2007, 2007.
+
+Druckmann, S., Berger, T. K., Hill, S., Schürmann, F., Markram, H.
+and Segev, I.. Evaluating automated parameter constraining
+procedures of neuron models by experimental and surrogate data.
+*Biological Cybernetics* 99:371-379, 10.1007/s00422-008-0269-2,
+2008.
+
+Du, J. L. and Yang, X. L.. Glycinergic synaptic transmission to
+bullfrog retinal bipolar cells is input-specific. *Neuroscience*
+113:779-784, 2002.
+
+Du, K., Wu, Y.-W., Lindroos, R., Liu, Y., Rózsa, B., Katona, G.,
+Ding, J. B. and Kotaleski, J. H.. Cell-type-specific inhibition of
+the dendritic plateau potential in striatal spiny projection
+neurons. *Proceedings of the National Academy of Sciences of the
+United States of America* 114:E7612-E7621,
+10.1073/pnas.1704893114, 2017.
+
+Du, X., Hao, H., Gigout, S., Huang, D., Yang, Y., Li, L., Wang,
+C., Sundt, D., Jaffe, D. B., Zhang, H. and Gamper, N.. Control of
+somatic membrane potential in nociceptive neurons and its
+implications for peripheral nociceptive transmission. *Pain*
+155:2306-2322, 10.1016/j.pain.2014.08.025, 2014.
+
+Dudman, J. T. and Nolan, M. F.. Stochastically gating ion channels
+enable patterned spike firing through activity-dependent
+modulation of spike probability. *PLoS Computational Biology*
+5:10.1371/journal.pcbi.1000290, 10.1371/journal.pcbi.1000290,
+2009.
+
+Duffley, G., Anderson, D. N., Vorwerk, J., Dorval, A. D. and
+Butson, C. R.. Evaluation of methodologies for computing the deep
+brain stimulation volume of tissue activated. *Journal of Neural
+Engineering* 16:066024, 10.1088/1741-2552/ab3c95, 2019.
+
+Dugladze, T., Maziashvili, N., Börgers, C., Gurgenidze, S.,
+Häussler, U., Winkelmann, A., Haas, C. A., Meier, J. C., Vida, I.,
+Kopell, N. J. and Gloveli, T.. GABA(B) autoreceptor-mediated cell
+type-specific reduction of inhibition in epileptic mice.
+*Proceedings of the National Academy of Sciences of the United
+States of America* 110:15073-15078, 10.1073/pnas.1313505110, 2013.
+
+Dugladze, T., Schmitz, D., Whittington, M. A., Vida, I. and
+Gloveli, T.. Segregation of axonal and somatic activity during
+fast network oscillations. *Science* 336:1458-1461,
+10.1126/science.1222017, 2012.
+
+Dugladze, T., Vida, I., Tort, A. B., Gross, A., Otahal, J.,
+Heinemann, U., Kopell, N. J. and Gloveli, T.. Impaired hippocampal
+rhythmogenesis in a mouse model of mesial temporal lobe epilepsy.
+*Proceedings of the National Academy of Sciences of the United
+States of America* 104:17530-17535, 2007.
+
+Duijnhouwer, J., Remme, M. W. H., van Ooyen, A. and van Pelt, J..
+Influence of dendritic topology on firing patterns in model
+neurons. *Neurocomputing* 38:183-189, 2001.
+
+Dukkipati, S. S., Garrett, T. L. and Elbasiouny, S. M.. The
+vulnerability of spinal motoneurons and soma size plasticity in a
+mouse model of amyotrophic lateral sclerosis. *Journal of
+Physiology* 596:1723-1745, 10.1113/JP275498, 2018.
+
+Dura-Bernal, S., Chadderdon, G. L., Neymotin, S., Francis, J. T.
+and Lytton, W.. Towards a real-time interface between a biomimetic
+model of sensorimotor cortex and a robotic arm. *Pattern
+Recognition Letters* 36:204 - 212,
+http://dx.doi.org/10.1016/j.patrec.2013.05.019, 2014.
+
+Dura-Bernal, S., Li, K., Neymotin, S. A., Francis, J. T.,
+Principe, J. C. and Lytton, W. W.. Restoring behavior via inverse
+neurocontroller in a lesioned cortical spiking model driving a
+virtual arm. *Frontiers in Neuroscience* 10:28,
+10.3389/fnins.2016.00028, 2016.
+
+Dura-Bernal, S., Neymotin, S. A., Kerr, C. C., Sivagnanam, S.,
+Majumdar, A., Francis, J. T. and Lytton, W. W.. Evolutionary
+algorithm optimization of biological learning parameters in a
+biomimetic neuroprosthesis. *IBM Journal of Research and
+Development* 61:6.1-6.14, 10.1147/JRD.2017.2656758, 2017.
+
+Dura-Bernal, S., Suter, B. A., Gleeson, P., Cantarelli, M.,
+Quintana, A., Rodriguez, F., Kedziora, D. J., Chadderdon, G. L.,
+Kerr, C. C., Neymotin, S. A., McDougal, R. A., Hines, M.,
+Shepherd, G. M. and Lytton, W. W.. NetPyNE, a tool for data-driven
+multiscale modeling of brain circuits. *eLife* 8:e44494,
+10.7554/eLife.44494, 2019.
+
+Dura-Bernal, S., Zhou, X., Neymotin, S. A., Przekwas, A., Francis,
+J. T. and Lytton, W. W.. Cortical spiking network interfaced with
+virtual musculoskeletal arm and robotic arm. *Frontiers in
+Neurorobotics* 9:13, 10.3389/fnbot.2015.00013, 2015.
+
+Durstewitz, D. and Gabriel, T.. Dynamical basis of irregular
+spiking in NMDA-driven prefrontal cortex neurons. *Cerebral
+Cortex* 17:894-908, 2007.
+
+Dyhrfjeld-Johnsen, J., Morgan, R. J., Földy, C. and Soltesz, I..
+Upregulated H-current in hyperexcitable CA1 dendrites after
+febrile seizures. *Frontiers in Cellular Neuroscience* 2:2,
+10.3389/neuro.03.002.2008, 2008.
+
+Dyhrfjeld-Johnsen, J., Santhakumar, V., Morgan, R. J., Huerta, R.,
+Tsimring, L. and Soltesz, I.. Topological determinants of
+epileptogenesis in large-scale structural and functional models of
+the dentate gyrus derived from experimental data. *Journal of
+Neurophysiology* 97:1566-1587, 2007.
+
+Dzubay, J. A. and Jahr, C. E.. The concentration of synaptically
+released glutamate outside of the climbing fiber-Purkinje cell
+synaptic cleft. *Journal of Neuroscience* 19:5265-5274, 1999.
+
+Ebner, C., Clopath, C., Jedlicka, P. and Cuntz, H.. Unifying
+long-term plasticity rules for excitatory synapses by modeling
+dendrites of cortical pyramidal neurons. *Cell Reports*
+29:4295-4307.e6, 10.1016/j.celrep.2019.11.068, 2019.
+
+Ecker, A., Romani, A., Sáray, S., Káli, S., Migliore, M., Falck,
+J., Lange, S., Mercer, A., Thomson, A. M., Muller, E., Reimann, M.
+W. and Ramaswamy, S.. Data-driven integration of hippocampal CA1
+synaptic physiology in silico. *Hippocampus* 10.1002/hipo.23220,
+2020.
+
+Edwards, D. H., Yeh, S. R., Arnett, L. D. and Nagapann, P. R..
+Changes in synaptic integration during the growth of the lateral
+giant neuron of the crayfish. *Journal of Neurophysiology*
+72:899-908, 1994.
+
+Egger, R., Narayanan, R. T., Guest, J. M., Bast, A., Udvary, D.,
+Messore, L. F., Das, S., de Kock, C. P. J. and Oberlaender, M..
+Cortical output is gated by horizontally projecting neurons in the
+deep layers. *Neuron* 105:122-137.e8,
+10.1016/j.neuron.2019.10.011, 2020.
+
+Egger, R., Schmitt, A. C., Wallace, D. J., Sakmann, B.,
+Oberlaender, M. and Kerr, J. N. D.. Robustness of sensory-evoked
+excitation is increased by inhibitory inputs to distal apical tuft
+dendrites.. *Proceedings of the National Academy of Sciences of
+the United States of America* 112:14072-14077,
+10.1073/pnas.1518773112, 2015.
+
+Egger, V., Nevian, T. and Bruno, R. M.. Subcolumnar dendritic and
+axonal organization of spiny stellate and star pyramid neurons
+within a barrel in rat somatosensory cortex. *Cerebral Cortex*
+18:876-889, 2008.
+
+Eggers, T., Kilgore, J., Green, D., Vrabec, T., Kilgore, K. and
+Bhadra, N.. Combining direct current and kilohertz frequency
+alternating current to mitigate onset activity during electrical
+nerve block. *Journal of Neural Engineering*
+1810.1088/1741-2552/abebed, 2021.
+
+Eguchi, A., Neymotin, S. A. and Stringer, S. M.. Color opponent
+receptive fields self-organize in a biophysical model of visual
+cortex via spike-timing dependent plasticity. *Frontiers in Neural
+Circuits* 8:16, 10.3389/fncir.2014.00016, 2014.
+
+Ehling, P., Cerina, M., Meuth, P., Kanyshkova, T., Bista, P.,
+Coulon, P., Meuth, S. G., Pape, H. C. and Budde, T..
+Ca2+-dependent large conductance K+ currents in thalamocortical
+relay neurons of different rat strains. *Pflügers Archiv-European
+Journal of Physiology* 465:469-480, 10.1007/s00424-012-1188-6,
+2013.
+
+Ehling, P., Meuth, P., Eichinger, P., Herrmann, A. M., Bittner,
+S., Pawlowski, M., Pankratz, S., Herty, M., Budde, T. and Meuth,
+S. G.. Human T cells in silico: modelling their
+electrophysiological behaviour in health and disease. *Journal of
+Theoretical Biology* 404:236-250, 10.1016/j.jtbi.2016.06.001,
+2016.
+
+Eiber, C. D., Payne, S. C., Biscola, N. P., Havton, L. A., Keast,
+J. R., Osborne, P. B. and Fallon, J. B.. Computational modelling
+of nerve stimulation and recording with peripheral visceral neural
+interfaces. *Journal of Neural Engineering*
+1810.1088/1741-2552/ac36e2, 2021.
+
+Eichinger, P., Herrmann, A. M., Ruck, T., Herty, M., Gola, L.,
+Kovac, S., Budde, T., Meuth, S. G. and Hundehege, P.. Human T
+cells in silico: modelling dynamic intracellular calcium and its
+influence on cellular electrophysiology. *Journal of Immunological
+Methods* 461:78-84, 10.1016/j.jim.2018.06.020, 2018.
+
+Eichner, H., Klug, T. and Borst, A.. Neural simulations on
+multi-core architectures. *Frontiers in Neuroinformatics* 3:21,
+10.3389/neuro.11.021.2009, 2009.
+
+Einevoll, G. T., Pettersen, K. H., Devor, A., Ulbert, I., Halgren,
+E. and Dale, A. M.. Laminar population analysis: estimating firing
+rates and evoked synaptic activity from multielectrode recordings
+in rat barrel cortex. *Journal of Neurophysiology* 97:2174-2190,
+2007.
+
+El Boustani, S., Marre, O., Behuret, S., Baudot, P., Yger, P.,
+Bal, T., Destexhe, A. and Fregnac, Y.. Network-state modulation of
+power-law frequency-scaling in visual cortical neurons. *PLoS
+Computational Biology* 5:e1000519, 10.1371/journal.pcbi.1000519,
+2009.
+
+El Boustani, S., Pospischil, M., Rudolph-Lilith, M. and Destexhe,
+A.. Activated cortical states: Experiments, analyses and models.
+*Journal of Physiology, Paris* 101:99-109, 2007.
+
+El Ghaleb, Y., Schneeberger, P. E., Fernández-Quintero, M. L.,
+Geisler, S. M., Pelizzari, S., Polstra, A. M., van Hagen, J. M.,
+Denecke, J., Campiglio, M., Liedl, K. R., Stevens, C. A., Person,
+R. E., Rentas, S., Marsh, E. D., Conlin, L. K., Tuluc, P.,
+Kutsche, K. and Flucher, B. E.. CACNA1I gain-of-function mutations
+differentially affect channel gating and cause neurodevelopmental
+disorders.. *Brain* 144:2092-2106, 10.1093/brain/awab101, 2021.
+
+Elaagouby, A. and Yuste, R.. Role of calcium electrogenesis in
+apical dendrites: generation of intrinsic oscillations by an axial
+current. *Journal of Computational Neuroscience* 7:41-53, 1999.
+
+ElBasiouny, S. M., Bennett, D. J. and Mushahwar, V. K.. Simulation
+of dendritic Ca(V)1.3 channels in cat lumbar motoneurons: spatial
+distribution. *Journal of Neurophysiology* 94:3961-3974, 2005.
+
+ElBasiouny, S. M., Bennett, D. J. and Mushahwar, V. K.. Simulation
+of Ca2+ persistent inward currents in spinal motoneurones: mode of
+activation and integration of synaptic inputs. *Journal of
+Physiology* 570:355-374, 2006.
+
+ElBasiouny, S. M.. Development of modified cable models to
+simulate accurate neuronal active behaviors. *Journal of Applied
+Physiology* 117:1243-1261, 10.1152/japplphysiol.00496.2014, 2014.
+
+ElBasiouny, S. M., Amendola, J., Durand, J. and Heckman, C. J..
+Evidence from computer simulations for alterations in the membrane
+biophysical properties and dendritic processing of synaptic inputs
+in mutant superoxide dismutase-1 motoneurons. *Journal of
+Neuroscience* 30:5544-5558, 10.1523/JNEUROSCI.0434-10.2010, 2010.
+
+ElBasiouny, S. M. and Mushahwar, V. K.. Modulation of motoneuronal
+firing behavior after spinal cord injury using intraspinal
+microstimulation current pulses: a modeling study. *Journal of
+Applied Physiology* 103:276-286, 2007a.
+
+ElBasiouny, S. M. and Mushahwar, V. K.. Suppressing the
+excitability of spinal motoneurons by extracellularly applied
+electrical fields: insights from computer simulations. *Journal of
+Applied Physiology* 103:1824-1836, 2007b.
+
+Elbaz, M., Buterman, R. and Ezra Tsur, E.. NeuroConstruct-based
+implementation of structured-light stimulated retinal circuitry.
+*BMC Neuroscience* 21:28, 10.1186/s12868-020-00578-0, 2020.
+
+El-Bizri, N., Kahlig, K. M., Shryock, J. C., George, Jr., A. L.,
+Belardinelli, L. and Rajamani, S.. Ranolazine block of human
+Na(v)1.4 sodium channels and paramyotonia congenita mutants.
+*Channels* 5:161-172, 10.4161/chan.5.2.14851, 2011.
+
+van Elburg, R. A. J. and van Ooyen, A.. A new measure for
+bursting. *Neurocomputing* 58-60:497-502,
+https://doi.org/10.1016/j.neucom.2004.01.086, 2004.
+
+van Elburg, R. A. J. and van Ooyen, A.. Generalization of the
+event-based Carnevale-Hines integration scheme for
+integrate-and-fire models. *Neural Computation* 21:1913-1930,
+2009.
+
+van Elburg, R. A. J. and van Ooyen, A.. Impact of dendritic size
+and dendritic topology on burst firing in pyramidal cells. *PLoS
+Computational Biology* 6:10.1371/journal.pcbi.1000781,
+10.1371/journal.pcbi.1000781, 2010.
+
+Elgueta, C. and Bartos, M.. Dendritic inhibition differentially
+regulates excitability of dentate gyrus parvalbumin-expressing
+interneurons and granule cells. *Nature Communications* 10:5561,
+10.1038/s41467-019-13533-3, 2019.
+
+Elgueta, C., Köhler, J. and Bartos, M.. Persistent discharges in
+dentate gyrus perisoma-inhibiting interneurons require
+hyperpolarization-activated cyclic nucleotide-gated channel
+activation. *Journal of Neuroscience* 35:4131-4139,
+10.1523/JNEUROSCI.3671-14.2015, 2015.
+
+Ellender, T. J., Raimondo, J. V., Irkle, A., Lamsa, K. P. and
+Akerman, C. J.. Excitatory effects of parvalbumin-expressing
+interneurons maintain hippocampal epileptiform activity via
+synchronous afterdischarges. *Journal of Neuroscience*
+34:15208-15222, 10.1523/JNEUROSCI.1747-14.2014, 2014.
+
+Emnett, C. M., Eisenman, L. N., Taylor, A. M., Izumi, Y.,
+Zorumski, C. F. and Mennerick, S.. Indistinguishable synaptic
+pharmacodynamics of the N-methyl-D-aspartate receptor channel
+blockers memantine and ketamine. *Molecular Pharmacology*
+84:935-947, 10.1124/mol.113.089334, 2013.
+
+Engel, D. and Jonas, P.. Presynaptic action potential
+amplification by voltage-gated Na+ channels in hippocampal mossy
+fiber boutons. *Neuron* 45:405-417, 2005.
+
+Engel, J., Schultens, H. A. and Schild, D.. Small conductance
+potassium channels cause an activity-dependent spike frequency
+adaptation and make the transfer function of neurons logarithmic.
+*Biophysical Journal* 76:1310-1319, 1999.
+
+Enoki, R., Kiuchi, T., Koizumi, A., Sasaki, G., Kudo, Y. and
+Miyakawa, H.. NMDA receptor-mediated depolarizing after-potentials
+in the basal dendrites of CA1 pyramidal neurons. *Neuroscience
+Research* 48:325-333, 2004.
+
+Enrico, P., Migliore, M., Spiga, S., Mulas, G., Caboni, F. and
+Diana, M.. Morphofunctional alterations in ventral tegmental area
+dopamine neurons in acute and prolonged opiates withdrawal. A
+computational perspective. *Neuroscience* 322:195-207,
+10.1016/j.neuroscience.2016.02.006, 2016.
+
+Erdi, P., Aradi, I. and Grobler, T.. Rhythmogenesis in single
+cells and population models: olfactory bulb and hippocampus.
+*Biosystems* 40:45-53, 1997.
+
+Eriksson, D., Fransén, E., Zilberter, Y. and Lansner, A.. Effects
+of short-term synaptic plasticity in a local microcircuit on cell
+firing. *Neurocomputing* 52-54:7-12, 2003.
+
+Ermolyuk, Y. S., Alder, F. G., Surges, R., Pavlov, I. Y.,
+Timofeeva, Y., Kullmann, D. M. and Volynski, K. E.. Differential
+triggering of spontaneous glutamate release by P/Q-, N- and R-type
+Ca2+ channels. *Nature Neuroscience* 16:1754-1763,
+10.1038/nn.3563, 2013.
+
+Esler, T. B., Maturana, M. I., Kerr, R. R., Grayden, D. B.,
+Burkitt, A. N. and Meffin, H.. Biophysical basis of the linear
+electrical receptive fields of retinal ganglion cells. *Journal of
+Neural Engineering* 15:055001, 10.1088/1741-2552/aacbaa, 2018.
+
+Evans, B. D., Jarvis, S., Schultz, S. R. and Nikolic, K.. PyRhO: a
+multiscale optogenetics simulation platform. *Frontiers in
+Neuroinformatics* 10:8, 10.3389/fninf.2016.00008, 2016.
+
+Ewart, T., Planas, J., Cremonesi, F., Langen, K., Schürmann, F.
+and Delalondre, F.. Neuromapp: a mini-application framework to
+improve neural simulators. In: *Lecture Notes in Computer
+Science*, edited by Kunkel, J., Yokota, R., Balaji, P. and Keyes,
+D.. Springer International Publishing, 2017, pp. 181-198.
+
+Eyal, G., Mansvelder, H. D., de Kock, C. P. J. and Segev, I..
+Dendrites impact the encoding capabilities of the axon. *Journal
+of Neuroscience* 34:8063-8071, 10.1523/JNEUROSCI.5431-13.2014,
+2014.
+
+Eyal, G., Verhoog, M. B., Testa-Silva, G., Deitcher, Y.,
+Benavides-Piccione, R., DeFelipe, J., de Kock, C. P. J.,
+Mansvelder, H. D. and Segev, I.. Human cortical pyramidal neurons:
+from spines to spikes via models. *Frontiers in Cellular
+Neuroscience* 12:181, 10.3389/fncel.2018.00181, 2018.
+
+Eyal, G., Verhoog, M. B., Testa-Silva, G., Deitcher, Y., Lodder,
+J. C., Benavides-Piccione, R., Morales, J., DeFelipe, J., de Kock,
+C. P., Mansvelder, H. D. and Segev, I.. Unique membrane properties
+and enhanced signal processing in human neocortical neurons.
+*eLife* 5:e16553, 10.7554/eLife.16553, 2016.
+
+Ezra-Tsur, E., Amsalem, O., Ankri, L., Patil, P., Segev, I. and
+Rivlin-Etzion, M.. Realistic retinal modeling unravels the
+differential role of excitation and inhibition to starburst
+amacrine cells in direction selectivity. *PLoS Computational
+Biology* 17:e1009754, 10.1371/journal.pcbi.1009754, 2021.
+
+Fan, Y., Wei, X., Yi, G., Lu, M., Wang, J. and Deng, B..
+Asymptotic input-output relationship predicts electric field
+effect on sublinear dendritic integration of AMPA synapses.
+*Neural Computation* :1-37, 10.1162/neco_a_01438, 2021.
+
+Farahani, F., Kronberg, G., FallahRad, M., Oviedo, H. V. and
+Parra, L. C.. Effects of direct current stimulation on synaptic
+plasticity in a single neuron. *Brain Stimulation* 14:588-597,
+10.1016/j.brs.2021.03.001, 2021.
+
+Fardet, T. and Levina, A.. Simple models including energy and
+spike constraints reproduce complex activity patterns and
+metabolic disruptions. *PLoS Computational Biology* 16:e1008503,
+10.1371/journal.pcbi.1008503, 2020.
+
+Farinella, M., Ruedt, D. T., Gleeson, P., Lanore, F. and Silver,
+R. A.. Glutamate-bound NMDARs arising from in vivo-like network
+activity extend spatio-temporal integration in a L5 cortical
+pyramidal cell model. *PLoS Computational Biology* 10:e1003590,
+10.1371/journal.pcbi.1003590, 2014.
+
+Farisello, P., Boido, D., Nieus, T., Medrihan, L., Cesca, F.,
+Valtorta, F., Baldelli, P. and Benfenati, F.. Synaptic and
+extrasynaptic origin of the excitation/inhibition imbalance in the
+hippocampus of synapsin I/II/III knockout mice. *Cerebral Cortex*
+23:581-593, 10.1093/cercor/bhs041, 2013.
+
+Farries, M. A. and Wilson, C. J.. Biophysical basis of the phase
+response curve of subthalamic neurons with generalization to other
+cell types. *Journal of Neurophysiology* 108:1838-1855,
+10.1152/jn.00054.2012, 2012.
+
+Farrow, K., Haag, J. and Borst, A.. Nonlinear, binocular
+interactions underlying flow field selectivity of a
+motion-sensitive neuron. *Nature Neuroscience* 9:1312-1320, 2006.
+
+Feetham, C. H., Nunn, N., Lewis, R., Dart, C. and Barrett-Jolley,
+R.. TRPV4 and K(Ca) ion channels functionally couple as
+osmosensors in the paraventricular nucleus. *British Journal of
+Pharmacology* 172:1753-1768, 10.1111/bph.13023, 2015.
+
+Fellner, A., Stiennon, I. and Rattay, F.. Analysis of upper
+threshold mechanisms of spherical neurons during extracellular
+stimulation. *Journal of Neurophysiology* 121:1315-1328,
+10.1152/jn.00700.2018, 2019.
+
+Fellous, J. M., Rudolph, M., Destexhe, A. and Sejnowski, T. J..
+Synaptic background noise controls the input/output
+characteristics of single cells in an in vitro model of in vivo
+activity. *Neuroscience* 122:811-829, 2003.
+
+Feng, B., Zhu, Y., La, J.-H., Wills, Z. P. and Gebhart, G. F..
+Experimental and computational evidence for an essential role of
+NaV1.6 in spike initiation at stretch-sensitive colorectal
+afferent endings. *Journal of Neurophysiology* 113:2618-2634,
+10.1152/jn.00717.2014, 2015.
+
+Feng, F., Headley, D. B., Amir, A., Kanta, V., Chen, Z., Paré, D.
+and Nair, S. S.. Gamma oscillations in the basolateral amygdala:
+biophysical mechanisms and computational consequences. *eNeuro*
+6:ENEURO.0388-18.2018, 10.1523/ENEURO.0388-18.2018, 2019.
+
+Feng, F., Headley, D. B. and Nair, S. S.. Model neocortical
+microcircuit supports beta and gamma rhythms [Online]. *Proc. 10th
+Int. IEEE/EMBS Conf. Neural Engineering* :91-94,
+10.1109/NER49283.2021.9441199, 2021.
+
+Feng, F., Samarth, P., Paré, D. and Nair, S. S.. Mechanisms
+underlying the formation of the amygdalar fear memory trace: a
+computational perspective. *Neuroscience* 322:370-376,
+10.1016/j.neuroscience.2016.02.059, 2016.
+
+Feng, H. F.. Is the integrate-and-fire model good enough? a
+review. *Neural Networks* 14:955-975, 2001.
+
+Feng, J. F. and Zhang, P.. Behavior of integrate-and-fire and
+Hodgkin-Huxley models with correlated inputs. *Physical Review E*
+63:051902, 2001.
+
+Fenton, A. A., Lytton, W. W., Barry, J. M., Lenck-Santini, P.-P.,
+Zinyuk, L. E., Kubík, S., Bures, J., Poucet, B., Muller, R. U. and
+Olypher, A. V.. Attention-like modulation of hippocampus place
+cell discharge. *Journal of Neuroscience* 30:4613-4625,
+10.1523/JNEUROSCI.5576-09.2010, 2010.
+
+Ferdous, Z. I., Yu, A., Zeng, Y., Guo, X., Yan, Z. and
+Berdichevsky, Y.. Efficient and accurate computational model of
+neuron with spike frequency adaptation. *Annual International
+Conference of the IEEE Engineering in Medicine and Biology
+Society* 2021:6496-6499, 10.1109/EMBC46164.2021.9629799, 2021.
+
+Ferguson, K. A., Huh, C. Y. L., Amilhon, B., Manseau, F.,
+Williams, S. and Skinner, F. K.. Network models provide insights
+into how oriens-lacunosum-moleculare and bistratified cell
+interactions influence the power of local hippocampal CA1 theta
+oscillations. *Frontiers in Systems Neuroscience* 9:110,
+10.3389/fnsys.2015.00110, 2015.
+
+Fernández de Sevilla, D., Fuenzalida, M., Porto Pazos, A. B. and
+Buño, W.. Selective shunting of the NMDA EPSP component by the
+slow afterhyperpolarization in rat CA1 pyramidal neurons. *Journal
+of Neurophysiology* 97:3242-3255, 2007.
+
+Ferrante, M. and Ascoli, G. A.. Distinct and synergistic
+feedforward inhibition of pyramidal cells by basket and
+bistratified interneurons. *Frontiers in Cellular Neuroscience*
+9:439, 10.3389/fncel.2015.00439, 2015.
+
+Ferrante, M., Blackwell, K. T., Migliore, M. and Ascoli, G. A..
+Computational models of neuronal biophysics and the
+characterization of potential neuropharmacological targets..
+*Current Medicinal Chemistry* 15:2456-2471, 2008.
+
+Ferrante, M., Migliore, M. and Ascoli, G. A.. Feed-forward
+inhibition as a buffer of the neuronal input-output relation..
+*Proceedings of the National Academy of Sciences of the United
+States of America* 106:18004-18009, 10.1073/pnas.0904784106, 2009.
+
+Ferrante, M., Migliore, M. and Ascoli, G. A.. Functional impact of
+dendritic branch-point morphology. *Journal of Neuroscience*
+33:2156-2165, 10.1523/JNEUROSCI.3495-12.2013, 2013.
+
+Ferrarese, L., Jouhanneau, J.-S., Remme, M. W. H., Kremkow, J.,
+Katona, G., Rózsa, B., Schreiber, S. and Poulet, J. F. A..
+Dendrite-specific amplification of weak synaptic input during
+network activity in vivo. *Cell Reports* 24:3455-3465.e5,
+10.1016/j.celrep.2018.08.088, 2018.
+
+Ferrario, A., Merrison-Hort, R., Soffe, S. R. and Borisyuk, R..
+Structural and functional properties of a probabilistic model of
+neuronal connectivity in a simple locomotor network. *eLife*
+7:e33281, 10.7554/eLife.33281, 2018.
+
+Ferrario, A., Palyanov, A., Koutsikou, S., Li, W., Soffe, S.,
+Roberts, A. and Borisyuk, R.. From decision to action: detailed
+modelling of frog tadpoles reveals neuronal mechanisms of
+decision-making and reproduces unpredictable swimming movements in
+response to sensory signals. *PLoS Computational Biology*
+17:e1009654, 10.1371/journal.pcbi.1009654, 2021.
+
+Fietkiewicz, C., Loparo, K. A. and Wilson, C. G.. Drive latencies
+in hypoglossal motoneurons indicate developmental change in the
+brainstem respiratory network. *Journal of Neural Engineering*
+8:065011, 10.1088/1741-2560/8/6/065011, 2011.
+
+Fietkiewicz, C., Shafer, G. O., Platt, E. A. and Wilson, C. G..
+Variability in respiratory rhythm generation: In vitro and in
+silico models. *Communications in Nonlinear Science and Numerical
+Simulation* 32:158 - 168,
+http://dx.doi.org/10.1016/j.cnsns.2015.08.018, 2016.
+
+Fineberg, J. D., Ritter, D. M. and Covarrubias, M..
+Modeling-independent elucidation of inactivation pathways in
+recombinant and native A-type Kv channels. *Journal of General
+Physiology* 140:513-527, 10.1085/jgp.201210869, 2012.
+
+Finelli, L. A., Haney, S., Bazhenov, M., Stopfer, M. and
+Sejnowski, T. J.. Synaptic learning rules and sparse coding in a
+model sensory system. *PLoS Computational Biology* 4:e1000062,
+10.1371/journal.pcbi.1000062, 2008.
+
+Fink, C. G., Gliske, S., Catoni, N. and Stacey, W. C.. Network
+mechanisms generating abnormal and normal hippocampal
+high-frequency oscillations: a computational analysis. *eNeuro*
+2:ENEURO.0024-15.2015, 10.1523/ENEURO.0024-15.2015, 2015.
+
+Finn, K. E., Zander, H. J., Graham, R. D., Lempka, S. F. and
+Weiland, J. D.. A patient-specific computational framework for the
+Argus ii implant. *IEEE Open Journal of Engineering in Medicine
+and Biology* 1:190-196, 10.1109/ojemb.2020.3001563, 2020.
+
+Fiorillo, C. D., Kim, J. K. and Hong, S. Z.. The meaning of spikes
+from the neuron's point of view: predictive homeostasis generates
+the appearance of randomness. *Frontiers in Computational
+Neuroscience* 8:49, 10.3389/fncom.2014.00049, 2014.
+
+Fischer, B. J. and Westover, M. B.. The neural multiple access
+channel. *Neurocomputing* 52-54:511-518, 2003.
+
+Fleidervish, I. A., Lasser-Ross, N., Gutnick, M. J. and Ross, W.
+N.. Na+ imaging reveals little difference in action
+potential-evoked Na+ influx between axon and soma. *Nature
+Neuroscience* 13:852-860, 10.1038/nn.2574, 2010.
+
+Fleidervish, I. A. and Libman, L.. How cesium dialysis affects the
+passive properties of pyramidal neurons: implications for voltage
+clamp studies of persistent sodium current. *New Journal of
+Physics* 10:035001, 2008.
+
+Fleidervish, I. A., Libman, L., Katz, E. and Gutnick, M. J..
+Endogenous polyamines regulate cortical neuronal excitability by
+blocking voltage-gated Na+ channels. *Proceedings of the National
+Academy of Sciences of the United States of America*
+105:18994-18999, 2008.
+
+Fleidervish, I. A., Friedman, A. and Gutnick, M. J.. Slow
+inactivation of Na+ current and slow cumulative spike adaptation
+in mouse and guinea-pig neocortical neurones in slices. *Journal
+of Physiology* 493:83-97, 1996.
+
+Fleming, J. E., Dunn, E. and Lowery, M. M.. Simulation of
+closed-loop deep brain stimulation control schemes for suppression
+of pathological beta oscillations in Parkinson's disease.
+*Frontiers in Neuroscience* 14:166, 10.3389/fnins.2020.00166,
+2020a.
+
+Fleming, J. E., Orłowski, J., Lowery, M. M. and Chaillet, A..
+Self-tuning deep brain stimulation controller for suppression of
+beta oscillations: analytical derivation and numerical validation.
+*Frontiers in Neuroscience* 14:639, 10.3389/fnins.2020.00639,
+2020b.
+
+Fletcher, L. N. and Williams, S. R.. Neocortical topology governs
+the dendritic integrative capacity of layer 5 pyramidal neurons.
+*Neuron* 101:76-90.e4, 10.1016/j.neuron.2018.10.048, 2019.
+
+Flores-Barrera, E., Laville, A., Plata, V., Tapia, D., Bargas, J.
+and Galarraga, E.. Inhibitory contribution to suprathreshold
+corticostriatal responses: an experimental and modeling study.
+*Cellular and Molecular Neurobiology* 29:719-731, 2009.
+
+Fohlmeister, J. F. and Miller, R. F.. Impulse encoding mechanisms
+of ganglion cells in the tiger salamander retina. *Journal of
+Neurophysiology* 78:1935-1947, 1997a.
+
+Fohlmeister, J. F. and Miller, R. F.. Mechanisms by which cell
+geometry controls repetitive impulse firing in retinal ganglion
+cells. *Journal of Neurophysiology* 78:1948-1964, 1997b.
+
+Fohlmeister, J. F.. Voltage gating by molecular subunits of Na+
+and K+ ion channels: higher-dimensional cubic kinetics, rate
+constants, and temperature. *Journal of Neurophysiology*
+113:3759-3777, 10.1152/jn.00551.2014, 2015.
+
+Fohlmeister, J. F., Cohen, E. D. and Newman, E. A.. Mechanisms and
+distribution of ion channels in retinal ganglion cells: using
+temperature as an independent variable. *Journal of
+Neurophysiology* 103:1357-1374, 10.1152/jn.00123.2009, 2010.
+
+Foldy, C., Aradi, I., Howard, A. and Soltesz, I.. Diversity beyond
+variance: modulation of firing rates and network coherence by
+GABAergic subpopulations. *European Journal of Neuroscience*
+19:119-130, 2003.
+
+Foley, J., Nguyen, H., Bennett, C. B. and Muschol, M.. Potassium
+accumulation as dynamic modulator of neurohypophysial
+excitability. *Neuroscience* 169:65-73,
+10.1016/j.neuroscience.2010.04.049, 2010.
+
+Fontaine, B., Peña, J. L. and Brette, R.. Spike-threshold
+adaptation predicted by membrane potential dynamics in vivo. *PLoS
+Computational Biology* 10:e1003560, 10.1371/journal.pcbi.1003560,
+2014.
+
+Ford, J. B., Ganguly, M., Poorman, M. E., Grissom, W. A., Jenkins,
+M. W., Chiel, H. J. and Jansen, E. D.. Identifying the role of
+block length in neural heat block to reduce temperatures during
+infrared neural inhibition. *Lasers in Surgery and Medicine*
+online:ahead of print, 10.1002/lsm.23139, 2019.
+
+Formento, E., Minassian, K., Wagner, F., Mignardot, J. B., Le
+Goff-Mignardot, C. G., Rowald, A., Bloch, J., Micera, S.,
+Capogrosso, M. and Courtine, G.. Electrical spinal cord
+stimulation must preserve proprioception to enable locomotion in
+humans with spinal cord injury. *Nature Neuroscience*
+21:1728-1741, 10.1038/s41593-018-0262-6, 2018.
+
+Forrest, M. D.. Mathematical model of bursting in dissociated
+purkinje neurons. *PLoS ONE* 8:e68765,
+10.1371/journal.pone.0068765, 2013.
+
+Forrest, M. D., Wall, M. J., Press, D. A. and Feng, J.. The
+sodium-potassium pump controls the intrinsic firing of the
+cerebellar Purkinje neuron. *PLoS ONE* 7:e51169,
+10.1371/journal.pone.0051169, 2012.
+
+Fortier, P. A.. Effects of electrical coupling among layer 4
+inhibitory interneurons on contrast-invariant orientation tuning.
+*Experimental Brain Research* 208:127-138,
+10.1007/s00221-010-2483-0, 2011.
+
+Fortier, P. A. and Bray, C.. Influence of asymmetric attenuation
+of single and paired dendritic inputs on summation of synaptic
+potentials and initiation of action potentials. *Neuroscience*
+236:195-209, 10.1016/j.neuroscience.2012.11.060, 2013.
+
+Foubert, L., Bennequin, D., Thomas, M.-A., Droulez, J. and
+Milleret, C.. Interhemispheric synchrony in visual cortex and
+abnormal postnatal visual experience. *Frontiers in Bioscience*
+15:681-707, 10.2741/3640, 2010.
+
+Foust, A. J., Yu, Y., Popovic, M., Zecevic, D. and McCormick, D.
+A.. Somatic membrane potential and Kv1 channels control spike
+repolarization in cortical axon collaterals and presynaptic
+boutons. *Journal of Neuroscience* 31:15490-15498,
+10.1523/JNEUROSCI.2752-11.2011, 2011.
+
+Foutz, T. J., Ackermann, Jr, D. M., Kilgore, K. L. and McIntyre,
+C. C.. Energy efficient neural stimulation: coupling circuit
+design and membrane biophysics. *PLoS ONE* 7:e51901,
+10.1371/journal.pone.0051901, 2012a.
+
+Foutz, T. J., Arlow, R. L. and McIntyre, C. C.. Theoretical
+principles underlying optical stimulation of a channelrhodopsin-2
+positive pyramidal neuron. *Journal of Neurophysiology*
+107:3235-3245, 10.1152/jn.00501.2011, 2012b.
+
+Foutz, T. J. and McIntyre, C. C.. Evaluation of novel stimulus
+waveforms for deep brain stimulation. *Journal of Neural
+Engineering* 7:066008, 10.1088/1741-2560/7/6/066008, 2010.
+
+Francavilla, R., Guet-McCreight, A., Amalyan, S., Hui, C. W.,
+Topolnik, D., Michaud, F., Marino, B., Tremblay, M.-È., Skinner,
+F. K. and Topolnik, L.. Alterations in intrinsic and synaptic
+properties of hippocampal Ca1 VIP interneurons during aging.
+*Frontiers in Cellular Neuroscience* 14:554405,
+10.3389/fncel.2020.554405, 2020.
+
+Franke, F., Natora, M., Meier, P., Hagen, E., Pettersen, K. H.,
+Linden, H., Einevoll, G. T. and Obermayer, K.. An automated online
+positioning system and simulation environment for multi-electrodes
+in extracellular recordings. *Annual International Conference of
+the IEEE Engineering in Medicine and Biology Society*
+2010:593-597, 10.1109/IEMBS.2010.5626631, 2010.
+
+Franks, K. M., Bartol, T. M. and Sejnowski, T. J.. An MCell model
+of calcium dynamics and frequency-dependence of calmodulin
+activation in dendritic spines. *Neurocomputing* 38:9-16, 2001.
+
+Franks, K. M. and Sejnowski, T. J.. Complexity of calcium
+signaling in synaptic spines. *Bioessays* 24:1130-1144, 2002.
+
+Fransén, E.. A synapse which can switch from inhibitory to
+excitatory and back. *Neurocomputing* 65-66:39-45, 2005.
+
+Fransén, E.. Neural response profile design: Reducing
+epileptogenic activity by modifying neuron responses to
+synchronized input using novel potassium channels obtained by
+parameter search optimization. *Neurocomputing* 70:1630-1634,
+2007.
+
+Fransén, E. and Tigerholm, J.. Role of A-type potassium currents
+in excitability, network synchronicity, and epilepsy.
+*Hippocampus* 20:877-887, 10.1002/hipo.20694, 2010.
+
+Freeman, D. K., Jeng, J. S., Kelly, S. K., Hartveit, E. and Fried,
+S. I.. Calcium channel dynamics limit synaptic release in response
+to prosthetic stimulation with sinusoidal waveforms. *Journal of
+Neural Engineering* 8:046005, 10.1088/1741-2560/8/4/046005, 2011.
+
+Frey, U., Egert, U., Heer, F., Hafizovic, S. and Hierlemann, A..
+Microelectronic system for high-resolution mapping of
+extracellular electric fields applied to brain slices. *Biosensors
+and Bioelectronics* 24:2191-2198, 2009.
+
+Friedrich, P., Vella, M., Gulyás, A. I., Freund, T. F. and Káli,
+S.. A flexible, interactive software tool for fitting the
+parameters of neuronal models. *Frontiers in Neuroinformatics*
+8:63, 10.3389/fninf.2014.00063, 2014.
+
+Frost Nylén, J., Carannante, I., Grillner, S. and Hellgren
+Kotaleski, J.. Reciprocal interaction between striatal cholinergic
+and low-threshold spiking interneurons - a computational study.
+*European Journal of Neuroscience* 53:2135-2148,
+10.1111/ejn.14854, 2021a.
+
+Frost Nylén, J., Hjorth, J. J. J., Grillner, S. and Hellgren
+Kotaleski, J.. Dopaminergic and cholinergic modulation of large
+scale networks in silico using Snudda. *Frontiers in Neural
+Circuits* 15:748989, 10.3389/fncir.2021.748989, 2021b.
+
+Fujita, T., Fukai, T. and Kitano, K.. Influences of membrane
+properties on phase response curve and synchronization stability
+in a model globus pallidus neuron.. *Journal of Computational
+Neuroscience* 32:539-553, 10.1007/s10827-011-0368-2, 2012.
+
+Gabbiani, F., Midtgaard, J. and Knöpfel, T.. Synaptic integration
+in a model of cerebellar granule cells. *Journal of
+Neurophysiology* 72:999-1009, 1994.
+
+Gaines, J. L., Finn, K. E., Slopsema, J. P., Heyboer, L. A. and
+Polasek, K. H.. A model of motor and sensory axon activation in
+the median nerve using surface electrical stimulation. *Journal of
+Computational Neuroscience* 45:29-43, 10.1007/s10827-018-0689-5,
+2018.
+
+Gal, E., Amsalem, O., Schindel, A., London, M., Schürmann, F.,
+Markram, H. and Segev, I.. The role of hub neurons in modulating
+cortical dynamics. *Frontiers in Neural Circuits* 15:718270,
+10.3389/fncir.2021.718270, 2021.
+
+Galati, D. F., Hiester, B. G. and Jones, K. R.. Computer
+simulations support a morphological contribution to BDNF
+enhancement of action potential generation. *Frontiers in Cellular
+Neuroscience* 10:209, 10.3389/fncel.2016.00209, 2016.
+
+Gallego-Delgado, P., James, R., Browne, E., Meng, J., Umashankar,
+S., Tan, L., Picon, C., Mazarakis, N. D., Faisal, A. A., Howell,
+O. W. and Reynolds, R.. Neuroinflammation in the normal-appearing
+white matter (NAWM) of the multiple sclerosis brain causes
+abnormalities at the nodes of Ranvier. *PLoS Biology* 18:e3001008,
+10.1371/journal.pbio.3001008, 2020.
+
+Galloni, A. R., Laffere, A. and Rancz, E.. Apical length governs
+computational diversity of layer 5 pyramidal neurons. *eLife*
+910.7554/eLife.55761, 2020.
+
+Gamal, M., Mousa, M. H., Eldawlatly, S. and Elbasiouny, S. M..
+In-silico development and assessment of a Kalman filter motor
+decoder for prosthetic hand control. *Computers in Biology and
+Medicine* 132:104353, 10.1016/j.compbiomed.2021.104353, 2021.
+
+Ganguly, M., Jenkins, M. W., Jansen, E. D. and Chiel, H. J..
+Thermal block of action potentials is primarily due to
+voltage-dependent potassium currents: a modeling study.. *Journal
+of neural engineering* 16:036020, 10.1088/1741-2552/ab131b, 2019.
+
+Gao, P. P., Graham, J. W., Zhou, W.-L., Jang, J., Angulo, S.,
+Dura-Bernal, S., Hines, M., Lytton, W. W. and Antic, S. D.. Local
+glutamate-mediated dendritic plateau potentials change the state
+of the cortical pyramidal neuron. *Journal of Neurophysiology*
+125:23-42, 10.1152/jn.00734.2019, 2021.
+
+García-Grajales, J. A., Rucabado, G., García-Dopico, A., Peña,
+J.-M. and Jérusalem, A.. Neurite, a finite difference large scale
+parallel program for the simulation of electrical signal
+propagation in neurites under mechanical loading. *PLoS ONE*
+10:e0116532, 10.1371/journal.pone.0116532, 2015.
+
+Garcia-Lazaro, J. A., Ho, S. S. M., Nair, A. and Schnupp, J. W.
+H.. Shifting and scaling adaptation to dynamic stimuli in
+somatosensory cortex. *European Journal of Neuroscience*
+26:2359-2368, 2007.
+
+Garden, D. L., Dodson, P. D., O'Donnell, C., White, M. D. and
+Nolan, M. F.. Tuning of synaptic integration in the medial
+entorhinal cortex to the organization of grid cell firing fields.
+*Neuron* 60:875-889, 2008.
+
+Garg, J., Lakhani, A. and Dave, V.. Effects of the involvement of
+calcium channels on neuronal hyperexcitability related to
+alzheimer's disease: a computational model. *Neurophysiology*
+52:334-347, 10.1007/s11062-021-09890-9, 2020.
+
+Gartland, A. J. and Detwiler, P. B.. Correlated variations in the
+parameters that regulate dendritic calcium signaling in mouse
+retinal ganglion cells. *Journal of Neuroscience* 31:18353-18363,
+10.1523/JNEUROSCI.4212-11.2011, 2011.
+
+Gasparini, S., Migliore, M. and Magee, J. C.. On the initiation
+and propagation of dendritic spikes in CA1 pyramidal neurons.
+*Journal of Neuroscience* 24:11046-11056, 2004.
+
+Ge, R., Qian, H., Chen, N. and Wang, J.-H.. Input-dependent
+subcellular localization of spike initiation between soma and axon
+at cortical pyramidal neurons. *Molecular Brain* 7:26,
+10.1186/1756-6606-7-26, 2014.
+
+Ge, R., Qian, H. and Wang, J.-H.. Physiological synaptic signals
+initiate sequential spikes at soma of cortical pyramidal neurons.
+*Molecular Brain* 4:19, 10.1186/1756-6606-4-19, 2011.
+
+Geerts, H., Spiros, A. and Roberts, P.. Impact of amyloid-beta
+changes on cognitive outcomes in Alzheimer's disease: analysis of
+clinical trials using a quantitative systems pharmacology model.
+*Alzheimer's Research & Therapy* 10{10.1186/s13195-018-0343-5},
+2018.
+
+Geerts, H., Spiros, A., Roberts, P. and Carr, R.. Quantitative
+systems pharmacology as an extension of PK/PD modeling in CNS
+research and development. *Journal of Pharmacokinetics and
+Pharmacodynamics* 40:257-265, 10.1007/s10928-013-9297-1, 2013.
+
+Geerts, H., Spiros, A., Roberts, P., Twyman, R., Alphs, L. and
+Grace, A. A.. Blinded prospective evaluation of computer-based
+mechanistic schizophrenia disease model for predicting drug
+response. *PLoS ONE* 7:e49732, 10.1371/journal.pone.0049732, 2012.
+
+Geiger, J. R. P., Lübke, J., Roth, A., Frotscher, M. and Jonas,
+P.. Submillisecond AMPA receptor-mediated signaling at a principal
+neuron-interneuron synapse. *Neuron* 18:1009-1023, 1997.
+
+Geiger, J. R. P., Roth, A., Taskin, B. and Jonas, P..
+Glutamate-mediated synaptic excitation of cortical interneurons.
+In: *Ionotropic Glutamate Receptors in the CNS*, edited by Jonas,
+P. and Monyer, H.. Berlin: Berlin, Springer-Verlag, 1999, pp.
+363-398.
+
+Gemin, O., Serna, P., Zamith, J., Assendorp, N., Fossati, M.,
+Rostaing, P., Triller, A. and Charrier, C.. Unique properties of
+dually innervated dendritic spines in pyramidal neurons of the
+somatosensory cortex uncovered by 3D correlative light and
+electron microscopy. *PLoS Biology* 19:e3001375,
+10.1371/journal.pbio.3001375, 2021.
+
+Genet, S., Sabarly, L., Guigon, E., Berry, H. and Delord, B..
+Dendritic signals command firing dynamics in a mathematical model
+of cerebellar Purkinje cells. *Biophysical Journal* 99:427-436,
+10.1016/j.bpj.2010.04.056, 2010.
+
+Gentiletti, D., Suffczynski, P., Gnatkovsky, V. and de Curtis, M..
+Changes of ionic concentrations during seizure transitions--a
+modeling study. *International Journal of Neural Systems*
+27:1750004, 2017.
+
+George, M. S., Abbott, L. F. and Siegelbaum, S. A.. HCN
+hyperpolarization-activated cation channels inhibit EPSPs by
+interactions with M-type K(+) channels. *Nature Neuroscience*
+12:577-584, 10.1038/nn.2307, 2009.
+
+Georgiadis, K., Wray, S., Ourselin, S., Warren, J. D. and Modat,
+M.. Computational modelling of pathogenic protein spread in
+neurodegenerative diseases. *PLoS ONE* 13:e0192518,
+10.1371/journal.pone.0192518, 2018.
+
+Gerlei, K., Passlack, J., Hawes, I., Vandrey, B., Stevens, H.,
+Papastathopoulos, I. and Nolan, M. F.. Grid cells are modulated by
+local head direction. *Nature Communications* 11:4228,
+10.1038/s41467-020-17500-1, 2020.
+
+Gertler, T. S., Chan, C. S. and Surmeier, D. J.. Dichotomous
+anatomical properties of adult striatal medium spiny neurons.
+*Journal of Neuroscience* 28:10814-10824, 2008.
+
+Gherardi, K. and Töreyin, H.. A cortical extracellular simulation
+model to create synthetic neural recordings [Online]. *2021 10th
+International IEEE/EMBS Conference on Neural Engineering*
+:465-468, 10.1109/NER49283.2021.9441104, 2021.
+
+Gibson, J. R., Beierlein, M. and Connors, B. W.. Functional
+properties of electrical synapses between inhibitory interneurons
+of neocortical layer 4. *Journal of Neurophysiology* 93:467-480,
+2005.
+
+Gidon, A. and Segev, I.. Spike-timing-dependent synaptic
+plasticity and synaptic democracy in dendrites. *Journal of
+Neurophysiology* 101:3226-3234, 2009.
+
+Gidon, A. and Segev, I.. Principles governing the operation of
+synaptic inhibition in dendrites.. *Neuron* 75:330-341,
+10.1016/j.neuron.2012.05.015, 2012.
+
+Gidon, A., Zolnik, T. A., Fidzinski, P., Bolduan, F., Papoutsi,
+A., Poirazi, P., Holtkamp, M., Vida, I. and Larkum, M. E..
+Dendritic action potentials and computation in human layer 2/3
+cortical neurons. *Science* 367:83-87, 10.1126/science.aax6239,
+2020.
+
+Gillies, A. and Willshaw, D.. Membrane channel interactions
+underlying rat subthalamic projection neuron rhythmic and bursting
+activity. *Journal of Neurophysiology* 95:2352-2365, 2006.
+
+Ginebaugh, S. P., Cyphers, E. D., Lanka, V., Ortiz, G., Miller, E.
+W., Laghaei, R. and Meriney, S. D.. The frog motor nerve terminal
+has very brief action potentials and three electrical regions
+predicted to differentially control transmitter release. *Journal
+of Neuroscience* 40:3504-3516, 10.1523/JNEUROSCI.2415-19.2020,
+2020.
+
+Gire, D. H., Franks, K. M., Zak, J. D., Tanaka, K. F., Whitesell,
+J. D., Mulligan, A. A., Hen, R. and Schoppa, N. E.. Mitral cells
+in the olfactory bulb are mainly excited through a multistep
+signaling path. *Journal of Neuroscience* 32:2964-2975,
+10.1523/JNEUROSCI.5580-11.2012, 2012.
+
+Glasauer, S. and Rössert, C.. Modelling drug modulation of
+nystagmus. *Progress in Brain Research* 171:527-534, 2008.
+
+Gleeson, P., Cantarelli, M., Marin, B., Quintana, A., Earnshaw,
+M., Sadeh, S., Piasini, E., Birgiolas, J., Cannon, R. C.,
+Cayco-Gajic, N. A., Crook, S., Davison, A. P., Dura-Bernal, S.,
+Ecker, A., Hines, M. L., Idili, G., Lanore, F., Larson, S. D.,
+Lytton, W. W., Majumdar, A., McDougal, R. A., Sivagnanam, S.,
+Solinas, S., Stanislovas, R., van Albada, S. J., van Geit, W. and
+Silver, R. A.. Open Source Brain: a collaborative resource for
+visualizing, analyzing, simulating, and developing standardized
+models of neurons and circuits. *Neuron* 103:395-411.e5,
+10.1016/j.neuron.2019.05.019, 2019.
+
+Gleeson, P., Crook, S., Cannon, R. C., Hines, M. L., Billings, G.
+O., Farinella, M., Morse, T. M., Davison, A. P., Ray, S., Bhalla,
+U. S., Barnes, S. R., Dimitrova, Y. D. and Silver, R. A.. NeuroML:
+a language for describing data driven models of neurons and
+networks with a high degree of biological detail. *PLoS
+Computational Biology* 6:e1000815, 10.1371/journal.pcbi.1000815,
+2010a.
+
+Gleeson, P., Silver, R. A. and Steuber, V.. Computer simulation
+environments. In: *Hippocampal Microcircuits*, edited by
+Cutsuridis, V., Graham, B., Cobb, S. and Vida, I.. Springer,
+2010b, pp. 593-609.
+
+Gleeson, P., Steuber, V. and Silver, R. A.. neuroConstruct: a tool
+for modeling networks of neurons in 3D space. *Neuron* 54:219-235,
+2007.
+
+Go, M. A., Choy, J. M. C., Colibaba, A. S., Redman, S., Bachor,
+H.-A., Stricker, C. and Daria, V. R.. Targeted pruning of a
+neuron's dendritic tree via femtosecond laser dendrotomy.
+*Scientific Reports* 6:19078, 10.1038/srep19078, 2016.
+
+Goetz, L., Roth, A. and Häusser, M.. Active dendrites enable
+strong but sparse inputs to determine orientation selectivity.
+*Proceedings of the National Academy of Sciences of the United
+States of America* 11810.1073/pnas.2017339118, 2021.
+
+Goffredo, M., Schmid, M., Conforto, S., Bilotti, F., Palma, C.,
+Vegni, L. and D'Alessio, T.. A two-step model to optimise
+transcutaneous electrical stimulation of the human upper arm.
+*Compel* 33:1329-1345, 10.1108/COMPEL-04-2013-0118, 2014.
+
+Gold, C., Girardin, C. C., Martin, K. A. C. and Koch, C..
+High-amplitude positive spikes recorded extracellularly in cat
+visual cortex.. *Journal of Neurophysiology* 102:3340-3351,
+10.1152/jn.91365.2008, 2009.
+
+Gold, C., Henze, D. A. and Koch, C.. Using extracellular action
+potential recordings to constrain compartmental models. *Journal
+of Computational Neuroscience* 23:39-58, 2007.
+
+Gold, C., Henze, D. A., Koch, C. and Buzsaki, G.. On the origin of
+the extracellular action potential waveform: a modeling study.
+*Journal of Neurophysiology* 95:3113-3128, 2006.
+
+Goldfarb, M., Schoorlemmer, J., Williams, A., Diwakar, S., Wang,
+C., Huan, X., Giza, J., Tchetchik, D., Kelley, K., Vega, A.,
+Matthews, G., Rossi, P., Ornitz, D. M. and D'Angelo, E..
+Fibroblast growth factor homologous factors control neuronal
+excitability through modulation of voltage-gated sodium channels.
+*Neuron* 55:449-463, 2007.
+
+Golding, N. L., Kath, W. L. and Spruston, N.. Dichotomy of
+action-potential backpropagation in CA1 pyramidal neuron
+dendrites. *Journal of Neurophysiology* 86:2998-3010, 2001.
+
+Golding, N. L., Mickus, T. J., Katz, Y., Kath, W. L. and Spruston,
+N.. Factors mediating powerful voltage attenuation along CA1
+pyramidal neuron dendrites. *Journal of Physiology* 568:69-82,
+2005.
+
+Goldstein, R. H., Barkai, O., Íñigo-Portugués, A., Katz, B., Lev,
+S. and Binshtok, A. M.. Location and plasticity of the sodium
+spike initiation zone in nociceptive terminals in vivo. *Neuron*
+102:801-812.e5, 10.1016/j.neuron.2019.03.005, 2019.
+
+Golestanirad, L., Gale, J. T., Manzoor, N. F., Park, H.-J., Glait,
+L., Haer, F., Kaltenbach, J. A. and Bonmassar, G.. Solenoidal
+micromagnetic stimulation enables activation of axons with
+specific orientation. *Frontiers in Physiology* 9:724,
+10.3389/fphys.2018.00724, 2018.
+
+Golestanirad, L., Izquierdo, A. P., Graham, S. J., Mosig, J. R.
+and Pollo, C.. Effect of realistic modeling of deep brain
+stimulation on the prediction of volume of activated tissue.
+*Progress In Electromagnetics Research* 126:1-16,
+10.2528/PIER12013108, 2012.
+
+Gomes, J.-M., Bedard, C., Valtcheva, S., Nelson, M., Khokhlova,
+V., Pouget, P., Venance, L., Bal, T. and Destexhe, A..
+Intracellular impedance measurements reveal non-ohmic properties
+of the extracellular medium around neurons. *Biophysical Journal*
+110:234-246, 10.1016/j.bpj.2015.11.019, 2016.
+
+Gómez González, J. F., Mel, B. W. and Poirazi, P.. Distinguishing
+linear vs. non-linear integration in CA1 radial oblique dendrites:
+it's about time. *Frontiers in Computational Neuroscience* 5:44,
+10.3389/fncom.2011.00044, 2011.
+
+Gomez, L., Budelli, R. and Pakdaman, K.. Dynamical behavior of a
+pacemaker neuron model with fixed delay stimulation. *Physical
+Review E* 64:061910, 2001.
+
+González, A., Ugarte, G., Restrepo, C., Herrera, G., Piña, R.,
+Gómez-Sánchez, J. A., Pertusa, M., Orio, P. and Madrid, R.. Role
+of the excitability brake potassium current IKD in cold allodynia
+induced by chronic peripheral nerve injury. *Journal of
+Neuroscience* 37:3109-3126, 10.1523/JNEUROSCI.3553-16.2017, 2017.
+
+Gonzalez-Perez, V., Neely, A., Tapia, C., Gonzalez-Gutierrez, G.,
+Contreras, G., Orio, P., Lagos, V., Rojas, G., Estevez, T., Stack,
+K. and Naranjo, D.. Slow inactivation in shaker K channels is
+delayed by intracellular tetraethylammonium. *Journal of General
+Physiology* 132:633-650, 2008.
+
+Goodliffe, J. W., Song, H., Rubakovic, A., Chang, W., Medalla, M.,
+Weaver, C. M. and Luebke, J. I.. Differential changes to D1 and D2
+medium spiny neurons in the 12-month-old Q175(+/-) mouse model of
+Huntington’s Disease. *PLoS ONE* 1310.1371/journal.pone.0200626,
+2018.
+
+Gorin, M., Tsitoura, C., Kahan, A., Watznauer, K., Drose, D. R.,
+Arts, M., Mathar, R., O'Connor, S., Hanganu-Opatz, I. L.,
+Ben-Shaul, Y. and Spehr, M.. Interdependent conductances drive
+infraslow intrinsic rhythmogenesis in a subset of accessory
+olfactory bulb projection neurons. *Journal of Neuroscience*
+36:3127-3144, 10.1523/JNEUROSCI.2520-15.2016, 2016.
+
+Goriounova, N. A., Heyer, D. B., Wilbers, R., Verhoog, M. B.,
+Giugliano, M., Verbist, C., Obermayer, J., Kerkhofs, A., Smeding,
+H., Verberne, M., Idema, S., Baayen, J. C., Pieneman, A. W., de
+Kock, C. P., Klein, M. and Mansvelder, H. D.. Large and fast human
+pyramidal neurons associate with intelligence. *eLife* 7:e41714,
+10.7554/eLife.41714, 2018.
+
+Goudar, V. and Buonomano, D. V.. A model of order-selectivity
+based on dynamic changes in the balance of excitation and
+inhibition produced by short-term synaptic plasticity. *Journal of
+Neurophysiology* 113:509-523, 10.1152/jn.00568.2014, 2015.
+
+Gouwens, N. W. and Wilson, R. I.. Signal propagation in Drosophila
+central neurons. *Journal of Neuroscience* 29:6239-6249, 2009.
+
+Gouwens, N. W., Berg, J., Feng, D., Sorensen, S. A., Zeng, H.,
+Hawrylycz, M. J., Koch, C. and Arkhipov, A.. Systematic generation
+of biophysically detailed models for diverse cortical neuron
+types. *Nature Communications* 9:710, 10.1038/s41467-017-02718-3,
+2018.
+
+Gow, A. and Devaux, J.. A model of tight junction function in
+central nervous system myelinated axons. *Neuron Glia Biology*
+4:307-317, 10.1017/S1740925X09990391, 2008.
+
+Goyer, D., Kurth, S., Gillet, C., Keine, C., Rübsamen, R. and
+Kuenzel, T.. Slow cholinergic modulation of spike probability in
+ultra-fast time-coding sensory neurons. *eNeuro*
+3:ENEURO.0186-16.2016, 10.1523/ENEURO.0186-16.2016, 2016.
+
+Gradwohl, G. and Grossman, Y.. Dendritic voltage dependent
+conductances increase the excitatory synaptic response and its
+postsynaptic inhibition in a reconstructed alpha-motoneuron: A
+computer model. *Neurocomputing* 38:223-229, 2001.
+
+Gradwohl, G. and Grossman, Y.. Analysis of dendritic distribution
+of voltage-dependent channels effects on EPSP and its reciprocal
+inhibition in alpha-motoneurons: computer model. *Neurocomputing*
+58-60:417-422, 2004.
+
+Gradwohl, G. and Grossman, Y.. A theoretical computer model of
+cellular modification associated with olfactory learning in the
+rat piriform cortex. *Neurocomputing* 65:549-555, 2005.
+
+Gradwohl, G. and Grossman, Y.. Excitatory and inhibitory synaptic
+inputs are modulated by the spatial distribution of dendritic
+voltage-dependent channels: Modelling in realistic
+alpha-motoneuron. *Neurocomputing* 70:1680-1684, 2007.
+
+Gradwohl, G. and Grossman, Y.. Analysis of the interaction between
+the dendritic conductance density and activated area in modulating
+alpha-motoneuron EPSP: statistical computer model. *Neural
+Computation* 20:1385-1410, 2008.
+
+Gradwohl, G. and Grossman, Y.. Statistical computer model analysis
+of the reciprocal and recurrent inhibitory postsynaptic potentials
+in alpha-motoneurons. *Neural Computation* 22:1764-1785, 2010.
+
+Gradwohl, G. and Grossman, Y.. Statistical computer model analysis
+of the reciprocal and recurrent inhibitions of the Ia-EPSP in
+α-motoneurons. *Neural Computation* 25:75-100,
+10.1162/NECO_a_00375, 2013.
+
+Gradwohl, G., Nitzan, R. and Grossman, Y.. Homogeneous
+distribution of excitatory and inhibitory synapses on the
+dendrites of the cat surea triceps alpha-motoneurons increases
+synaptic efficacy: computer model. *Neurocomputing* 26-7:155-162,
+1999.
+
+Graham, B. P.. Pattern recognition in a compartmental model of a
+CA1 pyramidal neuron. *Network* 12:473-492, 2001.
+
+Graham, B. P., Wong, A. Y. C. and Forsythe, I. D.. A computational
+model of synaptic transmission at the calyx of Held.
+*Neurocomputing* 38:37-42, 2001.
+
+Graham, B. P., Wong, A. Y. C. and Forsythe, I. D.. A
+multi-component model of depression at the calyx of Held.
+*Neurocomputing* 58-60:449-454, 2004.
+
+Graham, B. P., Saudargiene, A. and Cobb, S.. Spine head calcium as
+a measure of summed postsynaptic activity for driving synaptic
+plasticity. *Neural Computation* 26:2194-2222,
+10.1162/NECO_a_00640, 2014.
+
+Graham, R. D., Bruns, T. M., Duan, B. and Lempka, S. F.. Dorsal
+root ganglion stimulation for chronic pain modulates Aβ-fiber
+activity but not C-fiber activity: a computational modeling study.
+*Clinical Neurophysiology* 130:941-951,
+10.1016/j.clinph.2019.02.016, 2019.
+
+Graham, R. D., Bruns, T. M., Duan, B. and Lempka, S. F.. The
+effect of clinically controllable factors on neural activation
+during dorsal root ganglion stimulation. *Neuromodulation*
+24:655-671, 10.1111/ner.13211, 2021.
+
+Grant, P. F. and Lowery, M. M.. Effect of dispersive conductivity
+and permittivity in volume conductor models of deep brain
+stimulation. *IEEE Transactions on Biomedical Engineering*
+57:2386-2393, 10.1109/TBME.2010.2055054, 2010.
+
+Grant, P. F. and Lowery, M. M.. Contribution of dielectric
+dispersions to voltage waveforms arising from electrical
+stimulation [Online]. *IEEE Engineering in Medicine and Biology
+Society Proceedings* 2012:4148-4151, 10.1109/EMBC.2012.6346880,
+2012.
+
+Grant, P. F. and Lowery, M. M.. Simulation of cortico-basal
+ganglia oscillations and their suppression by closed loop deep
+brain stimulation. *IEEE Transactions on Neural Systems and
+Rehabilitation Engineering* 21:584-594,
+10.1109/TNSRE.2012.2202403, 2013.
+
+Grant, P. F. and Lowery, M. M.. Simplified parametric models of
+the dielectric properties of brain and muscle tissue during
+electrical stimulation. *Medical Engineering & Physics* 65:61-67,
+10.1016/j.medengphy.2018.12.018, 2019.
+
+Gratiy, S. L., Billeh, Y. N., Dai, K., Mitelut, C., Feng, D.,
+Gouwens, N. W., Cain, N., Koch, C., Anastassiou, C. A. and
+Arkhipov, A.. BioNet: a Python interface to NEURON for modeling
+large-scale networks. *PLoS ONE* 13:e0201630,
+10.1371/journal.pone.0201630, 2018.
+
+Grau-Serrat, V., Carr, C. E. and Simon, J. Z.. Modeling
+coincidence detection in nucleus laminaris. *Biological
+Cybernetics* 89:388-396, 2003.
+
+Greenberg, R. J., Velte, T. J., Humayun, M. S., Scarlatis, G. N.
+and de Juan, Jr., E.. A computational model of electrical
+stimulation of the retinal ganglion cell. *IEEE Transactions on
+Biomedical Engineering* 46:505-514, 1999.
+
+Grein, S., Stepniewski, M., Reiter, S., Knodel, M. M. and
+Queisser, G.. 1D-3D hybrid modeling-from multi-compartment models
+to full resolution models in space and time. *Frontiers in
+Neuroinformatics* 8:68, 10.3389/fninf.2014.00068, 2014.
+
+Greiner, N., Barra, B., Schiavone, G., Lorach, H., James, N.,
+Conti, S., Kaeser, M., Fallegger, F., Borgognon, S., Lacour, S.,
+Bloch, J., Courtine, G. and Capogrosso, M.. Recruitment of
+upper-limb motoneurons with epidural electrical stimulation of the
+cervical spinal cord. *Nature Communications* 12:435,
+10.1038/s41467-020-20703-1, 2021.
+
+Grienberger, C., Milstein, A. D., Bittner, K. C., Romani, S. and
+Magee, J. C.. Inhibitory suppression of heterogeneously tuned
+excitation enhances spatial coding in CA1 place cells. *Nature
+Neuroscience* 20:417-426, 10.1038/nn.4486, 2017.
+
+Grill, W. M., Snyder, A. N. and Miocinovic, S.. Deep brain
+stimulation creates an informational lesion of the stimulated
+nucleus. *Neuroreport* 15:1137-1140, 2004.
+
+Grill, W. M., Cantrell, M. B. and Robertson, M. S.. Antidromic
+propagation of action potentials in branched axons: implications
+for the mechanisms of action of deep brain stimulation. *Journal
+of Computational Neuroscience* 24:81-93, 2008.
+
+Grill, W. M., Simmons, A. M., Cooper, S. E., Miocinovic, S.,
+Montgomery, E. B., Baker, K. B. and Rezai, A. R.. Temporal
+excitation properties of paresthesias evoked by thalamic
+microstimulation. *Clinical Neurophysiology* 116:1227-1234, 2005.
+
+Grillo, F. W., Neves, G., Walker, A., Vizcay-Barrena, G., Fleck,
+R. A., Branco, T. and Burrone, J.. A distance-dependent
+distribution of presynaptic boutons tunes frequency-dependent
+dendritic integration. *Neuron* 99:275-282.e3,
+10.1016/j.neuron.2018.06.015, 2018.
+
+Grimes, W. N., Zhang, J., Graydon, C. W., Kachar, B. and Diamond,
+J. S.. Retinal parallel processors: more than 100 independent
+microcircuits operate within a single interneuron. *Neuron*
+65:873-885, 10.1016/j.neuron.2010.02.028, 2010.
+
+Grisham, W., Schottler, N. A. and Krasne, F. B.. SWIMMY: free
+software for teaching neurophysiology of neuronal circuits.
+*Journal of Undergraduate Neuroscience Education* 7:A1-A8, 2008.
+
+Groen, M. R., Paulsen, O., Pérez-Garci, E., Nevian, T., Wortel,
+J., Dekker, M. P., Mansvelder, H. D., van Ooyen, A. and Meredith,
+R. M.. Development of dendritic tonic GABAergic inhibition
+regulates excitability and plasticity in CA1 pyramidal neurons.
+*Journal of Neurophysiology* 112:287-299, 10.1152/jn.00066.2014,
+2014.
+
+Grosche, J., Kettenmann, H. and Reichenbach, A.. Bergmann glial
+cells form distinct morphological structures to interact with
+cerebellar neurons. *Journal of Neuroscience Research* 68:138-149,
+2002.
+
+Grosser, S., Barreda, F. J., Beed, P., Schmitz, D., Booker, S. A.
+and Vida, I.. Parvalbumin interneurons are differentially
+connected to principal cells in inhibitory feedback microcircuits
+along the dorsoventral axis of the medial entorhinal cortex.
+*eNeuro* 810.1523/ENEURO.0354-20.2020, 2021.
+
+Grossman, N., Simiaki, V., Martinet, C., Toumazou, C., Schultz, S.
+R. and Nikolic, K.. The spatial pattern of light determines the
+kinetics and modulates backpropagation of optogenetic action
+potentials. *Journal of Computational Neuroscience* 34:477-488,
+10.1007/s10827-012-0431-7, 2013.
+
+Grubb, M. S. and Burrone, J.. Activity-dependent relocation of the
+axon initial segment fine-tunes neuronal excitability. *Nature*
+465:1070-1074, 10.1038/nature09160, 2010.
+
+Grunditz, A., Holbro, N., Tian, L., Zuo, Y. and Oertner, T. G..
+Spine neck plasticity controls postsynaptic calcium signals
+through electrical compartmentalization. *Journal of Neuroscience*
+28:13457-13466, 2008.
+
+Gruntman, E., Romani, S. and Reiser, M. B.. Simple integration of
+fast excitation and offset, delayed inhibition computes
+directional selectivity in Drosophila. *Nature Neuroscience*
+21:250-257, 10.1038/s41593-017-0046-4, 2018.
+
+Gu, Y., Barry, J., McDougel, R., Terman, D. and Gu, C..
+Alternative splicing regulates kv3.1 polarized targeting to adjust
+maximal spiking frequency. *Journal of Biological Chemistry*
+287:1755-1769, 10.1074/jbc.M111.299305, 2012.
+
+Gudes, S., Barkai, O., Caspi, Y., Katz, B., Lev, S. and Binshtok,
+A. M.. The role of slow and persistent TTX-resistant sodium
+currents in acute tumor necrosis factor-α-mediated increase in
+nociceptors excitability. *Journal of Neurophysiology*
+113:601-619, 10.1152/jn.00652.2014, 2015.
+
+Guet-McCreight, A., Camiré, O., Topolnik, L. and Skinner, F. K..
+Using a semi-automated strategy to develop multi-compartment
+models that predict biophysical properties of interneuron-specific
+3 (IS3) cells in hippocampus. *eNeuro* 3:ENEURO.0087-16.2016,
+10.1523/ENEURO.0087-16.2016, 2016.
+
+Guet-McCreight, A. and Skinner, F. K.. Using computational models
+to predict in vivo synaptic inputs to interneuron specific 3 (IS3)
+cells of CA1 hippocampus that also allow their recruitment during
+rhythmic states. *PLoS ONE* 14:e0209429,
+10.1371/journal.pone.0209429, 2019.
+
+Guet-McCreight, A. and Skinner, F. K.. Computationally going where
+experiments cannot: a dynamical assessment of dendritic ion
+channel currents during in vivo-like states. *F1000Research*
+9:180, 10.12688/f1000research.22584.2, 2020.
+
+Guet-McCreight, A. and Skinner, F. K.. Deciphering how interneuron
+specific 3 cells control oriens lacunosum-moleculare cells to
+contribute to circuit function. *Journal of Neurophysiology*
+126:997-1014, 10.1152/jn.00204.2021, 2021.
+
+Gulledge, A. T. and Stuart, G. J.. Excitatory actions of GABA in
+the cortex. *Neuron* 37:299-309, 2003.
+
+Gulledge, A. T. and Bravo, J. J.. Neuron morphology influences
+axon initial segment plasticity. *eNeuro* 3:ENEURO.0085-15.2016,
+10.1523/ENEURO.0085-15.2016, 2016.
+
+Gulledge, A. T., Carnevale, N. T. and Stuart, G. J.. Electrical
+advantages of dendritic spines. *PLoS ONE* 7:e36007,
+10.1371/journal.pone.0036007, 2012.
+
+Gulyás, A. I., Freund, T. F. and Káli, S.. The effects of
+realistic synaptic distribution and 3D geometry on signal
+integration and extracellular field generation of hippocampal
+pyramidal cells and inhibitory neurons. *Frontiers in Neural
+Circuits* 10:88, 10.3389/fncir.2016.00088, 2016.
+
+Gunalan, K., Chaturvedi, A., Howell, B., Duchin, Y., Lempka, S.
+F., Patriat, R., Sapiro, G., Harel, N. and McIntyre, C. C..
+Creating and parameterizing patient-specific deep brain
+stimulation pathway-activation models using the hyperdirect
+pathway as an example. *PLoS ONE* 12:e0176132,
+10.1371/journal.pone.0176132, 2017.
+
+Gunalan, K., Howell, B. and McIntyre, C. C.. Quantifying axonal
+responses in patient-specific models of subthalamic deep brain
+stimulation. *NeuroImage* 172:263-277,
+10.1016/j.neuroimage.2018.01.015, 2018.
+
+Gunalan, K. and McIntyre, C. C.. Biophysical reconstruction of the
+signal conduction underlying short-latency cortical evoked
+potentials generated by subthalamic deep brain stimulation.
+*Clinical Neurophysiology* 131:542-547,
+10.1016/j.clinph.2019.09.020, 2020.
+
+Günay, C., Sieling, F. H., Dharmar, L., Lin, W.-H., Wolfram, V.,
+Marley, R., Baines, R. A. and Prinz, A. A.. Distal spike
+initiation zone location estimation by morphological simulation of
+ionic current filtering demonstrated in a novel model of an
+identified Drosophila motoneuron. *PLoS Computational Biology*
+11:e1004189, 10.1371/journal.pcbi.1004189, 2015.
+
+Guo, T., Lovell, N. H., Tsai, D., Twyford, P., Fried, S., Morley,
+J. W., Suaning, G. J. and Dokos, S.. Selective activation of ON
+and OFF retinal ganglion cells to high-frequency electrical
+stimulation: a computational modeling study. *IEEE Engineering in
+Medicine and Biology Society. Annual Conference* 2014:6108-6111,
+10.1109/EMBC.2014.6945023, 2014a.
+
+Guo, T., Tsai, D., Morley, J. W., Suaning, G. J., Kameneva, T.,
+Lovell, N. H. and Dokos, S.. Electrical activity of ON and OFF
+retinal ganglion cells: a modelling study. *Journal of Neural
+Engineering* 13:025005, 10.1088/1741-2560/13/2/025005, 2016.
+
+Guo, T., Tsai, D., Morley, J. W., Suaning, G. J., Lovell, N. H.
+and Dokos, S.. Cell-specific modeling of retinal ganglion cell
+electrical activity [Online]. *IEEE Engineering in Medicine and
+Biology Society Proceedings* 2013:6539-6542,
+10.1109/EMBC.2013.6611053, 2013a.
+
+Guo, T., Tsai, D., Morley, J. W., Suaning, G. J., Lovell, N. H.
+and Dokos, S.. Influence of cell morphology in a computational
+model of ON and OFF retinal ganglion cells [Online]. *IEEE
+Engineering in Medicine and Biology Society Proceedings*
+2013:4553-4556, 10.1109/EMBC.2013.6610560, 2013b.
+
+Guo, T., Tsai, D., Morley, J. W., Suaning, G. J., Lovell, N. H.
+and Dokos, S.. The unique characteristics of ON and OFF retinal
+ganglion cells: a modeling study. *IEEE Engineering in Medicine
+and Biology Society. Annual Conference* 2014:6096-6099,
+10.1109/EMBC.2014.6945020, 2014b.
+
+Guo, T., Tsai, D., Muralidharan, M., Li, M., Suaning, G. J.,
+Morley, J. W., Dokos, S. and Lovell, N. H.. Computational models
+and tools for developing sophisticated stimulation strategies for
+retinal neuroprostheses. *IEEE Engineering in Medicine and Biology
+Society. Annual Conference* 2018:2248-2251,
+10.1109/EMBC.2018.8512748, 2018.
+
+Guo, T., Tsai, D., Sovilj, S., Morley, J. W., Suaning, G. J.,
+Lovell, N. H. and Dokos, S.. Influence of active dendrites on
+firing patterns in a retinal ganglion cell model [Online]. *IEEE
+Engineering in Medicine and Biology Society Proceedings*
+2013:4557-4560, 10.1109/EMBC.2013.6610561, 2013c.
+
+Guo, T., Tsai, D., Yang, C. Y., Al Abed, A., Twyford, P., Fried,
+S. I., Morley, J. W., Suaning, G. J., Dokos, S. and Lovell, N. H..
+Mediating retinal ganglion cell spike rates using high-frequency
+electrical stimulation. *Frontiers in Neuroscience* 13:413,
+10.3389/fnins.2019.00413, 2019.
+
+Gupta, I., Cassará, A. M., Tarotin, I., Donega, M., Miranda, J.
+A., Sokal, D. M., Ouchouche, S., Dopson, W., Matteucci, P.,
+Neufeld, E., Schiefer, M. A., Rowles, A., McGill, P., Perkins, J.,
+Dolezalova, N., Saeb-Parsy, K., Kuster, N., Yazicioglu, R. F.,
+Witherington, J. and Chew, D. J.. Quantification of clinically
+applicable stimulation parameters for precision near-organ
+neuromodulation of human splenic nerves. *Communications Biology*
+3:577, 10.1038/s42003-020-01299-0, 2020.
+
+Gupta, S., Majawadia, A. and Manchanda, R.. A computational model
+of intracellular calcium oscillations in urinary bladder smooth
+muscle cells. *IEEE Engineering in Medicine and Biology Society.
+Annual Conference* 2017:2692-2695, 10.1109/EMBC.2017.8037412,
+2017.
+
+Gupta, S. and Manchanda, R.. A computational model of large
+conductance voltage and calcium activated potassium channels:
+implications for calcium dynamics and electrophysiology in
+detrusor smooth muscle cells. *Journal of Computational
+Neuroscience* 46:233-256, 10.1007/s10827-019-00713-9, 2019.
+
+Gurkiewicz, M. and Korngreen, A.. A numerical approach to ion
+channel modelling using whole-cell voltage-clamp recordings and a
+genetic algorithm. *PLoS Computational Biology* 3:e169,
+10.1371/journal.pcbi.0030169, 2007.
+
+Gurkiewicz, M., Korngreen, A., Waxman, S. G. and Lampert, A..
+Kinetic modeling of Nav1.7 provides insight into
+erythromelalgia-associated F1449V mutation. *Journal of
+Neurophysiology* 105:1546-1557, 10.1152/jn.00703.2010, 2011.
+
+Guzman, J. N., Sánchez-Padilla, J., Chan, C. S. and Surmeier, D.
+J.. Robust pacemaking in substantia nigra dopaminergic neurons.
+*Journal of Neuroscience* 29:11011-11019,
+10.1523/JNEUROSCI.2519-09.2009, 2009.
+
+Gwak, J. and Kwag, J.. Distinct subtypes of inhibitory
+interneurons differentially promote the propagation of rate and
+temporal codes in the feedforward neural network. *Chaos*
+30:053102, 10.1063/1.5134765, 2020.
+
+Głąbska, H., Chintaluri, C. and Wójcik, D. K.. Collection of
+simulated data from a thalamocortical network model.
+*Neuroinformatics* 15:87-99, 10.1007/s12021-016-9319-4, 2017.
+
+Głąbska, H., Potworowski, J., Łęski, S. and Wójcik, D. K..
+Independent components of neural activity carry information on
+individual populations. *PLoS ONE* 9:e105071,
+10.1371/journal.pone.0105071, 2014.
+
+Głąbska, H. T., Norheim, E., Devor, A., Dale, A. M., Einevoll, G.
+T. and Wójcik, D. K.. Generalized laminar population analysis
+(gLPA) for interpretation of multielectrode data from cortex.
+*Frontiers in Neuroinformatics* 10:1, 10.3389/fninf.2016.00001,
+2016.
+
+Ha, J. and Kuznetsov, A.. Interaction of NMDA receptor and
+pacemaking mechanisms in the midbrain dopaminergic neuron. *PLoS
+ONE* 8:e69984, 10.1371/journal.pone.0069984, 2013.
+
+Haddjeri-Hopkins, A., Tapia, M., Ramirez-Franco, J., Tell, F.,
+Marqueze-Pouey, B., Amalric, M. and Goaillard, J.-M.. Refining the
+identity and role of Kv4 channels in mouse substantia nigra
+dopaminergic neurons. *eNeuro* 810.1523/ENEURO.0207-21.2021, 2021.
+
+Hagen, E., Dahmen, D., Stavrinou, M. L., Lindén, H., Tetzlaff, T.,
+van Albada, S. J., Grün, S., Diesmann, M. and Einevoll, G. T..
+Hybrid scheme for modeling local field potentials from
+point-neuron networks. *Cerebral Cortex* 26:4461-4496,
+10.1093/cercor/bhw237, 2016.
+
+Hagen, E., Fossum, J. C., Pettersen, K. H., Alonso, J.-M.,
+Swadlow, H. A. and Einevoll, G. T.. Focal local field potential
+signature of the single-axon monosynaptic thalamocortical
+connection. *Journal of Neuroscience* 37:5123-5143,
+10.1523/JNEUROSCI.2715-16.2017, 2017.
+
+Hagen, E., Næss, S., Ness, T. V. and Einevoll, G. T.. Multimodal
+modeling of neural network activity: computing LFP, ECoG, EEG, and
+MEG signals with LFPy 2.0. *Frontiers in Neuroinformatics* 12:92,
+10.3389/fninf.2018.00092, 2018.
+
+Hagen, E., Ness, T. V., Khosrowshahi, A., Sørensen, C., Fyhn, M.,
+Hafting, T., Franke, F. and Einevoll, G. T.. ViSAPy: a Python tool
+for biophysics-based generation of virtual spiking activity for
+evaluation of spike-sorting algorithms. *Journal of Neuroscience
+Methods* 245:182-204, 10.1016/j.jneumeth.2015.01.029, 2015.
+
+Hahn, P. J. and McIntyre, C. C.. Modeling shifts in the rate and
+pattern of subthalamopallidal network activity during deep brain
+stimulation. *Journal of Computational Neuroscience* 28:425-441,
+10.1007/s10827-010-0225-8, 2010.
+
+Hai, A., Dormann, A., Shappir, J., Yitzchaik, S., Bartic, C.,
+Borghs, G., Langedijk, J. P. M. and Spira, M. E.. Spine-shaped
+gold protrusions improve the adherence and electrical coupling of
+neurons with the surface of micro-electronic devices. *Journal of
+the Royal Society Interface* 6:1153-1165, 10.1098/rsif.2009.0087,
+2009.
+
+Hales, C. G.. The origins of the brain's endogenous
+electromagnetic field and its relationship to provision of
+consciousness. *Journal of Integrative Neuroscience* 13:313-361,
+10.1142/S0219635214400056, 2014.
+
+Hallermann, S., de Kock, C. P. J., Stuart, G. J. and Kole, M. H.
+P.. State and location dependence of action potential metabolic
+cost in cortical pyramidal neurons. *Nature Neuroscience*
+15:1007-1014, 10.1038/nn.3132, 2012.
+
+Hallermann, S., Pawlu, C., Jonas, P. and Heckmann, M.. A large
+pool of releasable vesicles in a cortical glutamatergic synapse.
+*Proceedings of the National Academy of Sciences of the United
+States of America* 100:8975-8980, 2003.
+
+Halnes, G., Augustinaite, S., Heggelund, P., Einevoll, G. T. and
+Migliore, M.. A multi-compartment model for interneurons in the
+dorsal lateral geniculate nucleus. *PLoS Computational Biology*
+7:e1002160, 10.1371/journal.pcbi.1002160, 2011.
+
+Halnes, G., Mäki-Marttunen, T., Keller, D., Pettersen, K. H.,
+Andreassen, O. A. and Einevoll, G. T.. Effect of ionic diffusion
+on extracellular potentials in neural tissue. *PLoS Computational
+Biology* 12:e1005193, 10.1371/journal.pcbi.1005193, 2016.
+
+Halnes, G., Mäki-Marttunen, T., Pettersen, K. H., Andreassen, O.
+A. and Einevoll, G. T.. Ion diffusion may introduce spurious
+current sources in current-source density (CSD) analysis. *Journal
+of Neurophysiology* 118:114-120, 10.1152/jn.00976.2016, 2017.
+
+Halnes, G., Tennøe, S., Haug, T. M., Einevoll, G. T., Weltzien,
+F.-A. and Hodne, K.. A computational model for gonadotropin
+releasing cells in the teleost fish medaka. *PLoS Computational
+Biology* 15:e1006662, 10.1371/journal.pcbi.1006662, 2019.
+
+Hamada, M. S., Goethals, S., de Vries, S. I., Brette, R. and Kole,
+M. H. P.. Covariation of axon initial segment location and
+dendritic tree normalizes the somatic action potential.
+*Proceedings of the National Academy of Sciences of the United
+States of America* 113:14841-14846, 10.1073/pnas.1607548113, 2016.
+
+Hamada, M. S. and Kole, M. H. P.. Myelin loss and axonal ion
+channel adaptations associated with gray matter neuronal
+hyperexcitability. *Journal of Neuroscience* 35:7272-7286,
+10.1523/JNEUROSCI.4747-14.2015, 2015.
+
+Hamani, C., Amorim, B. O., Wheeler, A. L., Diwan, M., Driesslein,
+K., Covolan, L., Butson, C. R. and Nobrega, J. N.. Deep brain
+stimulation in rats: different targets induce similar
+antidepressant-like effects but influence different circuits.
+*Neurobiology of Disease* 71:205-214, 10.1016/j.nbd.2014.08.007,
+2014.
+
+Hanemaaijer, N. A. K., Popovic, M. A., Wilders, X., Grasman, S.,
+Pavón Arocas, O. and Kole, M. H. P.. Ca2+ entry through NaV
+channels generates submillisecond axonal Ca2+ signaling. *eLife*
+910.7554/eLife.54566, 2020.
+
+Hanson, J. E. and Madison, D. V.. Imbalanced pattern completion
+vs. separation in cognitive disease: network simulations of
+synaptic pathologies predict a personalized therapeutics strategy.
+*BMC Neuroscience* 11:96, 10.1186/1471-2202-11-96, 2010.
+
+Hanson, L., Sethuramanujam, S., deRosenroll, G., Jain, V. and
+Awatramani, G. B.. Retinal direction selectivity in the absence of
+asymmetric starburst amacrine cell responses. *eLife* 8:e42392,
+10.7554/eLife.42392, 2019.
+
+Hanuschkin, A., Yim, M. Y. and Wolfart, J.. A network model
+reveals that the experimentally observed switch of the granule
+cell phenotype during epilepsy can maintain the pattern separation
+function of the dentate gyrus. In: *Hippocampal Microcircuits: A
+Computational Modeler's Resource Book*. Cham: Springer
+International Publishing, 2018, pp. 779-805.
+
+Hao, J., Wang, X.-d., Dan, Y., Poo, M.-m. and Zhang, X.-h.. An
+arithmetic rule for spatial summation of excitatory and inhibitory
+inputs in pyramidal neurons. *Proceedings of the National Academy
+of Sciences of the United States of America* 106:21906-21911,
+10.1073/pnas.0912022106, 2009.
+
+Hardie, J. B. and Pearce, R. A.. Active and passive membrane
+properties and intrinsic kinetics shape synaptic inhibition in
+hippocampal ca1 pyramidal neurons. *Journal of Neuroscience*
+26:8559-8569, 2006.
+
+Harnett, M. T., Makara, J. K., Spruston, N., Kath, W. L. and
+Magee, J. C.. Synaptic amplification by dendritic spines enhances
+input cooperativity. *Nature* 491:599-602, 10.1038/nature11554,
+2012.
+
+Harrington, M. G., Chekmenev, E. Y., Schepkin, V., Fonteh, A. N.
+and Arakaki, X.. Sodium MRI in a rat migraine model and a NEURON
+simulation study support a role for sodium in migraine.
+*Cephalalgia* 31:1254-1265, 10.1177/0333102411408360, 2011.
+
+Harris, J. J., Engl, E., Attwell, D. and Jolivet, R. B..
+Energy-efficient information transfer at thalamocortical synapses.
+*PLoS Computational Biology* 15:e1007226,
+10.1371/journal.pcbi.1007226, 2019.
+
+Hartline, D. K. and Castelfranco, A. M.. Simulations of voltage
+clamping poorly space-clamped voltage-dependent conductances in a
+uniform cylindrical neurite. *Journal of Computational
+Neuroscience* 14:253-269, 2003.
+
+Hartline, D. K.. What is myelin?. *Neuron Glia Biology* 4:153-163,
+10.1017/S1740925X09990263, 2008.
+
+Hartman, D., Lehotzky, D., Ilieş, I., Levi, M. and Zupanc, G. K.
+H.. Modeling of sustained spontaneous network oscillations of a
+sexually dimorphic brainstem nucleus: the role of potassium
+equilibrium potential. *Journal of Computational Neuroscience*
+10.1007/s10827-021-00789-2, 2021.
+
+Hartmann, C. J., Chaturvedi, A. and Lujan, J. L.. Quantitative
+analysis of axonal fiber activation evoked by deep brain
+stimulation via activation density heat maps. *Frontiers in
+Neuroscience* 9:28, 10.3389/fnins.2015.00028, 2015.
+
+Hartveit, E., Veruki, M. L. and Zandt, B.-J.. Capacitance
+measurement of dendritic exocytosis in an electrically coupled
+inhibitory retinal interneuron: an experimental and computational
+study. *Physiological Reports* 7:e14186, 10.14814/phy2.14186,
+2019.
+
+Harty, R. C., Kim, T. H., Thomas, E. A., Cardamone, L., Jones, N.
+C., Petrou, S. and Wimmer, V. C.. Axon initial segment structural
+plasticity in animal models of genetic and acquired epilepsy.
+*Epilepsy Research* 105:272-279, 10.1016/j.eplepsyres.2013.03.004,
+2013.
+
+Hatori, Y. and Sakai, K.. Early representation of shape by onset
+synchronization of border-ownership-selective cells in the V1-V2
+network. *Journal of the Optical Society of America A--Optics
+Image Science and Vision* 31:716-729, 10.1364/JOSAA.31.000716,
+2014.
+
+Haug, S. J. and Segal, S. S.. Sympathetic neural inhibition of
+conducted vasodilatation along hamster feed arteries:
+complementary effects of alpha(1)- and alpha(2)-adrenoreceptor
+activation. *Journal of Physiology* 563:541-555, 2005.
+
+Häusser, M., Major, G. and Stuart, G. J.. Differential shunting of
+EPSPs by action potentials. *Science* 291:138-141, 2001.
+
+Häusser, M. and Roth, A.. Estimating the time course of the
+excitatory synaptic conductance in neocortical pyramidal cells
+using a novel voltage jump method. *Journal of Neuroscience*
+17:7606-7625, 1997.
+
+Häusser, M., Spruston, N. and Stuart, G. J.. Diversity and
+dynamics of dendritic signaling. *Science* 290:739-744, 2000.
+
+Häusser, M., Stuart, G., Racca, C. and Sakmann, B.. Axonal
+initiation and active dendritic propagation of action potentials
+in substantia nigra neurons. *Neuron* 15:637-647, 1995.
+
+Hawrylycz, M., Anastassiou, C., Arkhipov, A., Berg, J., Buice, M.,
+Cain, N., Gouwens, N. W., Gratiy, S., Iyer, R., Lee, J. H.,
+Mihalas, S., Mitelut, C., Olsen, S., Reid, R. C., Teeter, C., de
+Vries, S., Waters, J., Zeng, H., Koch, C. and MindScope. Inferring
+cortical function in the mouse visual system through large-scale
+systems neuroscience. *Proceedings of the National Academy of
+Sciences of the United States of America* 113:7337-7344,
+10.1073/pnas.1512901113, 2016.
+
+Hay, E., Hill, S., Schuermann, F., Markram, H. and Segev, I..
+Models of neocortical layer 5b pyramidal cells capturing a wide
+range of dendritic and perisomatic active properties. *PLoS
+Computational Biology* 7:e1002107, 10.1371/journal.pcbi.1002107,
+2011.
+
+Hay, E., Schürmann, F., Markram, H. and Segev, I.. Preserving
+axosomatic spiking features despite diverse dendritic morphology.
+*Journal of Neurophysiology* 109:2972-2981, 10.1152/jn.00048.2013,
+2013.
+
+Hay, E. and Segev, I.. Dendritic excitability and gain control in
+recurrent cortical microcircuits. *Cerebral Cortex* 25:3561-3571,
+10.1093/cercor/bhu200, 2015.
+
+Hayakawa, H., Samura, T., Kamijo, T. C., Sakai, Y. and Aihara, T..
+Spatial information enhanced by non-spatial information in
+hippocampal granule cells.. *Cognitive Neurodynamics* 9:1-12,
+10.1007/s11571-014-9309-x, 2015.
+
+Hayashida, Y., Rodríguez, C. V., Ogata, G., Partida, G. J., Oi,
+H., Stradleigh, T. W., Lee, S. C., Colado, A. F. and Ishida, A.
+T.. Inhibition of adult rat retinal ganglion cells by D1-type
+dopamine receptor activation.. *Journal of Neuroscience*
+29:15001-15016, 10.1523/JNEUROSCI.3827-09.2009, 2009.
+
+Hayashida, Y. and Yagi, T.. Contribution of Ca2+ transporters to
+electrical response of a non-spiking retinal neuron.
+*Neurocomputing* 44:7-12, 2002a.
+
+Hayashida, Y. and Yagi, T.. On the interaction between
+voltage-gated conductances and Ca2+ regulation mechanisms in
+retinal horizontal cells. *Journal of Neurophysiology* 87:172-182,
+2002b.
+
+Headley, D. B., Kyriazi, P., Feng, F., Nair, S. and Pare, D..
+Gamma oscillations in the basolateral amygdala: localization,
+microcircuitry, and behavioral correlates. *Journal of
+Neuroscience* 10.1523/JNEUROSCI.3159-20.2021, 2021.
+
+Heiberg, T., Hagen, E., Halnes, G. and Einevoll, G. T..
+Biophysical network modelling of the dLGN circuit: different
+effects of triadic and axonal inhibition on visual responses of
+relay cells. *PLoS Computational Biology* 12:e1004929,
+10.1371/journal.pcbi.1004929, 2016.
+
+Heilman, A. D. and Quattrochi, J.. Computational models of
+epileptiform activity in single neurons. *Biosystems* 78:1-21,
+2004.
+
+Heinzle, J., König, P. and Salazar, R. F.. Modulation of synchrony
+without changes in firing rates. *Cognitive Neurodynamics*
+1:225-235, 2007.
+
+Helmstaedter, M., Sakmann, B. and Feldmeyer, D.. The relation
+between dendritic geometry, electrical excitability, and axonal
+projections of L2/3 interneurons in rat barrel cortex. *Cerebral
+Cortex* 19:938-950, 2009.
+
+Hemond, P., Epstein, D., Boley, A., Migliore, M., Ascoli, G. A.
+and Jaffe, D. B.. Distinct classes of pyramidal cells exhibit
+mutually exclusive firing patterns in hippocampal area CA3b.
+*Hippocampus* 18:411-424, 2008.
+
+Hemond, P., Migliore, M., Ascoli, G. A. and Jaffe, D. B.. The
+membrane response of hippocampal Ca3b pyramidal neurons near rest:
+heterogeneity of passive properties and the contribution of
+hyperpolarization-activated currents. *Neuroscience* 160:359-370,
+2009.
+
+Henderson, D. and Miller, R. F.. Evidence for
+low-voltage-activated (LVA) calcium currents in the dendrites of
+tiger salamander retinal ganglion cells. *Visual Neuroscience*
+20:141-152, 2003.
+
+Henderson, D. and Miller, R. F.. Low-voltage activated calcium
+currents in ganglion cells of the tiger salamander retina:
+experiment and simulation. *Visual Neuroscience* 24:37-51, 2007.
+
+Hendrickson, P. J., Bingham, C., Song, D. and Berger, T. W.. A
+bi-directional communication paradigm between parallel NEURON and
+an external non-neuron process. *IEEE Engineering in Medicine and
+Biology Society. Annual Conference* 2016:1413-1416,
+10.1109/EMBC.2016.7590973, 2016.
+
+Hendrickson, P. J., Yu, G. J., Song, D. and Berger, T. W..
+Interactions between inhibitory interneurons and excitatory
+associational circuitry in determining spatio-temporal dynamics of
+hippocampal dentate granule cells: a large-scale computational
+study. *Frontiers in Systems Neuroscience* 9:155,
+10.3389/fnsys.2015.00155, 2015.
+
+Henze, D. A., Cameron, W. E. and Barrionuevo, G.. Dendritic
+morphology and its effects on the amplitude and rise-time of
+synaptic signals in hippocampal CA3 pyramidal cells. *Journal of
+Comparative Neurology* 369:331-344, 1996.
+
+Hepburn, I., Cannon, R. and De Schutter, E.. Efficient calculation
+of the quasi-static electrical potential on a tetrahedral mesh and
+its implementation in STEPS. *Frontiers In Computational
+Neuroscience* 7:129, 10.3389/fncom.2013.00129, 2013.
+
+Hernandez, O., Hernandez, L., Vera, D., Santander, A. and Zurek,
+E.. Thalamic reticular cells firing modes and its dependency on
+the frequency and amplitude ranges of the current stimulus.
+*Medical and Biological Engineering and Computing* 53:37-44,
+10.1007/s11517-014-1209-z, 2015.
+
+Hernandez, O. E. and Zurek, E. E.. Teaching and learning the
+Hodgkin-Huxley model based on software developed in NEURON's
+programming language hoc. *BMC Medical Education* 13:70,
+10.1186/1472-6920-13-70, 2013.
+
+Herrera, B., Sajad, A., Woodman, G. F., Schall, J. D. and Riera,
+J. J.. A minimal biophysical model of neocortical pyramidal cells:
+implications for frontal cortex microcircuitry and field potential
+generation. *Journal of Neuroscience*
+10.1523/JNEUROSCI.0221-20.2020, 2020.
+
+Herrmann, C. S. and Klaus, A.. Autapse turns neuron into
+oscillator. *International Journal of Bifurcation and Chaos*
+14:623-633, 2004.
+
+Herrmann, U. and Flanders, M.. Directional tuning of single motor
+units. *Journal of Neuroscience* 18:8402-8416, 1998.
+
+Herzog, A., Kube, K., Michaelis, B., de Lima, A. D. and Voigt, T..
+Displaced strategies optimize connectivity in neocortical
+networks. *Neurocomputing* 70:1121-1129, 2007.
+
+Herzog, R. I., Cummins, T. R. and Waxman, S. G.. Persistent
+TTX-resistant Na+ current affects resting potential and response
+to depolarization in simulated spinal sensory neurons. *Journal of
+Neurophysiology* 86:1351-1364, 2001.
+
+Heshmat, A., Sajedi, S., Schrott-Fischer, A. and Rattay, F..
+Polarity sensitivity of human auditory nerve fibers based on pulse
+shape, cochlear implant stimulation strategy and array. *Frontiers
+in Neuroscience* 15:751599, 10.3389/fnins.2021.751599, 2021.
+
+Hesprich, S. and Beardsley, S.. Computational characterization of
+the cellular origins of electroencephalography [Online]. *2019 9th
+International IEEE/EMBS Conference on Neural Engineering*,
+10.1109/ner.2019.8716883, 2019.
+
+Heys, J. G., Giocomo, L. M. and Hasselmo, M. E.. Cholinergic
+modulation of the resonance properties of stellate cells in layer
+II of medial entorhinal cortex. *Journal of Neurophysiology*
+104:258-270, 10.1152/jn.00492.2009, 2010.
+
+Higley, M. J. and Contreras, D.. Balanced excitation and
+inhibition determine spike timing during frequency adaptation.
+*Journal of Neuroscience* 26:448-457, 2006.
+
+Hilgetag, C. C. and Barbas, H.. Developmental mechanics of the
+primate cerebral cortex. *Anatomy and Embryology* 210:411-417,
+2005.
+
+Hill, M., Rios, E., Sudhakar, S. K., Roossien, D. H., Caldwell,
+C., Cai, D., Ahmed, O. J., Lempka, S. F. and Chestek, C. A..
+Quantitative simulation of extracellular single unit recording
+from the surface of cortex. *Journal of neural engineering*
+15:056007, 10.1088/1741-2552/aacdb8, 2018.
+
+Hill, S. A., Liu, X.-P., Borla, M. A., José, J. V. and O’Malley,
+D. M.. Neurokinematic modeling of complex swimming patterns of the
+larval zebrafish. *Neurocomputing* 65–66:61-68, 2005.
+
+Hines, M. and Carnevale, T.. NEURON Simulation Environment. In:
+*Encyclopedia of Computational Neuroscience*, edited by Jaeger, D.
+and Jung, R.. Springer New York, 2014, pp. 2012-2017.
+
+Hines, M. and Carnevale, T.. NEURON Simulation Environment. In:
+*Encyclopedia of Computational Neuroscience*, edited by Jaeger, D.
+and Jung, R.. Springer New York, 2015a, pp. 2012-2017.
+
+Hines, M. and Carnevale, T.. Numerical Integration Methods. In:
+*Encyclopedia of Computational Neuroscience*, edited by Jaeger, D.
+and Jung, R.. Springer New York, 2015b, pp. 2115-2124.
+
+Hines, M., Kumar, S. and Schürmann, F.. Comparison of neuronal
+spike exchange methods on a Blue Gene/P supercomputer. *Frontiers
+in Computational Neuroscience* 5:49, 10.3389/fncom.2011.00049,
+2011.
+
+Hines, M. L., Morse, T. M. and Carnevale, N. T.. Model structure
+analysis in NEURON: toward interoperability among neural
+simulators. *Methods in Molecular Biology* 401:91-102,
+10.1007/978-1-59745-520-6_6, 2007.
+
+Hines, M. and Shrager, P.. A computational test of the
+requirements for conduction in demyelinated axons. *Journal of
+Restorative Neurology and Neuroscience* 3:81-93, 1991.
+
+Hiratani, N. and Fukai, T.. Redundancy in synaptic connections
+enables neurons to learn optimally. *Proceedings of the National
+Academy of Sciences of the United States of America*
+115:E6871-E6879, 10.1073/pnas.1803274115, 2018.
+
+Hjorth, J. J. J., Hellgren Kotaleski, J. and Kozlov, A..
+Predicting synaptic connectivity for large-scale microcircuit
+simulations using Snudda. *Neuroinformatics*
+10.1007/s12021-021-09531-w, 2021.
+
+Hjorth, J. J. J., Kozlov, A., Carannante, I., Frost Nylén, J.,
+Lindroos, R., Johansson, Y., Tokarska, A., Dorst, M. C.,
+Suryanarayana, S. M., Silberberg, G., Hellgren Kotaleski, J. and
+Grillner, S.. The microcircuits of striatum in silico.
+*Proceedings of the National Academy of Sciences of the United
+States of America* 117:9554-9565, 10.1073/pnas.2000671117, 2020.
+
+Hô, N. and Destexhe, A.. Synaptic background activity enhances the
+responsiveness of neocortical pyramidal neurons. *Journal of
+Neurophysiology* 84:1488-1496, 2000.
+
+Hô, N., Kroger, H. and Destexhe, A.. Consequences of correlated
+synaptic bombardment on the responsiveness of neocortical
+pyramidal neurons. *Neurocomputing* 32:155-160, 2000.
+
+Hoch, T., Wenning, G. and Obermayer, K.. Optimal noise-aided
+signal transmission through populations of neurons. *Physical
+Review E* 68:011911, 2003.
+
+Hoffman, D. A., Magee, J. C., Colbert, C. M. and Johnston, D.. K+
+channel regulation of signal propagation in dendrites of
+hippocampal pyramidal neurons. *Nature* 387:869-875, 1997.
+
+Hoffmann, J. H. O., Meyer, H. S., Schmitt, A. C., Straehle, J.,
+Weitbrecht, T., Sakmann, B. and Helmstaedter, M.. Synaptic
+conductance estimates of the connection between local inhibitor
+interneurons and pyramidal neurons in layer 2/3 of a cortical
+column. *Cerebral Cortex* 25:4415-4429, 10.1093/cercor/bhv039,
+2015.
+
+Hokanson, J. A., Gaunt, R. A. and Weber, D. J.. Effects of
+synchronous electrode pulses on neural recruitment during
+multichannel microstimulation. *Scientific Reports* 8:13067,
+10.1038/s41598-018-31247-2, 2018.
+
+Holmes, W. R., Ambros-Ingerson, J. and Grover, L. M.. Fitting
+experimental data to models that use morphological data from
+public databases. *Journal of Computational Neuroscience*
+20:349-365, 2006.
+
+Holmes, W. R. and Grover, L. M.. Quantifying the magnitude of
+changes in synaptic level parameters with long-term potentiation.
+*Journal of Neurophysiology* 96:1478-1491, 2006.
+
+Holmes, W. R., Huwe, J. A., Williams, B., Rowe, M. H. and
+Peterson, E. H.. Models of utricular bouton afferents: role of
+afferent-hair cell connectivity in determining spike train
+regularity. *Journal of neurophysiology* 117:1969-1986,
+10.1152/jn.00895.2016, 2017.
+
+Holt, A. B. and Netoff, T. I.. Origins and suppression of
+oscillations in a computational model of Parkinson's disease.
+*Journal of Computational Neuroscience* 37:505-521,
+10.1007/s10827-014-0523-7, 2014.
+
+Holt, A. B., Wilson, D., Shinn, M., Moehlis, J. and Netoff, T. I..
+Phasic burst stimulation: a closed-loop approach to tuning deep
+brain stimulation parameters for Parkinson's disease. *PLoS
+Computational Biology* 12:e1005011, 10.1371/journal.pcbi.1005011,
+2016.
+
+Holt, G. R. and Koch, C.. Shunting inhibition does not have a
+divisive effect on firing rates. *Neural Computation* 9:1001-1013,
+1997.
+
+Holt, G. R. and Koch, C.. Electrical interactions via the
+extracellular potential near cell bodies. *Journal of
+Computational Neuroscience* 6:169-184, 1999.
+
+Hong, H., Lu, T., Wang, X., Wang, Y. and Sanchez, J. T.. Resurgent
+sodium current promotes action potential firing in the avian
+auditory brainstem. *Journal of Physiology* 596:423-443,
+10.1113/JP275083, 2018a.
+
+Hong, H., Wang, X., Lu, T., Zorio, D. A. R., Wang, Y. and Sanchez,
+J. T.. Diverse intrinsic properties shape functional phenotype of
+low-frequency neurons in the auditory brainstem. *Frontiers in
+Cellular Neuroscience* 12:175, 10.3389/fncel.2018.00175, 2018b.
+
+Hong, S., Ratté, S., Prescott, S. A. and De Schutter, E.. Single
+neuron firing properties impact correlation-based population
+coding.. *Journal of Neuroscience* 32:1413-1428,
+10.1523/JNEUROSCI.3735-11.2012, 2012a.
+
+Hong, S., Robberechts, Q. and De Schutter, E.. Efficient
+estimation of phase-response curves via compressive sensing..
+*Journal of Neurophysiology* 108:2069-2081, 10.1152/jn.00919.2011,
+2012b.
+
+Hong, S. H., Lundstrom, B. N. and Fairhall, A. L.. Intrinsic gain
+modulation and adaptive neural coding. *PLoS Computational
+Biology* 4:e1000119, 10.1371/journal.pcbi.1000119, 2008.
+
+Hönigsperger, C., Marosi, M., Murphy, R. and Storm, J. F..
+Dorsoventral differences in Kv7/M-current and its impact on
+resonance, temporal summation and excitability in rat hippocampal
+pyramidal cells. *Journal of Physiology* 593:1551-1580,
+10.1113/jphysiol.2014.280826, 2015.
+
+Honnuraiah, S. and Narayanan, R.. A calcium-dependent plasticity
+rule for HCN channels maintains activity homeostasis and stable
+synaptic learning. *PLoS ONE* 8:e55590,
+10.1371/journal.pone.0055590, 2013.
+
+Horcholle-Bossavit, G., Quenet, B. and Foucart, O.. Oscillation
+and coding in a formal neural network considered as a guide for
+plausible simulations of the insect olfactory system. *Biosystems*
+89:244-256, 2007.
+
+Hossain, W. A., Antic, S. D., Yang, Y., Rasband, M. N. and Morest,
+D. K.. Where is the spike generator of the cochlear nerve?
+Voltage-gated sodium channels in the mouse cochlea. *Journal of
+Neuroscience* 25:6857-6868, 2005.
+
+House, D. R. C., Elstrott, J., Koh, E., Chung, J. and Feldman, D.
+E.. Parallel regulation of feedforward inhibition and excitation
+during whisker map plasticity. *Neuron* 72:819-831,
+10.1016/j.neuron.2011.09.008, 2011.
+
+Housley, S. N., Nardelli, P., Powers, R. K., Rich, M. M. and Cope,
+T. C.. Chronic defects in intraspinal mechanisms of spike encoding
+by spinal motoneurons following chemotherapy. *Experimental
+Neurology* 331:113354, 10.1016/j.expneurol.2020.113354, 2020.
+
+Houston, C. M., Diamanti, E., Diamantaki, M., Kutsarova, E., Cook,
+A., Sultan, F. and Brickley, S. G.. Exploring the significance of
+morphological diversity for cerebellar granule cell excitability.
+*Scientific Reports* 7:46147, 10.1038/srep46147, 2017.
+
+Houweling, A. R., Bazhenov, M., Timofeev, I., Grenier, F.,
+Steriade, M. and Sejnowski, T. J.. Frequency-selective augmenting
+responses by short-term synaptic depression in cat neocortex.
+*Journal of Physiology* 542:599-617, 2002.
+
+Houweling, A. R., Bazhenov, M., Timofeev, I., Steriade, M. and
+Sejnowski, T. J.. Cortical and thalamic components of augmenting
+responses: A modeling study. *Neurocomputing* 26-27:735-742, 1999.
+
+Houweling, A. R., Modi, R. H., Ganter, P., Fellous, J. M. and
+Sejnowski, T. J.. Models of frequency preferences of prefrontal
+cortical neurons. *Neurocomputing* 38:231-238, 2001.
+
+Houweling, A. R., Bazhenov, M., Timofeev, I., Steriade, M. and
+Sejnowski, T. J.. Homeostatic synaptic plasticity can explain
+post-traumatic epileptogenesis in chronically isolated neocortex.
+*Cerebral Cortex* 15:834-845, 2005.
+
+Howard, A. L., Neu, A., Morgan, R. J., Echegoyen, J. C. and
+Soltesz, I.. Opposing modifications in intrinsic currents and
+synaptic inputs in post-traumatic mossy cells: evidence for
+single-cell homeostasis in a hyperexcitable network. *Journal of
+Neurophysiology* 97:2394-2409, 2007.
+
+Howell, B., Choi, K. S., Gunalan, K., Rajendra, J., Mayberg, H. S.
+and McIntyre, C. C.. Quantifying the axonal pathways directly
+stimulated in therapeutic subcallosal cingulate deep brain
+stimulation. *Human Brain Mapping* 40:889-903, 10.1002/hbm.24419,
+2019a.
+
+Howell, B. and Grill, W. M.. Evaluation of high-perimeter
+electrode designs for deep brain stimulation. *Journal of Neural
+Engineering* 11:046026, 10.1088/1741-2560/11/4/046026, 2014.
+
+Howell, B., Gunalan, K. and McIntyre, C. C.. A driving-force
+predictor for estimating pathway activation in patient-specific
+models of deep brain stimulation. *Neuromodulation* 22:403-415,
+10.1111/ner.12929, 2019b.
+
+Howell, B., Huynh, B. and Grill, W. M.. Design and in vivo
+evaluation of more efficient and selective deep brain stimulation
+electrodes. *Journal of Neural Engineering* 12:046030,
+10.1088/1741-2560/12/4/046030, 2015a.
+
+Howell, B., Lad, S. P. and Grill, W. M.. Evaluation of intradural
+stimulation efficiency and selectivity in a computational model of
+spinal cord stimulation. *PLoS ONE* 9:e114938,
+10.1371/journal.pone.0114938, 2014a.
+
+Howell, B. and McIntyre, C. C.. Analyzing the tradeoff between
+electrical complexity and accuracy in patient-specific
+computational models of deep brain stimulation. *Journal of Neural
+Engineering* 13:036023, 10.1088/1741-2560/13/3/036023, 2016.
+
+Howell, B. and McIntyre, C. C.. Role of soft-tissue heterogeneity
+in computational models of deep brain stimulation. *Brain
+Stimulation* 10:46-50, 10.1016/j.brs.2016.09.001, 2017.
+
+Howell, B. and McIntyre, C. C.. Feasibility of interferential and
+pulsed transcranial electrical stimulation for neuromodulation at
+the human scale. *Neuromodulation* 10.1111/ner.13137, 2020.
+
+Howell, B., Medina, L. E. and Grill, W. M.. Effects of
+frequency-dependent membrane capacitance on neural excitability.
+*Journal of Neural Engineering* 12:056015,
+10.1088/1741-2560/12/5/056015, 2015b.
+
+Howell, B., Naik, S. and Grill, W. M.. Influences of interpolation
+error, electrode geometry, and the electrode-tissue interface on
+models of electric fields produced by deep brain stimulation.
+*IEEE Transactions on Biomedical Engineering* 61:297-307,
+10.1109/TBME.2013.2292025, 2014b.
+
+Hsu, C.-L., Zhao, X., Milstein, A. D. and Spruston, N.. Persistent
+sodium current mediates the steep voltage dependence of spatial
+coding in hippocampal pyramidal neurons. *Neuron* 99:147-162.e8,
+10.1016/j.neuron.2018.05.025, 2018.
+
+Hsu, H., Huang, E., Yang, X.-C., Karschin, A., Labarca, C., Figl,
+A., Ho, B., Davidson, N. and Lester, H. A.. Slow and incomplete
+inactivations of voltage-gated channels dominate encoding in
+synthetic neurons. *Biophysical Journal* 65:1196-1206, 1993.
+
+Hu, E., Mergenthal, A., Bingham, C. S., Song, D., Bouteiller,
+J.-M. and Berger, T. W.. A glutamatergic spine model to enable
+multi-scale modeling of nonlinear calcium dynamics. *Frontiers in
+Computational Neuroscience* 12:58, 10.3389/fncom.2018.00058,
+2018a.
+
+Hu, E. Y., Bouteiller, J.-M. C., Song, D., Baudry, M. and Berger,
+T. W.. Volterra representation enables modeling of complex
+synaptic nonlinear dynamics in large-scale simulations. *Frontiers
+in Computational Neuroscience* 9:112, 10.3389/fncom.2015.00112,
+2015.
+
+Hu, H. and Jonas, P.. A supercritical density of Na(+) channels
+ensures fast signaling in GABAergic interneuron axons. *Nature
+Neuroscience* 17:686-693, 10.1038/nn.3678, 2014.
+
+Hu, H., Roth, F. C., Vandael, D. and Jonas, P.. Complementary
+tuning of Na+ and K+ channel gating underlies fast and
+energy-efficient action potentials in GABAergic interneuron axons.
+*Neuron* 98:156-165.e6, 10.1016/j.neuron.2018.02.024, 2018b.
+
+Hu, W. and Bean, B. P.. Differential control of axonal and somatic
+resting potential by voltage-dependent conductances in cortical
+layer 5 pyramidal neurons. *Neuron* 97:1315-1326.e3,
+10.1016/j.neuron.2018.02.016, 2018.
+
+Hu, W. Q., Tian, C. P., Li, T., Yang, M. P., Hou, H. and Shu, Y.
+S.. Distinct contributions of Na(v)1.6 and Na(v)1.2 in action
+potential initiation and backpropagation. *Nature Neuroscience*
+12:996-1002, 2009.
+
+Huang, S., Hong, S. and De Schutter, E.. Non-linear leak currents
+affect mammalian neuron physiology. *Frontiers in Cellular
+Neuroscience* 9:432, 10.3389/fncel.2015.00432, 2015.
+
+Hübel, N., Andrew, R. D. and Ullah, G.. Large extracellular space
+leads to neuronal susceptibility to ischemic injury in a Na+/K+
+pumps-dependent manner. *Journal of Computational Neuroscience*
+40:177-192, 10.1007/s10827-016-0591-y, 2016.
+
+Hugosdottir, R., Mørch, C. D., Jørgensen, C. K., Nielsen, C. W.,
+Olsen, M. V., Pedersen, M. J. and Tigerholm, J.. Altered
+excitability of small cutaneous nerve fibers during cooling
+assessed with the perception threshold tracking technique. *BMC
+Neuroscience* 20:47, 10.1186/s12868-019-0527-3, 2019.
+
+Hull, M. J., Soffe, S. R., Willshaw, D. J. and Roberts, A..
+Modelling the effects of electrical coupling between unmyelinated
+axons of brainstem neurons controlling rhythmic activity. *PLoS
+Computational Biology* 11:e1004240, 10.1371/journal.pcbi.1004240,
+2015.
+
+Hull, M. J., Soffe, S. R., Willshaw, D. J. and Roberts, A..
+Modelling feedback excitation, pacemaker properties and sensory
+switching of electrically coupled brainstem neurons controlling
+rhythmic activity. *PLoS Computational Biology* 12:e1004702,
+10.1371/journal.pcbi.1004702, 2016.
+
+Hull, M. J. and Willshaw, D. J.. morphforge: a toolbox for
+simulating small networks of biologically detailed neurons in
+Python. *Frontiers in Neuroinformatics* 7:47,
+10.3389/fninf.2013.00047, 2013.
+
+Hummos, A., Franklin, C. C. and Nair, S. S.. Intrinsic mechanisms
+stabilize encoding and retrieval circuits differentially in a
+hippocampal network model. *Hippocampus* 24:1430-1448,
+10.1002/hipo.22324, 2014.
+
+Hummos, A. and Nair, S. S.. An integrative model of the intrinsic
+hippocampal theta rhythm. *PLoS ONE* 12:e0182648,
+10.1371/journal.pone.0182648, 2017.
+
+Humphries, R., Mellor, J. R. and O'Donnell, C.. Acetylcholine
+boosts dendritic NMDA spikes in a Ca3 pyramidal neuron model.
+*Neuroscience* 10.1016/j.neuroscience.2021.11.014, 2021.
+
+Huth, T., Rittger, A., Saftig, P. and Alzheimer, C.. beta-Site
+APP-cleaving enzyme 1 (BACE1) cleaves cerebellar Na(+) channel
+beta 4-subunit and promotes Purkinje cell firing by slowing the
+decay of resurgent Na(+) current. *Pflügers Archiv-European
+Journal of Physiology* 461:355-371, 10.1007/s00424-010-0913-2,
+2011.
+
+Hyun, J. H., Eom, K., Lee, K.-H., Bae, J. Y., Bae, Y. C., Kim,
+M.-H., Kim, S., Ho, W.-K. and Lee, S.-H.. Kv1.2 mediates
+heterosynaptic modulation of direct cortical synaptic inputs in
+CA3 pyramidal cells. *Journal of Physiology* 593:3617-3643,
+10.1113/JP270372, 2015.
+
+Iancu, O. D., Zhang, J. M., Roberts, P. D. and Bell, C. C..
+Postsynaptic modulation of electrical EPSP size investigated using
+a compartmental model. *Neurocomputing* 70:1685-1688, 2007.
+
+Iannella, N. and Launey, T.. Modulating STDP balance impacts the
+dendritic mosaic. *Frontiers in Computational Neuroscience* 11:42,
+10.3389/fncom.2017.00042, 2017.
+
+Iannella, N. and Tanaka, S.. Synaptic efficacy cluster formation
+across the dendrite via STDP. *Neuroscience Letters* 403:24-29,
+2006.
+
+Iannella, N. L., Launey, T. and Tanaka, S.. Spike timing-dependent
+plasticity as the origin of the formation of clustered synaptic
+efficacy engrams. *Frontiers in Computational Neuroscience* 4:-,
+10.3389/fncom.2010.00021, 2010.
+
+Iascone, D. M., Li, Y., Sümbül, U., Doron, M., Chen, H., Andreu,
+V., Goudy, F., Blockus, H., Abbott, L. F., Segev, I., Peng, H. and
+Polleux, F.. Whole-neuron synaptic mapping reveals spatially
+precise excitatory/inhibitory balance limiting dendritic and
+somatic spiking. *Neuron* 106:566-578.e8,
+10.1016/j.neuron.2020.02.015, 2020.
+
+Iavarone, E., Yi, J., Shi, Y., Zandt, B.-J., O'Reilly, C., Van
+Geit, W., Rössert, C., Markram, H. and Hill, S. L..
+Experimentally-constrained biophysical models of tonic and burst
+firing modes in thalamocortical neurons. *PLoS Computational
+Biology* 15:e1006753, 10.1371/journal.pcbi.1006753, 2019.
+
+Ienna, A., Migliore, M. and Valenti, C.. Visualization of
+simulated arrhythmias due to gap junctions [Online]. *Proceedings
+of the 19th International Conference on Computer Systems and
+Technologies* :124–129, 10.1145/3274005.3274011, 2018.
+
+Igras, E., Foweraker, J. P. A., Ware, A. and Hulliger, M..
+Computer simulation of rhythm-generating networks. *Annals of the
+New York Academy of Sciences* 860:483-485, 1998.
+
+Ilin, V. A., Bai, Q., Watson, A. M., Volgushev, M. and Burton, E.
+A.. Mechanism of pacemaker activity in zebrafish DC2/4
+dopaminergic neurons. *Journal of Neuroscience* 41:4141-4157,
+10.1523/JNEUROSCI.2124-20.2021, 2021.
+
+Ilin, V., Malyshev, A., Wolf, F. and Volgushev, M.. Fast
+computations in cortical ensembles require rapid initiation of
+action potentials. *Journal of Neuroscience* 33:2281-2292,
+10.1523/JNEUROSCI.0771-12.2013, 2013.
+
+Inoue, M., Hashimoto, Y., Kudo, Y. and Miyakawa, H.. Dendritic
+attenuation of synaptic potentials in the CA1 region of rat
+hippocampal slices detected with an optical method. *European
+Journal of Neuroscience* 13:1711-1721, 2001.
+
+Inoue, M., Lin, H., Imanaga, I., Ogawa, K. and Warashina, A..
+InsP(3) receptor type 2 and oscillatory and monophasic Ca2+
+transients in rat adrenal chromaffin cells. *Cell Calcium*
+35:59-70, 2004.
+
+Iseri, E., Kosta, P., Paknahad, J., Bouteiller, J.-M. C. and
+Lazzi, G.. A computational model simulates light-evoked responses
+in the retinal cone pathway. *Annual International Conference of
+the IEEE Engineering in Medicine and Biology Society*
+2021:4482-4486, 10.1109/EMBC46164.2021.9630642, 2021.
+
+Ito, H., Sales, A. C., Fry, C. H., Kanai, A. J., Drake, M. J. and
+Pickering, A. E.. Probabilistic, spinally-gated control of bladder
+pressure and autonomous micturition by Barrington's nucleus CRH
+neurons. *eLife* 910.7554/eLife.56605, 2020.
+
+Ivanov, A. I., Launey, T., Gueritaud, J.-P. and Korogod, S. M..
+Electrical properties and morphology of motoneurons developing in
+dissociated unpurified co-culture of embryonic rat brainstem,
+spinal cord and hindlimb tissues. *Neurophysiology* 30:305-309,
+1999.
+
+Iyengar, R. S., Pithapuram, M. V., Singh, A. K. and Raghavan, M..
+Curated model development using NEUROiD: a web-based neuromotor
+integration and design platform. *Frontiers In Neuroinformatics*
+13:56, 10.3389/fninf.2019.00056, 2019.
+
+Jackson, M. B.. *Molecular and Cellular Biophysics*. New York, NY:
+address, Cambridge University Press, 2006.
+
+Jackson, M. E. and Cauller, L. J.. Evaluation of simplified
+compartmental models of reconstructed neocortical neurons for use
+in large-scale simulations of biological neural networks. *Brain
+Research Bulletin* 44:7-17, 1997.
+
+Jacobson, G. A., Diba, K., Yaron-Jakoubovitch, A., Oz, Y., Koch,
+C., Segev, I. and Yarom, Y.. Subthreshold voltage noise of rat
+neocortical pyramidal neurones. *Journal of Physiology*
+564:145-160, 2005.
+
+Jacoby, J., Nath, A., Jessen, Z. F. and Schwartz, G. W.. A
+self-regulating gap junction network of amacrine cells controls
+nitric oxide release in the retina. *Neuron* 100:1149-1162.e5,
+10.1016/j.neuron.2018.09.047, 2018.
+
+Jadi, M., Polsky, A., Schiller, J. and Mel, B. W..
+Location-dependent effects of inhibition on local spiking in
+pyramidal neuron dendrites. *PLoS Computational Biology*
+8:e1002550, 10.1371/journal.pcbi.1002550, 2012.
+
+Jadi, M. P., Behabadi, B. F., Poleg-Polsky, A., Schiller, J. and
+Mel, B. W.. An augmented two-layer model captures nonlinear analog
+spatial integration effects in pyramidal neuron dendrites.
+*Proceedings of the IEEE* 10210.1109/JPROC.2014.2312671, 2014.
+
+Jaffe, D. B. and Carnevale, N. T.. Passive normalization of
+synaptic integration influenced by dendritic architecture.
+*Journal of Neurophysiology* 82:3268-3285, 1999.
+
+Jaffe, D. B., Ross, W. N., Lisman, J. E., Miyakawa, H.,
+Lasser-Ross, N. and Johnston, D.. A model for dendritic Ca2+
+accumulation in hippocampal pyramidal neurons based on
+fluorescence imaging experiments. *Journal of Neurophysiology*
+71:1065-1077, 1994a.
+
+Jaffe, D. B. and Brenner, R.. A computational model for how the
+fast afterhyperpolarization paradoxically increases gain in
+regularly firing neurons. *Journal of Neurophysiology*
+119:1506-1520, 10.1152/jn.00385.2017, 2018.
+
+Jaffe, D. B., Fisher, S. A. and Brown, T. H.. Confocal laser
+scanning microscopy reveals voltage-gated calcium signals within
+hippocampal dendritic spines. *Journal of Neurobiology*
+25:220-223, 1994b.
+
+Jaffe, D. B., Wang, B. and Brenner, R.. Shaping of action
+potentials by type I and type II large-conductance
+Ca(2+)-activated K(+) channels. *Neuroscience* 192:205-218,
+10.1016/j.neuroscience.2011.06.028, 2011.
+
+Jain, A. and Narayanan, R.. Degeneracy in the emergence of
+spike-triggered average of hippocampal pyramidal neurons.
+*Scientific Reports* 10:374, 10.1038/s41598-019-57243-8, 2020.
+
+Jain, V., Murphy-Baum, B. L., deRosenroll, G., Sethuramanujam, S.,
+Delsey, M., Delaney, K. R. and Awatramani, G. B.. The functional
+organization of excitation and inhibition in the dendrites of
+mouse direction-selective ganglion cells. *eLife*
+910.7554/eLife.52949, 2020.
+
+Jamieson, J., Boyd, H. D. and McLachlan, E. M.. Simulations to
+derive membrane resistivity in three phenotypes of guinea pig
+sympathetic postganglionic neuron. *Journal of Neurophysiology*
+89:2430-2440, 2003.
+
+Jang, H. J. and Kwag, J.. GABA(A) receptor-mediated feedforward
+and feedback inhibition differentially modulate hippocampal spike
+timing-dependent plasticity. *Biochemical and Biophysical Research
+Communications* 427:466-472, 10.1016/j.bbrc.2012.08.081, 2012.
+
+Jang, H. J., Park, K., Lee, J., Kim, H., Han, K. H. and Kwag, J..
+GABAA receptor-mediated feedforward and feedback inhibition
+differentially modulate the gain and the neural code
+transformation in hippocampal CA1 pyramidal cells.
+*Neuropharmacology* 99:177-186, 10.1016/j.neuropharm.2015.06.005,
+2015.
+
+Jarecki, B. W., Piekarz, A. D., Jackson, II, J. O. and Cummins, T.
+R.. Human voltage-gated sodium channel mutations that cause
+inherited neuronal and muscle channelopathies increase resurgent
+sodium currents. *Journal of Clinical Investigation* 120:369-378,
+10.1172/JCI40801, 2010.
+
+Jarsky, T., Roxin, A., Kath, W. L. and Spruston, N.. Conditional
+dendritic spike propagation following distal synaptic activation
+of hippocampal CA1 pyramidal neurons. *Nature Neuroscience*
+8:1667-1676, 2005.
+
+Jarvis, S., Nikolic, K. and Schultz, S. R.. Neuronal gain
+modulability is determined by dendritic morphology: a
+computational optogenetic study. *PLoS Computational Biology*
+14:e1006027, 10.1371/journal.pcbi.1006027, 2018.
+
+Jedlicka, P., Benuskova, L. and Abraham, W. C.. A voltage-based
+STDP rule combined with fast BCM-like metaplasticity accounts for
+LTP and concurrent "heterosynaptic" LTD in the dentate gyrus in
+vivo. *PLoS Computational Biology* 11:e1004588,
+10.1371/journal.pcbi.1004588, 2015.
+
+Jedlicka, P., Deller, T., Gutkin, B. S. and Backus, K. H..
+Activity-dependent intracellular chloride accumulation and
+diffusion controls GABA(A) receptor-mediated synaptic
+transmission. *Hippocampus* 21:885-898, 10.1002/hipo.20804, 2011a.
+
+Jedlicka, P., Deller, T. and Schwarzacher, S. W.. Computational
+modeling of GABA(A) receptor-mediated paired-pulse inhibition in
+the dentate gyrus. *Journal of Computational Neuroscience*
+29:509-519, 10.1007/s10827-010-0214-y, 2010.
+
+Jedlicka, P., Hoon, M., Papadopoulos, T., Vlachos, A., Winkels,
+R., Poulopoulos, A., Betz, H., Deller, T., Brose, N., Varoqueaux,
+F. and Schwarzacher, S. W.. Increased dentate gyrus excitability
+in neuroligin-2-deficient mice in vivo. *Cerebral Cortex*
+21:357-367, 10.1093/cercor/bhq100, 2011b.
+
+Jeng, J., Tang, S., Molnar, A., Desai, N. J. and Fried, S. I.. The
+sodium channel band shapes the response to electric stimulation in
+retinal ganglion cells. *Journal of Neural Engineering* 8:036022,
+10.1088/1741-2560/8/3/036022, 2011.
+
+Jensen, T. P., Kopach, O., Reynolds, J. P., Savtchenko, L. P. and
+Rusakov, D. A.. Release probability increases towards distal
+dendrites boosting high-frequency signal transfer in the rodent
+hippocampus. *eLife* 1010.7554/eLife.62588, 2021.
+
+Jeub, M., Emrich, M., Pradier, B., Taha, O., Gailus-Durner, V.,
+Fuchs, H., de Angelis, M. H., Huylebroeck, D., Zimmer, A., Beck,
+H. and Racz, I.. The transcription factor Smad-interacting protein
+1 controls pain sensitivity via modulation of DRG neuron
+excitability. *Pain* 152:2384-2398, 10.1016/j.pain.2011.07.006,
+2011.
+
+Ji, H., Tucker, K. R., Putzier, I., Huertas, M. A., Horn, J. P.,
+Canavier, C. C., Levitan, E. S. and Shepard, P. D.. Functional
+characterization of ether-à-go-go-related gene potassium channels
+in midbrain dopamine neurons - implications for a role in
+depolarization block. *European Journal of Neuroscience*
+36:2906-2916, 10.1111/j.1460-9568.2012.08190.x, 2012.
+
+Jiang, M. C., ElBasiouny, S. M., Collins, 3rd, W. F. and Heckman,
+C. J.. The transformation of synaptic to system plasticity in
+motor output from the sacral cord of the adult mouse. *Journal of
+Neurophysiology* 114:1987-2004, 10.1152/jn.00337.2015, 2015.
+
+Jochems, A. and Yoshida, M.. A robust in vivo-like persistent
+firing supported by a hybrid of intracellular and synaptic
+mechanisms. *PLoS ONE* 10:e0123799, 10.1371/journal.pone.0123799,
+2015.
+
+John, J. and Manchanda, R.. Modulation of synaptic potentials and
+cell excitability by dendritic K(IR) and K(As) channels in nucleus
+accumbens medium spiny neurons: A computational study. *Journal of
+Biosciences* 36:309-328, 10.1007/s12038-011-9039-8, 2011.
+
+Johnson, C., Holmes, W. R., Brown, A. and Jung, P.. Minimizing the
+caliber of myelinated axons by means of nodal constrictions.
+*Journal of Neurophysiology* 114:1874-1884, 10.1152/jn.00338.2015,
+2015.
+
+Johnson, M. D. and McIntyre, C. C.. Quantifying the neural
+elements activated and inhibited by globus pallidus deep brain
+stimulation. *Journal of Neurophysiology* 100:2549-2563, 2008.
+
+Johnson, M. D., Zhang, J., Ghosh, D., McIntyre, C. C. and Vitek,
+J. L.. Neural targets for relieving parkinsonian rigidity and
+bradykinesia with pallidal deep brain stimulation.. *Journal of
+Neurophysiology* 108:567-577, 10.1152/jn.00039.2012, 2012.
+
+Johnston, D. and Wu, S. M.-S.. *Foundations of Cellular
+Neurophysiology*. Cambridge, MA: address, MIT Press, 1995.
+
+Johnston, J., Forsythe, I. D. and Kopp-Scheinpflug, C.. Going
+native: voltage-gated potassium channels controlling neuronal
+excitability. *Journal of Physiology* 588:3187-3200,
+10.1113/jphysiol.2010.191973, 2010.
+
+Johnston, J., Griffin, S. J., Baker, C. and Forsythe, I. D.. Kv4
+(A-type) potassium currents in the mouse medial nucleus of the
+trapezoid body. *European Journal of Neuroscience* 27:1391-1399,
+2008a.
+
+Johnston, J., Griffin, S. J., Baker, C., Skrzypiec, A., Chernova,
+T. and Forsythe, I. D.. Initial segment Kv2.2 channels mediate a
+slow delayed rectifier and maintain high frequency action
+potential firing in medial nucleus of the trapezoid body neurons.
+*Journal of Physiology* 586:3493-3509, 2008b.
+
+Johnston, J. and Lagnado, L.. General features of the retinal
+connectome determine the computation of motion anticipation.
+*eLife* 4:e06250, 10.7554/eLife.06250, 2015.
+
+Jones, K. E., Carlin, K. P., Rempel, J., Jordan, L. M. and
+Brownstone, R. M.. Simulation techniques for localising and
+identifying the kinetics of calcium channels in dendritic
+neurones. *Neurocomputing* 32:173-180, 2000.
+
+Jones, M. G., Rogers, E. R., Harris, J. P., Sullivan, A.,
+Ackermann, D. M., Russo, M., Lempka, S. F. and McMahon, S. B..
+Neuromodulation using ultra low frequency current waveform
+reversibly blocks axonal conduction and chronic pain. *Science
+Translational Medicine* 1310.1126/scitranslmed.abg9890, 2021.
+
+Jones, P. W. and Gabbiani, F.. Impact of neural noise on a
+sensory-motor pathway signaling impending collision. *Journal of
+Neurophysiology* 107:1067-1079, 10.1152/jn.00607.2011, 2012.
+
+Jones, S. R.. Biophysically principled computational neural
+network modeling of magneto-/electro-encephalography measured
+human brain oscillations. *Neuromethods* 67:459-485, DOI
+10.1007/7657_2011_16, 2012.
+
+Jones, S. R., Pritchett, D. L., Stufflebeam, S. M., Hamalainen, M.
+and Moore, C. I.. Neural correlates of tactile detection: a
+combined magnetoencephalography and biophysically based
+computational modeling study. *Journal of Neuroscience*
+27:10751-10764, 2007.
+
+Jones, S., Zylberberg, J. and Schoppa, N.. Cellular and synaptic
+mechanisms that differentiate mitral cells and superficial tufted
+cells into parallel output channels in the olfactory bulb.
+*Frontiers in Cellular Neuroscience* 14:614377,
+10.3389/fncel.2020.614377, 2020.
+
+Jones, S. L., To, M.-S. and Stuart, G. J.. Dendritic small
+conductance calcium-activated potassium channels activated by
+action potentials suppress EPSPs and gate spike-timing dependent
+synaptic plasticity. *eLife* 610.7554/eLife.30333, 2017.
+
+Jones, S. R., Pritchett, D. L., Sikora, M. A., Stufflebeam, S. M.,
+Hämäläinen, M. and Moore, C. I.. Quantitative analysis and
+biophysically realistic neural modeling of the MEG mu rhythm:
+rhythmogenesis and modulation of sensory-evoked responses..
+*Journal of Neurophysiology* 102:3554-3572, 10.1152/jn.00535.2009,
+2009.
+
+Joos, B., Barlow, B. M. and Morris, C. E.. Calculating the
+consequences of left-shifted Nav channel activity in sick
+excitable cells. *Handbook of Experimental Pharmacology*
+246:401-422, 10.1007/164_2017_63, 2018.
+
+Joucla, S., Branchereau, P., Cattaert, D. and Yvert, B..
+Extracellular neural microstimulation may activate much larger
+regions than expected by simulations: a combined experimental and
+modeling study. *PLoS ONE* 7:e41324, 10.1371/journal.pone.0041324,
+2012a.
+
+Joucla, S., Glière, A. and Yvert, B.. Current approaches to model
+extracellular electrical neural microstimulation. *Frontiers in
+Computational Neuroscience* 8:13, 10.3389/fncom.2014.00013, 2014.
+
+Joucla, S., Rousseau, L. and Yvert, B.. Focalizing electrical
+neural stimulation with penetrating microelectrode arrays: a
+modeling study. *Journal of Neuroscience Methods* 209:250-254,
+10.1016/j.jneumeth.2012.05.006, 2012b.
+
+Joucla, S. and Yvert, B.. Improved focalization of electrical
+microstimulation using microelectrode arrays: a modeling study.
+*PLoS ONE* 4:e4828, 10.1371/journal.pone.0004828, 2009a.
+
+Joucla, S. and Yvert, B.. The "mirror" estimate: an intuitive
+predictor of membrane polarization during extracellular
+stimulation. *Biophysical Journal* 96:3495-3508, 2009b.
+
+Justus, D., Dalügge, D., Bothe, S., Fuhrmann, F., Hannes, C.,
+Kaneko, H., Friedrichs, D., Sosulina, L., Schwarz, I., Elliott, D.
+A., Schoch, S., Bradke, F., Schwarz, M. K. and Remy, S..
+Glutamatergic synaptic integration of locomotion speed via
+septoentorhinal projections. *Nature Neuroscience* 20:16-19,
+10.1038/nn.4447, 2017.
+
+Kabaso, D., Coskren, P. J., Henry, B. I., Hof, P. R. and Wearne,
+S. L.. The electrotonic structure of pyramidal neurons
+contributing to prefrontal cortical circuits in macaque monkeys is
+significantly altered in aging. *Cerebral Cortex* 19:2248-2268,
+2009.
+
+Kagan, Z. B., RamRakhyani, A. K., Lazzi, G., Normann, R. A. and
+Warren, D. J.. In vivo magnetic stimulation of rat sciatic nerve
+with centimeter- and millimeter-scale solenoid coils. *IEEE
+Transactions on Neural Systems and Rehabilitation Engineering*
+24:1138-1147, 10.1109/TNSRE.2016.2544247, 2016.
+
+Kager, H., Wadman, W. J. and Somjen, G. G.. Simulated seizures and
+spreading depression in a neuron model incorporating interstitial
+space and ion concentrations. *Journal of Neurophysiology*
+84:495-512, 2000.
+
+Kager, H., Wadman, W. J. and Somjen, G. G.. Conditions for the
+triggering of spreading depression studied with computer
+simulations. *Journal of Neurophysiology* 88:2700-2712, 2002.
+
+Kager, H., Wadman, W. J. and Somjen, G. G.. Seizure-like
+afterdischarges simulated in a model neuron. *Journal of
+Computational Neuroscience* 22:105-128, 2007.
+
+Kahlig, K. M., Misra, S. N. and George, A.L., J.. Impaired
+inactivation gate stabilization predicts increased persistent
+current for an epilepsy-associated SCN1A mutation. *Journal of
+Neuroscience* 26:10958-10966, 2006.
+
+Kahlig, K. M., Hirakawa, R., Liu, L., George, Jr, A. L.,
+Belardinelli, L. and Rajamani, S.. Ranolazine reduces neuronal
+excitability by interacting with inactivated states of brain
+sodium channels. *Molecular Pharmacology* 85:162-174,
+10.1124/mol.113.088492, 2014.
+
+Kairiss, E. W., Mainen, Z. F., Claiborne, B. J. and Brown, T. H..
+Dendritic control of Hebbian computations. In: *Analysis and
+Modeling of Neural Systems*, edited by Eeckman, F.. Boston, MA:
+Boston, MA, Kluwer, 1992, pp. 69-83.
+
+Kalmbach, B. E., Buchin, A., Long, B., Close, J., Nandi, A.,
+Miller, J. A., Bakken, T. E., Hodge, R. D., Chong, P., de Frates,
+R., Dai, K., Maltzer, Z., Nicovich, P. R., Keene, C. D.,
+Silbergeld, D. L., Gwinn, R. P., Cobbs, C., Ko, A. L., Ojemann, J.
+G., Koch, C., Anastassiou, C. A., Lein, E. S. and Ting, J. T..
+h-Channels contribute to divergent intrinsic membrane properties
+of supragranular pyramidal neurons in human versus mouse cerebral
+cortex. *Neuron* 100:1194-1208.e5, 10.1016/j.neuron.2018.10.012,
+2018.
+
+Kamaleddin, M. A.. Degeneracy in the nervous system: from neuronal
+excitability to neural coding. *BioEssays* 44:e2100148,
+10.1002/bies.202100148, 2022.
+
+Kameda, H., Hioki, H., Tanaka, Y. H., Tanaka, T., Sohn, J.,
+Sonomura, T., Furuta, T., Fujiyama, F. and Kaneko, T..
+Parvalbumin-producing cortical interneurons receive inhibitory
+inputs on proximal portions and cortical excitatory inputs on
+distal dendrites. *European Journal of Neuroscience* 35:838-854,
+10.1111/j.1460-9568.2012.08027.x, 2012.
+
+Kameneva, T., Grayden, D. B., Meffin, H. and Burkitt, A. N..
+Simulating electrical stimulation of degenerative retinal ganglion
+cells with bi-phasic pulse trains [Online]. *IEEE Engineering in
+Medicine and Biology Society Proceedings* 2011:7103-7106,
+10.1109/IEMBS.2011.6091795, 2011a.
+
+Kameneva, T., Maturana, M. I., Hadjinicolaou, A. E., Cloherty, S.
+L., Ibbotson, M. R., Grayden, D. B., Burkitt, A. N. and Meffin,
+H.. Retinal ganglion cells: mechanisms underlying depolarization
+block and differential responses to high frequency electrical
+stimulation of ON and OFF cells. *Journal of Neural Engineering*
+13:016017, 10.1088/1741-2560/13/1/016017, 2016.
+
+Kameneva, T., Meffin, H. and Burkitt, A. N.. Differential
+stimulation of ON and OFF retinal ganglion cells: a modeling study
+[Online]. *IEEE Engineering in Medicine and Biology Society
+Proceedings* 2010:4246-4249, 10.1109/IEMBS.2010.5627176, 2010.
+
+Kameneva, T., Meffin, H. and Burkitt, A. N.. Modelling intrinsic
+electrophysiological properties of ON and OFF retinal ganglion
+cells. *Journal of Computational Neuroscience* 31:547-561,
+10.1007/s10827-011-0322-3, 2011b.
+
+Kamitani, Y., Bhalodia, V. M., Kubota, Y. and Shimojo, S.. A model
+of magnetic stimulation of neocortical neurons. *Neurocomputing*
+38:697-703, 2001.
+
+Kamiya, H.. Excitability tuning of axons by afterdepolarization.
+*Frontiers In Cellular Neuroscience* 13:407,
+10.3389/fncel.2019.00407, 2019a.
+
+Kamiya, H.. Modeling analysis of axonal after potential at
+hippocampal mossy fibers. *Frontiers In Cellular Neuroscience*
+13:210, 10.3389/fncel.2019.00210, 2019b.
+
+Kampa, B. M. and Stuart, G. J.. Calcium spikes in basal dendrites
+of layer 5 pyramidal neurons during action potential bursts.
+*Journal of Neuroscience* 26:7424-7432, 2006.
+
+Kanold, P. O. and Manis, P. B.. A physiologically based model of
+discharge pattern regulation by transient K+ currents in cochlear
+nucleus pyramidal cells. *Journal of Neurophysiology* 85:523-538,
+2001.
+
+Kanold, P. O. and Manis, P. B.. Encoding the timing of inhibitory
+inputs. *Journal of Neurophysiology* 93:2887-2897, 2005.
+
+Kanyshkova, T., Meuth, P., Bista, P., Liu, Z., Ehling, P., Caputi,
+L., Doengi, M., Chetkovich, D. M., Pape, H.-C. and Budde, T..
+Differential regulation of HCN channel isoform expression in
+thalamic neurons of epileptic and non-epileptic rat strains.
+*Neurobiology of Disease* 45:450-461, 10.1016/j.nbd.2011.08.032,
+2012.
+
+Kanyshkova, T., Pawlowski, M., Meuth, P., Dube, C., Bender, R. A.,
+Brewster, A. L., Baumann, A., Baram, T. Z., Pape, H. C. and Budde,
+T.. Postnatal expression pattern of HCN channel isoforms in
+thalamic neurons: relationship to maturation of thalamocortical
+oscillations. *Journal of Neuroscience* 29:8847-8857, 2009.
+
+Kaplan, B. A. and Lansner, A.. A spiking neural network model of
+self-organized pattern recognition in the early mammalian
+olfactory system. *Frontiers in Neural Circuits* 8:5,
+10.3389/fncir.2014.00005, 2014.
+
+Kapur, A., Lytton, W. W., Ketchum, K. L. and Haberly, L. B..
+Regulation of the NMDA component of EPSPs by different components
+of postsynaptic GABAergic inhibition: computer simulation analysis
+in piriform cortex. *Journal of Neurophysiology* 78:2546-2559,
+1997a.
+
+Kapur, A., Pearce, R. A., Lytton, W. W. and Haberly, L. B..
+GABAA-mediated IPSCs in piriform cortex have fast and slow
+components with different properties and locations on pyramidal
+cells. *Journal of Neurophysiology* 78:2531-2545, 1997b.
+
+Karadas, M., Olsson, C., Winther Hansen, N., Perrier, J.-F., Webb,
+J. L., Huck, A., Andersen, U. L. and Thielscher, A.. In-vitro
+recordings of neural magnetic activity from the auditory brainstem
+using color centers in diamond: a simulation study. *Frontiers in
+Neuroscience* 15:643614, 10.3389/fnins.2021.643614, 2021.
+
+Karadas, M., Wojciechowski, A. M., Huck, A., Dalby, N. O.,
+Andersen, U. L. and Thielscher, A.. Feasibility and resolution
+limits of opto-magnetic imaging of neural network activity in
+brain slices using color centers in diamond. *Scientific Reports*
+8:4503, 10.1038/s41598-018-22793-w, 2018.
+
+Karmarkar, U. R. and Buonomano, D. V.. A model of spike-timing
+dependent plasticity: one or two coincidence detectors?. *Journal
+of Neurophysiology* 88:507-513, 2002.
+
+Karmarkar, U. R. and Buonomano, D. V.. Timing in the absence of
+clocks: encoding time in neural network states. *Neuron*
+53:427-438, 2007.
+
+Karmarkar, U. R., Najarian, M. T. and Buonomano, D. V.. Mechanisms
+and significance of spike-timing dependent plasticity. *Biological
+Cybernetics* 87:373-382, 2002.
+
+Kase, D. and Imoto, K.. The role of HCN channels on membrane
+excitability in the nervous system. *Journal of Signal
+Transduction* 2012:619747, 10.1155/2012/619747, 2012.
+
+Kase, D., Inoue, T. and Imoto, K.. Roles of the subthalamic
+nucleus and subthalamic HCN channels in absence seizures. *Journal
+of Neurophysiology* 107:393-406, 10.1152/jn.00937.2010, 2012.
+
+Kase, D., Uta, D., Ishihara, H. and Imoto, K.. Inhibitory synaptic
+transmission from the substantia nigra pars reticulata to the
+ventral medial thalamus in mice. *Neuroscience Research* 97:26-35,
+10.1016/j.neures.2015.03.007, 2015.
+
+Kaspirzhnyi, A. V.. Local oscillatory properties of the dendritic
+membrane of hippocampal pyramidal neurons: a simulation study.
+*Neurophysiology* 49:178-182, 10.1007/s11062-017-9671-5, 2017.
+
+Kaspirzhnyi, A. V.. Conditions of switching between local electric
+activity modes in the dendritic membrane of hippocampal pyramidal
+neurons: a simulation study. *Neurophysiology* 50:152-158,
+10.1007/s11062-018-9731-5, 2018.
+
+Katona, G., Kaszás, A., Turi, G. F., Hájos, N., Tamás, G., Vizi,
+E. S. and Rózsa, B.. Roller Coaster Scanning reveals spontaneous
+triggering of dendritic spikes in CA1 interneurons. *Proceedings
+of the National Academy of Sciences of the United States of
+America* 108:2148-2153, 10.1073/pnas.1009270108, 2011.
+
+Katyare, N. and Sikdar, S. K.. Theta resonance and synaptic
+modulation scale activity patterns in the medial entorhinal cortex
+stellate cells. *Annals of the New York Academy of Sciences*
+1478:92-112, 10.1111/nyas.14434, 2020.
+
+Katz, Y., Menon, V., Nicholson, D. A., Geinisman, Y., Kath, W. L.
+and Spruston, N.. Synapse distribution suggests a two-stage model
+of dendritic integration in CA1 pyramidal neurons. *Neuron*
+63:171-177, 2009.
+
+Keane, M., Deyo, S., Abosch, A., Bajwa, J. A. and Johnson, M. D..
+Improved spatial targeting with directionally segmented deep brain
+stimulation leads for treating essential tremor. *Journal of
+Neural Engineering* 9:046005, 10.1088/1741-2560/9/4/046005, 2012.
+
+Keller, A., Ambert, N., Legendre, A., Bedez, M., Bouteiller,
+J.-M., Bischoff, S., Baudry, M. and Moussaoui, S.. Impact of
+synaptic localization and subunit composition of ionotropic
+glutamate receptors on synaptic function: modeling and simulation
+studies. *IEEE/ACM Transactions on Computational Biology and
+Bioinformatics* 10.1109/TCBB.2016.2561932, 2016.
+
+Keller, A. F., Bouteiller, J.-M. C. and Berger, T. W.. Development
+of a computational approach/model to explore NMDA receptors
+functions. *Methods in Molecular Biology* 1677:291-306,
+10.1007/978-1-4939-7321-7_17, 2017.
+
+Kelley, C., Dura-Bernal, S., Neymotin, S. A., Antic, S. D.,
+Carnevale, N. T., Migliore, M. and Lytton, W. W.. Effects of Ih
+and TASK-like shunting current on dendritic impedance in layer 5
+pyramidal-tract neurons. *Journal of Neurophysiology*
+125:1501-1516, 10.1152/jn.00015.2021, 2021.
+
+Kent, A. R. and Grill, W. M.. Model-based analysis and design of
+nerve cuff electrodes for restoring bladder function by selective
+stimulation of the pudendal nerve. *Journal of Neural Engineering*
+10:036010, 10.1088/1741-2560/10/3/036010, 2013a.
+
+Kent, A. R. and Grill, W. M.. Neural origin of evoked potentials
+during thalamic deep brain stimulation. *Journal of
+Neurophysiology* 110:826-843, 10.1152/jn.00074.2013, 2013b.
+
+Kent, A. R. and Grill, W. M.. Analysis of deep brain stimulation
+electrode characteristics for neural recording. *Journal of Neural
+Engineering* 11:046010, 10.1088/1741-2560/11/4/046010, 2014.
+
+Kent, A. R., Min, X., Hogan, Q. H. and Kramer, J. M.. Mechanisms
+of dorsal root ganglion stimulation in pain suppression: a
+computational modeling analysis. *Neuromodulation* 21:234-246,
+10.1111/ner.12754, 2018.
+
+Kent, A. R., Swan, B. D., Brocker, D. T., Turner, D. A., Gross, R.
+E. and Grill, W. M.. Measurement of evoked potentials during
+thalamic deep brain stimulation. *Brain Stimulation* 8:42-56,
+10.1016/j.brs.2014.09.017, 2015.
+
+Keren, N., Bar-Yehuda, D. and Korngreen, A.. Experimentally guided
+modelling of dendritic excitability in rat neocortical pyramidal
+neurones. *Journal of Physiology* 587:1413-1437, 2009.
+
+Keren, N., Peled, N. and Korngreen, A.. Constraining compartmental
+models using multiple voltage recordings and genetic algorithms.
+*Journal of Neurophysiology* 94:3730-3742, 2005.
+
+Kerr, C. C., Neymotin, S. A., Chadderdon, G. L., Fietkiewicz, C.
+T., Francis, J. T. and Lytton, W. W.. Electrostimulation as a
+prosthesis for repair of information flow in a computer model of
+neocortex. *IEEE Transactions on Neural Systems and Rehabilitation
+Engineering* 20:153-160, 10.1109/TNSRE.2011.2178614, 2012.
+
+Kerr, C. C., Van Albada, S. J., Neymotin, S. A., Chadderdon, G.
+L., Robinson, P. A. and Lytton, W. W.. Cortical information flow
+in Parkinson's disease: a composite network/field model.
+*Frontiers in Computational Neuroscience* 7:39,
+10.3389/fncom.2013.00039, 2013.
+
+Khadka, N., Liu, X., Zander, H., Swami, J., Rogers, E., Lempka, S.
+F. and Bikson, M.. Realistic anatomically detailed open-source
+spinal cord stimulation (RADO-SCS) model. *Journal of Neural
+Engineering* 17:026033, 10.1088/1741-2552/ab8344, 2020.
+
+Khaliq, Z. M., Gouwens, N. W. and Raman, I. M.. The contribution
+of resurgent sodium current to high-frequency firing in Purkinje
+neurons: an experimental and modeling study. *Journal of
+Neuroscience* 23:4899-4912, 2003.
+
+Khatri, S. N., Wu, W.-C., Yang, Y. and Pugh, J. R.. Mechanisms of
+GABAB receptor enhancement of extrasynaptic GABAA receptor
+currents in cerebellar granule cells. *Scientific Reports*
+9:16683, 10.1038/s41598-019-53087-4, 2019.
+
+Kidd, J. F. and Sattelle, D. B.. The effects of amyloid peptides
+on A-type K(+) currents of Drosophila larval cholinergic neurons:
+modeled actions on firing properties. *Invertebrate Neuroscience*
+6:207-213, 10.1007/s10158-006-0034-y, 2006.
+
+Kilgore, K. L. and Bhadra, N.. Nerve conduction block utilising
+high-frequency alternating current. *Medical and Biological
+Engineering and Computing* 42:394-406, 2004.
+
+Kim, D., Paré, D. and Nair, S. S.. Assignment of model amygdala
+neurons to the fear memory trace depends on competitive synaptic
+interactions. *Journal of Neuroscience* 33:14354-14358,
+10.1523/JNEUROSCI.2430-13.2013, 2013a.
+
+Kim, D., Paré, D. and Nair, S. S.. Mechanisms contributing to the
+induction and storage of Pavlovian fear memories in the lateral
+amygdala. *Learning and Memory* 20:421-430, 10.1101/lm.030262.113,
+2013b.
+
+Kim, D., Samarth, P., Feng, F., Pare, D. and Nair, S. S.. Synaptic
+competition in the lateral amygdala and the stimulus specificity
+of conditioned fear: a biophysical modeling study. *Brain
+Structure and Function* 221:2163-2182, 10.1007/s00429-015-1037-4,
+2016.
+
+Kim, H.. Impact of the localization of dendritic calcium
+persistent inward current on the input-output properties of spinal
+motoneuron pool: a computational study. *Journal of Applied
+Physiology* 123:1166-1187, 10.1152/japplphysiol.00034.2017, 2017a.
+
+Kim, H.. Muscle length-dependent contribution of motoneuron Cav1.3
+channels to force production in model slow motor unit. *Journal of
+Applied Physiology* 123:88-105, 10.1152/japplphysiol.00491.2016,
+2017b.
+
+Kim, H.. Linking motoneuron PIC location to motor function in
+closed-loop motor unit system including afferent feedback: a
+computational investigation. *eNeuro* 7:ENEURO.0014-20.2020,
+10.1523/eneuro.0014-20.2020, 2020.
+
+Kim, H. G. and Connors, B. W.. Apical dendrites of the neocortex:
+correlation between sodium- and calcium-dependent spiking and
+pyramidal cell morphology. *Journal of Neuroscience* 13:5301-5311,
+1993.
+
+Kim, H. and Heckman, C. J.. Foundational dendritic processing that
+is independent of the cell type-specific structure in model
+primary neurons. *Neuroscience Letters* 609:203-209,
+10.1016/j.neulet.2015.10.017, 2015.
+
+Kim, H. and Heckman, C. J.. Data for spatial characterization of
+AC signal propagation over primary neuron dendrites. *Data in
+Brief* 6:341-344, 10.1016/j.dib.2015.12.018, 2016.
+
+Kim, H. and Jones, K. E.. The retrograde frequency response of
+passive dendritic trees constrains the nonlinear firing behaviour
+of a reduced neuron model. *PLoS ONE* 7:e43654,
+10.1371/journal.pone.0043654, 2012.
+
+Kim, H., Jones, K. E. and Heckman, C. J.. Asymmetry in signal
+propagation between the soma and dendrites plays a key role in
+determining dendritic excitability in motoneurons. *PLoS ONE*
+9:e95454, 10.1371/journal.pone.0095454, 2014.
+
+Kim, H. and Kim, M.. PyMUS: python-based simulation software for
+virtual experiments on motor unit system. *Frontiers in
+Neuroinformatics* 12:15, 10.3389/fninf.2018.00015, 2018.
+
+Kim, H., Major, L. A. and Jones, K. E.. Derivation of cable
+parameters for a reduced model that retains asymmetric voltage
+attenuation of reconstructed spinal motor neuron dendrites..
+*Journal of Computational Neuroscience* 27:321-336,
+10.1007/s10827-009-0145-7, 2009.
+
+Kim, H., Sandercock, T. G. and Heckman, C. J.. An action
+potential-driven model of soleus muscle activation dynamics for
+locomotor-like movements. *Journal of Neural Engineering*
+12:046025, 10.1088/1741-2560/12/4/046025, 2015a.
+
+Kim, J., Nadal, M. S., Clemens, A. M., Baron, M., Jung, S. C.,
+Misumi, Y., Rudy, B. and Hoffman, D. A.. Kv4 accessory protein
+DPPX (DPP6) is a critical regulator of membrane excitability in
+hippocampal CA1 pyramidal neurons. *Journal of Neurophysiology*
+100:1835-1847, 2008.
+
+Kim, J. K. and Fiorillo, C. D.. Theory of optimal balance predicts
+and explains the amplitude and decay time of synaptic inhibition.
+*Nature Communications* 8:14566, 10.1038/ncomms14566, 2017.
+
+Kim, Y., Hsu, C.-L., Cembrowski, M. S., Mensh, B. D. and Spruston,
+N.. Dendritic sodium spikes are required for long-term
+potentiation at distal synapses on hippocampal pyramidal neurons.
+*eLife* 4:e06414, 10.7554/eLife.06414, 2015b.
+
+King, J. G., Hines, M., Hill, S., Goodman, P. H., Markram, H. and
+Schürmann, F.. A component-based extension framework for
+large-scale parallel simulations in NEURON. *Frontiers in
+Neuroinformatics* 3:10, 10.3389/neuro.11.010.2009, 2009.
+
+Kish, K. E., Graham, R. D., Wong, K. Y. and Weiland, J. D.. The
+effect of axon trajectory on retinal ganglion cell activation with
+epiretinal stimulation [Online]. *Proc. 10th Int. IEEE/EMBS Conf.
+Neural Engineering* :263-266, 10.1109/NER49283.2021.9441073, 2021.
+
+Kits, K. S., de Vlieger, T. A., Kooi, B. W. and Mansvelder, H. D..
+Diffusion barriers limit the effect of mobile calcium buffers on
+exocytosis of large dense cored vesicles. *Biophysical Journal*
+76:1693-1705, 1999.
+
+Klefenz, F. and Harczos, T.. Periodicity pitch perception.
+*Frontiers in Neuroscience* 14:486, 10.3389/fnins.2020.00486,
+2020.
+
+Klein, P. M., Lu, A. C., Harper, M. E., McKown, H. M., Morgan, J.
+D. and Beenhakker, M. P.. Tenuous inhibitory GABAergic signaling
+in the reticular thalamus. *Journal of Neuroscience* 38:1232-1248,
+10.1523/JNEUROSCI.1345-17.2017, 2018a.
+
+Klein, V., Davids, M., Wald, L. L., Schad, L. R. and Guérin, B..
+Sensitivity analysis of neurodynamic and electromagnetic
+simulation parameters for robust prediction of peripheral nerve
+stimulation. *Physics in Medicine and Biology* 64:015005,
+10.1088/1361-6560/aaf308, 2018b.
+
+Knowlton, C. J., Ziouziou, T. I., Hammer, N., Roeper, J. and
+Canavier, C. C.. Inactivation mode of sodium channels defines the
+different maximal firing rates of conventional versus atypical
+midbrain dopamine neurons. *PLoS Computational Biology*
+17:e1009371, 10.1371/journal.pcbi.1009371, 2021.
+
+Knox, A. T., Glauser, T., Tenney, J., Lytton, W. W. and Holland,
+K.. Modeling pathogenesis and treatment response in childhood
+absence epilepsy. *Epilepsia* 59:135-145, 10.1111/epi.13962, 2018.
+
+Kobayashi, C., Okamoto, K., Mochizuki, Y., Urakubo, H., Funayama,
+K., Ishikawa, T., Kashima, T., Ouchi, A., Szymanska, A. F., Ishii,
+S. and Ikegaya, Y.. GABAergic inhibition reduces the impact of
+synaptic excitation on somatic excitation. *Neuroscience Research*
+146:22-35, 10.1016/j.neures.2018.09.014, 2019.
+
+Kobayashi, K., Akiyama, T., Ohmori, I., Yoshinaga, H. and Gotman,
+J.. Action potentials contribute to epileptic high-frequency
+oscillations recorded with electrodes remote from neurons.
+*Clinical Neurophysiology* 126:873-881,
+10.1016/j.clinph.2014.08.010, 2015.
+
+Koch, C., Bernander, O. and Douglas, R. J.. Do neurons have a
+voltage or a current threshold for action potential initiation?.
+*Journal of Computational Neuroscience* 2:63-82, 1995.
+
+Koch, C., Rapp, M. and Segev, I.. A brief history of time
+(constants). *Cerebral Cortex* 6:93-101, 1996.
+
+Kochenov, A. V., Poddubnaya, E. P., Makedonsky, I. A. and Korogod,
+S. M.. Biophysical processes in a urinary bladder detrusor smooth
+muscle cell during rehabilitation stimulation of parasympathetic
+efferents: a simulation study. *Neurophysiology* 48:156-165,
+10.1007/s11062-016-9583-9, 2016.
+
+Kochenov, А. V., Poddubnaya, E. P., Makedonsky, I. A. and Korogod,
+S. М.. Biophysical processes in a urinary bladder detrusor smooth
+muscle cell during rehabilitation electrostimulation: a simulation
+study. *Neurophysiology* 47:174-184, 10.1007/s11062-015-9518-x,
+2015a.
+
+Kochenov, А. V., Poddubnaya, Y. P., Makedonsky, I. A. and Korogod,
+S. М.. Excitability characteristics of a urinary bladder detrusor
+smooth muscle cell as a basis for choosing parameters of
+rehabilitation electrostimulation: a simulation study.
+*Neurophysiology* 47:94-101, 10.1007/s11062-015-9504-3, 2015b.
+
+Kochubey, S. A., Savtchenko, L. P. and Sem'yanov, A. V..
+Modulation of oscillatory synchronization in an interneuronal
+network under the influence of tonic GABA-ergic inhibition: a
+model study. *Neurophysiology* 42:318-324,
+10.1007/s11062-011-9165-9, 2011a.
+
+Kochubey, S. and Savtchenko, L.. Geometrical size of the neuronal
+network plays a key role in synchronization of its activity.
+*Neurophysiology* 40:224-227, 2008.
+
+Kochubey, S., Semyanov, A. and Savtchenko, L.. Network with
+shunting synapses as a non-linear frequency modulator. *Neural
+Networks* 24:407-416, 10.1016/j.neunet.2011.03.005, 2011b.
+
+Koelman, L. A. and Lowery, M. M.. Beta-band resonance and
+intrinsic oscillations in a biophysically detailed model of the
+subthalamic nucleus-globus pallidus network. *Frontiers In
+Computational Neuroscience* 13:77, 10.3389/fncom.2019.00077, 2019.
+
+Kohl, C., Parviainen, T. and Jones, S. R.. Neural mechanisms
+underlying human auditory evoked responses revealed by Human
+Neocortical Neurosolver. *Brain Topography*
+10.1007/s10548-021-00838-0, 2021.
+
+Koizumi, A., Hayashida, Y., Kiuchi, T., Yamada, Y., Fujii, A.,
+Yagi, T. and Kaneko, A.. The interdependence and independence of
+amacrine cell dendrites: patch-clamp recordings and simulation
+studies on cultured gabaergic amacrine cells. *Journal of
+Integrative Neuroscience* 4:363-380, 2005.
+
+Koizumi, A., Jakobs, T. C. and Masland, R. H.. Inward rectifying
+currents stabilize the membrane potential in dendrites of mouse
+amacrine cells: patch-clamp recordings and single-cell RT-PCR.
+*Molecular Vision* 10:328-340, 2004.
+
+Koizumi, A., Jakobs, T. C. and Masland, R. H.. Regular mosaic of
+synaptic contacts among three retinal neurons. *Journal of
+Comparative Neurology* 519:341-357, 10.1002/cne.22522, 2011.
+
+Koizumi, A., Takayasu, M. and Takayasu, H.. Asynmetric inhibitory
+connections enhance directional selectivity in a three-layer
+simulation model of retinal networks. *Journal of Integrative
+Neuroscience* 9:337-350, 10.1142/S0219635210002469, 2010.
+
+Kolbaev, S. N., Mohapatra, N., Chen, R., Lombardi, A., Staiger, J.
+F., Luhmann, H. J., Jedlicka, P. and Kilb, W.. NKCC-1 mediated Cl-
+uptake in immature CA3 pyramidal neurons is sufficient to
+compensate phasic GABAergic inputs. *Scientific Reports* 10:18399,
+10.1038/s41598-020-75382-1, 2020.
+
+Kole, M. H. P., Brauer, A. U. and Stuart, G. J.. Inherited
+cortical HCN1 channel loss amplifies dendritic calcium
+electrogenesis and burst firing in a rat absence epilepsy model.
+*Journal of Physiology* 578:507-525, 2007.
+
+Kole, M. H. P., Hallermann, S. and Stuart, G. J.. Single Ih
+channels in pyramidal neuron dendrites: properties, distribution,
+and impact on action potential output. *Journal of Neuroscience*
+26:1677-1687, 2006.
+
+Kole, M. H. P., Ilschner, S. U., Kampa, B. M., Williams, S. R.,
+Ruben, P. C. and Stuart, G. J.. Action potential generation
+requires a high sodium channel density in the axon initial
+segment. *Nature Neuroscience* 11:178-186, 2008.
+
+Komendantov, A. O. and Ascoli, G. A.. Dendritic excitability and
+neuronal morphology as determinants of synaptic efficacy. *Journal
+of Neurophysiology* 101:1847-1866, 2009.
+
+Konstantoudaki, X., Papoutsi, A., Chalkiadaki, K., Poirazi, P. and
+Sidiropoulou, K.. Modulatory effects of inhibition on persistent
+activity in a cortical microcircuit model. *Frontiers in Neural
+Circuits* 8:7, 10.3389/fncir.2014.00007, 2014.
+
+Koos, T., Tepper, J. M. and Wilson, C. J.. Comparison of IPSCs
+evoked by spiny and fast-spiking neurons in the neostriatum.
+*Journal of Neuroscience* 24:7916-7922, 2004.
+
+Kopell, N., Börgers, C., Pervouchine, D., Malerba, P. and Tort.,
+A.. Gamma and theta rhythms in biophysical models of hippocampal
+circuits. In: *Hippocampal Microcircuits*, edited by Cutsuridis,
+V., Graham, B., Cobb, S. and Vida, I.. Springer, 2010, pp.
+423-457.
+
+Kopp-Scheinpflug, C., Tozer, A. J. B., Robinson, S. W., Tempel, B.
+L., Hennig, M. H. and Forsythe, I. D.. The sound of silence: ionic
+mechanisms encoding sound termination. *Neuron* 71:911-925,
+10.1016/j.neuron.2011.06.028, 2011.
+
+Korngreen, A., Kaiser, K. M. and Zilberter, Y.. Subthreshold
+inactivation of voltage-gated K+ channels modulates action
+potentials in neocortical bitufted interneurones from rats.
+*Journal of Physiology* 562:421-437, 2005.
+
+Korogod, S. M. and Kulagina, I. B.. Conditions of dominant
+effectiveness of distal sites of active uniform dendrites with
+distributed tonic inputs. *Neurophysiology* 30:310-315, 1998a.
+
+Korogod, S. M. and Kulagina, I. B.. Geometry-induced features of
+current transfer in neuronal dendrites with tonically activated
+conductances. *Biological Cybernetics* 79:231-240, 1998b.
+
+Korogod, S. M., Kulagina, I. B., Horcholle-Bossavit, G., Gogan, P.
+and Tyc-Dumont, S.. Activity-dependent reconfiguration of the
+effective dendritic field of motoneurons. *Journal of Comparative
+Neurology* 422:18-34, 2000.
+
+Korogod, S. M., Kulagina, I. B., Kukushka, V. I., Gogan, P. and
+Tyc-Dumont, S.. Spatial reconfiguration of charge transfer
+effectiveness in active bistable dendritic arborizations.
+*European Journal of Neuroscience* 16:2260-2270, 2002.
+
+Korogod, S. M., Kulagina, I. B. and Tyc-Dumont, S.. Transfer
+properties of neuronal dendrites with tonically activated
+conductances. *Neurophysiology* 30:203-207, 1998.
+
+Korogod, S. M. and Chernetchenko, D. V.. Nature of electrical
+tristability in a neuron model with bistable asymmetrical
+dendrites. *Neurophysiology* 40:412-416, 2008.
+
+Korogod, S. M. and Demianenko, L. E.. Temperature deactivation of
+the depolarizing TRP current as a mechanism of hypothermia-related
+inhibition of neuronal activity: a model study. *Neurophysiology*
+48:324-331, 10.1007/s11062-017-9605-2, 2016.
+
+Korogod, S. M. and Kaspirzhny, A. V.. Spatial heterogeneity of
+passive electrical transfer properties of neuronal dendrites due
+to their metrical asymmetry. *Biological Cybernetics* 105:305-317,
+10.1007/s00422-011-0467-1, 2011.
+
+Korogod, S. M. and Kochenov, A. V.. Mathematical model of the
+calcium-dependent chloride current in a smooth muscle cell.
+*Neurophysiology* 45:369-378, 10.1007/s11062-013-9382-5, 2013.
+
+Korogod, S. M., Kochenov, A. V. and Makedonsky, I. A.. Biophysical
+mechanism of parasympathetic excitation of urinary bladder smooth
+muscle cells: a simulation study. *Neurophysiology* 46:293-299,
+10.1007/s11062-014-9447-0, 2014a.
+
+Korogod, S. M., Kulagina, I. B. and Kukoushka, V. I.. Impulse
+coding of electrical and synaptic input actions by nucl. abducens
+motoneurons with active dendrites: a simulation study.
+*Neurophysiology* 44:89-97, 10.1007/s11062-012-9274-0, 2012.
+
+Korogod, S. M., Maksymchuk, N. V., Demianenko, L. E., Vlasov, O.
+O. and Cymbalyuk, G. S.. Adverse modulation of the firing patterns
+of cold receptors by volatile anesthetics affecting activation of
+TRPM8 channels: a modeling study. *Neurophysiology* 52:324-333,
+10.1007/s11062-021-09889-2, 2020.
+
+Korogod, S. M. and Novorodovskaya, T. S.. Impact of geometrical
+characteristics of the organellar store and organelle-free cytosol
+on intracellular calcium dynamics in the dendrite: a simulation
+study. *Neurophysiology* 41:16-27, 10.1007/s11062-009-9072-5,
+2009.
+
+Korogod, S. M., Osorio, N., Kulagina, I. B. and Delmas, P..
+Dynamic excitation states and firing patterns are controlled by
+sodium channel kinetics in myenteric neurons: a simulation study.
+*Channels* 8:536-543, 10.4161/19336950.2014.973784, 2014b.
+
+Kosta, P., Iseri, E., Loizos, K., Paknahad, J., Pfeiffer, R. L.,
+Sigulinsky, C. L., Anderson, J. R., Jones, B. W. and Lazzi, G..
+Model-based comparison of current flow in rod bipolar cells of
+healthy and early-stage degenerated retina. *Experimental Eye
+Research* 207:108554, 10.1016/j.exer.2021.108554, 2021.
+
+Kosta, P., Loizos, K. and Lazzi, G.. Stimulus waveform design for
+decreasing charge and increasing stimulation selectivity in
+retinal prostheses. *Healthcare Technology Letters* 7:66-71,
+10.1049/htl.2019.0115, 2020a.
+
+Kosta, P., Mize, J., Warren, D. J. and Lazzi, G.. Simulation-based
+optimization of figure-of-eight coil designs and orientations for
+magnetic stimulation of peripheral nerve. *IEEE Transactions on
+Neural Systems and Rehabilitation Engineering* 28:2901-2913,
+10.1109/TNSRE.2020.3038406, 2020b.
+
+Kosta, P., Warren, D. J. and Lazzi, G.. Selective stimulation of
+rat sciatic nerve using an array of mm-size magnetic coils: a
+simulation study. *Healthcare Technology Letters* 6:70-75,
+10.1049/htl.2018.5020, 2019.
+
+Kourennyi, D. E., Liu, X.-D., Hart, J., Mahmud, F., Baldridge, W.
+H. and Barnes, S.. Reciprocal modulation of calcium dynamics at
+rod and cone photoreceptor synapses by nitric oxide. *Journal of
+Neurophysiology* 92:477-483, 2004.
+
+Koutsikou, S., Merrison-Hort, R., Buhl, E., Ferrario, A., Li,
+W.-C., Borisyuk, R., Soffe, S. R. and Roberts, A.. A simple
+decision to move in response to touch reveals basic sensory memory
+and mechanisms for variable response times. *Journal of
+Physiology* 596:6219-6233, 10.1113/JP276356, 2018.
+
+Koutsou, A., Bugmann, G. and Christodoulou, C.. On learning time
+delays between the spikes from different input neurons in a
+biophysical model of a pyramidal neuron. *Bioystems* 136:80-89,
+10.1016/j.biosystems.2015.08.005, 2015.
+
+Kovalsky, Y., Amir, R. and Devor, M.. Simulation in sensory
+neurons reveals a key role for delayed Na+ current in subthreshold
+oscillations and ectopic discharge: implications for neuropathic
+pain. *Journal of Neurophysiology* 102:1430-1442, 2009.
+
+Kovalsky, Y., Arnir, R. and Devor, M.. Subthreshold oscillations
+facilitate neuropathic spike discharge by overcoming membrane
+accommodation. *Experimental Neurology* 210:194-206, 2008.
+
+Krauthamer, V. and Crosheck, T.. Effects of high-rate electrical
+stimulation upon firing in modelled and real neurons. *Medical and
+Biological Engineering and Computing* 40:360-366, 2002.
+
+Kress, G. J., Dowling, M. J., Eisenman, L. N. and Mennerick, S..
+Axonal sodium channel distribution shapes the depolarized action
+potential threshold of dentate granule neurons. *Hippocampus*
+20:558-571, 10.1002/hipo.20667, 2010.
+
+Kretzberg, J., Kretschmer, F. and Marin-Burgin, A.. Effects of
+multiple spike-initiation zones in touch sensory cells of the
+leech. *Neurocomputing* 70:1645-1651, 2007.
+
+Krishnamurthy, P., Silberberg, G. and Lansner, A.. A cortical
+attractor network with Martinotti cells driven by facilitating
+synapses. *PLoS ONE* 7:e30752, 10.1371/journal.pone.0030752, 2012.
+
+Krishnamurthy, P., Silberberg, G. and Lansner, A.. Long-range
+recruitment of Martinotti cells causes surround suppression and
+promotes saliency in an attractor network model. *Frontiers in
+Neural Circuits* 9:60, 10.3389/fncir.2015.00060, 2015.
+
+Kronberg, G., Rahman, A., Sharma, M., Bikson, M. and Parra, L. C..
+Direct current stimulation boosts hebbian plasticity in vitro.
+*Brain Stimulation* 13:287-301, 10.1016/j.brs.2019.10.014, 2020.
+
+Krueppel, R., Remy, S. and Beck, H.. Dendritic integration in
+hippocampal dentate granule cells. *Neuron* 71:512-528,
+10.1016/j.neuron.2011.05.043, 2011.
+
+Kuba, H., Adachi, R. and Ohmori, H.. Activity-dependent and
+activity-independent development of the axon initial segment.
+*Journal of Neuroscience* 34:3443-3453,
+10.1523/JNEUROSCI.4357-13.2014, 2014.
+
+Kuba, H., Ishii, T. M. and Ohmori, H.. Axonal site of spike
+initiation enhances auditory coincidence detection. *Nature*
+444:1069-1072, 2006.
+
+Kuba, H. and Ohmori, H.. Roles of axonal sodium channels in
+precise auditory time coding at nucleus magnocellularis of the
+chick. *Journal of Physiology* 587:87-100, 2009.
+
+Kuba, H., Yamada, R., Ishiguro, G. and Adachi, R.. Redistribution
+of Kv1 and Kv7 enhances neuronal excitability during structural
+axon initial segment plasticity. *Nature Communications* 6:8815,
+10.1038/ncomms9815, 2015.
+
+Kubat Öktem, E., Mruk, K., Chang, J., Akin, A., Kobertz, W. R. and
+Brown, R. H.. Mutant SOD1 protein increases Nav1.3 channel
+excitability. *Journal of Biological Physics* 42:351-370,
+10.1007/s10867-016-9411-x, 2016.
+
+Kube, K., Herzog, A., Michaelis, B., de Lima, A. D. and Voigt, T..
+Spike-timing-dependent plasticity in small-world networks.
+*Neurocomputing* 71:1694-1704, 2008.
+
+Kubota, Y., Karube, F., Nomura, M., Gulledge, A. T., Mochizuki,
+A., Schertel, A. and Kawaguchi, Y.. Conserved properties of
+dendritic trees in four cortical interneuron subtypes. *Scientific
+Reports* 1:89, 10.1038/srep00089, 2011.
+
+Kubota, Y., Kondo, S., Nomura, M., Hatada, S., Yamaguchi, N.,
+Mohamed, A. A., Karube, F., Lübke, J. and Kawaguchi, Y..
+Functional effects of distinct innervation styles of pyramidal
+cells by fast spiking cortical interneurons. *eLife* 4:e07919,
+10.7554/eLife.07919, 2015.
+
+Kuck, A., Stegeman, D. F. and van Asseldonk, E. H. F.. Modeling
+trans-spinal direct current stimulation for the modulation of the
+lumbar spinal motor pathways. *Journal of Neural Engineering*
+14:056014, 10.1088/1741-2552/aa7960, 2017.
+
+Kuenzel, T., Borst, J. G. G. and van der Heijden, M.. Factors
+controlling the input-output relationship of spherical bushy cells
+in the gerbil cochlear nucleus. *Journal of Neuroscience*
+31:4260-4273, 10.1523/JNEUROSCI.5433-10.2011, 2011.
+
+Kuenzel, T., Nerlich, J., Wagner, H., Rübsamen, R. and Milenkovic,
+I.. Inhibitory properties underlying non-monotonic input-output
+relationship in low-frequency spherical bushy neurons of the
+gerbil. *Frontiers in Neural Circuits* 9:14,
+10.3389/fncir.2015.00014, 2015.
+
+Kuenzel, T., Wirth, M. J., Luksch, H., Wagner, H. and Mey, J..
+Increase of Kv3.1b expression in avian auditory brainstem neurons
+correlates with synaptogenesis in vivo and in vitro.. *Brain
+Research* 1302:64-75, 10.1016/j.brainres.2009.09.046, 2009.
+
+Kuhn, A., Keller, T., Lawrence, M. and Morari, M.. A model for
+transcutaneous current stimulation: simulations and experiments.
+*Medical and Biological Engineering and Computing* 47:279-289,
+2009.
+
+Kulagina, I. B.. Transfer properties of branching dendrites with
+tonically activated inputs. *Neurophysiology* 30:316-319, 1999.
+
+Kulagina, I. B.. Phase relationships between calcium and voltage
+oscillations in different dendrites of Purkinje neurons.
+*Neurophysiology* 40:404-411, 2008.
+
+Kulagina, I. B.. Impact of structural characteristics of
+reconstructed motoneurons on their excitability (a simulation
+study). *Neurophysiology* 41:116-121, 10.1007/s11062-009-9082-3,
+2009.
+
+Kulagina, I. B.. Electrical bistability of the motoneuronal
+dendritic membrane determined by non-inactivating inward currents:
+a model study. *Neurophysiology* 42:379-386, 2011.
+
+Kulagina, I. B.. Features of active electrical states of
+asymmetrical dendrites of brainstem motoneurons during generation
+of stochastic impulse patterns: a simulation study.
+*Neurophysiology* 44:1-6, 2012a.
+
+Kulagina, I. B.. Patterns of impulsation generated by abducens
+motoneurons with active reconstructed dendrites: a simulation
+study. *Neurophysiology* 43:335-343, 2012b.
+
+Kulagina, I. B. and Durand, J.. Comparative analysis of geometry
+and electrical properties of simulated normal and genetically
+modified motoneurons. *Neurophysiology* 43:217-222, 2011.
+
+Kulagina, I. B. and Korogod, S. M.. Dependence of transformation
+of intrinsic rhythmic impulse activity of neurons on
+spatio-temporal organization of synaptic actions on dendrites: a
+simulation study. *Neurophysiology* 43:425-431, 2012.
+
+Kulagina, I. B., Korogod, S. M., Horcholle-Bossavit, G., Batini,
+C. and Tyc-Dumont, S.. The electro-dynamics of the dendritic space
+in purkinje cells of the cerebellum. *Archives Italiennes de
+Biologie* 145:211-233, 2007.
+
+Kulagina, I. B., Kukushka, V. I. and Korogod, S. M..
+Structure-dependent electrical and concentration processes in the
+dendrites of pyramidal neurons of superficial neocortical layers:
+model study. *Neurophysiology* 43:77-89, 2011.
+
+Kulagina, I. B., Launey, T., Kukushka, V. I. and Korogod, S. M..
+Conversion of electrical and synaptic actions into impulse
+discharge patterns in purkinje neurons with active dendrites: a
+simulation study. *Neurophysiology* 44:187-200,
+10.1007/s11062-012-9286-9, 2012.
+
+Kulagina, I. B. and Myakoushko, V. A.. Influence of the state of
+TTX-resistant sodium channels on electrical activity of a
+nociceptive sensory fiber: a model study. *Neurophysiology*
+43:1-7, 2011.
+
+Kulagina, I. B., Myakoushko, V. A. and Korogod, S. M.. Remote
+modulation of current transfer from dendritic glutamatergic
+synapses by GABA-ergic synapses of the somatic zone of
+motoneurons: a simulation study. *Neurophysiology* 42:148-156,
+2010.
+
+Kumar, A. and Mehta, M. R.. Frequency-dependent changes in
+NMDAR-dependent synaptic plasticity. *Frontiers in Computational
+Neuroscience* 5:38, 10.3389/fncom.2011.00038, 2011.
+
+Kumar, A., Schiff, O., Barkai, E., Mel, B. W., Poleg-Polsky, A.
+and Schiller, J.. NMDA spikes mediate amplification of inputs in
+the rat piriform cortex. *eLife* 7:e38446, 10.7554/eLife.38446,
+2018.
+
+Kumar, S., Heidelberger, P., Chen, D. and Hines, M.. Optimization
+of applications with non-blocking neighborhood collectives via
+multisends on the Blue Gene/P supercomputer. *24th IEEE
+International Parallel and Distributed Processing Symposium*
+2010:1-11, 10.1109/IPDPS.2010.5470407, 2010.
+
+Kumaravelu, K., Oza, C. S., Behrend, C. E. and Grill, W. M..
+Model-based deconstruction of cortical evoked potentials generated
+by subthalamic nucleus deep brain stimulation. *Journal of
+Neurophysiology* 120:662-680, 10.1152/jn.00862.2017, 2018.
+
+Kumaravelu, K., Sombeck, J., Miller, L. E., Bensmaia, S. J. and
+Grill, W. M.. Stoney vs. Histed: quantifying the spatial effects
+of intracortical microstimulation. *Brain Stimulation* 15:141-151,
+10.1016/j.brs.2021.11.015, 2022.
+
+Kumaravelu, K., Tomlinson, T., Callier, T., Sombeck, J., Bensmaia,
+S. J., Miller, L. E. and Grill, W. M.. A comprehensive model-based
+framework for optimal design of biomimetic patterns of electrical
+stimulation for prosthetic sensation. *Journal of Neural
+Engineering* 17:046045, 10.1088/1741-2552/abacd8, 2020.
+
+Kumbhar, P., Hines, M., Fouriaux, J., Ovcharenko, A., King, J.,
+Delalondre, F. and Schürmann, F.. CoreNEURON: an optimized compute
+engine for the NEURON simulator. *Frontiers In Neuroinformatics*
+13:63, 10.3389/fninf.2019.00063, 2019a.
+
+Kumbhar, P., Hines, M., Ovcharenko, A., Mallon, D. A., King, J.,
+Sainz, F., Schürmann, F. and Delalondre, F.. Leveraging a
+cluster-booster architecture for brain-scale simulations [Online].
+*High Performance Computing: 31st International Conference*
+31:363-380, 10.1007/978-3-319-41321-1_19, 2016.
+
+Kumbhar, P. S., Sivagnanam, S., Yoshimoto, K., Hines, M.,
+Carnevale, T. and Majumdar, A.. Performance analysis of
+computational neuroscience software NEURON on Knights Corner many
+core processors [Online]. *Software Challenges to Exascale
+Computing* 2:67-76, 2019b.
+
+Kuncel, A. M., Birdno, M. J., Swan, B. D. and Grill, W. M.. Tremor
+reduction and modeled neural activity during cycling thalamic deep
+brain stimulation. *Clinical Neurophysiology* 123:1044-1052,
+10.1016/j.clinph.2011.07.052, 2012.
+
+Kuncel, A. M., Cooper, S. E., Wolgamuth, B. R. and Grill, W. M..
+Amplitude- and frequency-dependent changes in neuronal regularity
+parallel changes in tremor with thalamic deep brain stimulation.
+*IEEE Transactions on Neural Systems and Rehabilitation
+Engineering* 15:190-197, 2007.
+
+Kuo, J. J., Lee, R. H., Zhang, L. and Heckman, C. J.. Essential
+role of the persistent sodium current in spike initiation during
+slowly rising inputs in mouse spinal neurones. *Journal of
+Physiology* 574:819-834, 2006.
+
+Kuriyama, R., Casellato, C., D'Angelo, E. and Yamazaki, T..
+Real-time simulation of a cerebellar scaffold model on graphics
+processing units. *Frontiers in Cellular Neuroscience* 15:623552,
+10.3389/fncel.2021.623552, 2021.
+
+Kuznetsova, A. Y., Huertas, M. A., Kuznetsov, A. S., Paladini, C.
+A. and Canavier, C. C.. Regulation of firing frequency in a
+computational model of a midbrain dopaminergic neuron. *Journal of
+Computational Neuroscience* 28:389-403, 10.1007/s10827-010-0222-y,
+2010.
+
+Kwag, J., Jang, H. J., Kim, M. and Lee, S.. M-type potassium
+conductance controls the emergence of neural phase codes: a
+combined experimental and neuron modelling study. *Journal of the
+Royal Society Interface* 1110.1098/rsif.2014.0604, 2014.
+
+Kwon, T., Sakamoto, M., Peterka, D. S. and Yuste, R.. Attenuation
+of synaptic potentials in dendritic spines. *Cell Reports*
+20:1100-1110, 10.1016/j.celrep.2017.07.012, 2017.
+
+Labarrera, C., Deitcher, Y., Dudai, A., Weiner, B., Kaduri
+Amichai, A., Zylbermann, N. and London, M.. Adrenergic modulation
+regulates the dendritic excitability of layer 5 pyramidal neurons
+in vivo. *Cell Reports* 23:1034-1044,
+10.1016/j.celrep.2018.03.103, 2018.
+
+Labrakakis, C., Rudolph, U. and De Koninck, Y.. The heterogeneity
+in GABAA receptor-mediated IPSC kinetics reflects heterogeneity of
+subunit composition among inhibitory and excitatory interneurons
+in spinal lamina II. *Frontiers in Cellular Neuroscience* 8:424,
+10.3389/fncel.2014.00424, 2014.
+
+Lai, H. Y., Liao, L. D., Lin, C. T., Hsu, J. H., He, X., Chen, Y.
+Y., Chang, J. Y., Chen, H. F., Tsang, S. and Shih, Y. Y. I..
+Design, simulation and experimental validation of a novel flexible
+neural probe for deep brain stimulation and multichannel
+recording. *Journal of Neural Engineering* 9:036001,
+10.1088/1741-2560/9/3/036001, 2012.
+
+Laing, C. R., Doiron, B., Longtin, A., Noonan, L., Turner, R. W.
+and Maler, L.. Type I burst excitability. *Journal of
+Computational Neuroscience* 14:329-342, 2003.
+
+Lajeunesse, F., Kröger, H. and Timofeev, I.. Regulation of AMPA
+and NMDA receptor-mediated EPSPs in dendritic trees of
+thalamocortical cells. *Journal of Neurophysiology* 109:13-30,
+10.1152/jn.01090.2011, 2013.
+
+Lambert, R. C., Tuleau-Malot, C., Bessaih, T., Rivoirard, V.,
+Bouret, Y., Leresche, N. and Reynaud-Bouret, P.. Reconstructing
+the functional connectivity of multiple spike trains using Hawkes
+models. *Journal of Neuroscience Methods* 297:9-21,
+10.1016/j.jneumeth.2017.12.026, 2018.
+
+Larkum, M. E., Launey, T., Dityatev, A. and Lüscher, H.-R..
+Integration of excitatory postsynaptic potentials in dendrites of
+motoneurons of rat spinal cord slice cultures. *Journal of
+Neurophysiology* 80:924-935, 1998.
+
+Larkum, M. E., Watanabe, S., Lasser-Ross, N., Rhodes, P. and Ross,
+W. N.. Dendritic properties of turtle pyramidal neurons. *Journal
+of Neurophysiology* 99:683-694, 2008.
+
+Larkum, M. E., Nevian, T., Sandler, M., Polsky, A. and Schiller,
+J.. Synaptic integration in tuft dendrites of layer 5 pyramidal
+neurons: a new unifying principle.. *Science* 325:756-760,
+10.1126/science.1171958, 2009.
+
+Lasiene, J., Shupe, L., Perlmutter, S. and Horner, P.. No evidence
+for chronic demyelination in spared axons after spinal cord injury
+in a mouse. *Journal of Neuroscience* 28:3887-3896, 2008.
+
+Latimer, B., Bergin, D., Guntu, V., Schulz, D. and Nair, S.. Open
+source software tools for teaching neuroscience. *Journal of
+Undergraduate Neuroscience Education* 16:A197-A202, 2018.
+
+Latimer, B., Bergin, D., Guntu, V., Schulz, D. and Nair, S..
+Integrating model-based approaches into a neuroscience
+curriculum—an interdisciplinary neuroscience course in
+engineering. *IEEE Transactions on Education* 62:48-56,
+10.1109/TE.2018.2859411, 2019.
+
+Latorre, M. A. and Wårdell, K.. A comparison between single and
+double cable neuron models applicable to deep brain stimulation.
+*Biomedical Physics & Engineering Express* 5:025026,
+10.1088/2057-1976/aafdd9, 2019.
+
+Laudanski, J., Torben-Nielsen, B., Segev, I. and Shamma, S..
+Spatially distributed dendritic resonance selectively filters
+synaptic input. *PLoS Computational Biology* 10:e1003775,
+10.1371/journal.pcbi.1003775, 2014.
+
+Lavian, H. and Korngreen, A.. Inhibitory short-term plasticity
+modulates neuronal activity in the rat entopeduncular nucleus in
+vitro. *European Journal of Neuroscience* 43:870-884,
+10.1111/ejn.12965, 2016.
+
+Lavzin, M., Rapoport, S., Polsky, A., Garion, L. and Schiller, J..
+Nonlinear dendritic processing determines angular tuning of barrel
+cortex neurons in vivo. *Nature* 490:397-401, 10.1038/nature11451,
+2012.
+
+Law, R. G., Pugliese, S., Shin, H., Sliva, D. D., Lee, S.,
+Neymotin, S., Moore, C. and Jones, S. R.. Thalamocortical
+mechanisms regulating the relationship between transient beta
+events and human tactile perception. *Cerebral Cortex* 32:668-688,
+10.1093/cercor/bhab221, 2022.
+
+Lawrence, J. J., Saraga, F., Churchill, J. F., Statland, J. M.,
+Travis, K. E., Skinner, F. K. and McBain, C. J.. Somatodendritic
+Kv7-KCNQ-M channels control interspike interval in hippocampal
+interneurons. *Journal of Neuroscience* 26:12325-12338, 2006.
+
+Lazarewicz, M. T., Boer-Iwema, S. and Ascoli, G. A.. Practical
+aspects in anatomically accurate simulations of neuronal
+electrophysiology. In: *Computational Neuroanatomy: Principles and
+Methods*, edited by Ascoli, G. A.. Totowa, NJ: Totowa, NJ, Humana
+Press, 2002a, pp. 127-148.
+
+Lazarewicz, M. T., Migliore, M. and Ascoli, G. A.. A new bursting
+model of CA3 pyramidal cell physiology suggests multiple locations
+for spike initiation. *Biosystems* 67:129-137, 2002b.
+
+Lazarewicz, M. T., Das, S. and Finkel, L. H.. Recognition of
+temporal event sequences by a network of cortical neurons.
+*Neurocomputing* 65:143-151, 2005.
+
+Le Franc, Y. and Le Masson, G.. Multiple firing patterns in deep
+dorsal horn neurons of the spinal cord: computational analysis of
+mechanisms and functional implications. *Journal of
+Neurophysiology* 104:1978-1996, 10.1152/jn.00919.2009, 2010.
+
+Le Masson, G., Przedborski, S. and Abbott, L. F.. A computational
+model of motor neuron degeneration. *Neuron* 83:975-988,
+10.1016/j.neuron.2014.07.001, 2014.
+
+Le Ray, D., De Sevilla, D. F., Porto, A. B., Fuenzalida, M. and
+Buno, W.. Heterosynaptic metaplastic regulation of synaptic
+efficacy in CA1 pyramidal neurons of rat hippocampus.
+*Hippocampus* 14:1011-1025, 2004.
+
+Leão, R. M., Kushmerick, C., Pinaud, R., Renden, R., Li, G. L.,
+Taschenberger, H., Spirou, G., Levinson, S. R. and von Gersdorff,
+H.. Presynaptic Na+ channels: locus, development, and recovery
+from inactivation at a high-fidelity synapse. *Journal of
+Neuroscience* 25:3724-3738, 2005.
+
+Leão, R. N., Leão, R. M., da Costa, L. F., Levinson, S. R. and
+Walmsley, B.. A novel role for MNTB neuron dendrites in regulating
+action potential amplitude and cell excitability during repetitive
+firing. *European Journal of Neuroscience* 27:3095-3108, 2008.
+
+Leblois, A., Bodor, A. L., Person, A. L. and Perkel, D. J..
+Millisecond timescale disinhibition mediates fast information
+transmission through an avian basal ganglia loop.. *Journal of
+Neuroscience* 29:15420-15433, 10.1523/JNEUROSCI.3060-09.2009,
+2009.
+
+Lee, D., Hershey, B., Bradley, K. and Yearwood, T.. Predicted
+effects of pulse width programming in spinal cord stimulation: a
+mathematical modeling study. *Medical and Biological Engineering
+and Computing* 49:765-774, 10.1007/s11517-011-0780-9, 2011a.
+
+Lee, D. C., Jensen, A. L., Schiefer, M. A., Morgan, C. W. and
+Grill, W. M.. Structural mechanisms to produce differential
+dendritic gains. *Brain Research* 1033:117-127, 2005.
+
+Lee, G., Matsunaga, A., Dura-Bernal, S., Zhang, W., Lytton, W. W.,
+Francis, J. T. and Fortes, J. A. B.. Towards real-time
+communication between in vivo neurophysiological data sources and
+simulator-based brain biomimetic models. *Journal of Computational
+Surgery* 3:1-23, 10.1186/s40244-014-0012-3, 2014a.
+
+Lee, H.-M., Howell, B., Grill, W. M. and Ghovanloo, M..
+Stimulation efficiency with decaying exponential waveforms in a
+wirelessly powered switched-capacitor discharge stimulation
+system. *IEEE Transactions on Bio-Medical Engineering*
+65:1095-1106, 10.1109/TBME.2017.2741107, 2018.
+
+Lee, K. H., Hitti, F. L., Chang, S.-Y., Lee, D. C., Roberts, D.
+W., McIntyre, C. C. and Leiter, J. C.. High frequency stimulation
+abolishes thalamic network oscillations: an electrophysiological
+and computational analysis. *Journal of Neural Engineering*
+8:046001, 10.1088/1741-2560/8/4/046001, 2011b.
+
+Lee, S. C., Hayashida, Y. and Ishida, A. T.. Availability of
+low-threshold Ca2+ current in retinal ganglion cells. *Journal of
+Neurophysiology* 90:3888-3901, 2003.
+
+Lee, S. and Jones, S. R.. Distinguishing mechanisms of gamma
+frequency oscillations in human current source signals using a
+computational model of a laminar neocortical network. *Frontiers
+in Human Neuroscience* 7:869, 2013.
+
+Lee, S.-H., Marchionni, I., Bezaire, M., Varga, C., Danielson, N.,
+Lovett-Barron, M., Losonczy, A. and Soltesz, I..
+Parvalbumin-positive basket cells differentiate among hippocampal
+pyramidal cells. *Neuron* 82:1129-1144,
+10.1016/j.neuron.2014.03.034, 2014b.
+
+Lee, S.-J. and Bai, S.-H.. The effects of low chloride fluids on
+light responses of the catfish retinal neurons. *Neurocomputing*
+44:25-32, 2002.
+
+Lee, T. P. and Buonomano, D. V.. Unsupervised formation of
+vocalization-sensitive neurons: a cortical model based on
+short-term and homeostatic plasticity. *Neural Computation*
+24:2579-2603, 10.1162/NECO_a_00345, 2012.
+
+Lefler, Y., Amsalem, O., Vrieler, N., Segev, I. and Yarom, Y..
+Using subthreshold events to characterize the functional
+architecture of the electrically coupled inferior olive network.
+*eLife* 910.7554/eLife.43560, 2020.
+
+Lehto, L. J., Slopsema, J. P., Johnson, M. D., Shatillo, A.,
+Teplitzky, B. A., Utecht, L., Adriany, G., Mangia, S., Sierra, A.,
+Low, W. C., Gröhn, O. and Michaeli, S.. Orientation selective deep
+brain stimulation. *Journal of Neural Engineering* 14:016016,
+10.1088/1741-2552/aa5238, 2017.
+
+Lei, C.-L., Kellard, J. A., Hara, M., Johnson, J. D., Rodriguez,
+B. and Briant, L. J. B.. Beta-cell hubs maintain Ca2+ oscillations
+in human and mouse islet simulations. *Islets* 10:151-167,
+10.1080/19382014.2018.1493316, 2018.
+
+Leleo, E. G. and Segev, I.. Burst control: Synaptic conditions for
+burst generation in cortical layer 5 pyramidal neurons. *PLoS
+Computational Biology* 17:e1009558, 10.1371/journal.pcbi.1009558,
+2021.
+
+Lemaire, T., Neufeld, E., Kuster, N. and Micera, S.. Understanding
+ultrasound neuromodulation using a computationally efficient and
+interpretable model of intramembrane cavitation. *Journal of
+Neural Engineering* 16:046007, 10.1088/1741-2552/ab1685, 2019.
+
+Lemaire, T., Vicari, E., Neufeld, E., Kuster, N. and Micera, S..
+MorphoSONIC: a morphologically structured intramembrane cavitation
+model reveals fiber-specific neuromodulation by ultrasound.
+*iScience* 24:103085, 10.1016/j.isci.2021.103085, 2021.
+
+Lempka, S. F., Howell, B., Gunalan, K., Machado, A. G. and
+McIntyre, C. C.. Characterization of the stimulus waveforms
+generated by implantable pulse generators for deep brain
+stimulation. *Clinical Neurophysiology* 129:731-742,
+10.1016/j.clinph.2018.01.015, 2018.
+
+Lempka, S. F., Johnson, M. D., Moffitt, M. A., Otto, K. J., Kipke,
+D. R. and McIntyre, C. C.. Theoretical analysis of intracortical
+microelectrode recordings. *Journal of Neural Engineering*
+8:045006, 10.1088/1741-2560/8/4/045006, 2011.
+
+Lempka, S. F. and McIntyre, C. C.. Theoretical analysis of the
+local field potential in deep brain stimulation applications.
+*PLoS ONE* 8:e59839, 10.1371/journal.pone.0059839, 2013.
+
+Lempka, S. F., McIntyre, C. C., Kilgore, K. L. and Machado, A. G..
+Computational analysis of kilohertz frequency spinal cord
+stimulation for chronic pain management.. *Anesthesiology*
+122:1362-1376, 10.1097/ALN.0000000000000649, 2015.
+
+Lempka, S. F., Zander, H. J., Anaya, C. J., Wyant, A., Ozinga, J.
+G. and Machado, A. G.. Patient-specific analysis of neural
+activation during spinal cord stimulation for pain.
+*Neuromodulation* 23:572-581, 10.1111/ner.13037, 2020.
+
+Lenz, M., Platschek, S., Priesemann, V., Becker, D., Willems, L.
+M., Ziemann, U., Deller, T., Müller-Dahlhaus, F., Jedlicka, P. and
+Vlachos, A.. Repetitive magnetic stimulation induces plasticity of
+excitatory postsynapses on proximal dendrites of cultured mouse
+CA1 pyramidal neurons. *Brain Structure and Function*
+220:3323-3337, 10.1007/s00429-014-0859-9, 2015.
+
+Letzkus, J. J., Kampa, B. M. and Stuart, G. J.. Learning rules for
+spike timing-dependent plasticity depend on dendritic synapse
+location. *Journal of Neuroscience* 26:10420-10429, 2006.
+
+Leys, S. P., Mackie, G. O. and Meech, R. W.. Impulse conduction in
+a sponge. *Journal of Experimental Biology* 202:1139-1150, 1999.
+
+Lezmy, J., Lipinsky, M., Khrapunsky, Y., Patrich, E., Shalom, L.,
+Peretz, A., Fleidervish, I. A. and Attali, B.. M-current
+inhibition rapidly induces a unique CK2-dependent plasticity of
+the axon initial segment. *Proceedings of the National Academy of
+Sciences of the United States of America* 114:E10234-E10243,
+10.1073/pnas.1708700114, 2017.
+
+Li, C. and Gulledge, A. T.. NMDA receptors enhance the fidelity of
+synaptic integration. *eNeuro* 10.1523/ENEURO.0396-20.2020, 2021.
+
+Li, G. and Cleland, T. A.. A two-layer biophysical model of
+cholinergic neuromodulation in olfactory bulb. *Journal of
+Neuroscience* 33:3037-3058, 10.1523/JNEUROSCI.2831-12.2013, 2013.
+
+Li, G. and Cleland, T. A.. A coupled-oscillator model of olfactory
+bulb gamma oscillations. *PLoS Computational Biology* 13:e1005760,
+10.1371/journal.pcbi.1005760, 2017.
+
+Li, G., Linster, C. and Cleland, T. A.. Functional differentiation
+of cholinergic and noradrenergic modulation in a biophysical model
+of olfactory bulb granule cells. *Journal of Neurophysiology*
+114:3177-3200, 10.1152/jn.00324.2015, 2015a.
+
+Li, M. R. and Greenside, H.. Stable propagation of a burst through
+a one-dimensional homogeneous excitatory chain model of songbird
+nucleus HVC. *Physical Review E* 74:011918, 2006.
+
+Li, M. H., Yan, Y., Wang, Q. X., Zhao, H. H., Chai, X. Y., Sui, X.
+H., Ren, Q. S. and Li, L. M.. A simulation of current focusing and
+steering with penetrating optic nerve electrodes. *Journal of
+Neural Engineering* 10:066007, 10.1088/1741-2560/10/6/066007,
+2013a.
+
+Li, S., Liu, N., Yao, L., Zhang, X., Zhou, D. and Cai, D..
+Determination of effective synaptic conductances using somatic
+voltage clamp. *PLoS Computational Biology* 15:e1006871,
+10.1371/journal.pcbi.1006871, 2019a.
+
+Li, S., Liu, N., Zhang, X., McLaughlin, D. W., Zhou, D. and Cai,
+D.. Dendritic computations captured by an effective point neuron
+model. *Proceedings of the National Academy of Sciences of the
+United States of America* 116:15244-15252,
+10.1073/pnas.1904463116, 2019b.
+
+Li, S., Liu, N., Zhang, X.-H., Zhou, D. and Cai, D.. Bilinearity
+in spatiotemporal integration of synaptic inputs. *PLoS
+Computational Biology* 10:e1004014, 10.1371/journal.pcbi.1004014,
+2014.
+
+Li, S., McLaughlin, D. W. and Zhou, D.. Mathematical modeling and
+analysis of spatial neuron dynamics: dendritic integration and
+beyond. *Communications on Pure and Applied Mathematics*
+10.1002/cpa.22020, 2021.
+
+Li, S., Xu, J., Chen, G., Lin, L., Zhou, D. and Cai, D.. The
+characterization of hippocampal theta-driving neurons - a
+time-delayed mutual information approach. *Scientific Reports*
+7:5637, 10.1038/s41598-017-05527-2, 2017a.
+
+Li, S., Zhou, D. and Cai, D.. Analysis of the dendritic
+integration of excitatory and inhibitory inputs using cable
+models. *Communications In Mathematical Sciences* 13:565-575,
+2015b.
+
+Li, X. and Ascoli, G. A.. Computational simulation of the
+input-output relationship in hippocampal pyramidal cells. *Journal
+of Computational Neuroscience* 21:191-209, 2006.
+
+Li, X. and Holmes, W. R.. Biophysical attributes that affect
+CaMKII activation deduced with a novel spatial stochastic
+simulation approach. *PLoS Computational Biology* 14:e1005946,
+10.1371/journal.pcbi.1005946, 2018.
+
+Li, X., Morita, K., Robinson, H. P. C. and Small, M.. Impact of
+gamma-oscillatory inhibition on the signal transmission of a
+cortical pyramidal neuron. *Cognitive Neurodynamics* 5:241-251,
+10.1007/s11571-011-9169-6, 2011.
+
+Li, X., Morita, K., Robinson, H. P. C. and Small, M.. Control of
+layer 5 pyramidal cell spiking by oscillatory inhibition in the
+distal apical dendrites: a computational modeling study. *Journal
+of Neurophysiology* 109:2739-2756, 10.1152/jn.00397.2012, 2013b.
+
+Li, X., Xu, Q. and He, J.. Spike propagation in axons under
+stretch growth conditions in cultured neurons from dorsal root
+ganglion. *Journal of Integrative Neuroscience* 16:177-187,
+10.3233/JIN-170007, 2017b.
+
+Li, X. S. and Ascoli, G. A.. Effects of synaptic synchrony on the
+neuronal input-output relationship. *Neural Computation*
+20:1717-1731, 2008.
+
+Li, Y., Xu, J., Liu, Y., Zhu, J., Liu, N., Zeng, W., Huang, N.,
+Rasch, M. J., Jiang, H., Gu, X., Li, X., Luo, M., Li, C., Teng,
+J., Chen, J., Zeng, S., Lin, L. and Zhang, X.. A distinct
+entorhinal cortex to hippocampal CA1 direct circuit for olfactory
+associative learning. *Nature Neuroscience* 20:559-570,
+10.1038/nn.4517, 2017c.
+
+Liebmann, L., Karst, H., Sidiropoulou, K., van Gemert, N., Meijer,
+O. C., Poirazi, P. and Joëls, M.. Differential effects of
+corticosterone on the slow afterhyperpolarization in the
+basolateral amygdala and CA1 region: possible role of calcium
+channel subunits. *Journal of Neurophysiology* 99:958-968, 2008.
+
+Lin, X. and Hant, J.. Computer-simulation studies on roles of
+potassium currents in neurotransmission of the auditory nerve.
+*Hearing Research* 152:90-99, 2001.
+
+Lin, Z., Lin, Y., Schorge, S., Pan, J. Q., Beierlein, M. and
+Lipscombe, D.. Alternative splicing of a short cassette exon in
+a1B generates functionally distinct N-type calcium channels in
+central and peripheral neurons. *Journal of Neuroscience*
+19:5322-5331, 1999.
+
+Lin, Z., Tropper, C., Mcdougal, R. A., Patoary, M. N. I., Lytton,
+W. W., Yao, Y. and Hines, M. L.. Multithreaded stochastic PDEs for
+reactions and diffusions in neurons. *ACM Transactions on Modeling
+and Computer Simulation* 2710.1145/2987373, 2017a.
+
+Lin, Z., Tropper, C., Yao, Y., Mcdougal, R. A., Ishlam Patoary, M.
+N., Lytton, W. W. and Hines, M. L.. Load balancing for
+multi-threaded PDES of stochastic reaction-diffusion in neurons.
+*Journal of Simulation* 11:267-284, 10.1057/s41273-016-0033-x,
+2017b.
+
+Linaro, D., Bizzarri, F., Brambilla, A., Granato, A. and
+Giugliano, M.. Modelling the effects of early exposure to alcohol
+on the excitability of cortical neurons [Online]. *2020 IEEE
+International Symposium on Circuits and Systems (ISCAS)*,
+10.1109/iscas45731.2020.9180633, 2020.
+
+Linaro, D., Storace, M. and Giugliano, M.. Accurate and fast
+simulation of channel noise in conductance-based model neurons by
+diffusion approximation. *PLoS Computational Biology* 7:e1001102,
+10.1371/journal.pcbi.1001102, 2011.
+
+Lindén, H., Hagen, E., Łęski, S., Norheim, E. S., Pettersen, K. H.
+and Einevoll, G. T.. LFPy: a tool for biophysical simulation of
+extracellular potentials generated by detailed model neurons.
+*Frontiers In Neuroinformatics* 7:41, 10.3389/fninf.2013.00041,
+2013.
+
+Lindén, H., Pettersen, K. H. and Einevoll, G. T.. Intrinsic
+dendritic filtering gives low-pass power spectra of local field
+potentials. *Journal of Computational Neuroscience* 29:423-444,
+10.1007/s10827-010-0245-4, 2010.
+
+Lindén, H., Tetzlaff, T., Potjans, T. C., Pettersen, K. H., Gruen,
+S., Diesmann, M. and Einevoll, G. T.. Modeling the spatial reach
+of the LFP. *Neuron* 72:859-872, 10.1016/j.neuron.2011.11.006,
+2011.
+
+Lindgren, C. A. and Moore, J. W.. Identification of ionic currents
+at presynaptic nerve endings of the lizard. *Journal of
+Physiology* 414:201-222, 1989.
+
+Lindroos, R., Dorst, M. C., Du, K., Filipović, M., Keller, D.,
+Ketzef, M., Kozlov, A. K., Kumar, A., Lindahl, M., Nair, A. G.,
+Pérez-Fernández, J., Grillner, S., Silberberg, G. and Hellgren
+Kotaleski, J.. Basal ganglia neuromodulation over multiple
+temporal and structural scales-simulations of direct pathway MSNs
+investigate the fast onset of dopaminergic effects and predict the
+role of Kv4.2. *Frontiers in Neural Circuits* 12:3,
+10.3389/fncir.2018.00003, 2018.
+
+Lindroos, R. and Hellgren Kotaleski, J.. Predicting complex spikes
+in striatal projection neurons of the direct pathway following
+neuromodulation by acetylcholine and dopamine. *European Journal
+of Neuroscience* 10.1111/ejn.14891, 2020.
+
+Lindsay, A. E., Lindsay, K. A. and Rosenberg, J. R.. Increased
+computational accuracy in multi-compartmental cable models by a
+novel approach for precise point process localization. *Journal of
+Computational Neuroscience* 19:21-38, 2005.
+
+Lipowsky, R., Gillessen, T. and Alzheimer, C.. Dendritic Na+
+channels amplify EPSPs in hippocampal CA1 pyramidal cells.
+*Journal of Neurophysiology* 76:2181-2191, 1996.
+
+Liu, B.-h., Li, P., Sun, Y. J., Li, Y.-t., Zhang, L. I. and Tao,
+H. W.. Intervening inhibition underlies simple-cell receptive
+field structure in visual cortex. *Nature Neuroscience* 13:89-96,
+10.1038/nn.2443, 2010a.
+
+Liu, C., Li, Q., Su, Y. and Bao, L.. Prostaglandin E-2 promotes
+Na(V)1.8 trafficking via its intracellular RRR motif through the
+protein kinase A pathway. *Traffic* 11:405-417,
+10.1111/j.1600-0854.2009.01027.x, 2010b.
+
+Liu, C. Y., Xiao, C., Fraser, S. E., Lester, H. A. and Koos, D.
+S.. Electrophysiological characterization of Grueneberg ganglion
+olfactory neurons: spontaneous firing, sodium conductance, and
+hyperpolarization-activated currents. *Journal of Neurophysiology*
+108:1318-1334, 10.1152/jn.00907.2011, 2012.
+
+Liu, J., Ogden, A., Comery, T. A., Spiros, A., Roberts, P. and
+Geerts, H.. Prediction of efficacy of vabicaserin, a 5-HT2C
+agonist, for the treatment of schizophrenia using a quantitative
+systems pharmacology model. *CPT Pharmacometrics and Systems
+Pharmacology* 3:e111, 10.1038/psp.2014.7, 2014.
+
+Liu, J. K.. Learning rule of homeostatic synaptic scaling:
+presynaptic dependent or not. *Neural Computation* 23:3145-3161,
+2011.
+
+Liu, J. K. and Buonomano, D. V.. Embedding multiple trajectories
+in simulated recurrent neural networks in a self-organizing
+manner.. *Journal of Neuroscience* 29:13172-13181,
+10.1523/JNEUROSCI.2358-09.2009, 2009.
+
+Liu, N., Yang, Y., Ge, L., Liu, M., Colecraft, H. M. and Liu, X..
+Cooperative and acute inhibition by multiple C-terminal motifs of
+L-type Ca(2+) channels. *eLife* 6:e21989, 10.7554/eLife.21989,
+2017.
+
+Liu, S. and Zheng, P.. Altered PKA modulation in the Na(v)1.1
+epilepsy variant I1656M. *Journal of Neurophysiology*
+110:2090-2098, 10.1152/jn.00921.2012, 2013.
+
+Liu, Z., Kimura, Y., Higashijima, S.-I., Hildebrand, D. G. C.,
+Morgan, J. L. and Bagnall, M. W.. Central vestibular tuning arises
+from patterned convergence of otolith afferents. *Neuron*
+108:748-762.e4, 10.1016/j.neuron.2020.08.019, 2020.
+
+Liu, Z., Ren, J. H. and Murphy, T. H.. Decoding of synaptic
+voltage waveforms by specific classes of recombinant
+high-threshold Ca2+ channels. *Journal of Physiology* 553:473-488,
+2003.
+
+Llorens, V. C. and Fransén, E.. Intrinsic desynchronization
+properties of neurons containing dendritic rapidly activating
+K-currents. *Neurocomputing* 58-60:137-143, 2004.
+
+Loizos, K., Cela, C., Marc, R. and Lazzi, G.. Virtual electrode
+design for increasing spatial resolution in retinal prosthesis.
+*Healthcare Technology Letters* 3:93-97, 10.1049/htl.2015.0043,
+2016a.
+
+Loizos, K., Lazzi, G., Lauritzen, J. S., Anderson, J., Jones, B.
+W. and Marc, R.. A multi-scale computational model for the study
+of retinal prosthetic stimulation. *IEEE Engineering in Medicine
+and Biology Society. Annual Conference* 2014:6100-6103,
+10.1109/EMBC.2014.6945021, 2014.
+
+Loizos, K., Marc, R., Humayun, M., Anderson, J. R., Jones, B. W.
+and Lazzi, G.. Increasing electrical stimulation efficacy in
+degenerated retina: stimulus waveform design in a multiscale
+computational model. *IEEE Transactions on Neural Systems and
+Rehabilitation Engineering* 26:1111-1120,
+10.1109/TNSRE.2018.2832055, 2018.
+
+Loizos, K., RamRakhyani, A. K., Anderson, J., Marc, R. and Lazzi,
+G.. On the computation of a retina resistivity profile for
+applications in multi-scale modeling of electrical stimulation and
+absorption. *Physics in Medicine and Biology* 61:4491-4505,
+10.1088/0031-9155/61/12/4491, 2016b.
+
+Lombardi, A., Jedlicka, P., Luhmann, H. J. and Kilb, W.. Giant
+depolarizing potentials trigger transient changes in the
+intracellular Cl- concentration in CA3 pyramidal neurons of the
+immature mouse hippocampus. *Frontiers in Cellular Neuroscience*
+12:420, 10.3389/fncel.2018.00420, 2018.
+
+Lombardi, A., Jedlicka, P., Luhmann, H. J. and Kilb, W..
+Interactions between membrane resistance, GABA-A receptor
+properties, bicarbonate dynamics and Cl- transport shape
+activity-dependent changes of intracellular Cl- concentration.
+*International Journal of Molecular Sciences*
+2010.3390/ijms20061416, 2019.
+
+Lombardi, A., Jedlicka, P., Luhmann, H. J. and Kilb, W..
+Coincident glutamatergic depolarizations enhance GABAA
+receptor-dependent Cl- influx in mature and suppress Cl- efflux in
+immature neurons. *PLoS Computational Biology* 17:e1008573,
+10.1371/journal.pcbi.1008573, 2021a.
+
+Lombardi, A., Luhmann, H. J. and Kilb, W.. Modelling the spatial
+and temporal constrains of the GABAergic influence on neuronal
+excitability. *PLoS Computational Biology* 17:e1009199,
+10.1371/journal.pcbi.1009199, 2021b.
+
+Lombardo, J. and Harrington, M. A.. Nonreciprocal mechanisms in
+up- and downregulation of spinal motoneuron excitability by
+modulators of KCNQ/Kv7 channels. *Journal of Neurophysiology*
+116:2114-2124, 10.1152/jn.00446.2016, 2016.
+
+Lonardoni, D., Amin, H., Di Marco, S., Maccione, A., Berdondini,
+L. and Nieus, T.. Recurrently connected and localized neuronal
+communities initiate coordinated spontaneous activity in neuronal
+networks. *PLoS Computational Biology* 13:e1005672,
+10.1371/journal.pcbi.1005672, 2017.
+
+London, M., Meunier, C. and Segev, I.. Signal transfer in passive
+dendrites with nonuniform membrane conductance. *Journal of
+Neuroscience* 19:8219-8233, 1999.
+
+London, M., Roth, A., Beeren, L., Haeusser, M. and Latham, P. E..
+Sensitivity to perturbations in vivo implies high noise and
+suggests rate coding in cortex. *Nature* 466:123-127,
+10.1038/nature09086, 2010.
+
+London, M., Schreibman, A., Häusser, M., Larkum, M. E. and Segev,
+I.. The information efficacy of a synapse. *Nature Neuroscience*
+5:332-340, 2002.
+
+London, M. and Segev, I.. Synaptic scaling in vitro and in vivo.
+*Nature Neuroscience* 4:853-854, 2001.
+
+López-Jury, L., Meza, R. C., Brown, M. T. C., Henny, P. and
+Canavier, C. C.. Morphological and biophysical determinants of the
+intracellular and extracellular waveforms in nigral dopaminergic
+neurons: a computational study. *Journal of Neuroscience*
+38:8295-8310, 10.1523/JNEUROSCI.0651-18.2018, 2018.
+
+Lopreore, C. L., Bartol, T. M., Coggan, J. S., Keller, D. X.,
+Sosinsky, G. E., Ellisman, M. H. and Sejnowski, T. J..
+Computational modeling of three-dimensional electrodiffusion in
+biological systems: application to the node of Ranvier.
+*Biophysical Journal* 95:2624-2635, 2008.
+
+Lorenzo, J., Vuillaume, R., Binczak, S. and Jacquir, S..
+Identification of synaptic integration mode in CA3 pyramidal
+neuron model [Online]. *2019 9th International IEEE/EMBS
+Conference on Neural Engineering*, 10.1109/ner.2019.8717136, 2019.
+
+Losavio, B. E., Liang, Y., Santamaria-Pang, A., Kakadiaris, I. A.,
+Colbert, C. M. and Saggau, P.. Live neuron morphology
+automatically reconstructed from multiphoton and confocal imaging
+data. *Journal of Neurophysiology* 100:2422-2429, 2008.
+
+Lovelace, J. J. and Cios, K. J.. A very simple spiking neuron
+model that allows for modeling of large, complex systems. *Neural
+Computation* 20:65-90, 2008.
+
+Lowe, G.. Inhibition of backpropagating action potentials in
+mitral cell secondary dendrites. *Journal of Neurophysiology*
+88:64-85, 2002.
+
+Lu, A. C., Lee, C. K., Kleiman-Weiner, M., Truong, B., Wang, M.,
+Huguenard, J. R. and Beenhakker, M. P.. Nonlinearities between
+inhibition and T-type calcium channel activity bidirectionally
+regulate thalamic oscillations. *eLife* 910.7554/eLife.59548,
+2020.
+
+Lu, H., Chestek, C. A., Shaw, K. M. and Chiel, H. J.. Selective
+extracellular stimulation of individual neurons in ganglia.
+*Journal of Neural Engineering* 5:287-309, 2008.
+
+Lu, T., Wade, K., Hong, H. and Sanchez, J. T.. Ion channel
+mechanisms underlying frequency-firing patterns of the avian
+nucleus magnocellularis: a computational model. *Channels*
+11:444-458, 10.1080/19336950.2017.1327493, 2017.
+
+Lubba, C. H., Le Guen, Y., Jarvis, S., Jones, N. S., Cork, S. C.,
+Eftekhar, A. and Schultz, S. R.. PyPNS: multiscale simulation of a
+peripheral nerve in Python. *Neuroinformatics* 17:63-81,
+10.1007/s12021-018-9383-z, 2018.
+
+Luebke, J. I., Medalla, M., Amatrudo, J. M., Weaver, C. M.,
+Crimins, J. L., Hunt, B., Hof, P. R. and Peters, A.. Age-related
+changes to layer 3 pyramidal cells in the rhesus monkey visual
+cortex. *Cerebral Cortex* 25:1454-1468, 10.1093/cercor/bht336,
+2015.
+
+Luebke, J. I., Weaver, C. M., Rocher, A. B., Rodriguez, A.,
+Crimins, J. L., Dickstein, D. L., Wearne, S. L. and Hof, P. R..
+Dendritic vulnerability in neurodegenerative disease: insights
+from analyses of cortical pyramidal neurons in transgenic mouse
+models. *Brain Structure and Function* 214:181-199,
+10.1007/s00429-010-0244-2, 2010.
+
+Lujan, B., Kushmerick, C., Banerjee, T. D., Dagda, R. K. and
+Renden, R.. Glycolysis selectively shapes the presynaptic action
+potential waveform. *Journal of Neurophysiology* 116:2523-2540,
+10.1152/jn.00629.2016, 2016.
+
+Luján, J. L., Chaturvedi, A., Malone, D. A., Rezai, A. R.,
+Machado, A. G. and McIntyre, C. C.. Axonal pathways linked to
+therapeutic and nontherapeutic outcomes during psychiatric deep
+brain stimulation. *Human Brain Mapping* 33:958-968,
+10.1002/hbm.21262, 2011.
+
+Lundqvist, M., Herman, P. and Lansner, A.. Effect of prestimulus
+alpha power, phase, and synchronization on stimulus detection
+rates in a biophysical attractor network model. *Journal of
+Neuroscience* 33:11817-11824, 10.1523/JNEUROSCI.5155-12.2013,
+2013a.
+
+Lundqvist, M., Herman, P., Palva, M., Palva, S., Silverstein, D.
+and Lansner, A.. Stimulus detection rate and latency, firing rates
+and 1-40Hz oscillatory power are modulated by infra-slow
+fluctuations in a bistable attractor network model. *Neuroimage*
+83:458-471, 10.1016/j.neuroimage.2013.06.080, 2013b.
+
+Luo, F., Dittrich, M., Stiles, J. R. and Meriney, S. D..
+Single-pixel optical fluctuation analysis of calcium channel
+function in active zones of motor nerve terminals. *Journal of
+Neuroscience* 31:11268-11281, 10.1523/JNEUROSCI.1394-11.2011,
+2011a.
+
+Luo, J., Macias, S., Ness, T. V., Einevoll, G. T., Zhang, K. and
+Moss, C. F.. Neural timing of stimulus events with microsecond
+precision. *PLoS Biology* 16:e2006422,
+10.1371/journal.pbio.2006422, 2018.
+
+Luo, Q., Jiang, X., Chen, B., Zhu, Y. and Gao, J.-H.. Modeling
+neuronal current MRI signal with human neuron. *Magnetic Resonance
+in Medicine* 65:1680-1689, 10.1002/mrm.22764, 2011b.
+
+Luo, X., Guet-McCreight, A., Villette, V., Francavilla, R.,
+Marino, B., Chamberland, S., Skinner, F. K. and Topolnik, L..
+Synaptic mechanisms underlying the network state-dependent
+recruitment of VIP-expressing interneurons in the Ca1 hippocampus.
+*Cerebral Cortex* 10.1093/cercor/bhz334, 2020.
+
+Lupascu, C. A., Morabito, A., Merenda, E., Marinelli, S.,
+Marchetti, C., Migliore, R., Cherubini, E. and Migliore, M.. A
+general procedure to study subcellular models of transsynaptic
+signaling at inhibitory synapses. *Frontiers in Neuroinformatics*
+10:23, 10.3389/fninf.2016.00023, 2016.
+
+Lupascu, C. A., Morabito, A., Ruggeri, F., Parisi, C., Pimpinella,
+D., Pizzarelli, R., Meli, G., Marinelli, S., Cherubini, E.,
+Cattaneo, A. and Migliore, M.. Computational modeling of
+inhibitory transsynaptic signaling in hippocampal and cortical
+neurons expressing intrabodies against gephyrin. *Frontiers In
+Cellular Neuroscience* 14:173, 10.3389/fncel.2020.00173, 2020.
+
+Luque, N. R., Naveros, F., Carrillo, R. R., Ros, E. and Arleo, A..
+Spike burst-pause dynamics of Purkinje cells regulate sensorimotor
+adaptation. *PLoS Computational Biology* 15:e1006298,
+10.1371/journal.pcbi.1006298, 2019.
+
+Lüscher, H.-R. and Larkum, M.. Modeling action potential
+initiation and back-propagation in dendrites of cultured rat
+motoneurons. *Journal of Neurophysiology* 80:715-729, 1998.
+
+Luthman, J., Hoebeek, F. E., Maex, R., Davey, N., Adams, R., De
+Zeeuw, C. I. and Steuber, V.. STD-dependent and independent
+encoding of input irregularity as spike rate in a computational
+model of a cerebellar nucleus neuron. *Cerebellum* 10:667-682,
+10.1007/s12311-011-0295-9, 2011.
+
+Luz, L. L., Szucs, P., Pinho, R. and Safronov, B. V.. Monosynaptic
+excitatory inputs to spinal lamina I
+anterolateral-tract-projecting neurons from neighbouring lamina I
+neurons. *Journal of Physiology* 588:4489-4505,
+10.1113/jphysiol.2010.197012, 2010.
+
+Lv, T., Zhang, P.-M., Gong, H.-Q. and Liang, P.-J..
+Caffeine-induced Ca(2+) oscillations in type I horizontal cell of
+carp retina: a mathematical model. *Channels* 8:509-518,
+10.4161/19336950.2014.965113, 2014.
+
+Lytton, W. W.. Simulations of a phase comparing neuron of the
+electric fish Eigenmannia. *Journal of Comparative Physiology A*
+169:117-125, 1991.
+
+Lytton, W. W.. "Small cell" simulations: physiological features of
+a phase difference detector. In: *Analysis and Modeling of Neural
+Systems II*, edited by Eeckman, F.. Norwell, MA: Norwell, MA,
+Kluwer, 1992, pp. .
+
+Lytton, W. W.. Optimizing synaptic conductance calculation for
+network simulations. *Neural Computation* 8:501-509, 1996.
+
+Lytton, W. W.. Computer model of clonazepam's effect in thalamic
+slice. *Neuroreport* 8:3339-3343, 1997.
+
+Lytton, W. W.. Adapting a feedforward heteroassociative network to
+Hodgkin-Huxley dynamics. *Journal of Computational Neuroscience*
+5:353-364, 1998.
+
+Lytton, W. W.. *From Computer to Brain*. New York: address,
+Springer-Verlag, 2002.
+
+Lytton, W. W.. Neural Query System - data-mining from within the
+NEURON simulator. *Neuroinformatics* 4:163-175, 2006.
+
+Lytton, W. W., Contreras, D., Destexhe, A. and Steriade, M..
+Dynamic interactions determine partial thalamic quiescence in a
+computer network model of spike-and-wave seizures. *Journal of
+Neurophysiology* 77:1679-1696, 1997.
+
+Lytton, W. W., Destexhe, A. and Sejnowski, T. J.. Control of slow
+oscillations in the thalamocortical neuron: a computer model.
+*Neuroscience* 70:673-684, 1996.
+
+Lytton, W. W., Hellman, K. M. and Sutula, T. P.. Computer models
+of hippocampal circuit changes of the kindling model of epilepsy.
+*Artificial Intelligence in Medicine* 13:81-97, 1998.
+
+Lytton, W. W. and Hines, M.. Hybrid neural networks - combining
+abstract and realistic neural units [Online]. *IEEE Engineering in
+Medicine and Biology Society Proceedings* 6:3996-3998, 2004.
+
+Lytton, W. W. and Lipton, P.. Can the hippocampus tell time? The
+temporo-septal engram shift model. *Neuroreport* 10:2301-2306,
+1999.
+
+Lytton, W. W., Neymotin, S. A., Wester, J. C. and Contreras, D..
+Neocortical simulation for epilepsy surgery guidance: localization
+and intervention. In: *Computational Surgery and Dual Training:
+Computing, Robotics and Imaging*, edited by Garbey, M., Bass, B.
+L., Berceli, S., Collet, C. and Cerveri, P.. Springer, 2014, pp.
+339-349.
+
+Lytton, W. W. and Omurtag, A.. Tonic-clonic transitions in
+computer simulation. *Journal of Clinical Neurophysiology*
+24:175-181, 2007.
+
+Lytton, W. W., Orman, R. and Stewart, M.. Computer simulation of
+epilepsy: implications for seizure spread and behavioral
+dysfunction. *Epilepsy and Behavior* 7:336-344, 2005.
+
+Lytton, W., Orman, R. and Stewart, M.. Broadening of activity with
+flow across neural structures. *Perception* 37:401-407, 2008a.
+
+Lytton, W. W. and Sejnowski, T. C.. Simulations of cortical
+pyramidal neurons synchronized by inhibitory interneurons.
+*Journal of Neurophysiology* 66:1059-1079, 1991.
+
+Lytton, W. W. and Sejnowski, T. J.. Computer model of
+ethosuximide's effect on a thalamic neuron. *Annals of Neurology*
+32:131-139, 1992a.
+
+Lytton, W. W. and Sejnowski, T. J.. Inhibitory interneurons can
+rapidly phase-lock neural populations. In: *Induced Rhythms in the
+Brain*, edited by Bacar, E. and Bullock, T. H.. Boston: Boston,
+Birkhaeuser, 1992b, pp. .
+
+Lytton, W. W. and Stewart, M.. A rule-based firing model for
+neural networks. *International Journal for Bioelectromagnetism*
+7:47-50, 2005.
+
+Lytton, W. W. and Stewart, M.. Rule-based firing for network
+simulations. *Neurocomputing* 69:1160-1164, 2006.
+
+Lytton, W. W., Stewart, M. and Hines, M. L.. Simulation of large
+networks: technique and progress. In: *Computational Neuroscience
+in Epilepsy*, edited by Soltesz, I. and Staley, K.. Elsevier,
+2008b, pp. 3-17.
+
+Lytton, W. W. and Wathey, J. C.. Realistic single-neuron modeling.
+*Seminars in Neuroscience* 4:15-25, 1992.
+
+Lytton, W. W., Neymotin, S. A. and Hines, M. L.. The virtual slice
+setup. *Journal of Neuroscience Methods* 171:309-315, 2008c.
+
+Lytton, W. W., Omurtag, A., Neymotin, S. A. and Hines, M. L..
+Just-in-time connectivity for large spiking networks. *Neural
+Computation* 20:2745-2756, 2008d.
+
+Lytton, W. W., Seidenstein, A. H., Dura-Bernal, S., McDougal, R.
+A., Schürmann, F. and Hines, M. L.. Simulation neurotechnologies
+for advancing brain research: parallelizing large networks in
+NEURON. *Neural Computation* 28:2063-2090, 10.1162/NECO_a_00876,
+2016.
+
+Lytton, W. W. and Stewart, M.. Data mining through simulation.
+*Methods in Molecular Biology* 401:155-166,
+10.1007/978-1-59745-520-6_9, 2007.
+
+Łęski, S., Lindén, H., Tetzlaff, T., Pettersen, K. H. and
+Einevoll, G. T.. Frequency dependence of signal power and spatial
+reach of the local field potential. *PLoS Computational Biology*
+9:e1003137, 10.1371/journal.pcbi.1003137, 2013.
+
+Łęski, S., Pettersen, K. H., Tunstall, B., Einevoll, G. T., Gigg,
+J. and Wójcik, D. K.. Inverse current source density method in two
+dimensions: inferring neural activation from multielectrode
+recordings. *Neuroinformatics* 9:401-425,
+10.1007/s12021-011-9111-4, 2011.
+
+Ma, J. and Lowe, G.. Action potential backpropagation and
+multiglomerular signaling in the rat vomeronasal system. *Journal
+of Neuroscience* 24:9341-9352, 2004.
+
+Ma, M., Futia, G. L., de Souza, F. M. S., Ozbay, B. N., Llano, I.,
+Gibson, E. A. and Restrepo, D.. Molecular layer interneurons in
+the cerebellum encode for valence in associative learning. *Nature
+Communications* 11:4217, 10.1038/s41467-020-18034-2, 2020.
+
+Maccabee, P. J., Nagarajan, S. S., Amassian, V. E., Durand, D. M.,
+Szabo, A. Z., Ahad, A. B., Cracco, R. Q., Lai, K. S. and Eberle,
+L. P.. Influence of pulse sequence, polarity and amplitude on
+magnetic stimulation of human and porcine peripheral nerve.
+*Journal of Physiology* 513:571-585, 1998.
+
+Maccaferri, G.. Complex synaptic dynamics of GABAergic networks of
+the hippocampus. In: *Computational Neuroscience in Epilepsy*,
+edited by Soltesz, I. and Staley, K.. Elsevier, 2008, pp. 288-303.
+
+Magalhães, B. R. C., Hines, M., Sterling, T. and Schuermann, F..
+Exploiting flow graph of system of ODEs to accelerate the
+simulation of biologically-detailed neural networks [Online].
+*2019 IEEE International Parallel and Distributed Processing
+Symposium (IPDPS)* , 10.1109/ipdps.2019.00028, 2019a.
+
+Magalhães, B. R. C., Sterling, T., Hines, M. and Schürmann, F..
+Asynchronous branch-parallel simulation of detailed neuron models.
+*Frontiers In Neuroinformatics* 13:54, 10.3389/fninf.2019.00054,
+2019b.
+
+Magalhães, B. R. C., Sterling, T., Hines, M. and Schürmann, F..
+Fully-asynchronous cache-efficient simulation of detailed neural
+networks [Online]. *Computational Science -- ICCS 2019* :421-434,
+2019c.
+
+Magee, J. C. and Cook, E. P.. Somatic EPSP amplitude is
+independent of synapse location in hippocampal pyramidal neurons.
+*Nature Neuroscience* 3:895-903, 2000.
+
+Magee, J. C. and Cook, E. P.. Synaptic scaling in vitro and in
+vivo - reply. *Nature Neuroscience* 4:854-855, 2001.
+
+Magistretti, J., Castelli, L., Forti, L. and D'Angelo, E.. Kinetic
+and functional analysis of transient, persistent and resurgent
+sodium currents in rat cerebellar granule cells in situ: an
+electrophysiological and modelling study. *Journal of Physiology*
+573:83-106, 2006.
+
+Magland, J., Jun, J. J., Lovero, E., Morley, A. J., Hurwitz, C.
+L., Buccino, A. P., Garcia, S. and Barnett, A. H.. SpikeForest,
+reproducible web-facing ground-truth validation of automated
+neural spike sorters. *eLife* 910.7554/eLife.55167, 2020.
+
+Mahapatra, C., Brain, K. L. and Manchanda, R.. Computational
+studies on urinary bladder smooth muscle: modeling ion channels
+and their role in generating electrical activity [Online]. *2015
+7th International IEEE/EMBS Conference on Neural Engineering*,
+10.1109/ner.2015.7146752, 2015.
+
+Mahapatra, C., Brain, K. L. and Manchanda, R.. Computational study
+of ATP gated potassium ion channel in urinary bladder over
+activity [Online]. *2016 International Conference on Inventive
+Computation Technologies*, 10.1109/inventive.2016.7824861, 2016.
+
+Mahapatra, C., Brain, K. L. and Manchanda, R.. A biophysically
+constrained computational model of the action potential of mouse
+urinary bladder smooth muscle. *PLoS ONE* 13:e0200712,
+10.1371/journal.pone.0200712, 2018a.
+
+Mahapatra, C., Brain, K. L. and Manchanda, R.. Computational study
+of Hodgkin-Huxley type calcium-dependent potassium current in
+urinary bladder over activity [Online]. *2018 IEEE 8th
+International Conference on Computational Advances in Bio and
+Medical Sciences* , 10.1109/iccabs.2018.8541971, 2018b.
+
+Mahapatra, C. and Manchanda, R.. Computational simulation of spike
+patterns in STN neuron using Izhikevich model [Online]. *2016
+International Conference on Inventive Computation Technologies*,
+10.1109/inventive.2016.7824871, 2016.
+
+Mahapatra, C. and Manchanda, R.. Modeling vas deferens smooth
+muscle electrophysiology: role of ion channels in generating
+electrical activity [Online]. *Soft Computing for Problem Solving*
+817:{655-663}, {10.1007/978-981-13-1595-4\_52}, 2019.
+
+Mahnam, A., Hashemi, S. M. R. and Grill, W. M.. Computational
+evaluation of methods for measuring the spatial extent of neural
+activation. *Journal of Neuroscience Methods* 173:153-164, 2008.
+
+Mahnam, A., Hashemi, S. M. R. and Grill, W. M.. Measurement of the
+current-distance relationship using a novel refractory interaction
+technique. *Journal of Neural Engineering* 6:036005, 2009.
+
+Mahrous, A. A., Mousa, M. H. and Elbasiouny, S. M.. The
+mechanistic basis for successful spinal cord stimulation to
+generate steady motor outputs. *Frontiers In Cellular
+Neuroscience* 13:359, 10.3389/fncel.2019.00359, 2019.
+
+Mainen, Z. F., Joerges, J., Huguenard, J. and Sejnowski, T. J.. A
+model of spike initiation in neocortical pyramidal neurons.
+*Neuron* 15:1427-1439, 1995.
+
+Mainen, Z. F. and Sejnowski, T. J.. Reliability of spike encoding
+in neocortical neurons [Online]. *Proceedings of the Joint
+Symposium on Neural Computation, University of California, San
+Diego and California Institute of Technology* 4:24-29, 1994.
+
+Mainen, Z. F. and Sejnowski, T. J.. Reliability of spike timing in
+neocortical neurons. *Science* 268:1503-1506, 1995.
+
+Mainen, Z. F. and Sejnowski, T. J.. Influence of dendritic
+structure on firing pattern in model neocortical neurons. *Nature*
+382:363-366, 1996.
+
+Mainen, Z. F. and Sejnowski, T. J.. Modeling active dendritic
+processes in pyramidal neurons. In: *Methods in Neuronal
+Modeling*, edited by Koch, C. and Segev, I.. Cambridge, MA:
+Cambridge, MA, MIT Press, 1998, pp. 171-209.
+
+Maingret, F., Coste, B., Padilla, F., Clerc, N., Crest, M.,
+Korogod, S. M. and Delmas, P.. Inflammatory mediators increase
+Nav1.9 current and excitability in nociceptors through a
+coincident detection mechanism. *Journal of General Physiology*
+131:211-225, 2008.
+
+Major, G., Polsky, A., Denk, W., Schiller, J. and Tank, D. W..
+Spatio-temporally graded NMDA spike/plateau potentials in basal
+dendrites of neocortical pyramidal neurons. *Journal of
+Neurophysiology* 99:2584-2601, 2008.
+
+Majoral, D., Zemmar, A. and Vicente, R.. A model for time interval
+learning in the Purkinje cell. *PLoS Computational Biology*
+16:e1007601, 10.1371/journal.pcbi.1007601, 2020.
+
+Mäki-Marttunen, T., Devor, A., Phillips, W. A., Dale, A. M.,
+Andreassen, O. A. and Einevoll, G. T.. Computational modeling of
+genetic contributions to excitability and neural coding in layer V
+pyramidal cells: applications to schizophrenia pathology.
+*Frontiers In Computational Neuroscience* 13:66,
+10.3389/fncom.2019.00066, 2019a.
+
+Mäki-Marttunen, T., Halnes, G., Devor, A., Metzner, C., Dale, A.
+M., Andreassen, O. A. and Einevoll, G. T.. A stepwise neuron model
+fitting procedure designed for recordings with high spatial
+resolution: application to layer 5 pyramidal cells. *Journal of
+Neuroscience Methods* 293:264-283, 10.1016/j.jneumeth.2017.10.007,
+2018.
+
+Mäki-Marttunen, T., Halnes, G., Devor, A., Witoelar, A., Bettella,
+F., Djurovic, S., Wang, Y., Einevoll, G. T., Andreassen, O. A. and
+Dale, A. M.. Functional effects of schizophrenia-linked genetic
+variants on intrinsic single-neuron excitability: a modeling
+study. *Biological Psychiatry: Cognitive Neuroscience and
+Neuroimaging* 1:49-59, 10.1016/j.bpsc.2015.09.002, 2016.
+
+Mäki-Marttunen, T., Iannella, N., Edwards, A. G., Einevoll, G. T.
+and Blackwell, K. T.. A unified computational model for cortical
+post-synaptic plasticity. *eLife* 910.7554/eLife.55714, 2020.
+
+Mäki-Marttunen, T., Krull, F., Bettella, F., Hagen, E., Næss, S.,
+Ness, T. V., Moberget, T., Elvsåshagen, T., Metzner, C., Devor,
+A., Edwards, A. G., Fyhn, M., Djurovic, S., Dale, A. M.,
+Andreassen, O. A. and Einevoll, G. T.. Alterations in
+schizophrenia-associated genes can lead to increased power in
+delta oscillations. *Cerebral Cortex* 29:875-891,
+10.1093/cercor/bhy291, 2019b.
+
+Malaga, K. A., Schroeder, K. E., Patel, P. R., Irwin, Z. T.,
+Thompson, D. E., Nicole Bentley, J., Lempka, S. F., Chestek, C. A.
+and Patil, P. G.. Data-driven model comparing the effects of glial
+scarring and interface interactions on chronic neural recordings
+in non-human primates. *Journal of Neural Engineering* 13:016010,
+10.1088/1741-2560/13/1/016010, 2016.
+
+Maling, N., Lempka, S. F., Blumenfeld, Z., Bronte-Stewart, H. and
+McIntyre, C. C.. Biophysical basis of subthalamic local field
+potentials recorded from deep brain stimulation electrodes.
+*Journal of Neurophysiology* 120:1932-1944, 10.1152/jn.00067.2018,
+2018.
+
+Malinvaud, D., Vassias, I., Reichenberger, I., Rössert, C. and
+Straka, H.. Functional organization of vestibular commissural
+connections in frog. *Journal of Neuroscience* 30:3310-3325,
+10.1523/JNEUROSCI.5318-09.2010, 2010.
+
+Mandairon, N., Ferretti, C. J., Stack, C. M., Rubin, D. B.,
+Cleland, T. A. and Linster, C.. Cholinergic modulation in the
+olfactory bulb influences spontaneous olfactory discrimination in
+adult rats. *European Journal of Neuroscience* 24:3234-3244, 2006.
+
+Mandge, D., Bhatnagar, A. and Manchanda, R.. Computational model
+for intercellular communication between DRG neurons via satellite
+glial cells using ATP [Online]. *2017 8th International IEEE/EMBS
+Conference on Neural Engineering*, 10.1109/ner.2017.8008434, 2017.
+
+Mandge, D. and Manchanda, R.. Computational studies on bladder
+small dorsal root ganglion neurons: modelling BK channels
+[Online]. *2015 37th Annual International Conference of the IEEE
+Engineering in Medicine and Biology Society*,
+10.1109/embc.2015.7319606, 2015.
+
+Mandge, D. and Manchanda, R.. A biophysically detailed
+computational model of urinary bladder small DRG neuron soma.
+*PLoS Computational Biology* 1410.1371/journal.pcbi.1006293, 2018.
+
+Mandge, D., Shukla, P. R., Bhatnagar, A. and Manchanda, R..
+Computational model for cross-depolarization in DRG neurons via
+satellite glial cells using [K]o: role of Kir4.1 channels and
+extracellular leakage [Online]. *2019 41st Annual International
+Conference of the IEEE Engineering in Medicine and Biology
+Society* , 10.1109/embc.2019.8857153, 2019.
+
+Manis, P. B. and Campagnola, L.. A biophysical modelling platform
+of the cochlear nucleus and other auditory circuits: from channels
+to networks. *Hearing Research* 360:76-91,
+10.1016/j.heares.2017.12.017, 2018.
+
+Manita, S. and Ross, W. N.. Synaptic activation and membrane
+potential changes modulate the frequency of spontaneous elementary
+Ca2+ release events in the dendrites of pyramidal neurons.
+*Journal of Neuroscience* 29:7833-7845, 2009.
+
+Manita, S. and Ross, W. N.. IP3 mobilization and diffusion
+determine the timing window of Ca2+ release by synaptic
+stimulation and a spike in rat CA1 pyramidal cells. *Hippocampus*
+20:524-539, 10.1002/hipo.20644, 2010.
+
+Manninen, T., Aćimović, J., Havela, R., Teppola, H. and Linne,
+M.-L.. Challenges in reproducibility, replicability, and
+comparability of computational models and tools for neuronal and
+glial networks, cells, and subcellular structures. *Frontiers in
+Neuroinformatics* 12:20, 10.3389/fninf.2018.00020, 2018.
+
+Manookin, M. B., Puller, C., Rieke, F., Neitz, J. and Neitz, M..
+Distinctive receptive field and physiological properties of a
+wide-field amacrine cell in the macaque monkey retina. *Journal of
+Neurophysiology* 114:1606-1616, 10.1152/jn.00484.2015, 2015.
+
+Manor, Y., Rinzel, J., Segev, I. and Yarom, Y.. Low-amplitude
+oscillations in the inferior olive: a model based on electrical
+coupling of neurons with heterogeneous channel densities. *Journal
+of Neurophysiology* 77:2736-2752, 1997.
+
+Marasco, A., Limongiello, A. and Migliore, M.. Fast and accurate
+low-dimensional reduction of biophysically detailed neuron models.
+*Scientific Reports* 2:928, 10.1038/srep00928, 2012.
+
+Marasco, A., Limongiello, A. and Migliore, M.. Using Strahler's
+analysis to reduce up to 200-fold the run time of realistic neuron
+models. *Scientific Reports* 3:2934, 10.1038/srep02934, 2013.
+
+Marcelin, B., Chauviere, L., Becker, A., Migliore, M., Esclapez,
+M. and Bernard, C.. h channel-dependent deficit of theta
+oscillation resonance and phase shift in temporal lobe epilepsy.
+*Neurobiology of Disease* 33:436-447, 2009.
+
+Marcelin, B., Liu, Z., Chen, Y., Lewis, A. S., Becker, A.,
+McClelland, S., Chetkovich, D. M., Migliore, M., Baram, T. Z.,
+Esclapez, M. and Bernard, C.. Dorsoventral differences in
+intrinsic properties in developing CA1 pyramidal cells. *Journal
+of Neuroscience* 32:3736-3747, 10.1523/JNEUROSCI.5870-11.2012,
+2012.
+
+Marder, C. P. and Buonomano, D. V.. Timing and balance of
+inhibition enhance the effect of long-term potentiation on cell
+firing. *Journal of Neuroscience* 24:8873-8884, 2004.
+
+Margrie, T. W. and Schaefer, A. T.. Theta oscillation coupled
+spike latencies yield computational vigour in a mammalian sensory
+system. *Journal of Physiology* 546:363-374, 2003.
+
+Marianelli, P., Capogrosso, M., Bassi Luciani, L., Panarese, A.
+and Micera, S.. A computational framework for electrical
+stimulation of vestibular nerve. *IEEE Transactions on Neural
+Systems and Rehabilitation Engineering* 23:897-909,
+10.1109/TNSRE.2015.2407861, 2015.
+
+Markaki, M., Orphanoudakis, S. and Poirazi, P.. Modelling reduced
+excitability in aged CA1 neurons as a calcium-dependent process.
+*Neurocomputing* 65:305-314, 2005.
+
+Markram, H., Lübke, J., Frotscher, M., Roth, A. and Sakmann, B..
+Physiology and anatomy of synaptic connections between thick
+tufted pyramidal neurones in the developing rat neocortex.
+*Journal of Physiology* 500:409-440, 1997.
+
+Markram, H., Muller, E., Ramaswamy, S., Reimann, M. W., Abdellah,
+M., Sanchez, C. A., Ailamaki, A., Alonso-Nanclares, L., Antille,
+N., Arsever, S., Kahou, G. A. A., Berger, T. K., Bilgili, A.,
+Buncic, N., Chalimourda, A., Chindemi, G., Courcol, J.-D.,
+Delalondre, F., Delattre, V., Druckmann, S., Dumusc, R., Dynes,
+J., Eilemann, S., Gal, E., Gevaert, M. E., Ghobril, J.-P., Gidon,
+A., Graham, J. W., Gupta, A., Haenel, V., Hay, E., Heinis, T.,
+Hernando, J. B., Hines, M., Kanari, L., Keller, D., Kenyon, J.,
+Khazen, G., Kim, Y., King, J. G., Kisvarday, Z., Kumbhar, P.,
+Lasserre, S., Le Bé, J.-V., Magalhães, B. R. C., Merchán-Pérez,
+A., Meystre, J., Morrice, B. R., Muller, J., Muñoz-Céspedes, A.,
+Muralidhar, S., Muthurasa, K., Nachbaur, D., Newton, T. H., Nolte,
+M., Ovcharenko, A., Palacios, J., Pastor, L., Perin, R., Ranjan,
+R., Riachi, I., Rodríguez, J.-R., Riquelme, J. L., Rössert, C.,
+Sfyrakis, K., Shi, Y., Shillcock, J. C., Silberberg, G., Silva,
+R., Tauheed, F., Telefont, M., Toledo-Rodriguez, M., Tränkler, T.,
+Van Geit, W., Díaz, J. V., Walker, R., Wang, Y., Zaninetta, S. M.,
+DeFelipe, J., Hill, S. L., Segev, I. and Schürmann, F..
+Reconstruction and simulation of neocortical microcircuitry.
+*Cell* 163:456-492, 10.1016/j.cell.2015.09.029, 2015.
+
+Marsalek, P., Koch, C. and Maunsell, J.. On the relationship
+between synaptic input and spike output jitter in individual
+neurons. *Proceedings of the National Academy of Sciences of the
+United States of America* 94:735-740, 1997.
+
+Marti Mengual, U., Wybo, W. A. M., Spierenburg, L. J. E.,
+Santello, M., Senn, W. and Nevian, T.. Efficient low-pass
+dendro-somatic coupling in the apical dendrite of layer 5
+pyramidal neurons in the anterior cingulate cortex. *Journal of
+Neuroscience* 10.1523/JNEUROSCI.3028-19.2020, 2020.
+
+Martin, E., Cazenave, W., Cattaert, D. and Branchereau, P..
+Embryonic alteration of motoneuronal morphology induces
+hyperexcitability in the mouse model of amyotrophic lateral
+sclerosis. *Neurobiology of Disease* 54:116-126,
+10.1016/j.nbd.2013.02.011, 2013.
+
+Martinello, K., Giacalone, E., Migliore, M., Brown, D. A. and
+Shah, M. M.. The subthreshold-active Kv7 current regulates
+neurotransmission by limiting spike-induced Ca2+ influx in
+hippocampal mossy fiber synaptic terminals. *Communications
+Biology* 2:145, 10.1038/s42003-019-0408-4, 2019.
+
+Martínez-Cañada, P., Mobarhan, M. H., Halnes, G., Fyhn, M.,
+Morillas, C., Pelayo, F. and Einevoll, G. T.. Biophysical network
+modeling of the dLGN circuit: Effects of cortical feedback on
+spatial response properties of relay cells. *PLoS Computational
+Biology* 14:e1005930, 10.1371/journal.pcbi.1005930, 2018.
+
+Martínez-Cañada, P., Ness, T. V., Einevoll, G. T., Fellin, T. and
+Panzeri, S.. Computation of the electroencephalogram (EEG) from
+network models of point neurons. *PLoS Computational Biology*
+17:e1008893, 10.1371/journal.pcbi.1008893, 2021a.
+
+Martínez-Cañada, P., Noei, S. and Panzeri, S.. Methods for
+inferring neural circuit interactions and neuromodulation from
+local field potential and electroencephalogram measures. *Brain
+Informatics* 8:27, 10.1186/s40708-021-00148-y, 2021b.
+
+Masoli, S. and D'Angelo, E.. Synaptic activation of a detailed
+purkinje cell model predicts voltage-dependent control of
+burst-pause responses in active dendrites. *Frontiers in Cellular
+Neuroscience* 11:278, 10.3389/fncel.2017.00278, 2017.
+
+Masoli, S., Ottaviani, A., Casali, S. and D'Angelo, E.. Cerebellar
+Golgi cell models predict dendritic processing and mechanisms of
+synaptic plasticity. *PLoS Computational Biology* 16:e1007937,
+10.1371/journal.pcbi.1007937, 2020a.
+
+Masoli, S., Rizza, M. F., Sgritta, M., Van Geit, W., Schürmann, F.
+and D'Angelo, E.. Single neuron optimization as a basis for
+accurate biophysical modeling: the case of cerebellar granule
+cells. *Frontiers in Cellular Neuroscience* 11:71,
+10.3389/fncel.2017.00071, 2017.
+
+Masoli, S., Solinas, S. and D'Angelo, E.. Action potential
+processing in a detailed Purkinje cell model reveals a critical
+role for axonal compartmentalization. *Frontiers in Cellular
+Neuroscience* 9:47, 10.3389/fncel.2015.00047, 2015.
+
+Masoli, S., Tognolina, M., Laforenza, U., Moccia, F. and D'Angelo,
+E.. Parameter tuning differentiates granule cell subtypes
+enriching transmission properties at the cerebellum input stage.
+*Communications Biology* 3:222, 10.1038/s42003-020-0953-x, 2020b.
+
+Massobrio, P. and Martinoia, S.. Modelling small-patterned
+neuronal networks coupled to microelectrode arrays. *Journal of
+Neural Engineering* 5:350-359, 2008.
+
+Massobrio, P., Massobrio, G. and Martinoia, S.. Multi-program
+approach for simulating recorded extracellular signals generated
+by neurons coupled to microelectrode arrays. *Neurocomputing*
+70:2467-2476, 2007.
+
+Masurkar, A. V. and Chen, W. R.. Calcium currents of olfactory
+bulb juxtaglomerular cells: profile and multiple conductance
+plateau potential simulation. *Neuroscience* 192:231-246,
+10.1016/j.neuroscience.2011.06.016, 2011a.
+
+Masurkar, A. V. and Chen, W. R.. Potassium currents of olfactory
+bulb juxtaglomerular cells: characterization, simulation, and
+implications for plateau potential firing. *Neuroscience*
+192:247-262, 10.1016/j.neuroscience.2011.06.012, 2011b.
+
+Masurkar, A. V., Tian, C., Warren, R., Reyes, I., Lowes, D. C.,
+Brann, D. H. and Siegelbaum, S. A.. Postsynaptic integrative
+properties of dorsal CA1 pyramidal neuron subpopulations. *Journal
+of Neurophysiology* 123:980-992, 10.1152/jn.00397.2019, 2020.
+
+Mateos-Aparicio, P., Murphy, R. and Storm, J. F.. Complementary
+functions of SK and Kv7/M potassium channels in excitability
+control and synaptic integration in rat hippocampal dentate
+granule cells. *Journal of Physiology* 592:669-693,
+10.1113/jphysiol.2013.267872, 2014.
+
+Mateus, J. C., Lopes, C., Aroso, M., Costa, A. R., Gerós, A.,
+Meneses, J., Faria, P., Neto, E., Lamghari, M., Sousa, M. M. and
+Aguiar, P.. Bidirectional flow of action potentials in axons
+drives activity dynamics in neuronal cultures. *Journal of Neural
+Engineering* 1810.1088/1741-2552/ac41db, 2021.
+
+Matsubara, T. and Torikai, H.. An asynchronous recurrent network
+of cellular automaton-based neurons and its reproduction of
+spiking neural network activities. *IEEE Transactions on Neural
+Networks and Learning Systems* 27:836-852,
+10.1109/TNNLS.2015.2425893, 2016.
+
+Matsumura, R., Yamamoto, H., Hayakawa, T., Katsurabayashi, S.,
+Niwano, M. and Hirano-Iwata, A.. Dependence and homeostasis of
+membrane impedance on cell morphology in cultured hippocampal
+neurons. *Scientific Reports* 8:9905, 10.1038/s41598-018-28232-0,
+2018.
+
+Mattioni, M., Cohen, U. and Le Novère, N.. Neuronvisio: a
+graphical user interface with 3D capabilities for NEURON.
+*Frontiers In Neuroinformatics* 6:20, 10.3389/fninf.2012.00020,
+2012.
+
+Mattioni, M. and Le Novère, N.. Integration of biochemical and
+electrical signaling-multiscale model of the medium spiny neuron
+of the striatum. *PLoS ONE* 8:e66811,
+10.1371/journal.pone.0066811, 2013.
+
+Maturana, M. I., Grayden, D. B., Burkitt, A. N., Meffin, H. and
+Kameneva, T.. Multicompartment retinal ganglion cells response to
+high frequency bi-phasic pulse train stimulation: simulation
+results [Online]. *IEEE Engineering in Medicine and Biology
+Society Proceedings* 2013:69-72, 10.1109/EMBC.2013.6609439, 2013a.
+
+Maturana, M. I., Kameneva, T., Burkitt, A. N., Meffin, H. and
+Grayden, D. B.. The effect of morphology upon electrophysiological
+responses of retinal ganglion cells: simulation results. *Journal
+of Computational Neuroscience* 36:157-175,
+10.1007/s10827-013-0463-7, 2014.
+
+Maturana, M. I., Wong, R., Cloherty, S. L., Ibbotson, M. R.,
+Hadjinicolaou, A. E., Grayden, D. B., Burkitt, A. N., Meffin, H.,
+O'Brien, B. J. and Kameneva, T.. Retinal ganglion cells
+electrophysiology: The effect of cell morphology on impulse
+waveform [Online]. *IEEE Engineering in Medicine and Biology
+Society Proceedings* 2013:2583-2586, 10.1109/EMBC.2013.6610068,
+2013b.
+
+Matzner, A., Gorodetski, L., Korngreen, A. and Bar-Gad, I..
+Dynamic input-dependent encoding of individual basal ganglia
+neurons. *Scientific Reports* 10:5833, 10.1038/s41598-020-62750-0,
+2020.
+
+Maurice, N., Mercer, J., Chan, C. S., Hernandez-Lopez, S., Held,
+J., Tkatch, T. and Surmeier, D. J.. D2 dopamine receptor-mediated
+modulation of voltage-dependent Na+ channels reduces autonomous
+activity in striatal cholinergic interneurons. *Journal of
+Neuroscience* 24:10289-10301, 2004.
+
+Mazzatenta, A., Giugliano, M., Campidelli, S., Gambazzi, L.,
+Businaro, L., Markram, H., Prato, M. and Ballerini, L..
+Interfacing neurons with carbon nanotubes: electrical signal
+transfer and synaptic stimulation in cultured brain circuits.
+*Journal of Neuroscience* 27:6931-6936, 2007.
+
+Mazzoni, A., Lindén, H., Cuntz, H., Lansner, A., Panzeri, S. and
+Einevoll, G. T.. Computing the local field potential (lfp) from
+integrate-and-fire network models. *PLoS Computational Biology*
+11:e1004584, 10.1371/journal.pcbi.1004584, 2015.
+
+McBain, C. and Dingledine, R.. Dual-component miniature excitatory
+synaptic currents in rat hippocampal CA3 pyramidal neurons.
+*Journal of Neurophysiology* 68:16-27, 1992.
+
+McCafferty, C., David, F., Venzi, M., Lőrincz, M. L., Delicata,
+F., Atherton, Z., Recchia, G., Orban, G., Lambert, R. C., Di
+Giovanni, G., Leresche, N. and Crunelli, V.. Cortical drive and
+thalamic feed-forward inhibition control thalamic output synchrony
+during absence seizures. *Nature Neuroscience* 21:744-756,
+10.1038/s41593-018-0130-4, 2018.
+
+McCauley, J. P., Petroccione, M. A., D'Brant, L. Y., Todd, G. C.,
+Affinnih, N., Wisnoski, J. J., Zahid, S., Shree, S., Sousa, A. A.,
+Guzman, R. M. D., Migliore, R., Brazhe, A., Leapman, R. D.,
+Khmaladze, A., Semyanov, A., Zuloaga, D. G., Migliore, M. and
+Scimemi, A.. Circadian modulation of neurons and astrocytes
+controls synaptic plasticity in hippocampal area Ca1. *Cell
+Reports* 33:108255, 10.1016/j.celrep.2020.108255, 2020.
+
+McColgan, T., Kuokkanen, P. T., Carr, C. E. and Kempter, R..
+Dynamics of synaptic extracellular field potentials in the nucleus
+laminaris of the barn owl. *Journal of Neurophysiology*
+121:1034-1047, 10.1152/jn.00648.2017, 2019.
+
+McColgan, T., Liu, J., Kuokkanen, P. T., Carr, C. E., Wagner, H.
+and Kempter, R.. Dipolar extracellular potentials generated by
+axonal projections. *eLife* 6:e26106, 10.7554/eLife.26106, 2017.
+
+McCormick, D. A., Shu, Y. and Yu, Y.. Neurophysiology: Hodgkin and
+Huxley model--still standing?. *Nature* 445:E1-2; discussion E2-3,
+10.1038/nature05523, 2007.
+
+McDonnell, M. D., Iannella, N., To, M.-S., Tuckwell, H. C., Jost,
+J., Gutkin, B. S. and Ward, L. M.. A review of methods for
+identifying stochastic resonance in simulations of single neuron
+models. *Network* 26:35-71, 10.3109/0954898X.2014.990064, 2015.
+
+McDougal, R. A., Morse, T. M., Hines, M. L. and Shepherd, G. M..
+ModelView for ModelDB: online presentation of model structure.
+*Neuroinformatics* 13:459-470, 10.1007/s12021-015-9269-2, 2015.
+
+McDougal, R. A. and Shepherd, G. M.. 3D-printer visualization of
+neuron models.. *Frontiers in Neuroinformatics* 9:18,
+10.3389/fninf.2015.00018, 2015.
+
+McDougal, R. A., Hines, M. L. and Lytton, W. W..
+Reaction-diffusion in the NEURON simulator. *Frontiers in
+Neuroinformatics* 7:28, 10.3389/fninf.2013.00028, 2013.
+
+McIntyre, A. B. R. and Cleland, T. A.. Biophysical constraints on
+lateral inhibition in the olfactory bulb. *Journal of
+Neurophysiology* 115:2937-2949, 10.1152/jn.00671.2015, 2016.
+
+McIntyre, C. C. and Grill, W. M.. Excitation of central nervous
+system neurons by nonuniform electric fields. *Biophysical
+Journal* 76:878-888, 1999.
+
+McIntyre, C. C. and Grill, W. M.. Selective microstimulation of
+central nervous system neurons. *Annals of Biomedical Engineering*
+28:219-233, 2000.
+
+McIntyre, C. C. and Grill, W. M.. Extracellular stimulation of
+central neurons: influence of stimulus waveform and frequency on
+neuronal output. *Journal of Neurophysiology* 88:1592-1604, 2002.
+
+McIntyre, C. C., Grill, W. M., Sherman, D. L. and Thakor, N. V..
+Cellular effects of deep brain stimulation: model-based analysis
+of activation and inhibition. *Journal of Neurophysiology*
+91:1457-1469, 2004a.
+
+McIntyre, C. C., Miocinovic, S. and Butson, C. R.. Computational
+analysis of deep brain stimulation. *Expert Reviews of Medical
+Devices* 4:615-622, 2007.
+
+McIntyre, C. C., Richardson, A. G. and Grill, W. M.. Modeling the
+excitability of mammalian nerve fibers: influence of
+afterpotentials on the recovery cycle. *Journal of
+Neurophysiology* 87:995-1006, 2002.
+
+McIntyre, C. C., Mori, S., Sherman, D. L., Thakor, N. V. and
+Vitek, J. L.. Electric field and stimulating influence generated
+by deep brain stimulation of the subthalamic nucleus. *Clinical
+Neurophysiology* 115:589-595, 2004b.
+
+McTavish, T. S., Migliore, M., Shepherd, G. M. and Hines, M. L..
+Mitral cell spike synchrony modulated by dendrodendritic synapse
+location. *Frontiers in Computational Neuroscience* 6:3,
+10.3389/fncom.2012.00003, 2012.
+
+Mease, R. A., Famulare, M., Gjorgjieva, J., Moody, W. J. and
+Fairhall, A. L.. Emergence of adaptive computation by single
+neurons in the developing cortex. *Journal of Neuroscience*
+33:12154-12170, 10.1523/JNEUROSCI.3263-12.2013, 2013.
+
+Medan, V., Mäki-Marttunen, T., Sztarker, J. and Preuss, T..
+Differential processing in modality-specific Mauthner cell
+dendrites. *Journal of Physiology* 596:667-689, 10.1113/JP274861,
+2018.
+
+Medina, L. E. and Grill, W. M.. Volume conductor model of
+transcutaneous electrical stimulation with kilohertz signals.
+*Journal of Neural Engineering* 11:066012,
+10.1088/1741-2560/11/6/066012, 2014.
+
+Medini, C., Nair, B., D'Angelo, E., Naldi, G. and Diwakar, S..
+Modeling spike-train processing in the cerebellum granular layer
+and changes in plasticity reveal single neuron effects in neural
+ensembles. *Computational Intelligence and Neuroscience*
+2012:359529, 10.1155/2012/359529, 2012.
+
+Medinilla, V., Johnson, O. and Gasparini, S.. Features of proximal
+and distal excitatory synaptic inputs to layer V neurons of the
+rat medial entorhinal cortex. *Journal of Physiology* 591:169-183,
+10.1113/jphysiol.2012.237172, 2013.
+
+Medlock, L., Sekiguchi, K., Hong, S., Dura-Bernal, S., Lytton, W.
+W. and Prescott, S. A.. Multiscale computer model of the spinal
+dorsal horn reveals changes in network processing associated with
+chronic pain. *Journal of Neuroscience*
+10.1523/JNEUROSCI.1199-21.2022, 2022.
+
+Meffin, H., Burkitt, A. N. and Grayden, D. B.. An analytical model
+for the 'large, fluctuating synaptic conductance state' typical of
+neocortical neurons in vivo. *Journal of Computational
+Neuroscience* 16:159-175, 2004.
+
+Mehaffey, W. H., Doiron, B., Maler, L. and Turner, R. W..
+Deterministic multiplicative gain control with active dendrites.
+*Journal of Neuroscience* 25:9968-9977, 2005.
+
+Mei, J. and Singh, T.. Intra-thalamic and thalamocortical
+connectivity [Online]. *Proceedings of the 1st International
+Workshop on Software Engineering for Cognitive Services*,
+10.1145/3195555.3195556, 2018.
+
+Mel, B. W.. NMDA-based pattern discrimination in a modeled
+cortical neuron. *Neural Computation* 4:502-517, 1992a.
+
+Mel, B. W.. The clusteron: toward a simple abstraction for a
+complex neuron. In: *Advances in Neural Information Processing
+Systems*, edited by Moody, J., Hanson, S. and Lippmann, R.. San
+Mateo, CA: San Mateo, CA, Morgan Kaufmann, 1992b, pp. 35-42.
+
+Mel, B. W.. Synaptic integration in an excitable dendritic tree.
+*Journal of Neurophysiology* 70:1086-1101, 1993.
+
+Mel, B. W., Niebur, E. and Croft, D. W.. How neurons may respond
+to temporal structure in their inputs. In: *Computational
+Neuroscience: Trends in Research, 1997*, edited by Bower, J. M..
+New York: New York, Plenum Press, 1997a, pp. 135-140.
+
+Mel, B. W., Ruderman, D. L. and Archie, K. A.. Complex-cell
+responses derived from center-surround inputs: the surprising
+power of intradendritic computation. In: *Advances in Neural
+Information Processing Systems*, edited by Mozer, M. C., Jordan,
+M. I. and Petsche, T.. Cambridge, MA: Cambridge, MA, MIT Press,
+1997b, pp. 83-89.
+
+Mel, B. W., Ruderman, D. L. and Archie, K. A.. Toward a
+single-cell account for binocular disparity tuning: an energy
+model may be hiding in your dendrites. In: *Advances in Neural
+Information Processing Systems*, edited by Jordan, M. I., Kearns,
+M. J. and Solla, S. A.. Cambridge, MA: Cambridge, MA, MIT Press,
+1997c, pp. 208-214.
+
+Mel, B. W., Ruderman, D. L. and Archie, K. A..
+Translation-invariant orientation tuning in visual "complex" cells
+could derive from intradendritic computations. *Journal of
+Neuroscience* 18:4325-4334, 1998.
+
+Melnick, I. V., Santos, S. F. A., Szokol, K., Szucs, P. and
+Safronov, B. V.. Ionic basis of tonic firing in spinal substantia
+gelatinosa neurons of rat. *Journal of Neurophysiology*
+91:646-655, 2004a.
+
+Melnick, I. V., Santos, S. F. A. and Safronov, B. V.. Mechanism of
+spike frequency adaptation in substantia gelatinosa neurones of
+rat. *Journal of Physiology* 559:383-395, 2004b.
+
+Meng, K., Fellner, A., Rattay, F., Ghezzi, D., Meffin, H.,
+Ibbotson, M. R. and Kameneva, T.. Upper stimulation threshold for
+retinal ganglion cell activation. *Journal of Neural Engineering*
+15:046012, 10.1088/1741-2552/aabb7d, 2018.
+
+Menon, V., Musial, T. F., Liu, A., Katz, Y., Kath, W. L.,
+Spruston, N. and Nicholson, D. A.. Balanced synaptic impact via
+distance-dependent synapse distribution and complementary
+expression of AMPARs and NMDARs in hippocampal dendrites. *Neuron*
+80:1451-1463, 10.1016/j.neuron.2013.09.027, 2013.
+
+Menon, V., Spruston, N. and Kath, W. L.. A state-mutating genetic
+algorithm to design ion-channel models. *Proceedings of the
+National Academy of Sciences of the United States of America*
+106:16829-16834, 2009.
+
+Mercer, J. N., Chan, C. S., Tkatch, T., Held, J. and Surmeier, D.
+J.. Nav1.6 sodium channels are critical to pacemaking and fast
+spiking in globus pallidus neurons. *Journal of Neuroscience*
+27:13552-13566, 2007.
+
+Mergenthal, A., Bouteiller, J.-M. C., Yu, G. J. and Berger, T. W..
+A computational model of the cholinergic modulation of Ca1
+pyramidal cell activity. *Frontiers in Computational Neuroscience*
+14:75, 10.3389/fncom.2020.00075, 2020.
+
+Mergenthal, A. R., Bouteiller, J.-M. C. and Berger, T. W..
+Cholinergic modulation of CA1 pyramidal cells via M1 muscarinic
+receptor activation: a computational study at physiological and
+supraphysiological levels. *IEEE Engineering in Medicine and
+Biology Society. Annual Conference* 2018:1396-1399,
+10.1109/EMBC.2018.8512574, 2018.
+
+Merrison-Hort, R., Yousif, N., Ferrario, A. and Borisyuk, R..
+Oscillatory neural models of the basal ganglia for action
+selection in healthy and Parkinsonian cases. In: *Computational
+Neurology and Psychiatry*. Springer International Publishing,
+2017, pp. 149-189.
+
+Meseke, M., Evers, J. F. and Duch, C.. Developmental changes in
+dendritic shape and synapse location tune single-neuron
+computations to changing behavioral functions. *Journal of
+Neurophysiology* 102:41-58, 10.1152/jn.90899.2008, 2009.
+
+Meuth, P., Meuth, S. G., Jacobi, D., Broicher, T., Pape, H.-C. and
+Budde, T.. Get the rhythm: modeling of neuronal activity. *JUNE*
+4:A1-A11, 2005.
+
+Meuth, S. G., Kanyshkova, T., Meuth, P., Landgraf, P., Munsch, T.,
+Ludwig, A., Hofmann, F., Pape, H.-C. and Budde, T.. Membrane
+resting potential of thalamocortical relay neurons is shaped by
+the interaction among task3 and hcn2 channels. *Journal of
+Neurophysiology* 96:1517-1529, 2006.
+
+Meuth, S. G., Bittner, S., Meuth, P., Simon, O. J., Budde, T. and
+Wiendl, H.. TWIK-related acid-sensitive K+ channel 1 (TASK1) and
+TASK3 critically influence T lymphocyte effector functions.
+*Journal of Biological Chemistry* 283:14559-14570, 2008.
+
+Meza, R. C., López-Jury, L., Canavier, C. C. and Henny, P.. Role
+of the axon initial segment in the control of spontaneous
+frequency of nigral dopaminergic neurons in vivo. *Journal of
+Neuroscience* 38:733-744, 2018.
+
+Miceli, F., Soldovieri, M. V., Ambrosino, P., Barrese, V.,
+Migliore, M., Cilio, M. R. and Taglialatela, M..
+Genotype-phenotype correlations in neonatal epilepsies caused by
+mutations in the voltage sensor of K(v)7.2 potassium channel
+subunits. *Proceedings of the National Academy of Sciences of the
+United States of America* 110:4386-4391, 10.1073/pnas.1216867110,
+2013.
+
+Miceli, F., Soldovieri, M. V., Ambrosino, P., De Maria, M.,
+Migliore, M., Migliore, R. and Taglialatela, M.. Early-onset
+epileptic encephalopathy caused by gain-of-function mutations in
+the voltage sensor of Kv7.2 and Kv7.3 potassium channel subunits.
+*Journal of Neuroscience* 35:3782-3793,
+10.1523/JNEUROSCI.4423-14.2015, 2015.
+
+Miceli, F., Soldovieri, M. V., Lugli, L., Bellini, G., Ambrosino,
+P., Migliore, M., del Giudice, E. M., Ferrari, F., Pascotto, A.
+and Taglialatela, M.. Neutralization of a unique,
+negatively-charged residue in the voltage sensor of K(V)7.2
+subunits in a sporadic case of benign familial neonatal seizures.
+*Neurobiology of Disease* 34:501-510, 2009.
+
+Miceli, S., Ness, T. V., Einevoll, G. T. and Schubert, D..
+Impedance spectrum in cortical tissue: implications for
+propagation of LFP signals on the microscopic level. *eNeuro*
+4:ENEURO.0291-16.2016, 10.1523/ENEURO.0291-16.2016, 2017.
+
+Michaelevski, I., Korngreen, A. and Lotan, I.. Interaction of
+syntaxin with a single Kv1.1 channel: a possible mechanism for
+modulating neuronal excitability. *Pflügers Archiv-European
+Journal of Physiology* 454:477-494, 2007.
+
+Michalikova, M., Remme, M. W. H. and Kempter, R.. Extracellular
+waveforms reveal an axonal origin of spikelets in pyramidal
+neurons. *Journal of Neurophysiology* 120:1484-1495,
+10.1152/jn.00463.2017, 2018.
+
+Migliore, M.. Modeling the attenuation and failure of action
+potentials in the dendrites of hippocampal neurons. *Biophysical
+Journal* 71:2394-2403, 1996.
+
+Migliore, M.. On the integration of subthreshold inputs from
+perforant path and Schaffer collaterals in hippocampal CA1
+pyramidal neurons. *Journal of Computational Neuroscience*
+14:185-192, 2003.
+
+Migliore, M., Ascoli, G. A. and Jaffe, D. B.. CA3 cells: detailed
+and simplified pyramidal cell models. In: *Hippocampal
+Microcircuits*, edited by Cutsuridis, V., Graham, B., Cobb, S. and
+Vida, I.. Springer, 2010a, pp. 353-374.
+
+Migliore, M., Cannia, C. and Canavier, C. C.. A modeling study
+suggesting a possible pharmacological target to mitigate the
+effects of ethanol on reward-related dopaminergic signaling.
+*Journal of Neurophysiology* 99:2703-2707, 2008a.
+
+Migliore, M., Cannia, C., Lytton, W. W., Markram, H. and Hines, M.
+L.. Parallel network simulations with NEURON. *Journal of
+Computational Neuroscience* 21:119-129, 2006.
+
+Migliore, M., Cavarretta, F., Hines, M. L. and Shepherd, G. M..
+Functional neurology of a brain system: a 3D olfactory bulb model
+to process natural odorants. *Functional Neurology* 28:241-243,
+10.11138/FNeur/2013.28.3.241, 2013.
+
+Migliore, M., Cavarretta, F., Hines, M. L. and Shepherd, G. M..
+Distributed organization of a brain microcircuit analyzed by
+three-dimensional modeling: the olfactory bulb. *Frontiers in
+Computational Neuroscience* 8:50, 10.3389/fncom.2014.00050, 2014.
+
+Migliore, M., Cavarretta, F., Marasco, A., Tulumello, E., Hines,
+M. L. and Shepherd, G. M.. Synaptic clusters function as odor
+operators in the olfactory bulb. *Proceedings of the National
+Academy of Sciences of the United States of America*
+112:8499-8504, 10.1073/pnas.1502513112, 2015a.
+
+Migliore, M., Cook, E. P., Jaffe, D. B., Turner, D. A. and
+Johnston, D.. Computer simulations of morphometrically
+reconstructed CA3 hippocampal neurons. *Journal of
+Neurophysiology* 73:1157-1168, 1995.
+
+Migliore, M. and Culotta, M.. Energy efficient modulation of
+dendritic processing functions. *Biosystems* 48:157-163, 1998.
+
+Migliore, M., De Blasi, I., Tegolo, D. and Migliore, R.. A
+modeling study suggesting how a reduction in the context-dependent
+input on CA1 pyramidal neurons could generate schizophrenic
+behavior. *Neural Networks* 24:552-559,
+10.1016/j.neunet.2011.01.001, 2011.
+
+Migliore, M., De Simone, G. and Migliore, R.. Effect of the
+initial synaptic state on the probability to induce long-term
+potentiation and depression. *Biophysical Journal* 108:1038 -
+1046, http://dx.doi.org/10.1016/j.bpj.2014.12.048, 2015b.
+
+Migliore, M., Ferrante, M. and Ascoli, G. A.. Signal propagation
+in oblique dendrites of CA1 pyramidal cells. *Journal of
+Neurophysiology* 94:4145-4155, 2005a.
+
+Migliore, M., Hines, M. L., McTavish, T. S. and Shepherd, G. M..
+Functional roles of distributed synaptic clusters in the
+mitral-granule cell network of the olfactory bulb. *Frontiers in
+Integrative Neuroscience* 4:122, 10.3389/fnint.2010.00122, 2010b.
+
+Migliore, M., Hines, M. L. and Shepherd, G. M.. The role of distal
+dendritic gap junctions in synchronization of mitral cell axonal
+output. *Journal of Computational Neuroscience* 18:151-161, 2005b.
+
+Migliore, M., Hoffman, D. A., Magee, J. C. and Johnston, D.. Role
+of an A-type K+ conductance in the back-propagation of action
+potentials in the dendrites of hippocampal pyramidal neurons.
+*Journal of Computational Neuroscience* 7:5-15, 1999.
+
+Migliore, M., Inzirillo, C. and Shepherd, G. M.. Learning
+mechanism for column formation in the olfactory bulb. *Frontiers
+in Integrative Neuroscience* 1:12, 10.3389/neuro.07.012.2007,
+2007.
+
+Migliore, M., Messineo, L. and Cardaci, M.. A model of the effects
+of cognitive load on the subjective estimation and production of
+time intervals. *Biosystems* 58:187-193, 2000.
+
+Migliore, M., Messineo, L., Cardaci, M. and Ayala, G. F..
+Quantitative modeling of perception and production of time
+intervals. *Journal of Neurophysiology* 86:2754-2760, 2001.
+
+Migliore, M., Messineo, L. and Ferrante, M.. Dendritic I-h
+selectively blocks temporal summation of unsynchronized distal
+inputs in CA1 pyramidal neurons. *Journal of Computational
+Neuroscience* 16:5-13, 2004.
+
+Migliore, M. and Migliore, R.. Know your current I(h): interaction
+with a shunting current explains the puzzling effects of its
+pharmacological or pathological modulations. *PLoS ONE* 7:e36867,
+10.1371/journal.pone.0036867, 2012.
+
+Migliore, M., Novara, G. and Tegolo, D.. Single neuron binding
+properties and the magical number 7. *Hippocampus* 18:1122-1130,
+2008b.
+
+Migliore, M. and Shepherd, G. M.. Emerging rules for the
+distributions of active dendritic conductances. *Nature Reviews
+Neuroscience* 3:362-370, 2002.
+
+Migliore, M. and Shepherd, G. M.. Dendritic action potentials
+connect distributed dendrodendritic microcircuits. *Journal of
+Computational Neuroscience* 24:207-221, 2008.
+
+Migliore, R., De Simone, G., Leinekugel, X. and Migliore, M.. The
+possible consequences for cognitive functions of external electric
+fields at power line frequency on hippocampal CA1 pyramidal
+neurons. *European Journal of Neuroscience* 45:1024-1031,
+10.1111/ejn.13325, 2017.
+
+Migliore, R., Lupascu, C. A., Bologna, L. L., Romani, A., Courcol,
+J.-D., Antonel, S., Van Geit, W. A. H., Thomson, A. M., Mercer,
+A., Lange, S., Falck, J., Rössert, C. A., Shi, Y., Hagens, O.,
+Pezzoli, M., Freund, T. F., Kali, S., Muller, E. B., Schürmann,
+F., Markram, H. and Migliore, M.. The physiological variability of
+channel density in hippocampal CA1 pyramidal cells and
+interneurons explored using a unified data-driven modeling
+workflow. *PLoS Computational Biology* 14:e1006423,
+10.1371/journal.pcbi.1006423, 2018.
+
+Mikulovic, S., Restrepo, C. E., Siwani, S., Bauer, P., Pupe, S.,
+Tort, A. B. L., Kullander, K. and Leão, R. N.. Ventral hippocampal
+OLM cells control type 2 theta oscillations and response to
+predator odor. *Nature Communications* 9:3638,
+10.1038/s41467-018-05907-w, 2018.
+
+Miles, J. D., Kilgore, K. L., Bhadra, N. and Lahowetz, E. A..
+Effects of ramped amplitude waveforms on the onset response of
+high-frequency mammalian nerve block. *Journal of Neural
+Engineering* 4:390-398, 2007.
+
+Miller, R. F., Staff, N. P. and Velte, T. J.. Form and function of
+ON-OFF amacrine cells in the amphibian retina. *Journal of
+Neurophysiology* 95:3171-3190, 2006.
+
+Milstein, J. N. and Koch, C.. Dynamic moment analysis of the
+extracellular electric field of a biologically realistic spiking
+neuron. *Neural Computation* 20:2070-2084, 2008.
+
+Minneci, F., Janahmadi, M., Migliore, M., Dragicevic, N., Avossa,
+D. and Cherubini, E.. Signaling properties of stratum oriens
+interneurons in the hippocampus of transgenic mice expressing EGFP
+in a subset of somatostatin-containing cells. *Hippocampus*
+17:538-553, 2007.
+
+Miocinovic, S. and Grill, W. M.. Sensitivity of temporal
+excitation properties to the neuronal element activated by
+extracellular stimulation. *Journal of Neuroscience Methods*
+132:91-99, 2004.
+
+Miocinovic, S., Parent, M., Butson, C. R., Hahn, P. J., Russo, G.
+S., Vitek, J. L. and McIntyre, C. C.. Computational analysis of
+subthalamic nucleus and lenticular fasciculus activation during
+therapeutic deep brain stimulation. *Journal of Neurophysiology*
+96:1569-1580, 2006.
+
+Miocinovic, S., Zhang, J. Y., Xu, W. D., Russo, G. S., Vitek, J.
+L. and McIntyre, C. C.. Stereotactic neurosurgical planning,
+recording, and visualization for deep brain stimulation in
+non-human primates. *Journal of Neuroscience Methods* 162:32-41,
+2007.
+
+Miralles, F. and Solsona, C.. Activity-dependent modulation of the
+presynaptic potassium current in the frog neuromuscular junction.
+*Journal of Physiology* 495:717-732, 1996.
+
+Mirzakhalili, E., Barra, B., Capogrosso, M. and Lempka, S. F..
+Biophysics of temporal interference stimulation. *Cell Systems*
+11:557-572.e5, 10.1016/j.cels.2020.10.004, 2020.
+
+Mishra, J., Fellous, J. M. and Sejnowski, T. J.. Selective
+attention through phase relationship of excitatory and inhibitory
+input synchrony in a model cortical neuron. *Neural Networks*
+19:1329-1346, 2006.
+
+Mishra, P. and Narayanan, R.. High-conductance states and A-type
+K+ channels are potential regulators of the conductance-current
+balance triggered by HCN channels. *Journal of Neurophysiology*
+113:23-43, 10.1152/jn.00601.2013, 2015.
+
+Mishra, P. and Narayanan, R.. Disparate forms of heterogeneities
+and interactions among them drive channel decorrelation in the
+dentate gyrus: degeneracy and dominance. *Hippocampus* 29:378-403,
+10.1002/hipo.23035, 2019.
+
+Mishra, P. and Narayanan, R.. Ion-channel regulation of response
+decorrelation in a heterogeneous multi-scale model of the dentate
+gyrus. *Current Research in Neurobiology* 2:100007,
+10.1016/j.crneur.2021.100007, 2021.
+
+Mittal, D. and Narayanan, R.. Degeneracy in the robust expression
+of spectral selectivity, subthreshold oscillations, and intrinsic
+excitability of entorhinal stellate cells. *Journal of
+Neurophysiology* 120:576-600, 10.1152/jn.00136.2018, 2018.
+
+Miura, K., Tsubo, Y., Okada, M. and Fukai, T.. Balanced excitatory
+and inhibitory inputs to cortical neurons decouple firing
+irregularity from rate modulations. *Journal of Neuroscience*
+27:13802-13812, 2007.
+
+Miyamura, Y., Hitomi, S., Omiya, Y., Ujihara, I., Kokabu, S.,
+Morimoto, Y. and Ono, K.. Isoliquiritigenin, an active ingredient
+of Glycyrrhiza, elicits antinociceptive effects via inhibition of
+NaV channels. *Naunyn-Schmiedeberg's Archives of Pharmacology*
+394:967-980, 10.1007/s00210-020-02030-w, 2021.
+
+Miyasho, T., Takagi, H., Suzuki, H., Watanabe, S., Inoue, M.,
+Kudo, Y. and Miyakawa, H.. Low-threshold potassium channels and a
+low-threshold calcium channel regulate Ca2+ spike firing in the
+dendrites of cerebellar Purkinje neurons: a modeling study. *Brain
+Research* 891:106-115, 2001.
+
+Miyazaki, K., Manita, S. and Ross, W. N.. Developmental profile of
+localized spontaneous Ca(2+) release events in the dendrites of
+rat hippocampal pyramidal neurons. *Cell Calcium* 52:422-432,
+10.1016/j.ceca.2012.08.001, 2012.
+
+Miyazaki, K. and Ross, W. N.. Sodium dynamics in pyramidal neuron
+dendritic spines: synaptically evoked entry predominantly through
+AMPA receptors and removal by diffusion. *Journal of Neuroscience*
+37:9964-9976, 10.1523/JNEUROSCI.1758-17.2017, 2017.
+
+Mo, C. H. and Koch, C.. Modeling reverse-phi motion-selective
+neurons in cortex: double synaptic-veto mechanism. *Neural
+Computation* 15:735-759, 2003.
+
+Mo, C. H., Gu, M. and Koch, C.. A learning rule for local synaptic
+interactions between excitation and shunting inhibition. *Neural
+Computation* 16:2507-2532, 2004.
+
+Moezzi, B., Schaworonkow, N., Plogmacher, L., Goldsworthy, M. R.,
+Hordacre, B., McDonnell, M. D., Iannella, N., Ridding, M. C. and
+Triesch, J.. Simulation of electromyographic recordings following
+transcranial magnetic stimulation. *Journal of Neurophysiology*
+120:2532-2541, 10.1152/jn.00626.2017, 2018.
+
+Moffitt, M. A. and McIntyre, C. C.. Model-based analysis of
+cortical recording with silicon microelectrodes. *Clinical
+Neurophysiology* 116:2240-2250, 2005.
+
+Moffitt, M. A., McIntyre, C. C. and Grill, W. M.. Prediction of
+myelinated nerve fiber stimulation thresholds: limitations of
+linear models. *IEEE Transactions on Biomedical Engineering*
+51:229-236, 2004.
+
+Mohan, H., Verhoog, M. B., Doreswamy, K. K., Eyal, G., Aardse, R.,
+Lodder, B. N., Goriounova, N. A., Asamoah, B., B Brakspear, A. B.
+C., Groot, C., van der Sluis, S., Testa-Silva, G., Obermayer, J.,
+Boudewijns, Z. S. R. M., Narayanan, R. T., Baayen, J. C., Segev,
+I., Mansvelder, H. D. and de Kock, C. P. J.. Dendritic and axonal
+architecture of individual pyramidal neurons across layers of
+adult human neocortex. *Cerebral Cortex* 25:4839-4853,
+10.1093/cercor/bhv188, 2015.
+
+Mohapatra, D. P., Misonou, H., Pan, S. J., Held, J. E., Surmeier,
+D. J. and Trimmer, J. S.. Regulation of intrinsic excitability in
+hippocampal neurons by activity-dependent modulation of the KV2.1
+potassium channel. *Channels* 3:46-56, 2009.
+
+Mohapatra, N., Tønnesen, J., Vlachos, A., Kuner, T., Deller, T.,
+Nägerl, U. V., Santamaria, F. and Jedlicka, P.. Spines slow down
+dendritic chloride diffusion and affect short-term ionic
+plasticity of GABAergic inhibition. *Scientific Reports* 6:23196,
+10.1038/srep23196, 2016.
+
+Moldwin, T. and Segev, I.. Perceptron learning and classification
+in a modeled cortical pyramidal cell. *Frontiers in Computational
+Neuroscience* 1410.3389/fncom.2020.00033, 2020.
+
+Molina-Martínez, B., Jentsch, L.-V., Ersoy, F., van der Moolen,
+M., Donato, S., Ness, T. V., Heutink, P., Jones, P. D. and Cesare,
+P.. A multimodal 3D neuro-microphysiological system with
+neurite-trapping microelectrodes. *Biofabrication*
+1410.1088/1758-5090/ac463b, 2022.
+
+Mondragón-González, S. L. and Burguière, E.. Bio-inspired
+benchmark generator for extracellular multi-unit recordings.
+*Scientific Reports* 7:43253, 10.1038/srep43253, 2017.
+
+Moore, J.. Enhancing the Hodgkin-Huxley equations: simulations
+based on the first publication in the Biophysical Journal.
+*Biophysical Journal* 109:1317 - 1320,
+http://dx.doi.org/10.1016/j.bpj.2015.08.008, 2015.
+
+Moore, J. W. and Hines, M.. Some consequences of intracellular
+calcium binding on phasic synaptic transmitter release. In:
+*Calcium, Neuronal Function, and Transmitter Release*, edited by
+Rahamimoff, R. and Katz, B.. Martinus Nijhoff, 1986, pp. 115-140.
+
+Moore, J. W. and Stuart, A. E.. `Neurons in
+Action <http://neuron.duke.edu/>`__\ *: Computer Simulations with
+NeuroLab*. Sunderland, MA: address, Sinauer Associates, 2000.
+
+Moore, J. W. and Stuart, A. E.. `Neurons in
+Action <http://neuron.duke.edu/>`__\ *2: Tutorials and Simulations
+using NEURON*. Sunderland, MA: address, Sinauer Associates, 2007.
+
+Moore, J. J., Ravassard, P. M., Ho, D., Acharya, L., Kees, A. L.,
+Vuong, C. and Mehta, M. R.. Dynamics of cortical dendritic
+membrane potential and spikes in freely behaving rats. *Science*
+35510.1126/science.aaj1497, 2017.
+
+Moortgat, K. T., Bullock, T. H. and Sejnowski, T. J.. Gap junction
+effects on precision and frequency of a model pacemaker network.
+*Journal of Neurophysiology* 83:984-997, 2000.
+
+Moradi, F.. Information coding and oscillatory activity in synfire
+neural networks with and without inhibitory coupling. *Biological
+Cybernetics* 91:283-294, 2004.
+
+Moradi, K., Kaka, G. and Gharibzadeh, S.. The role of passive
+normalization, voltage-gated channels and synaptic scaling in
+site-independence of somatic EPSP amplitude in CA1 pyramidal
+neurons. *Neuroscience Research* 73:8-16,
+10.1016/j.neures.2012.02.009, 2012.
+
+Moradi, K., Moradi, K., Ganjkhani, M., Hajihasani, M.,
+Gharibzadeh, S. and Kaka, G.. A fast model of voltage-dependent
+NMDA receptors. *Journal of Computational Neuroscience*
+34:521-531, 10.1007/s10827-012-0434-4, 2013.
+
+Moraud, E. M., Capogrosso, M., Formento, E., Wenger, N.,
+DiGiovanna, J., Courtine, G. and Micera, S.. Mechanisms underlying
+the neuromodulation of spinal circuits for correcting gait and
+balance deficits after spinal cord injury. *Neuron* 89:814-828,
+10.1016/j.neuron.2016.01.009, 2016.
+
+Moreira-Lobo, D. C., Cruz, J. S., Silva, F. R., Ribeiro, F. M.,
+Kushmerick, C. and Oliveira, F. A.. Thiamine deficiency increases
+Ca2+ current and Cav1.2 L-type Ca2+ channel levels in cerebellum
+granular neurons. *Cellular and Molecular Neurobiology*
+37:453-460, 10.1007/s10571-016-0378-8, 2017.
+
+Morel, D., Singh, C. and Levy, W. B.. Linearization of excitatory
+synaptic integration at no extra cost. *Journal of Computational
+Neuroscience* 44:173-188, 10.1007/s10827-017-0673-5, 2018.
+
+Morgan, R. J. and Soltesz, I.. Functional consequences of
+transformed network topology in hippocampal sclerosis. In:
+*Computational Neuroscience in Epilepsy*, edited by Soltesz, I.
+and Staley, K.. Elsevier, 2008a, pp. 112-131.
+
+Morgan, R. J. and Soltesz, I.. Microcircuit model of the dentate
+gyrus in epilepsy. In: *Hippocampal Microcircuits*, edited by
+Cutsuridis, V., Graham, B., Cobb, S. and Vida, I.. Springer, 2010,
+pp. 495-525.
+
+Morgan, R. J. and Soltesz, I.. Nonrandom connectivity of the
+epileptic dentate gyrus predicts a major role for neuronal hubs in
+seizures. *Proceedings of the National Academy of Sciences of the
+United States of America* 105:6179-6184, 2008b.
+
+Morita, K.. Differential cortical activation of the striatal
+direct and indirect pathway cells: reconciling the anatomical and
+optogenetic results by using a computational method. *Journal of
+Neurophysiology* 112:120-146, 10.1152/jn.00625.2013, 2014.
+
+Morita, K., Kalra, R., Aihara, K. and Robinson, H. P. C..
+Recurrent synaptic input and the timing of
+gamma-frequency-modulated firing of pyramidal cells during
+neocortical "UP" states. *Journal of Neuroscience* 28:1871-1881,
+2008.
+
+Morse, T. M., Carnevale, N. T., Mutalik, P. G., Migliore, M. and
+Shepherd, G. M.. Abnormal excitability of oblique dendrites
+implicated in early Alzheimer's: a computational study. *Frontiers
+in Neural Circuits* 4:16, 10.3389/fncir.2010.00016, 2010.
+
+Mosher, C. P., Wei, Y., Kamiński, J., Nandi, A., Mamelak, A. N.,
+Anastassiou, C. A. and Rutishauser, U.. Cellular classes in the
+human brain revealed in vivo by heartbeat-related modulation of
+the extracellular action potential waveform. *Cell Reports*
+30:3536-3551.e6, 10.1016/j.celrep.2020.02.027, 2020.
+
+Mou, Z., Triantis, I. F., Woods, V. M., Toumazou, C. and Nikolic,
+K.. A simulation study of the combined thermoelectric
+extracellular stimulation of the sciatic nerve of the Xenopus
+laevis: the localized transient heat block. *IEEE Transactions on
+Biomedical Engineering* 59:1758-1769, 10.1109/TBME.2012.2194146,
+2012.
+
+Moubarak, E., Engel, D., Dufour, M. A., Tapia, M., Tell, F. and
+Goaillard, J.-M.. Robustness to axon initial segment variation is
+explained by somatodendritic excitability in rat substantia nigra
+dopaminergic neurons. *Journal of Neuroscience* 39:5044-5063,
+10.1523/JNEUROSCI.2781-18.2019, 2019.
+
+Moulin, C., Glière, A., Barbier, D., Joucla, S., Yvert, B.,
+Mailley, P. and Guillemaud, R.. A new 3-D finite-element model
+based on thin-film approximation for microelectrode array
+recording of extracellular action potential. *IEEE Transactions on
+Biomedical Engineering* 55:683-692, 10.1109/TBME.2007.903522,
+2008.
+
+Mourdoukoutas, A. P., Truong, D. Q., Adair, D. K., Simon, B. J.
+and Bikson, M.. High-resolution multi-scale computational model
+for non-invasive cervical vagus nerve stimulation.
+*Neuromodulation* 21:261-268, 10.1111/ner.12706, 2018.
+
+Mousa, M. H. and Elbasiouny, S. M.. Dendritic distributions of
+L-type Ca2+ and SK_L channels in spinal motoneurons: a simulation
+study. *Journal of Neurophysiology* 124:1285-1307,
+10.1152/jn.00169.2020, 2020.
+
+Mousa, M. H. and Elbasiouny, S. M.. Estimating the effects of
+slicing on the electrophysiological properties of spinal
+motoneurons under normal and disease conditions. *Journal of
+Neurophysiology* 125:1450-1467, 10.1152/jn.00543.2020, 2021.
+
+Moyer, J. T., Halterman, B. L., Finkel, L. H. and Wolf, J. A..
+Lateral and feedforward inhibition suppress asynchronous activity
+in a large, biophysically-detailed computational model of the
+striatal network. *Frontiers in Computational Neuroscience* 8:152,
+10.3389/fncom.2014.00152, 2014.
+
+Moyer, J. T., Wolf, J. A. and Finkel, L. H.. Effects of
+dopaminergic modulation on the integrative properties of the
+ventral striatal medium spiny neuron. *Journal of Neurophysiology*
+98:3731-3748, 2007.
+
+Mu, P., Moyer, J. T., Ishikawa, M., Zhang, Y., Panksepp, J., Sorg,
+B. A., Schlüter, O. M. and Dong, Y.. Exposure to cocaine
+dynamically regulates the intrinsic membrane excitability of
+nucleus accumbens neurons. *Journal of Neuroscience* 30:3689-3699,
+10.1523/JNEUROSCI.4063-09.2010, 2010.
+
+Mueller, J. K. and Grill, W. M.. Model-based analysis of multiple
+electrode array stimulation for epiretinal visual prostheses.
+*Journal of Neural Engineering* 10:036002,
+10.1088/1741-2560/10/3/036002, 2013.
+
+Mukherjee, P. and Kaplan, E.. Dynamics of neurons in the cat
+lateral geniculate nucleus: in vivo electrophysiology and
+computational modeling. *Journal of Neurophysiology* 74:1222-1243,
+1995.
+
+Mukherjee, P. and Kaplan, E.. The maintained discharge of neurons
+in the cat lateral geniculate nucleus: spectral analysis and
+computational modeling. *Visual Neuroscience* 15:529-539, 1998.
+
+Mukunda, C. L. and Narayanan, R.. Degeneracy in the regulation of
+short-term plasticity and synaptic filtering by presynaptic
+mechanisms. *Journal of Physiology* 595:2611-2637,
+10.1113/JP273482, 2017.
+
+Muller, E., Buesing, L., Schemmel, J. and Meier, K..
+Spike-frequency adapting neural ensembles: beyond mean adaptation
+and renewal theories. *Neural Computation* 19:2958-3010, 2007.
+
+Muller, S. Z., Zadina, A. N., Abbott, L. F. and Sawtell, N. B..
+Continual learning in a multi-layer network of an electric fish.
+*Cell* 179:1382-1392.e10, 10.1016/j.cell.2019.10.020, 2019.
+
+Müllner, F. E., Wierenga, C. J. and Bonhoeffer, T.. Precision of
+inhibition: dendritic inhibition by individual GABAergic synapses
+on hippocampal pyramidal cells is confined in space and time.
+*Neuron* 87:576-589, 10.1016/j.neuron.2015.07.003, 2015.
+
+Munro, E. and Kopell, N.. Subthreshold somatic voltage in
+neocortical pyramidal cells can control whether spikes propagate
+from the axonal plexus to axon terminals: a model study.. *Journal
+of Neurophysiology* 107:2833-2852, 10.1152/jn.00709.2011, 2012.
+
+Murase, S., Lantz, C. L., Kim, E., Gupta, N., Higgins, R.,
+Stopfer, M., Hoffman, D. A. and Quinlan, E. M.. Matrix
+metalloproteinase-9 regulates neuronal circuit development and
+excitability. *Molecular Neurobiology* 53:3477-3493,
+10.1007/s12035-015-9295-y, 2016.
+
+Murbartian, J., Arias, J. M. and Perez-Reyes, E.. Functional
+impact of alternative splicing of human T-type Ca(v)3.3 calcium
+channels. *Journal of Neurophysiology* 92:3399-3407, 2004.
+
+Murphy, B. K. and Miller, K. D.. Multiplicative gain changes are
+induced by excitation or inhibition alone. *Journal of
+Neuroscience* 23:10040-10051, 2003.
+
+Murphy, G. G., Fedorov, N. B., Giese, K. P., Ohno, M., Friedman,
+E., Chen, R. and Silva, A. J.. Increased neuronal excitability,
+synaptic plasticity, and learning in aged Kv beta 1.1 knockout
+mice. *Current Biology* 14:1907-1915, 2004.
+
+Mushtaq, M., Haq, R. U., Anwar, W., Marshall, L., Bazhenov, M.,
+Zia, K., Alam, H., Hertel, L., Awan, A. A. and Martinetz, T.. A
+computational study of suppression of sharp wave ripple complexes
+by controlling calcium and gap junctions in pyramidal cells.
+*Bioengineered* 12:2603-2615, 10.1080/21655979.2021.1936894, 2021.
+
+Musselman, E. D., Cariello, J. E., Grill, W. M. and Pelot, N. A..
+ASCENT (Automated Simulations to Characterize Electrical Nerve
+Thresholds): a pipeline for sample-specific computational modeling
+of electrical stimulation of peripheral nerves. *PLoS
+Computational Biology* 17:e1009285, 10.1371/journal.pcbi.1009285,
+2021.
+
+Mustafá, E. R., Gonzalez, S. C. and Raingo, J.. Ghrelin
+selectively inhibits CaV3.3 subtype of low-voltage-gated calcium
+channels. *Molecular Neurobiology* 57:722-735,
+10.1007/s12035-019-01738-y, 2019.
+
+Nadim, F., Manor, Y., Nusbaum, M. P. and Marder, E.. Frequency
+regulation of a slow rhythm by a fast periodic input. *Journal of
+Neuroscience* 18:5053-5067, 1998.
+
+Nadin, B. M. and Pfaffinger, P. J.. Dipeptidyl peptidase-like
+protein 6 is required for normal electrophysiological properties
+of cerebellar granule cells. *Journal of Neuroscience*
+30:8551-8565, 10.1523/JNEUROSCI.5489-09.2010, 2010.
+
+Nadin, B. M. and Pfaffinger, P. J.. A new TASK for dipeptidyl
+peptidase-like protein 6. *PLoS ONE* 8:e60831,
+10.1371/journal.pone.0060831, 2013.
+
+Næss, S., Halnes, G., Hagen, E., Hagler, D. J., Dale, A. M.,
+Einevoll, G. T. and Ness, T. V.. Biophysically detailed forward
+modeling of the neural origin of EEG and MEG signals. *NeuroImage*
+225:117467, 10.1016/j.neuroimage.2020.117467, 2021.
+
+Nair, D. R., Burgess, R. C., McIntyre, C. C. and Luders, H. O..
+Chronic subdural electrodes in the management of epilepsy.
+*Clinical Neurophysiology* 119:11-28, 2008.
+
+Nakano, T., Yoshimoto, J. and Doya, K.. A model-based prediction
+of the calcium responses in the striatal synaptic spines depending
+on the timing of cortical and dopaminergic inputs and
+post-synaptic spikes. *Frontiers in Computational Neuroscience*
+7:119, 10.3389/fncom.2013.00119, 2013.
+
+Narayanan, R. and Chattarji, S.. Computational analysis of the
+impact of chronic stress on intrinsic and synaptic excitability in
+the hippocampus. *Journal of Neurophysiology* 103:3070-3083,
+10.1152/jn.00913.2009, 2010.
+
+Narayanan, R., Dougherty, K. J. and Johnston, D.. Calcium store
+depletion induces persistent perisomatic increases in the
+functional density of h channels in hippocampal pyramidal neurons.
+*Neuron* 68:921-935, 10.1016/j.neuron.2010.11.033, 2010.
+
+Narayanan, R. and Johnston, D.. Long-term potentiation in rat
+hippocampal neurons is accompanied by spatially widespread changes
+in intrinsic oscillatory dynamics and excitability. *Neuron*
+56:1061-1075, 10.1016/j.neuron.2007.10.033, 2007.
+
+Narayanan, R. and Johnston, D.. The h channel mediates location
+dependence and plasticity of intrinsic phase response in rat
+hippocampal neurons. *Journal of Neuroscience* 28:5846-5850, 2008.
+
+Narayanan, R. and Johnston, D.. The h current is a candidate
+mechanism for regulating the sliding modification threshold in a
+BCM-like synaptic learning rule. *Journal of Neurophysiology*
+104:1020-1033, 10.1152/jn.01129.2009, 2010.
+
+Nardelli, P., Powers, R., Cope, T. C. and Rich, M. M.. Increasing
+motor neuron excitability to treat weakness in sepsis. *Annals of
+Neurology* 82:961-971, 10.1002/ana.25105, 2017.
+
+Nataraj, K., Le Roux, N., Nahmani, M., Lefort, S. and Turrigiano,
+G.. Visual deprivation suppresses L5 pyramidal neuron excitability
+by preventing the induction of intrinsic plasticity. *Neuron*
+68:750-762, 10.1016/j.neuron.2010.09.033, 2010.
+
+Navas-Olive, A., Valero, M., Jurado-Parras, T., de Salas-Quiroga,
+A., Averkin, R. G., Gambino, G., Cid, E. and de la Prida, L. M..
+Multimodal determinants of phase-locked dynamics across
+deep-superficial hippocampal sublayers during theta oscillations.
+*Nature Communications* 11:2217, 10.1038/s41467-020-15840-6, 2020.
+
+Nelson, M. T., Todorovic, S. M. and Perez-Reyes, E.. The role of
+T-type calcium channels in epilepsy and pain. *Current
+Pharmaceutical Design* 12:2189-2197, 2006.
+
+Nenadic, Z. and Burdick, J. W.. A control algorithm for autonomous
+optimization of extracellular recordings. *IEEE Transactions on
+Biomedical Engineering* 53:941-955, 2006.
+
+Nerlich, J., Kuenzel, T., Keine, C., Korenic, A., Rübsamen, R. and
+Milenkovic, I.. Dynamic fidelity control to the central auditory
+system: synergistic glycine/GABAergic inhibition in the cochlear
+nucleus. *Journal of Neuroscience* 34:11604-11620,
+10.1523/JNEUROSCI.0719-14.2014, 2014.
+
+Ness, T. V., Chintaluri, C., Potworowski, J., Łęski, S., Głąbska,
+H., Wójcik, D. K. and Einevoll, G. T.. Modelling and analysis of
+electrical potentials recorded in microelectrode arrays (MEAs).
+*Neuroinformatics* 13:403-426, 10.1007/s12021-015-9265-6, 2015.
+
+Ness, T. V., Remme, M. W. H. and Einevoll, G. T.. Active
+subthreshold dendritic conductances shape the local field
+potential. *Journal of Physiology* 594:3809-3825,
+10.1113/JP272022, 2016.
+
+Ness, T. V., Remme, M. W. H. and Einevoll, G. T.. h-type membrane
+current shapes the local field potential from populations of
+pyramidal neurons. *Journal of Neuroscience* 38:6011-6024,
+10.1523/JNEUROSCI.3278-17.2018, 2018.
+
+Neubig, M. and Destexhe, A.. Low threshold calcium T-current IV
+curve geometry is alterable through the distribution of T-channels
+in thalamic relay neurons. *Neurocomputing* 26-27:215-221, 1999.
+
+Neubig, M. and Destexhe, A.. Are the conductances of inhibitory
+synapses on thalamic relay neurons inhomogeneous? Are synapses
+from individual afferents clustered?. *Neurocomputing*
+32-33:213-218, 2000.
+
+Neubig, M. and Destexhe, A.. Dendritic organization of
+thalamocortical relay neurons and dual functions of inhibitory
+synaptic drives. *Thalamus and Related Systems* 1:39-52, 2001.
+
+Neubig, M., Destexhe, A. and Sejnowski, T. J.. Variability of
+quantal synaptic currents in thalamocortical neurons. *Thalamus
+and Related Systems* 2:153-168, 10.1016/S1472-9288(03)00008-6,
+2003.
+
+Neubig, M., Ulrich, D., Huguenard, J. and Destexhe, A.. Dendritic
+calcium currents in thalamic relay cells. In: *Computational
+Neuroscience: Trends in Research, 1998*, edited by Bower, J. M..
+New York: New York, Plenum Press, 1998, pp. 233-238.
+
+Neumaier, F., Alpdogan, S., Hescheler, J. and Schneider, T..
+Zn2+-induced changes in Cav2.3 channel function: An
+electrophysiological and modeling study. *Journal of General
+Physiology* 15210.1085/jgp.202012585, 2020.
+
+Nevian, T., Larkum, M. E., Polsky, A. and Schiller, J.. Properties
+of basal dendrites of layer 5 pyramidal neurons: a direct
+patch-clamp recording study. *Nature Neuroscience* 10:206-214,
+10.1038/nn1826, 2007.
+
+Neville, K. R. and Lytton, W. W.. Potentiation of Ca2+ influx
+through NMDA channels by action potentials: a computer model.
+*Neuroreport* 10:3711-3716, 1999.
+
+Newton, A. J. H., McDougal, R. A., Hines, M. L. and Lytton, W. W..
+Using NEURON for reaction-diffusion modeling of extracellular
+dynamics. *Frontiers in Neuroinformatics* 12:41,
+10.3389/fninf.2018.00041, 2018.
+
+Newton, T. H., Reimann, M. W., Abdellah, M., Chevtchenko, G.,
+Muller, E. B. and Markram, H.. In silico voltage-sensitive dye
+imaging reveals the emergent dynamics of cortical populations.
+*Nature Communications* 12:3630, 10.1038/s41467-021-23901-7, 2021.
+
+Neymotin, S. A., Chadderdon, G. L., Kerr, C. C., Francis, J. T.
+and Lytton, W. W.. Reinforcement learning of two-joint virtual arm
+reaching in a computer model of sensorimotor cortex. *Neural
+Computation* 25:3263-3293, 10.1162/NECO_a_00521, 2013a.
+
+Neymotin, S. A., Daniels, D. S., Caldwell, B., McDougal, R. A.,
+Carnevale, N. T., Jas, M., Moore, C. I., Hines, M. L., Hämäläinen,
+M. and Jones, S. R.. Human Neocortical Neurosolver (HNN), a new
+software tool for interpreting the cellular and network origin of
+human MEG/EEG data. *eLife* 910.7554/eLife.51214, 2020.
+
+Neymotin, S. A., Dura-Bernal, S., Lakatos, P., Sanger, T. D. and
+Lytton, W. W.. Multitarget multiscale simulation for
+pharmacological treatment of dystonia in motor cortex. *Frontiers
+in Pharmacology* 7:157, 10.3389/fphar.2016.00157, 2016a.
+
+Neymotin, S. A., Dura-Bernal, S., Moreno, H. and Lytton, W. W..
+Computer modeling for pharmacological treatments for dystonia.
+*Drug Discovery Today. Disease Models* 19:51-57,
+10.1016/j.ddmod.2017.02.003, 2016b.
+
+Neymotin, S. A., Hilscher, M. M., Moulin, T. C., Skolnick, Y.,
+Lazarewicz, M. T. and Lytton, W. W.. Ih tunes theta/gamma
+oscillations and cross-frequency coupling in an in silico CA3
+model. *PLoS ONE* 8:e76285, 10.1371/journal.pone.0076285, 2013b.
+
+Neymotin, S. A., Jacobs, K. M., Fenton, A. A. and Lytton, W. W..
+Synaptic information transfer in computer models of neocortical
+columns. *Journal of Computational Neuroscience* 30:69-84,
+10.1007/s10827-010-0253-4, 2011a.
+
+Neymotin, S. A., Lazarewicz, M. T., Sherif, M., Contreras, D.,
+Finkel, L. H. and Lytton, W. W.. Ketamine disrupts theta
+modulation of gamma in a computer model of hippocampus. *Journal
+of Neuroscience* 31:11733-11743, 10.1523/JNEUROSCI.0501-11.2011,
+2011b.
+
+Neymotin, S. A., Lee, H., Fenton, A. A. and Lytton, W. W..
+Interictal EEG discoordination in a rat seizure model. *Journal of
+Clinical Neurophysiology* 27:438-444,
+10.1097/WNP.0b013e3181fe059e, 2010.
+
+Neymotin, S. A., Lee, H., Park, E., Fenton, A. A. and Lytton, W.
+W.. Emergence of physiological oscillation frequencies in a
+computer model of neocortex. *Frontiers in Computational
+Neuroscience* 5:19, 10.3389/fncom.2011.00019, 2011c.
+
+Neymotin, S. A., McDougal, R. A., Bulanova, A. S., Zeki, M.,
+Lakatos, P., Terman, D., Hines, M. L. and Lytton, W. W.. Calcium
+regulation of HCN channels supports persistent activity in a
+multiscale model of neocortex. *Neuroscience* 316:344-366,
+10.1016/j.neuroscience.2015.12.043, 2016c.
+
+Neymotin, S. A., McDougal, R. A., Sherif, M. A., Fall, C. P.,
+Hines, M. L. and Lytton, W. W.. Neuronal calcium wave propagation
+varies with changes in endoplasmic reticulum parameters: a
+computer model. *Neural Computation* 27:898-924,
+10.1162/NECO_a_00712, 2015.
+
+Neymotin, S. A., Suter, B. A., Dura-Bernal, S., Shepherd, G. M.
+G., Migliore, M. and Lytton, W. W.. Optimizing computer models of
+corticospinal neurons to replicate in vitro dynamics. *Journal of
+Neurophysiology* 117:148-162, 10.1152/jn.00570.2016, 2017.
+
+Neymotin, S., Uhlrich, D. J., Manning, K. A. and Lytton, W. W..
+Data mining of time-domain features from neural extracellular
+field data. *Studies in Computational Intelligence* 151:119-140,
+2008.
+
+Ng, L. J., Volman, V., Gibbons, M. M., Phohomsiri, P., Cui, J.,
+Swenson, D. J. and Stuhmiller, J. H.. A mechanistic end-to-end
+concussion model that translates head kinematics to neurologic
+injury. *Frontiers in Neurology* 8:269, 10.3389/fneur.2017.00269,
+2017.
+
+Nicholson, D. A., Trana, R., Katz, Y., Kath, W. L., Spruston, N.
+and Geinisman, Y.. Distance-dependent differences in synapse
+number and AMPA receptor expression in hippocampal CA1 pyramidal
+neurons. *Neuron* 50:431-442, 2006.
+
+Niculescu, D., Hirdes, W., Hornig, S., Pongs, O. and Schwarz, J.
+R.. Erg potassium currents of neonatal mouse Purkinje cells
+exhibit fast gating kinetics and are inhibited by mGluR1
+activation. *Journal of Neuroscience* 33:16729-16740,
+10.1523/JNEUROSCI.5523-12.2013, 2013.
+
+Nie, Y., Fellous, J.-M. and Tatsuno, M.. Influence of external
+inputs and asymmetry of connections on information-geometric
+measures involving up to ten neuronal interactions. *Neural
+Computation* 26:2247-2293, 10.1162/NECO_a_00633, 2014.
+
+Niedringhaus, M., Chen, X., Conant, K. and Dzakpasu, R.. Synaptic
+potentiation facilitates memory-like attractor dynamics in
+cultured in vitro hippocampal networks. *PLoS ONE* 8:e57144,
+10.1371/journal.pone.0057144, 2013.
+
+Nieus, T., Sola, E., Mapelli, J., Saftenku, E., Rossi, P. and
+D'Angelo, E.. LTP regulates burst initiation and frequency at
+mossy fiber-granule cell synapses of rat cerebellum: Experimental
+observations and theoretical predictions. *Journal of
+Neurophysiology* 95:686-699, 2006.
+
+Nieus, T. R., Mapelli, L. and D'Angelo, E.. Regulation of output
+spike patterns by phasic inhibition in cerebellar granule cells.
+*Frontiers in Cellular Neuroscience* 8:246,
+10.3389/fncel.2014.00246, 2014.
+
+Nigro, M. J., Perin, P. and Magistretti, J.. Differential effects
+of Zn(2+) on activation, deactivation, and inactivation kinetics
+in neuronal voltage-gated Na(+) channels. *Pflügers
+Archiv-European Journal of Physiology* 462:331-347,
+10.1007/s00424-011-0972-z, 2011.
+
+Nikolic, K., Jarvis, S., Grossman, N. and Schultz, S..
+Computational models of optogenetic tools for controlling neural
+circuits with light [Online]. *IEEE Engineering in Medicine and
+Biology Society Proceedings* 2013:5934-5937,
+10.1109/EMBC.2013.6610903, 2013.
+
+Nishino, E., Yamada, R., Kuba, H., Hioki, H., Furuta, T., Kaneko,
+T. and Ohmori, H.. Sound-intensity-dependent compensation for the
+small interaural time difference cue for sound source
+localization.. *Journal of Neuroscience* 28:7153-7164,
+10.1523/JNEUROSCI.4398-07.2008, 2008.
+
+Nolte, M., Reimann, M. W., King, J. G., Markram, H. and Muller, E.
+B.. Cortical reliability amid noise and chaos. *Nature
+Communications* 10:3792, 10.1038/s41467-019-11633-8, 2019.
+
+Nörenberg, A., Hu, H., Vida, I., Bartos, M. and Jonas, P..
+Distinct nonuniform cable properties optimize rapid and efficient
+activation of fast-spiking GABAergic interneurons. *Proceedings of
+the National Academy of Sciences of the United States of America*
+107:894-899, 10.1073/pnas.0910716107, 2010.
+
+Novorodovskaya, T. S.. A simulation study of calcium dynamics
+features caused by exchange between the cytosol and organellar
+stores of neurons. *Neurophysiology* 41:380-388, 2009.
+
+Novorodovskaya, T. S. and Korogod, S. M.. Comparative model
+analysis of calcium exchange between the cytosol and stores of
+mitochondria or endoplasmic reticulum. *Neurophysiology*
+41:307-318, 2009.
+
+Novorodovskaya, T. S. and Kulagina, I. B.. Structure dependence of
+the calcium dynamics in purkinje neuron dendrites during
+generation of bursting discharges: a simulation study.
+*Neurophysiology* 42:92-103, 2010.
+
+Novorodovskaya, T. S. and Kulagina, I. B.. Simulation study of
+non-organellar binding of calcium by fast and slow buffers in
+dendrites containing an organellar store. *Neurophysiology*
+42:307-317, 10.1007/s11062-011-9164-x, 2011.
+
+O'Boyle, M. P., Carnevale, N. T., Claiborne, B. J. and Brown, T.
+H.. A new graphical approach for visualizing the relationship
+between anatomical and electrotonic structure. In: *Computational
+Neuroscience: Trends in Research 1995*, edited by Bower, J. M..
+San Diego: San Diego, Academic Press, 1996, pp. 423-428.
+
+O'Connor, S., Angelo, K. and Jacob, T. J. C.. Burst firing versus
+synchrony in a gap junction connected olfactory bulb mitral cell
+network model. *Frontiers in Computational Neuroscience* 6:75,
+10.3389/fncom.2012.00075, 2012.
+
+O'Donnell, C. and van Rossum, M. C. W.. Systematic analysis of the
+contributions of stochastic voltage gated channels to neuronal
+noise. *Frontiers in Computational Neuroscience* 8:105,
+10.3389/fncom.2014.00105, 2014.
+
+O'Donnell, C. and van Rossum, M. C. W.. Spontaneous action
+potentials and neural coding in unmyelinated axons.. *Neural
+Computation* 27:801-818, 10.1162/NECO_a_00705, 2015.
+
+O'Halloran, D. M.. Simulation model of CA1 pyramidal neurons
+reveal opposing roles for the Na+/Ca2+ exchange current and
+Ca2+-activated K+ current during spike-timing dependent synaptic
+plasticity. *PLoS ONE* 15:e0230327, 10.1371/journal.pone.0230327,
+2020.
+
+Ohana, O., Portner, H. and Martin, K. A. C.. Fast recruitment of
+recurrent inhibition in the cat visual cortex. *PLoS ONE*
+7:e40601, 10.1371/journal.pone.0040601, 2012.
+
+Ohana, O. and Sakmann, B.. Transmitter release modulation in nerve
+terminals of rat neocortical pyramidal cells by intracellular
+calcium buffers. *Journal of Physiology* 513:135-148, 1998.
+
+Ohura, S. and Kamiya, H.. Short-term depression of axonal spikes
+at the mouse hippocampal mossy fibers and sodium channel-dependent
+modulation. *eNeuro* 5:ENEURO.0415-17.2018,
+10.1523/ENEURO.0415-17.2018, 2018a.
+
+Ohura, S. and Kamiya, H.. Sodium channel-dependent and
+-independent mechanisms underlying axonal afterdepolarization at
+mouse hippocampal mossy fibers. *eNeuro* 5:ENEURO.0254-18.2018,
+10.1523/ENEURO.0254-18.2018, 2018b.
+
+Oláh, V. J., Lukacsovich, D., Winterer, J., Arszovszki, A.,
+Lőrincz, A., Nusser, Z., Földy, C. and Szabadics, J.. Functional
+specification of CCK+ interneurons by alternative isoforms of
+Kv4.3 auxiliary subunits. *eLife* 910.7554/eLife.58515, 2020.
+
+Oláh, V. J., Tarcsay, G. and Brunner, J.. Small size of recorded
+neuronal structures confines the accuracy in direct axonal voltage
+measurements. *eNeuro* 810.1523/ENEURO.0059-21.2021, 2021.
+
+Olivares, E. and Orio, P.. Mathematical modeling of TRPM8 and the
+cold thermoreceptors. In: *TRP Channels in Sensory Transduction*,
+edited by Madrid, R. and Bacigalupo, J.. Springer International
+Publishing, 2015, pp. 209-223.
+
+Olivares, E., Salgado, S., Maidana, J. P., Herrera, G., Campos,
+M., Madrid, R. and Orio, P.. TRPM8-dependent dynamic response in a
+mathematical model of cold thermoreceptor. *PLoS ONE* 10:e0139314,
+10.1371/journal.pone.0139314, 2015.
+
+Oltedal, L. and Hartveit, E.. Transient release kinetics of rod
+bipolar cells revealed by capacitance measurement of exocytosis
+from axon terminals in rat retinal slices. *Journal of Physiology*
+588:1469-1487, 10.1113/jphysiol.2010.186916, 2010.
+
+Oltedal, L., Morkve, S. H., Veruki, L. and Hartveit, E.. Patch
+clamp investigations and compartmental modeling of rod bipolar
+axon terminals in an in vitro thin slice preparation of the
+mammalian retina. *Journal of Neurophysiology* 97:1171-1187, 2007.
+
+Oltedal, L., Veruki, M. L. and Hartveit, E.. Passive membrane
+properties and electrotonic signal processing in retinal rod
+bipolar cells. *Journal of Physiology* 587:829-849, 2009.
+
+Olypher, A. V., Lytton, W. W. and Prinz, A. A.. Input-to-output
+transformation in a model of the rat hippocampal CA1 network.
+*Frontiers in Computational Neuroscience* 6:57,
+10.3389/fncom.2012.00057, 2012.
+
+Omori, T., Aonishi, T., Miyakawa, H., Inoue, M. and Okada, M..
+Estimated distribution of specific membrane resistance in
+hippocampal CA1 pyramidal neuron. *Brain Research* 1125:199-208,
+2006.
+
+Omori, T., Aonishi, T., Miyakawa, H., Inoue, M. and Okada, M..
+Steep decrease in the specific membrane resistance in the apical
+dendrites of hippocampal CA1 pyramidal neurons. *Neuroscience
+Research* 64:83-95, 2009.
+
+Omurtag, A. and Lytton, W. W.. Spectral method and high-order
+finite differences for the nonlinear cable equation. *Neural
+Computation* 22:2113-2136, 2010.
+
+Ona-Jodar, T., Gerkau, N. J., Sara Aghvami, S., Rose, C. R. and
+Egger, V.. Two-photon Na+ imaging reports somatically evoked
+action potentials in rat olfactory bulb mitral and granule cell
+neurites. *Frontiers in Cellular Neuroscience* 11:50,
+10.3389/fncel.2017.00050, 2017.
+
+van Ooyen, A., Duijnhouwer, J., Remme, M. W. H. and van Pelt, J..
+The effect of dendritic topology on firing patterns in model
+neurons. *Network* 13:311-325, 2002.
+
+van Ooyen, A. and van Elburg, R. A. J.. Dendritic size and
+topology influence burst firing in pyramidal cells. In: *The
+Computing Dendrite*, edited by Cuntz, H., Remme, M. and
+Torben-Nielsen, B.. , 2014, pp. 381-395.
+
+Opsal, N., Canfield, P., Banks, T. and Nair, S. S.. An efficient
+pipeline for biophysical modeling of neurons [Online]. *Proc. 10th
+Int. IEEE/EMBS Conf. Neural Engineering* :99-102,
+10.1109/NER49283.2021.9441222, 2021.
+
+Ordemann, G. J., Apgar, C. J., Chitwood, R. A. and Brager, D. H..
+Altered A-type potassium channel function impairs dendritic spike
+initiation and temporoammonic long-term potentiation in Fragile X
+syndrome. *Journal of Neuroscience*
+10.1523/JNEUROSCI.0082-21.2021, 2021.
+
+Orio, P., Parra, A., Madrid, R., González, O., Belmonte, C. and
+Viana, F.. Role of Ih in the firing pattern of mammalian cold
+thermoreceptor endings. *Journal of Neurophysiology*
+108:3009-3023, 10.1152/jn.01033.2011, 2012.
+
+Orio, P. and Soudry, D.. Simple, fast and accurate implementation
+of the diffusion approximation algorithm for stochastic ion
+channels with multiple states. *PLoS ONE* 7:e36670,
+10.1371/journal.pone.0036670, 2012.
+
+Ortner, N. J., Bock, G., Dougalis, A., Kharitonova, M., Duda, J.,
+Hess, S., Tuluc, P., Pomberger, T., Stefanova, N., Pitterl, F.,
+Ciossek, T., Oberacher, H., Draheim, H. J., Kloppenburg, P., Liss,
+B. and Striessnig, J.. Lower affinity of isradipine for L-type
+Ca2+ channels during substantia nigra dopamine neuron-like
+activity: implications for neuroprotection in Parkinson's disease.
+*Journal of Neuroscience* 37:6761-6777,
+10.1523/JNEUROSCI.2946-16.2017, 2017.
+
+Orts-Del'Immagine, A., Seddik, R., Tell, F., Airault, C.,
+Er-Raoui, G., Najimi, M., Trouslard, J. and Wanaverbecq, N.. A
+single polycystic kidney disease 2-like 1 channel opening acts as
+a spike generator in cerebrospinal fluid-contacting neurons of
+adult mouse brainstem. *Neuropharmacology* 101:549-565,
+10.1016/j.neuropharm.2015.07.030, 2016.
+
+Osorio, N., Korogod, S. and Delmas, P.. Specialized functions of
+Nav1.5 and Nav1.9 channels in electrogenesis of myenteric neurons
+in intact mouse ganglia. *Journal of Neuroscience* 34:5233-5244,
+10.1523/JNEUROSCI.0057-14.2014, 2014.
+
+Ostroumov, K.. A new stochastic tridimensional model of neonatal
+rat spinal motoneuron for investigating compartmentalization of
+neuronal conductances and their influence on firing. *Journal of
+Neuroscience Methods* 163:362-372, 2007.
+
+Osypenko, D. S., Dovgan, A. V., Kononenko, N. I., Dromaretsky, A.
+V., Matvieienko, M., Rybachuk, O. A., Zhang, J., Korogod, S. M.,
+Venkataraman, V. and Belan, P.. Perturbed Ca2+-dependent signaling
+of DYT2 hippocalcin mutant as mechanism of autosomal recessive
+dystonia. *Neurobiology of Disease* 132:104529,
+10.1016/j.nbd.2019.104529, 2019.
+
+Otopalik, A. G., Goeritz, M. L., Sutton, A. C., Brookings, T.,
+Guerini, C. and Marder, E.. Sloppy morphological tuning in
+identified neurons of the crustacean stomatogastric ganglion.
+*eLife* 6:e22352, 10.7554/eLife.22352, 2017a.
+
+Otopalik, A. G., Pipkin, J. and Marder, E.. Neuronal morphologies
+built for reliable physiology in a rhythmic motor circuit. *eLife*
+8:e41728, 10.7554/eLife.41728, 2019.
+
+Otopalik, A. G., Sutton, A. C., Banghart, M. and Marder, E.. When
+complex neuronal structures may not matter. *eLife* 6:e23508,
+10.7554/eLife.23508, 2017b.
+
+Ouanounou, G., Baux, G. and Bal, T.. A novel synaptic plasticity
+rule explains homeostasis of neuromuscular transmission. *eLife*
+5:e12190, 10.7554/eLife.12190, 2016.
+
+Overstreet, C. K., Klein, J. D. and Helms Tillery, S. I..
+Computational modeling of direct neuronal recruitment during
+intracortical microstimulation in somatosensory cortex. *Journal
+of Neural Engineering* 10:066016, 10.1088/1741-2560/10/6/066016,
+2013.
+
+Ovsepian, S. V., Steuber, V., Le Berre, M., O'Hara, L., O'Leary,
+V. B. and Dolly, J. O.. A defined heteromeric KV1 channel
+stabilizes the intrinsic pacemaking and regulates the output of
+deep cerebellar nuclear neurons to thalamic targets. *Journal of
+Physiology* 591:1771-1791, 10.1113/jphysiol.2012.249706, 2013.
+
+Ozer, M., Graham, L. J., Erkaymaz, O. and Uzuntarla, M.. Impact of
+synaptic noise and conductance state on spontaneous cortical
+firing. *Neuroreport* 18:1371-1374, 2007.
+
+Padamsey, Z., Katsanevaki, D., Dupuy, N. and Rochefort, N. L..
+Neocortex saves energy by reducing coding precision during food
+scarcity. *Neuron* 110:280-296.e10, 10.1016/j.neuron.2021.10.024,
+2022.
+
+Padmashri, R., Ganguly, A., Mondal, P. P., Rajan, K. and Sikdar,
+S. K.. Kynurenate treatment of autaptic hippocampal microcultures
+affect localized voltage-dependent calcium diffusion in the
+dendrites. *Cell Calcium* 39:247-258, 2006.
+
+Paduraru, O.. Influence of the basal arborization on the firing
+pattern of a burst firing layer 5 neocortical neuron. *Proceedings
+of the Romanian Academy Series A-Mathematics Physics Technical
+Sciences Information Science* 8:65-70, 2007.
+
+Paknahad, J., Kosta, P., Bouteiller, J.-M. C., Humayun, M. S. and
+Lazzi, G.. Mechanisms underlying activation of retinal bipolar
+cells through targeted electrical stimulation: a computational
+study. *Journal of Neural Engineering* 1810.1088/1741-2552/ac3dd8,
+2021a.
+
+Paknahad, J., Kosta, P., Iseri, E., Farzad, S., Bouteiller, J.-M.
+C., Humayun, M. S. and Lazzi, G.. Modeling ON cone bipolar cells
+for electrical stimulation [Online]. *Proc. 43rd Annual Int. Conf.
+of the IEEE Engineering in Medicine Biology Society (EMBC)*
+:6547-6550, 10.1109/EMBC46164.2021.9629884, 2021b.
+
+Paknahad, J., Loizos, K., Humayun, M. and Lazzi, G..
+Responsiveness of retinal ganglion cells through frequency
+modulation of electrical stimulation: a computational modeling
+study. *Annual International Conference of the IEEE Engineering in
+Medicine and Biology Society* 2020:3393-3398,
+10.1109/EMBC44109.2020.9176125, 2020a.
+
+Paknahad, J., Loizos, K., Humayun, M. and Lazzi, G.. Targeted
+stimulation of retinal ganglion cells in epiretinal prostheses: a
+multiscale computational study. *IEEE Transactions on Neural
+Systems and Rehabilitation Engineering* 28:2548-2556,
+10.1109/TNSRE.2020.3027560, 2020b.
+
+Paknahad, J., Loizos, K., Yue, L., Humayun, M. S. and Lazzi, G..
+Color and cellular selectivity of retinal ganglion cell subtypes
+through frequency modulation of electrical stimulation.
+*Scientific Reports* 11:5177, 10.1038/s41598-021-84437-w, 2021c.
+
+Palmer, L. M., Clark, B. A., Gründemann, J., Roth, A., Stuart, G.
+J. and Häusser, M.. Initiation of simple and complex spikes in
+cerebellar Purkinje cells. *Journal of Physiology* 588:1709-1717,
+10.1113/jphysiol.2010.188300, 2010.
+
+Palmer, L. M., Shai, A. S., Reeve, J. E., Anderson, H. L.,
+Paulsen, O. and Larkum, M. E.. NMDA spikes enhance action
+potential generation during sensory input. *Nature Neuroscience*
+17:383-390, 10.1038/nn.3646, 2014.
+
+Palmer, L. M. and Stuart, G. J.. Membrane potential changes in
+dendritic spines during action potentials and synaptic input.
+*Journal of Neuroscience* 29:6897-6903, 2009.
+
+Pan, Y. and Cummins, T. R.. Distinct functional alterations in
+SCN8A epilepsy mutant channels. *Journal of Physiology*
+598:381-401, 10.1113/JP278952, 2020.
+
+Papasavvas, C. A., Parrish, R. R. and Trevelyan, A. J..
+Propagating activity in neocortex, mediated by gap junctions and
+modulated by extracellular potassium. *eNeuro*
+710.1523/ENEURO.0387-19.2020, 2020.
+
+Papoutsi, A., Kastellakis, G. and Poirazi, P.. Basal tree
+complexity shapes functional pathways in the prefrontal cortex.
+*Journal of Neurophysiology* 118:1970-1983, 10.1152/jn.00099.2017,
+2017.
+
+Papoutsi, A., Sidiropoulou, K., Cutsuridis, V. and Poirazi, P..
+Induction and modulation of persistent activity in a layer V PFC
+microcircuit model. *Frontiers in Neural Circuits* 7:161,
+10.3389/fncir.2013.00161, 2013.
+
+Papoutsi, A., Sidiropoulou, K. and Poirazi, P.. Dendritic
+nonlinearities reduce network size requirements and mediate ON and
+OFF states of persistent activity in a PFC microcircuit model.
+*PLoS Computational Biology* 10:e1003764,
+10.1371/journal.pcbi.1003764, 2014.
+
+Parashar, M., Saha, K. and Bandyopadhyay, S.. Axon hillock
+currents enable single-neuron-resolved 3d reconstruction using
+diamond nitrogen-vacancy magnetometry. *Communications Physics*
+3:174, 10.1038/s42005-020-00439-6, 2020.
+
+Parasuram, H., Nair, B., D'Angelo, E., Hines, M., Naldi, G. and
+Diwakar, S.. Computational modeling of single neuron extracellular
+electric potentials and network local field potentials using
+LFPsim. *Frontiers in Computational Neuroscience* 10:65,
+10.3389/fncom.2016.00065, 2016.
+
+Parasuram, H., Nair, B., Naldi, G., D'Angelo, E. and Diwakar, S..
+A modeling based study on the origin and nature of evoked
+post-synaptic local field potentials in granular layer. *Journal
+of Physiology, Paris* 105:71-82, 10.1016/j.jphysparis.2011.07.011,
+2011.
+
+Parasuram, H., Nair, B., Naldi, G., D'Angelo, E. and Diwakar, S..
+Understanding cerebellum granular layer network computations
+through mathematical reconstructions of evoked local field
+potentials. *Annals of Neurosciences* 25:11-24, 10.1159/000481905,
+2018.
+
+Paré, D., Lang, E. J. and Destexhe, A.. Inhibitory control of
+somatodendritic interactions underlying action potentials in
+neocortical pyramidal neurons in vivo: an intracellular and
+computational study. *Neuroscience* 84:377-402, 1998.
+
+Parekh, R. and Ascoli, G. A.. Neuronal morphology goes digital: a
+research hub for cellular and system neuroscience. *Neuron*
+77:1017-1038, 10.1016/j.neuron.2013.03.008, 2013.
+
+Park, A., Hoffman, K. and Keller, A.. Roles of GABAA and GABAB
+receptors in regulating thalamic activity by the zona incerta: a
+computational study. *Journal of Neurophysiology* 112:2580-2596,
+10.1152/jn.00282.2014, 2014.
+
+Park, D. S., Shekhar, A., Santucci, J., Redel-Traub, G., Solinas,
+S., Mintz, S., Lin, X., Chang, E. W., Narke, D., Xia, Y.,
+Goldfarb, M. and Fishman, G. I.. Ionic mechanisms of impulse
+propagation failure in the FHF2-deficient heart. *Circulation
+Research* 127:1536-1548, 10.1161/CIRCRESAHA.120.317349, 2020a.
+
+Park, H.-J. and Durand, D. M.. Motion control of the ankle joint
+with a multiple contact nerve cuff electrode: a simulation study.
+*Biological Cybernetics* 108:445-457, 10.1007/s00422-014-0612-8,
+2014.
+
+Park, J., Papoutsi, A., Ash, R. T., Marin, M. A., Poirazi, P. and
+Smirnakis, S. M.. Contribution of apical and basal dendrites to
+orientation encoding in mouse V1 L2/3 pyramidal neurons. *Nature
+Communications* 10:5372, 10.1038/s41467-019-13029-0, 2019a.
+
+Park, K., Lee, J., Jang, H. J., Richards, B. A., Kohl, M. M. and
+Kwag, J.. Optogenetic activation of parvalbumin and somatostatin
+interneurons selectively restores theta-nested gamma oscillations
+and oscillation-induced spike timing-dependent long-term
+potentiation impaired by amyloid β oligomers. *BMC Biology* 18:7,
+10.1186/s12915-019-0732-7, 2020b.
+
+Park, S. and Kwag, J.. Dendritic-targeting interneuron controls
+spike timing of hippocampal CA1 pyramidal neuron via activation of
+I(h). *Neuroscience Letters* 523:9-14,
+10.1016/j.neulet.2012.06.010, 2012.
+
+Park, S., Sohn, J.-W., Cho, J. and Huh, Y.. A computational
+modeling reveals that strength of inhibitory input, E/I balance,
+and distance of excitatory input modulate thalamocortical bursting
+properties. *Experimental Neurobiology* 28:568-577,
+10.5607/en.2019.28.5.568, 2019b.
+
+Park, S. W., Jang, H. J., Kim, M. and Kwag, J.. Spatiotemporally
+random and diverse grid cell spike patterns contribute to the
+transformation of grid cell to place cell in a neural network
+model. *PLoS ONE* 14:e0225100, 10.1371/journal.pone.0225100,
+2019c.
+
+Parker, J. L., Laird-Wah, J. and Cousins, M. J.. Comparison of a
+simple model of dorsal column axons with the electrically evoked
+compound action potential. *Bioelectronics in Medicine* 1:117-130,
+10.2217/bem-2017-0006, 2018.
+
+Parker, J. L., Obradovic, M., Hesam Shariati, N., Gorman, R. B.,
+Karantonis, D. M., Single, P. S., Laird-Wah, J., Bickerstaff, M.
+and Cousins, M. J.. Evoked compound action potentials reveal
+spinal cord dorsal column neuroanatomy. *Neuromodulation*
+23:82-95, 10.1111/ner.12968, 2020.
+
+Pashut, T., Magidov, D., Ben-Porat, H., Wolfus, S., Friedman, A.,
+Perel, E., Lavidor, M., Bar-Gad, I., Yeshurun, Y. and Korngreen,
+A.. Patch-clamp recordings of rat neurons from acute brain slices
+of the somatosensory cortex during magnetic stimulation.
+*Frontiers in Cellular Neuroscience* 8:145,
+10.3389/fncel.2014.00145, 2014.
+
+Pashut, T., Wolfus, S., Friedman, A., Lavidor, M., Bar-Gad, I.,
+Yeshurun, Y. and Korngreen, A.. Mechanisms of magnetic stimulation
+of central nervous system neurons. *PLoS Computational Biology*
+7:e1002022, 10.1371/journal.pcbi.1002022, 2011.
+
+Patel, R. R., Barbosa, C., Xiao, Y. and Cummins, T. R.. Human
+Nav1.6 channels generate larger resurgent currents than human
+Nav1.1 channels, but the Navβ4 peptide does not protect either
+isoform from use-dependent reduction. *PLoS ONE* 10:e0133485,
+10.1371/journal.pone.0133485, 2015.
+
+Patoary, M. N. I., Tropper, C., McDougal, R. A., Lin, Z. and
+Lytton, W. W.. Parallel stochastic discrete event simulation of
+calcium dynamics in NEURON. *IEEE/ACM Transactions on
+Computational Biology and Bioinformatics* 16:1007-1019,
+10.1109/TCBB.2017.2756930, 2019.
+
+Paucar, M., Ågren, R., Li, T., Lissmats, S., Bergendal, Å.,
+Weinberg, J., Nilsson, D., Savichetva, I., Sahlholm, K., Nilsson,
+J. and Svenningsson, P.. V374a kcnd3 pathogenic variant associated
+with paroxysmal ataxia exacerbations. *Neurology Genetics* 7:e546,
+10.1212/NXG.0000000000000546, 2021.
+
+Pavlov, I., Savtchenko, L. P., Kullmann, D. M., Semyanov, A. and
+Walker, M. C.. Outwardly rectifying tonically active GABAA
+receptors in pyramidal cells modulate neuronal offset, not gain..
+*Journal of Neuroscience* 29:15341-15350,
+10.1523/JNEUROSCI.2747-09.2009, 2009.
+
+Pavlov, I., Savtchenko, L. P., Song, I., Koo, J., Pimashkin, A.,
+Rusakov, D. A. and Semyanov, A.. Tonic GABAA conductance
+bidirectionally controls interneuron firing pattern and
+synchronization in the CA3 hippocampal network. *Proceedings of
+the National Academy of Sciences of the United States of America*
+111:504-509, 10.1073/pnas.1308388110, 2014.
+
+Pavlov, I., Scimemi, A., Savtchenko, L., Kullmann, D. M. and
+Walker, M. C.. I(h)-mediated depolarization enhances the temporal
+precision of neuronal integration. *Nature Communications* 2:199,
+10.1038/ncomms1202, 2011.
+
+Payne, H. L., French, R. L., Guo, C. C., Nguyen-Vu, T. B.,
+Manninen, T. and Raymond, J. L.. Cerebellar Purkinje cells control
+eye movements with a rapid rate code that is invariant to spike
+irregularity. *eLife* 8:e37102, 10.7554/eLife.37102, 2019.
+
+Pei, Z., Xiao, Y., Meng, J., Hudmon, A. and Cummins, T. R..
+Cardiac sodium channel palmitoylation regulates channel
+availability and myocyte excitability with implications for
+arrhythmia generation. *Nature Communications* 7:12035,
+10.1038/ncomms12035, 2016.
+
+Pelot, N. A., Behrend, C. E. and Grill, W. M.. Modeling the
+response of small myelinated axons in a compound nerve to
+kilohertz frequency signals. *Journal of Neural Engineering*
+14:046022, 10.1088/1741-2552/aa6a5f, 2017.
+
+Pelot, N. A., Behrend, C. E. and Grill, W. M.. On the parameters
+used in finite element modeling of compound peripheral nerves.
+*Journal of Neural Engineering* 16:016007,
+10.1088/1741-2552/aaeb0c, 2019.
+
+Pelot, N. A., Catherall, D. C., Thio, B. J., Titus, N. D., Liang,
+E. D., Henriquez, C. S. and Grill, W. M.. Excitation properties of
+computational models of unmyelinated peripheral axons. *Journal of
+Neurophysiology* 125:86-104, 10.1152/jn.00315.2020, 2021.
+
+Pelot, N. A., Thio, B. J. and Grill, W. M.. Modeling current
+sources for neural stimulation in COMSOL. *Frontiers in
+Computational Neuroscience* 12:40, 10.3389/fncom.2018.00040, 2018.
+
+Peña, E., Pelot, N. A. and Grill, W. M.. Quantitative comparisons
+of block thresholds and onset responses for charge-balanced
+kilohertz frequency waveforms. *Journal of Neural Engineering*
+17:046048, 10.1088/1741-2552/abadb5, 2020.
+
+Peña, E., Pelot, N. A. and Grill, W. M.. Non-monotonic kilohertz
+frequency neural block thresholds arise from amplitude- and
+frequency-dependent charge imbalance. *Scientific Reports*
+11:5077, 10.1038/s41598-021-84503-3, 2021.
+
+Peña, E., Zhang, S., Deyo, S., Xiao, Y. and Johnson, M. D..
+Particle swarm optimization for programming deep brain stimulation
+arrays. *Journal of Neural Engineering* 14:016014,
+10.1088/1741-2552/aa52d1, 2017.
+
+Peña, E., Zhang, S., Patriat, R., Aman, J. E., Vitek, J. L.,
+Harel, N. and Johnson, M. D.. Multi-objective particle swarm
+optimization for postoperative deep brain stimulation targeting of
+subthalamic nucleus pathways. *Journal of Neural Engineering*
+15:066020, 10.1088/1741-2552/aae12f, 2018.
+
+Pena, R. F. O., Ceballos, C. C., Lima, V. and Roque, A. C..
+Interplay of activation kinetics and the derivative conductance
+determines resonance properties of neurons. *Physical Review E*
+9710.1103/physreve.97.042408, 2018.
+
+Pena, R. F. O., Lima, V., Shimoura, R. O., Ceballos, C. C.,
+Rotstein, H. G. and Roque, A. C.. Asymmetrical voltage response in
+resonant neurons shaped by nonlinearities. *Chaos* 29:103135,
+10.1063/1.5110033, 2019.
+
+Pendyam, S., Bravo-Rivera, C., Burgos-Robles, A., Sotres-Bayon,
+F., Quirk, G. J. and Nair, S. S.. Fear signaling in the
+prelimbic-amygdala circuit: a computational modeling and recording
+study. *Journal of Neurophysiology* 110:844-861,
+10.1152/jn.00961.2012, 2013.
+
+Peng, Y., Barreda Tomas, F. J., Pfeiffer, P., Drangmeister, M.,
+Schreiber, S., Vida, I. and Geiger, J. R. P.. Spatially structured
+inhibition defined by polarized parvalbumin interneuron axons
+promotes head direction tuning. *Science Advances*
+710.1126/sciadv.abg4693, 2021.
+
+Perge, J. A., Koch, K., Miller, R., Sterling, P. and
+Balasubramanian, V.. How the optic nerve allocates space, energy
+capacity, and information. *Journal of Neuroscience* 29:7917-7928,
+2009.
+
+Pernía-Andrade, A. J., Goswami, S. P., Stickler, Y., Fröbe, U.,
+Schlögl, A. and Jonas, P.. A deconvolution-based method with high
+sensitivity and temporal resolution for detection of spontaneous
+synaptic currents in vitro and in vivo. *Biophysical Journal*
+103:1429-1439, 10.1016/j.bpj.2012.08.039, 2012.
+
+Peron, S. P., Krapp, H. G. and Gabbiani, F.. Influence of
+electrotonic structure and synaptic mapping on the receptive field
+properties of a collision-detecting neuron. *Journal of
+Neurophysiology* 97:159-177, 2007.
+
+Peron, S. P., Jones, P. W. and Gabbiani, F.. Precise subcellular
+input retinotopy and Its computational consequences in an
+identified visual interneuron. *Neuron* 63:830-842,
+10.1016/j.neuron.2009.09.010, 2009.
+
+Perra, E., Rapeaux, A. and Nikolic, K.. The crucial role of nerve
+depolarisation in high frequency conduction block in mammalian
+nerves: simulation study. *IEEE Engineering in Medicine and
+Biology Society. Annual Conference* 2018:2214-2217,
+10.1109/EMBC.2018.8512759, 2018.
+
+Perreault, M. C. and Raastad, M.. Contribution of morphology and
+membrane resistance to integration of fast synaptic signals in two
+thalamic cell types. *Journal of Physiology* 577:205-220, 2006.
+
+Perumal, M. B., Latimer, B., Xu, L., Stratton, P., Nair, S. and
+Sah, P.. Microcircuit mechanisms for the generation of sharp-wave
+ripples in the basolateral amygdala: a role for chandelier
+interneurons. *Cell Reports* 35:109106,
+10.1016/j.celrep.2021.109106, 2021.
+
+Peterson, E. J., Izad, O. and Tyler, D. J.. Predicting myelinated
+axon activation using spatial characteristics of the extracellular
+field. *Journal of Neural Engineering* 8:046030,
+10.1088/1741-2560/8/4/046030, 2011.
+
+Petersson, M. E. and Fransén, E.. Long-lasting small-amplitude
+TRP-mediated dendritic depolarizations in CA1 pyramidal neurons
+are intrinsically stable and originate from distal tuft regions..
+*European Journal of Neuroscience* 36:2917-2925,
+10.1111/j.1460-9568.2012.08199.x, 2012.
+
+Petersson, M. E., Yoshida, M. and Fransén, E. A.. Low-frequency
+summation of synaptically activated transient receptor potential
+channel-mediated depolarizations. *European Journal of
+Neuroscience* 34:578-593, 10.1111/j.1460-9568.2011.07791.x, 2011.
+
+Petrini, E. M., Nieus, T., Ravasenga, T., Succol, F., Guazzi, S.,
+Benfenati, F. and Barberis, A.. Influence of GABAAR monoliganded
+states on GABAergic responses. *Journal of Neuroscience*
+31:1752-1761, 10.1523/JNEUROSCI.1453-10.2011, 2011.
+
+Petrini, F. M., Mazzoni, A., Rigosa, J., Giambattistelli, F.,
+Granata, G., Barra, B., Pampaloni, A., Guglielmelli, E., Zollo,
+L., Capogrosso, M., Micera, S. and Raspopovic, S..
+Microneurography as a tool to develop decoding algorithms for
+peripheral neuro-controlled hand prostheses. *Biomedical
+Engineering Online* 18:44, 10.1186/s12938-019-0659-9, 2019.
+
+Petrovici, M. A.. *Form Versus Function: Theory and Models for
+Neuronal Substrates*. Springer International Publishing,
+10.1007/978-3-319-39552-4, 2016.
+
+Petrovici, M. A., Bill, J., Bytschok, I., Schemmel, J. and Meier,
+K.. Stochastic inference with spiking neurons in the
+high-conductance state. *Physical Review E* 94:042312,
+10.1103/PhysRevE.94.042312, 2016.
+
+Pettersen, K. H. and Einevoll, G. T.. Amplitude variability and
+extracellular low-pass filtering of neuronal spikes. *Biophysical
+Journal* 94:784-802, 2008.
+
+Pettersen, K. H., Hagen, E. and Einevoll, G. T.. Estimation of
+population firing rates and current source densities from laminar
+electrode recordings. *Journal of Computational Neuroscience*
+24:291-313, 2008.
+
+Pettersen, K. H., Lindén, H., Tetzlaff, T. and Einevoll, G. T..
+Power laws from linear neuronal cable theory: power spectral
+densities of the soma potential, soma membrane current and
+single-neuron contribution to the EEG. *PLoS Computational
+Biology* 10:e1003928, 10.1371/journal.pcbi.1003928, 2014.
+
+Pezo, D., Soudry, D. and Orio, P.. Diffusion approximation-based
+simulation of stochastic ion channels: which method to use?.
+*Frontiers in Computational Neuroscience* 8:139,
+10.3389/fncom.2014.00139, 2014.
+
+Pfanzelt, S., Rössert, C., Rohregger, M., Glasauer, S., Moore, L.
+E. and Straka, H.. Differential dynamic processing of afferent
+signals in frog tonic and phasic second-order vestibular neurons.
+*Journal of Neuroscience* 28:10349-10362,
+10.1523/JNEUROSCI.3368-08.2008, 2008.
+
+Pfeil, T., Grübl, A., Jeltsch, S., Müller, E., Müller, P.,
+Petrovici, M. A., Schmuker, M., Brüderle, D., Schemmel, J. and
+Meier, K.. Six networks on a universal neuromorphic computing
+substrate. *Frontiers in neuroscience* 7:11,
+10.3389/fnins.2013.00011, 2013.
+
+Pham, D.-T. J., Yu, G. J., Bouteiller, J.-M. C. and Berger, T. W..
+Bridging hierarchies in multi-scale models of neural systems:
+look-up tables enable computationally efficient simulations of
+non-linear synaptic dynamics. *Frontiers in Computational
+Neuroscience* 15:733155, 10.3389/fncom.2021.733155, 2021.
+
+Phohomsiri, P., Gibbons, M., Volman, V., Cui, J. and Ng, L.. A
+fast-running, end-to-end concussion risk model for assessment of
+complex human head kinematics. *Military Medicine* 183:339-346,
+10.1093/milmed/usx202, 2018.
+
+Phoka, E., Cuntz, H., Roth, A. and Häusser, M.. A new approach for
+determining phase response curves reveals that Purkinje cells can
+act as perfect integrators. *PLoS Computational Biology*
+6:e1000768, 10.1371/journal.pcbi.1000768, 2010.
+
+Pimentel, J. M., Moioli, R. C., de Araujo, M. F. P., Ranieri, C.
+M., Romero, R. A. F., Broz, F. and Vargas, P. A.. Neuro4PD: an
+initial neurorobotics model of Parkinson's disease. *Frontiers in
+Neurorobotics* 15:640449, 10.3389/fnbot.2021.640449, 2021.
+
+Piña, R., Ugarte, G., Campos, M., Íñigo-Portugués, A., Olivares,
+E., Orio, P., Belmonte, C., Bacigalupo, J. and Madrid, R.. Role of
+TRPM8 channels in altered cold sensitivity of corneal primary
+sensory neurons induced by axonal damage. *Journal of
+Neuroscience* 39:8177-8192, 10.1523/JNEUROSCI.0654-19.2019, 2019.
+
+Pinotsis, D. A., Geerts, J. P., Pinto, L., FitzGerald, T. H. B.,
+Litvak, V., Auksztulewicz, R. and Friston, K. J.. Linking
+canonical microcircuits and neuronal activity: Dynamic causal
+modelling of laminar recordings. *NeuroImage* 146:355-366,
+10.1016/j.neuroimage.2016.11.041, 2017.
+
+Pissadaki, E. K. and Bolam, J. P.. The energy cost of action
+potential propagation in dopamine neurons: clues to susceptibility
+in Parkinson's disease. *Frontiers In Computational Neuroscience*
+7:13, 10.3389/fncom.2013.00013, 2013.
+
+Pissadaki, E. K. and Poirazi, P.. Modulation of excitability in
+CA1 pyramidal neurons via the interplay of entorhinal cortex and
+CA3 inputs. *Neurocomputing* 70:1735-1740, 2007.
+
+Pissadaki, E. K., Sidiropoulou, K., Reczko, M. and Poirazi, P..
+Encoding of spatio-temporal input characteristics by a CA1
+pyramidal neuron model. *PLoS Computational Biology* 6:e1001038,
+10.1371/journal.pcbi.1001038, 2010.
+
+Piwkowska, Z., Destexhe, A. and Bal, T.. Associating living cells
+and computational models: from basics to present applications of
+the dynamic-clamp. In: *Dynamic-Clamp: From Principles to
+Applications*, edited by Destexhe, A. and Bal, T.. Springer,
+2009a, pp. 1-30.
+
+Piwkowska, Z., Pospischil, M., Brette, R., Sliwa, J.,
+Rudolph-Lilith, M., Bal, T. and Destexhe, A.. Characterizing
+synaptic conductance fluctuations in cortical neurons and their
+influence on spike generation. *Journal of Neuroscience Methods*
+169:302-322, 2008.
+
+Piwkowska, Z., Pospischil, M., Rudolph-Lilith, M., Bal, T. and
+Destexhe, A.. Testing methods for synaptic conductance analysis
+using controlled conductance injection with dynamic clamp. In:
+*Dynamic-Clamp: From Principles to Applications*, edited by
+Destexhe, A. and Bal, T.. Springer, 2009b, pp. 115-140.
+
+Piwkowska, Z., Rudolph, M., Badoual, M., Destexhe, A. and Bal, T..
+Re-creating active states in vitro with a dynamic-clamp protocol.
+*Neurocomputing* 65-66:55-60, 2005.
+
+Platschek, S., Cuntz, H., Vuksic, M., Deller, T. and Jedlicka, P..
+A general homeostatic principle following lesion induced dendritic
+remodeling. *Acta Neuropathologica Communications*
+410.1186/s40478-016-0285-8, 2016.
+
+Plotkin, J. L., Day, M. and Surmeier, D. J.. Synaptically driven
+state transitions in distal dendrites of striatal spiny neurons.
+*Nature Neuroscience* 14:881-888, 10.1038/nn.2848, 2011.
+
+Poirazi, P., Brannon, T. and Mel, B. W.. Arithmetic of
+subthreshold synaptic summation in a model CA1 pyramidal cell.
+*Neuron* 37:977-987, 2003a.
+
+Poirazi, P., Brannon, T. and Mel, B. W.. Pyramidal neuron as
+two-layer neural network. *Neuron* 37:989-999, 2003b.
+
+Poirazi, P. and Pissadaki, E.. The making of a detailed CA1
+pyramidal neuron model. In: *Hippocampal Microcircuits*, edited by
+Cutsuridis, V., Graham, B., Cobb, S. and Vida, I.. Springer, 2010,
+pp. 317-352.
+
+Poleg-Polsky, A.. Effects of neural morphology and input
+distribution on synaptic processing by global and focal
+NMDA-spikes. *PLoS ONE* 10:e0140254, 10.1371/journal.pone.0140254,
+2015.
+
+Poleg-Polsky, A.. Dendritic spikes expand the range of
+well-tolerated population noise structures. *Journal of
+Neuroscience* 39:9173-9184, 10.1523/JNEUROSCI.0638-19.2019, 2019.
+
+Poleg-Polsky, A. and Diamond, J. S.. Imperfect space clamp permits
+electrotonic interactions between inhibitory and excitatory
+synaptic conductances, distorting voltage clamp recordings. *PLoS
+ONE* 6:e19463, 10.1371/journal.pone.0019463, 2011.
+
+Poleg-Polsky, A. and Diamond, J. S.. NMDA receptors
+multiplicatively scale visual signals and enhance directional
+motion discrimination in retinal ganglion cells. *Neuron*
+89:1277-1290, 10.1016/j.neuron.2016.02.013, 2016a.
+
+Poleg-Polsky, A. and Diamond, J. S.. Retinal circuitry balances
+contrast tuning of excitation and inhibition to enable reliable
+computation of direction selectivity. *Journal of Neuroscience*
+36:5861-5876, 10.1523/JNEUROSCI.4013-15.2016, 2016b.
+
+Polsky, A., Mel, B. and Schiller, J.. Encoding and decoding bursts
+by NMDA spikes in basal dendrites of layer 5 pyramidal neurons.
+*Journal of Neuroscience* 29:11891-11903,
+10.1523/JNEUROSCI.5250-08.2009, 2009.
+
+Poolos, N. P., Migliore, M. and Johnston, D.. Pharmacological
+upregulation of h-channels reduces the excitability of pyramidal
+neuron dendrites. *Nature Neuroscience* 5:767-774, 2002.
+
+Popovic, M. A., Carnevale, N., Rozsa, B. and Zecevic, D..
+Electrical behaviour of dendritic spines as revealed by voltage
+imaging. *Nature Communications* 6:8436, 10.1038/ncomms9436, 2015.
+
+Popovic, M. A., Gao, X., Carnevale, N. T. and Zecevic, D..
+Cortical dendritic spine heads are not electrically isolated by
+the spine neck from membrane potential signals in parent
+dendrites. *Cerebral Cortex* 24:385-395, 10.1093/cercor/bhs320,
+2014.
+
+Portegys, T. E.. Training sensory–motor behavior in the connectome
+of an artificial C. elegans. *Neurocomputing* 168:128 - 134,
+http://dx.doi.org/10.1016/j.neucom.2015.06.007, 2015.
+
+Pospischil, M., Piwkowska, Z., Bal, T. and Destexhe, A..
+Characterizing neuronal activity by describing the membrane
+potential as a stochastic process. *Journal of Physiology, Paris*
+103:98-106, 10.1016/j.jphysparis.2009.05.010, 2009a.
+
+Pospischil, M., Piwkowska, Z., Bal, T. and Destexhe, A..
+Extracting synaptic conductances from single membrane potential
+traces. *Neuroscience* 158:545-552, 2009b.
+
+Pospischil, M., Piwkowska, Z., Bal, T. and Destexhe, A..
+Comparison of different neuron models to conductance-based
+post-stimulus time histograms obtained in cortical pyramidal cells
+using dynamic-clamp in vitro. *Biological Cybernetics*
+105:167-180, 10.1007/s00422-011-0458-2, 2011.
+
+Pospischil, M., Piwkowska, Z., Rudolph, M., Bal, T. and Destexhe,
+A.. Calculating event-triggered average synaptic conductances from
+the membrane potential. *Journal of Neurophysiology* 97:2544-2552,
+2007.
+
+Pospischil, M., Toledo-Rodriguez, M., Monier, C., Piwkowska, Z.,
+Bal, T., Fregnac, Y., Markram, H. and Destexhe, A.. Minimal
+Hodgkin-Huxley type models for different classes of cortical and
+thalamic neurons. *Biological Cybernetics* 99:427-441, 2008.
+
+Postlethwaite, M., Hennig, M. H., Steinert, J. R., Graham, B. P.
+and Forsythe, I. D.. Acceleration of AMPA receptor kinetics
+underlies temperature-dependent changes in synaptic strength at
+the rat calyx of Held. *Journal of Physiology* 579:69-84, 2007.
+
+Potrusil, T., Heshmat, A., Sajedi, S., Wenger, C., Johnson Chacko,
+L., Glueckert, R., Schrott-Fischer, A. and Rattay, F.. Finite
+element analysis and three-dimensional reconstruction of
+tonotopically aligned human auditory fiber pathways: a
+computational environment for modeling electrical stimulation by a
+cochlear implant based on micro-CT. *Hearing Research* 393:108001,
+10.1016/j.heares.2020.108001, 2020.
+
+Pouille, F., McTavish, T. S., Hunter, L. E., Restrepo, D. and
+Schoppa, N. E.. Intraglomerular gap junctions enhance
+interglomerular synchrony in a sparsely connected olfactory bulb
+network. *Journal of Physiology* 595:5965-5986, 10.1113/JP274408,
+2017.
+
+Pouille, F., Watkinson, O., Scanziani, M. and Trevelyan, A. J..
+The contribution of synaptic location to inhibitory gain control
+in pyramidal cells. *Physiological Reports* 1:e00067,
+10.1002/phy2.67, 2013.
+
+Poulsen, A. H., Tigerholm, J., Andersen, O. K. and Mørch, C. D..
+Increased preferential activation of small cutaneous nerve fibers
+by optimization of electrode design parameters. *Journal of Neural
+Engineering* 10.1088/1741-2552/abd1c1, 2020a.
+
+Poulsen, A. H., Tigerholm, J., Meijs, S., Andersen, O. K. and
+Mørch, C. D.. Comparison of existing electrode designs for
+preferential activation of cutaneous nociceptors. *Journal of
+Neural Engineering* 10.1088/1741-2552/ab85b1, 2020b.
+
+Pousinha, P. A., Mouska, X., Bianchi, D., Temido-Ferreira, M.,
+Rajão-Saraiva, J., Gomes, R., Fernandez, S. P., Salgueiro-Pereira,
+A. R., Gandin, C., Raymond, E. F., Barik, J., Goutagny, R.,
+Bethus, I., Lopes, L. V., Migliore, M. and Marie, H.. The amyloid
+precursor protein C-terminal domain alters CA1 neuron firing,
+modifying hippocampus oscillations and impairing spatial memory
+encoding. *Cell Reports* 29:317-331.e5,
+10.1016/j.celrep.2019.08.103, 2019.
+
+Power, J. M., Bocklisch, C., Curby, P. and Sah, P.. Location and
+function of the slow afterhyperpolarization channels in the
+basolateral amygdala. *Journal of Neuroscience* 31:526-537,
+10.1523/JNEUROSCI.1045-10.2011, 2011.
+
+Powers, B. E., Lasiene, J., Plemel, J. R., Shupe, L., Perlmutter,
+S. I., Tetzlaff, W. and Horner, P. J.. Axonal thinning and
+extensive remyelination without chronic demyelination in spinal
+injured rats. *Journal of Neuroscience* 32:5120-5125,
+10.1523/JNEUROSCI.0002-12.2012, 2012a.
+
+Powers, R. K., ElBasiouny, S. M., Rymer, W. Z. and Heckman, C. J..
+Contribution of intrinsic properties and synaptic inputs to
+motoneuron discharge patterns: a simulation study. *Journal of
+Neurophysiology* 107:808-823, 10.1152/jn.00510.2011, 2012b.
+
+Powers, R. K. and Heckman, C. J.. Contribution of intrinsic
+motoneuron properties to discharge hysteresis and its estimation
+based on paired motor unit recordings: a simulation study.
+*Journal of Neurophysiology* 114:184-198, 10.1152/jn.00019.2015,
+2015.
+
+Powers, R. K. and Heckman, C. J.. Synaptic control of the shape of
+the motoneuron pool input-output function. *Journal of
+Neurophysiology* 117:1171-1184, 10.1152/jn.00850.2016, 2017.
+
+Pozzorini, C., Mensi, S., Hagens, O., Naud, R., Koch, C. and
+Gerstner, W.. Automated high-throughput characterization of single
+neurons by means of simplified spiking models. *PLoS Computational
+Biology* 11:e1004275, 10.1371/journal.pcbi.1004275, 2015.
+
+Presannan, A., Rajendran, A., Nair, B. and Diwakar, S..
+Reproducing the firing properties of a cerebellum deep cerebellar
+nucleus with a multi-compartmental morphologically realistic
+biophysical model [Online]. *2018 International Conference on
+Advances in Computing, Communications and Informatics*
+7:1371-1375, 2018.
+
+Prescott, S. A. and De Koninck, Y.. Integration time in a subset
+of spinal lamina I neurons is lengthened by sodium and calcium
+currents acting synergistically to prolong subthreshold
+depolarization. *Journal of Neuroscience* 25:4743-4754, 2005.
+
+Prescott, S. A. and De Koninck, Y.. Gain control of firing rate by
+shunting inhibition: roles of synaptic noise and dendritic
+saturation. *Proceedings of the National Academy of Sciences of
+the United States of America* 100:2076-2081, 2003.
+
+Prescott, S. A., Sejnowski, T. J. and De Koninck, Y.. Reduction of
+anion reversal potential subverts the inhibitory control of firing
+rate in spinal lamina I neurons: towards a biophysical basis for
+neuropathic pain. *Molecular Pain* 2:32, 10.1186/1744-8069-2-32,
+2006.
+
+Prime, L. and Pichon, Y.. Role of ligand-gated ion channels in the
+swimming behaviour of Xenopus tadpoles: experimental data and
+modelling experiments. *European Biophysics Journal with
+Biophysics Letters* 33:265-273, 2004.
+
+Probst, D., Petrovici, M. A., Bytschok, I., Bill, J., Pecevski,
+D., Schemmel, J. and Meier, K.. Probabilistic inference in
+discrete spaces can be implemented into networks of LIF neurons.
+*Frontiers in Computational Neuroscience* 9:13,
+10.3389/fncom.2015.00013, 2015.
+
+Proddutur, A., Yu, J., Elgammal, F. S. and Santhakumar, V..
+Seizure-induced alterations in fast-spiking basket cell GABA
+currents modulate frequency and coherence of gamma oscillation in
+network simulations. *Chaos* 23:046109, 10.1063/1.4830138, 2013.
+
+Psarrou, M., Stefanou, S. S., Papoutsi, A., Tzilivaki, A.,
+Cutsuridis, V. and Poirazi, P.. A simulation study on the effects
+of dendritic morphology on layer V prefrontal pyramidal cell
+firing behavior. *Frontiers in Cellular Neuroscience* 8:287,
+10.3389/fncel.2014.00287, 2014.
+
+Publio, R., Ceballos, C. C. and Roque, A. C.. Dynamic range of
+vertebrate retina ganglion cells: importance of active dendrites
+and coupling by electrical synapses. *PLoS ONE* 7:e48517,
+10.1371/journal.pone.0048517, 2012.
+
+Publio, R., Oliveira, R. F. and Roquea, A. C.. A realistic model
+of rod photoreceptor for use in a retina network model.
+*Neurocomputing* 69:1020-1024, 2006.
+
+Publio, R., Oliveira, R. F. and Roque, A. C.. A computational
+study on the role of gap junctions and rod i(h) conductance in the
+enhancement of the dynamic range of the retina. *PLoS ONE*
+4:e6970, 10.1371/journal.pone.0006970, 2009.
+
+Pugh, J. R. and Raman, I. M.. GABAA receptor kinetics in the
+cerebellar nuclei: evidence for detection of transmitter from
+distant release sites. *Biophysical Journal* 88:1740-1754, 2005.
+
+Qi, G. and Feldmeyer, D.. Dendritic target region-specific
+formation of synapses between excitatory layer 4 neurons and layer
+6 pyramidal cells. *Cerebral Cortex* 26:1569-1579,
+10.1093/cercor/bhu334, 2015.
+
+Quindlen, J. C., Stolarski, H. K., Johnson, M. D. and Barocas, V.
+H.. A multiphysics model of the Pacinian corpuscle. *Integrative
+Biology* 8:1111-1125, 10.1039/c6ib00157b, 2016.
+
+Quindlen-Hotek, J. C. and Barocas, V. H.. A finite-element model
+of mechanosensation by a Pacinian corpuscle cluster in human skin.
+*Biomechanics and Modeling in Mechanobiology* 17:1053-1067,
+10.1007/s10237-018-1011-1, 2018.
+
+Quindlen-Hotek, J. C., Bloom, E. T., Johnston, O. K. and Barocas,
+V. H.. An inter-species computational analysis of vibrotactile
+sensitivity in Pacinian and Herbst corpuscles. *Royal Society Open
+Science* 7:191439, 10.1098/rsos.191439, 2020.
+
+Raastad, M.. The slow depolarization following individual spikes
+in thin, unmyelinated axons in mammalian cortex. *Frontiers In
+Cellular Neuroscience* 13:203, 10.3389/fncel.2019.00203, 2019.
+
+Raastad, M., Enriquez-Denton, M. and Kiehn, O.. Synaptic signaling
+in an active central network only moderately changes passive
+membrane properties. *Proceedings of the National Academy of
+Sciences of the United States of America* 95:10251-10256, 1998.
+
+Raastad, M. and Lipowski, R.. Diversity of postsynaptic amplitude
+and failure probability of unitary excitatory synapses between CA3
+and CA1 cells in the rat hippocampus. *European Journal of
+Neuroscience* 8:1265-1274, 1996.
+
+Rabang, C. F. and Bartlett, E. L.. A computational model of
+cellular mechanisms of temporal coding in the medial geniculate
+body (MGB). *PLoS ONE* 6:e29375, 10.1371/journal.pone.0029375,
+2011.
+
+Rabang, C. F., Parthasarathy, A., Venkataraman, Y., Fisher, Z. L.,
+Gardner, S. M. and Bartlett, E. L.. A computational model of
+inferior colliculus responses to amplitude modulated sounds in
+young and aged rats. *Frontiers in Neural Circuits* 6:77,
+10.3389/fncir.2012.00077, 2012.
+
+Rabinowitch, I. and Segev, I.. The endurance and selectivity of
+spatial patterns of long-yerm potentiation/depression in dendrites
+under homeostatic synaptic slasticity. *Journal of Neuroscience*
+26:13474-13484, 2006a.
+
+Rabinowitch, I. and Segev, I.. The interplay between homeostatic
+synaptic plasticity and functional dendritic compartments.
+*Journal of Neurophysiology* 96:276-283, 2006b.
+
+Radecki, D. Z., Johnson, E. L., Brown, A. K., Meshkin, N. T.,
+Perrine, S. A. and Gow, A.. Corticohippocampal dysfunction in the
+OBiden mouse model of primary oligodendrogliopathy. *Scientific
+Reports* 8:16116, 10.1038/s41598-018-34414-7, 2018.
+
+Radhakrishnan, S., Nutakki, C., Nair, B. and Diwakar, S.. Modeling
+nitric oxide induced neural activity and neurovascular coupling in
+a cerebellum circuit [Online]. *2018 International Conference on
+Advances in Computing, Communications and Informatics* 7:139-142,
+2018.
+
+Rahman, A., Reato, D., Arlotti, M., Gasca, F., Datta, A., Parra,
+L. C. and Bikson, M.. Cellular effects of acute direct current
+stimulation: somatic and synaptic terminal effects. *Journal of
+Physiology* 591:2563-2578, 10.1113/jphysiol.2012.247171, 2013.
+
+Raikov, I. and De Schutter, E.. The layer-oriented approach to
+declarative languages for biological modeling. *PLoS Computational
+Biology* 8:e1002521, 10.1371/journal.pcbi.1002521, 2012.
+
+Rajaram, E., Kaltenbach, C., Fischl, M. J., Mrowka, L.,
+Alexandrova, O., Grothe, B., Hennig, M. H. and Kopp-Scheinpflug,
+C.. Slow NMDA-mediated excitation accelerates offset-response
+latencies generated via a post-inhibitory rebound mechanism.
+*eNeuro* 6:ENEURO.0106-19.2019, 10.1523/ENEURO.0106-19.2019, 2019.
+
+Rajendran, A., Thankamani, A., Nirmala, N., Nair, B. and Diwakar,
+S.. Computational neuroscience of substantia nigra circuit and
+dopamine modulation during Parkinson's disease [Online]. *2017
+International Conference on Advances in Computing, Communications
+and Informatics* 7:522-526, 10.1109/ICACCI.2017.8125892, 2017.
+
+Rama, S., Zbili, M., Fékété, A., Tapia, M., Benitez, M. J.,
+Boumedine, N., Garrido, J. J. and Debanne, D.. The role of axonal
+Kv1 channels in CA3 pyramidal cell excitability. *Scientific
+Reports* 7:315, 10.1038/s41598-017-00388-1, 2017.
+
+Ramaswamy, S., Colangelo, C. and Markram, H.. Data-driven modeling
+of cholinergic modulation of neural microcircuits: bridging
+neurons, synapses and network activity. *Frontiers in Neural
+Circuits* 12:77, 10.3389/fncir.2018.00077, 2018.
+
+Ramaswamy, S., Courcol, J.-D., Abdellah, M., Adaszewski, S. R.,
+Antille, N., Arsever, S., Atenekeng, G., Bilgili, A., Brukau, Y.,
+Chalimourda, A., Chindemi, G., Delalondre, F., Dumusc, R.,
+Eilemann, S., Gevaert, M. E., Gleeson, P., Graham, J. W.,
+Hernando, J. B., Kanari, L., Katkov, Y., Keller, D., King, J. G.,
+Ranjan, R., Reimann, M. W., Rössert, C., Shi, Y., Shillcock, J.
+C., Telefont, M., Van Geit, W., Diaz, J. V., Walker, R., Wang, Y.,
+Zaninetta, S. M., DeFelipe, J., Hill, S. L., Muller, J., Segev,
+I., Schürmann, F., Muller, E. B. and Markram, H.. The neocortical
+microcircuit collaboration portal: a resource for rat
+somatosensory cortex. *Frontiers in Neural Circuits* 9:44,
+10.3389/fncir.2015.00044, 2015.
+
+Ramaswamy, S., Hill, S. L., King, J. G., Schürmann, F., Wang, Y.
+and Markram, H.. Intrinsic morphological diversity of thick-tufted
+layer 5 pyramidal neurons ensures robust and invariant properties
+of in silico synaptic connections. *Journal of Physiology*
+590:737-752, 10.1113/jphysiol.2011.219576, 2012.
+
+Ramos-de-Miguel, Á., Escobar, J. M., Greiner, D. and Ramos-Macías,
+Á.. A multiobjective optimization procedure for the electrode
+design of cochlear implants. *International Journal for Numerical
+Methods in Biomedical Engineering* 34:e2992, 10.1002/cnm.2992,
+2018.
+
+Ramracheya, R., Chapman, C., Chibalina, M., Dou, H., Miranda, C.,
+González, A., Moritoh, Y., Shigeto, M., Zhang, Q., Braun, M.,
+Clark, A., Johnson, P. R., Rorsman, P. and Briant, L. J. B.. GLP-1
+suppresses glucagon secretion in human pancreatic alpha-cells by
+inhibition of P/Q-type Ca2+ channels. *Physiological Reports*
+6:e13852, 10.14814/phy2.13852, 2018.
+
+RamRakhyani, A. K., Kagan, Z. B., Warren, D. J., Normann, R. A.
+and Lazzi, G.. A μm-scale computational model of magnetic neural
+stimulation in multifascicular peripheral nerves. *IEEE
+Transactions on Biomedical Engineering* 62:2837-2849,
+10.1109/TBME.2015.2446761, 2015.
+
+Ran, Y., Huang, Z., Baden, T., Schubert, T., Baayen, H., Berens,
+P., Franke, K. and Euler, T.. Type-specific dendritic integration
+in mouse retinal ganglion cells. *Nature Communications* 11:2101,
+10.1038/s41467-020-15867-9, 2020.
+
+Rane, M. and Manchanda, R.. Effects of location and extent of
+spine clustering on synaptic integration in striatal medium spiny
+neurons-a computational study. *Medical and Biological Engineering
+and Computing* 56:1173-1187, 10.1007/s11517-017-1760-5, 2018.
+
+Rane, M., Shah, A., Sheth, S. and Manchanda, R.. Computational
+investigation of effects of UP state on EPSP in striatal medium
+spiny neurons [Online]. *2012 International Conference on
+Biomedical Engineering*, 10.1109/icobe.2012.6178980, 2012.
+
+Ranieri, C. M., Pimentel, J. M., Romano, M. R., Elias, L. A.,
+Romero, R. A. F., Lones, M. A., Araujo, M. F. P., Vargas, P. A.
+and Moioli, R. C.. A data-driven biophysical computational model
+of Parkinson’s disease based on marmoset monkeys. *IEEE Access*
+9:122548-122567, 10.1109/ACCESS.2021.3108682, 2021.
+
+Ranjan, R., Khazen, G., Gambazzi, L., Ramaswamy, S., Hill, S. L.,
+Schürmann, F. and Markram, H.. Channelpedia: an integrative and
+interactive database for ion channels. *Frontiers In
+Neuroinformatics* 5:36, 10.3389/fninf.2011.00036, 2011.
+
+Rapeaux, A., Nikolic, K., Williams, I., Eftekhar, A. and
+Constandinou, T. G.. Fiber size-selective stimulation using action
+potential filtering for a peripheral nerve interface: a simulation
+study. *IEEE Engineering in Medicine and Biology Society. Annual
+Conference* 2015:3411-3414, 10.1109/EMBC.2015.7319125, 2015.
+
+Rapp, M., Yarom, Y. and Segev, I.. Modeling back propagating
+action potential in weakly excitable dendrites of neocortical
+pyramidal cells. *Proceedings of the National Academy of Sciences
+of the United States of America* 93:11985-11990, 1996.
+
+Rapp, M., Yarom, Y. and Segev, I.. A detailed model of signal
+transmission in excitable dendrites of rat neocortical pyramidal
+cells. In: *Computational Neuroscience: Trends in Research, 1997*,
+edited by Bower, J. M.. New York: New York, Plenum Press, 1997,
+pp. 183-188.
+
+Raspopovic, S., Capogrosso, M., Badia, J., Navarro, X. and Micera,
+S.. Experimental validation of a hybrid computational model for
+selective stimulation using transverse intrafascicular
+multichannel electrodes. *IEEE Transactions on Neural Systems and
+Rehabilitation Engineering* 20:395-404,
+10.1109/TNSRE.2012.2189021, 2012.
+
+Raspopovic, S., Capogrosso, M. and Micera, S.. A computational
+model for the stimulation of rat sciatic nerve using a transverse
+intrafascicular multichannel electrode. *IEEE Transactions on
+Neural Systems and Rehabilitation Engineering* 19:333-344,
+10.1109/TNSRE.2011.2151878, 2011.
+
+Rathour, R. K. and Narayanan, R.. Inactivating ion channels
+augment robustness of subthreshold intrinsic response dynamics to
+parametric variability in hippocampal model neurons. *Journal of
+Physiology* 590:5629-5652, 10.1113/jphysiol.2012.239418, 2012a.
+
+Rathour, R. K. and Narayanan, R.. Influence fields: a quantitative
+framework for representation and analysis of active dendrites.
+*Journal of Neurophysiology* 107:2313-2334, 10.1152/jn.00846.2011,
+2012b.
+
+Rathour, R. K. and Narayanan, R.. Homeostasis of functional maps
+in active dendrites emerges in the absence of individual
+channelostasis. *Proceedings of the National Academy of Sciences
+of the United States of America* 111:E1787-E1796,
+10.1073/pnas.1316599111, 2014.
+
+Rattay, F., Paredes, L. P. and Leao, R. N.. Strength-duration
+relationship for intra-versus extracellular stimulation with
+microelectrodes. *Neuroscience* 214:1-13,
+10.1016/j.neuroscience.2012.04.004, 2012.
+
+Ratté, S., Prescott, S. A., Collinge, J. and Jefferys, J. G. R..
+Hippocampal bursts caused by changes in NMDA receptor-dependent
+excitation in a mouse model of variant CJD. *Neurobiology of
+Disease* 32:96-104, 10.1016/j.nbd.2008.06.007, 2008.
+
+Ray, S., Aldworth, Z. N. and Stopfer, M. A.. Feedback inhibition
+and its control in an insect olfactory circuit. *eLife*
+910.7554/eLife.53281, 2020.
+
+Ray, S. and Bhalla, U. S.. PyMOOSE: interoperable scripting in
+Python for MOOSE. *Frontiers in Neuroinformatics* 2:6,
+10.3389/neuro.11.006.2008, 2008.
+
+Raymond, S. A.. Subblocking concentrations of local-anesthetics -
+effects on impulse generation and conduction in single myelinated
+sciatic-nerve axons in frog. *Anesthesia and Analgesia*
+75:906-921, 1992.
+
+Recugnat, M., Undurraga, J. A. and McAlpine, D.. Spike-Rate
+Adaptation in a Computational Model of Human-Shaped Spiral
+Ganglion Neurons.. *IEEE transactions on bio-medical engineering*
+69:602-612, 10.1109/TBME.2021.3102129, 2022.
+
+Reetz, O., Stadler, K. and Strauss, U.. Protein kinase C
+activation mediates interferon-β-induced neuronal excitability
+changes in neocortical pyramidal neurons. *Journal of
+Neuroinflammation* 11:185, 10.1186/s12974-014-0185-4, 2014.
+
+Regev, N., Degani-Katzav, N., Korngreen, A., Etzioni, A., Siloni,
+S., Alaimo, A., Chikvashvili, D., Villarroel, A., Attali, B. and
+Lotan, I.. Selective interaction of syntaxin 1A with KCNQ2:
+possible implications for specific modulation of presynaptic
+activity. *PLoS ONE* 4:e6586, 10.1371/journal.pone.0006586, 2009.
+
+Reich, M. M., Steigerwald, F., Sawalhe, A. D., Reese, R., Gunalan,
+K., Johannes, S., Nickl, R., Matthies, C., McIntyre, C. C. and
+Volkmann, J.. Short pulse width widens the therapeutic window of
+subthalamic neurostimulation. *Annals of Clinical and
+Translational Neurology* 2:427-432, 10.1002/acn3.168, 2015.
+
+Reilly, J. P.. Survey of numerical electrostimulation models.
+*Physics in Medicine and Biology* 61:4346-4363,
+10.1088/0031-9155/61/12/4346, 2016.
+
+Reimann, M. W., Anastassiou, C. A., Perin, R., Hill, S. L.,
+Markram, H. and Koch, C.. A biophysically detailed model of
+neocortical local field potentials predicts the critical role of
+active membrane currents. *Neuron* 79:375-390, 2013.
+
+Reimann, M. W., Nolte, M., Scolamiero, M., Turner, K., Perin, R.,
+Chindemi, G., Dłotko, P., Levi, R., Hess, K. and Markram, H..
+Cliques of neurons bound into cavities provide a missing link
+between structure and function. *Frontiers In Computational
+Neuroscience* 11:48, 10.3389/fncom.2017.00048, 2017.
+
+Reimer, I. C. G., Staude, B., Boucsein, C. and Rotter, S.. A new
+method to infer higher-order spike correlations from membrane
+potentials. *Journal of Computational Neuroscience* 35:169-186,
+10.1007/s10827-013-0446-8, 2013.
+
+Remme, M. W. H., Bergmann, U., Alevi, D., Schreiber, S.,
+Sprekeler, H. and Kempter, R.. Hebbian plasticity in parallel
+synaptic pathways: a circuit mechanism for systems memory
+consolidation. *PLoS Computational Biology* 17:e1009681,
+10.1371/journal.pcbi.1009681, 2021.
+
+Remme, M. W. H., Lengyel, M. and Gutkin, B. S..
+Democracy-independence trade-off in oscillating dendrites and its
+implications for grid cells. *Neuron* 66:429-437,
+10.1016/j.neuron.2010.04.027, 2010.
+
+Remme, M. W. H. and Rinzel, J.. Role of active dendritic
+conductances in subthreshold input integration. *Journal of
+Computational Neuroscience* 31:13-30, 10.1007/s10827-010-0295-7,
+2011.
+
+Rempe, M. J., Spruston, N., Kath, W. L. and Chopp, D. L..
+Compartmental neural simulations with spatial adaptivity. *Journal
+of Computational Neuroscience* 25:465-480,
+10.1007/s10827-008-0089-3, 2008.
+
+Ren, H., Shi, Y.-J., Lu, Q.-C., Liang, P.-J. and Zhang, P.-M.. The
+role of the entorhinal cortex in epileptiform activities of the
+hippocampus. *Theoretical Biology and Medical Modelling* 11:14,
+10.1186/1742-4682-11-14, 2014.
+
+Reuveni, I., Friedman, A., Amitai, Y. and Gutnick, M. J.. Stepwise
+repolarization from Ca2+ plateaus in neocortical pyramidal cells:
+evidence for nonhomogeneous distribution of HVA Ca2+ channels in
+dendrites. *Journal of Neuroscience* 13:4609-4621, 1993.
+
+Reuveni, I., Saar, D. and Barkai, E.. A novel whole-cell mechanism
+for long-term memory enhancement. *PLoS ONE* 8:e68131,
+10.1371/journal.pone.0068131, 2013.
+
+Rich, S., Moradi Chameh, H., Sekulic, V., Valiante, T. A. and
+Skinner, F. K.. Modeling reveals human-rodent differences in
+h-current kinetics influencing resonance in cortical layer 5
+neurons. *Cerebral Cortex* 31:845-872, 10.1093/cercor/bhaa261,
+2021.
+
+Richardson, A. G., McIntyre, C. C. and Grill, W. M.. Modelling the
+effects of electric fields on nerve fibres: influence of the
+myelin sheath. *Medical and Biological Engineering and Computing*
+38:438-446, 2000.
+
+Richardson, M. J. E. and Silberberg, G.. Measurement and analysis
+of postsynaptic potentials using a novel voltage-deconvolution
+method. *Journal of Neurophysiology* 99:1020-1031, 2008.
+
+Richmond, P., Cope, A., Gurney, K. and Allerton, D. J.. From model
+specification to simulation of biologically constrained networks
+of spiking neurons. *Neuroinformatics* 12:307-323,
+10.1007/s12021-013-9208-z, 2014.
+
+Rinker, J. A., Fulmer, D. B., Trantham-Davidson, H., Smith, M. L.,
+Williams, R. W., Lopez, M. F., Randall, P. K., Chandler, L. J.,
+Miles, M. F., Becker, H. C. and Mulholland, P. J.. Differential
+potassium channel gene regulation in BXD mice reveals novel
+targets for pharmacogenetic therapies to reduce heavy alcohol
+drinking. *Alcohol* 58:33-45, 10.1016/j.alcohol.2016.05.007, 2017.
+
+Ritzau-Jost, A., Delvendahl, I., Rings, A., Byczkowicz, N.,
+Harada, H., Shigemoto, R., Hirrlinger, J., Eilers, J. and
+Hallermann, S.. Ultrafast action potentials mediate kilohertz
+signaling at a central synapse. *Neuron* 84:152-163,
+10.1016/j.neuron.2014.08.036, 2014.
+
+Rivera, B., Campos, M., Orio, P., Madrid, R. and Pertusa, M..
+Negative modulation of TRPM8 channel function by protein kinase C
+in trigeminal cold thermoreceptor neurons. *International Journal
+of Molecular Sciences* 2110.3390/ijms21124420, 2020.
+
+Rivera, B., Moreno, C., Lavanderos, B., Hwang, J. Y.,
+Fernández-Trillo, J., Park, K.-S., Orio, P., Viana, F., Madrid, R.
+and Pertusa, M.. Constitutive phosphorylation as a key regulator
+of TRPM8 channel function. *Journal of Neuroscience* 41:8475-8493,
+10.1523/JNEUROSCI.0345-21.2021, 2021.
+
+Rizou, M. E. and Prodromakis, T.. Magnetic stimulation in the
+microscale: the development of a 6 x 6 array of micro-coils for
+stimulation of excitable cells in vitro. *Biomedical Physics &
+Engineering Express* 4:025016, 10.1088/2057-1976/aaa0dd, 2018.
+
+Rizza, M. F., Locatelli, F., Masoli, S., Sánchez-Ponce, D., Muñoz,
+A., Prestori, F. and D'Angelo, E.. Stellate cell computational
+modeling predicts signal filtering in the molecular layer circuit
+of cerebellum. *Scientific Reports* 11:3873,
+10.1038/s41598-021-83209-w, 2021.
+
+Roberts, A., Conte, D., Hull, M., Merrison-Hort, R., Al Azad, A.
+K., Buhl, E., Borisyuk, R. and Soffe, S. R.. Can simple rules
+control development of a pioneer vertebrate neuronal network
+generating behavior?. *Journal of Neuroscience* 34:608-621,
+10.1523/JNEUROSCI.3248-13.2014, 2014.
+
+Roberts, P. D.. Modeling inhibitory plasticity in the
+electrosensory system of Mormyrid electric fish. *Journal of
+Neurophysiology* 84:2035-2047, 2000.
+
+Roberts, P. D. and Leen, T. K.. Anti-Hebbian
+spike-timing-dependent plasticity and adaptive sensory processing.
+*Frontiers in Computational Neuroscience* 4:156,
+10.3389/fncom.2010.00156, 2010.
+
+Roberts, P. D., Spiros, A. and Geerts, H.. Simulations of
+symptomatic treatments for Alzheimer's disease: computational
+analysis of pathology and mechanisms of drug action. *Alzheimers
+Research & Therapy* 4:50, 10.1186/alzrt153, 2012.
+
+Rogala, J., Waleszczyk, W. J., Lęski, S., Wróbel, A. and Wójcik,
+D. K.. Reciprocal inhibition and slow calcium decay in
+perigeniculate interneurons explain changes of spontaneous firing
+of thalamic cells caused by cortical inactivation. *Journal of
+Computational Neuroscience* 34:461-476, 10.1007/s10827-012-0430-8,
+2013.
+
+Rogers, E. R., Zander, H. J. and Lempka, S. F.. Influence of
+morphology and waveform parameters on the neural response to
+spinal cord stimulation [Online]. *Proc. 10th Int. IEEE/EMBS Conf.
+Neural Engineering* :259-262, 10.1109/NER49283.2021.9441267,
+2021a.
+
+Rogers, E. R., Zander, H. J. and Lempka, S. F.. Neural recruitment
+during conventional, burst, and 10-kHz spinal cord stimulation for
+pain. *The Journal of Pain* 10.1016/j.jpain.2021.09.005, 2021b.
+
+Rojas, P., Akrouh, A., Eisenman, L. N. and Mennerick, S..
+Differential effects of axon initial segment and somatodendritic
+GABA(A) receptors on excitability measures in rat dentate granule
+neurons. *Journal of Neurophysiology* 105:366-379,
+10.1152/jn.00165.2010, 2011.
+
+Romanenko, S., Harvey, A. R., Hool, L., Fan, S. and Wallace, V.
+P.. Millimeter wave radiation activates leech nociceptors via
+TRPV1-like receptor sensitization. *Biophysical Journal*
+116:2331-2345, 10.1016/j.bpj.2019.04.021, 2019.
+
+Romani, A., Marchetti, C., Bianchi, D., Leinekugel, X., Poirazi,
+P., Migliore, M. and Marie, H.. Computational modeling of the
+effects of amyloid-beta on release probability at hippocampal
+synapses. *Frontiers in Computational Neuroscience* 7:1,
+10.3389/fncom.2013.00001, 2013.
+
+Romano, M. R., Moioli, R. C. and Elias, L. A.. Evaluation of
+frequency-dependent effects of deep brain stimulation in a
+cortex-basal ganglia-thalamus network model of Parkinson’s disease
+[Online]. *Proc. 42nd Annual Int. Conf. of the IEEE Engineering in
+Medicine Biology Society* :3638-3641,
+10.1109/EMBC44109.2020.9176570, 2020.
+
+Romaro, C., Najman, F. A., Lytton, W. W., Roque, A. C. and
+Dura-Bernal, S.. NetPyNE implementation and scaling of the
+Potjans-Diesmann cortical microcircuit model.. *Neural
+Computation* 33:1993-2032, 10.1162/neco_a_01400, 2021.
+
+Romeni, S., Valle, G., Mazzoni, A. and Micera, S.. Tutorial: a
+computational framework for the design and optimization of
+peripheral neural interfaces. *Nature Protocols* 15:3129-3153,
+10.1038/s41596-020-0377-6, 2020.
+
+Ross, M. D., Chimento, T., Doshay, D. and Cheng, R..
+Computer-assisted 3-dimensional reconstruction and simulations of
+vestibular macular neural connectivities. *Annals of the New York
+Academy of Sciences* 656:75-91, 1992.
+
+Rössert, C., Moore, L. E., Straka, H. and Glasauer, S.. Cellular
+and network contributions to vestibular signal processing: impact
+of ion conductances, synaptic inhibition, and noise. *Journal of
+Neuroscience* 31:8359-8372, 10.1523/JNEUROSCI.6161-10.2011, 2011.
+
+Rössert, C., Pozzorini, C., Chindemi, G., Davison, A. P., Eroe,
+C., King, J., Newton, T. H., Nolte, M., Ramaswamy, S., Reimann, M.
+W., Wybo, W., Gewaltig, M.-O., Gerstner, W., Markram, H., Segev,
+I. and Muller, E.. Automated point-neuron simplification of
+data-driven microcircuit models. *arXiv* pdf:1604.00087v2, 2016.
+
+Rössert, C., Solinas, S., D'Angelo, E., Dean, P. and Porrill, J..
+Model cerebellar granule cells can faithfully transmit modulated
+firing rate signals.. *Frontiers in Cellular Neuroscience* 8:304,
+10.3389/fncel.2014.00304, 2014.
+
+Roth, A. and Häusser, M.. Compartmental models of rat cerebellar
+Purkinje cells based on simultaneous somatic and dendritic
+patch-clamp recordings. *Journal of Physiology* 535:445-472, 2001.
+
+Rothman, J. S., Cathala, L., Steuber, V. and Silver, R. A..
+Synaptic depression enables neuronal gain control. *Nature*
+457:1015-1018, 2009.
+
+Routh, B. N., Johnston, D., Harris, K. and Chitwood, R. A..
+Anatomical and electrophysiological comparison of CA1 pyramidal
+neurons of the rat and mouse.. *Journal of Neurophysiology*
+102:2288-2302, 10.1152/jn.00082.2009, 2009.
+
+Routh, B. N., Rathour, R. K., Baumgardner, M. E., Kalmbach, B. E.,
+Johnston, D. and Brager, D. H.. Increased transient Na+
+conductance and action potential output in layer 2/3 prefrontal
+cortex neurons of the fmr1(-/y) mouse. *Journal of Physiology*
+595:4431-4448, 10.1113/JP274258, 2017.
+
+Rowan, M. and Neymotin, S.. Synaptic scaling balances learning in
+a spiking model of neocortex. In: *Adaptive and Natural Computing
+Algorithms*, edited by Tomassini, M., Antonioni, A., Daolio, F.
+and Buesser, P.. Springer Berlin Heidelberg, 2013, pp. 20-29.
+
+Rowan, M. J. M., DelCanto, G., Yu, J. J., Kamasawa, N. and
+Christie, J. M.. Synapse-level determination of action potential
+duration by K(+) channel clustering in axons. *Neuron* 91:370-383,
+10.1016/j.neuron.2016.05.035, 2016.
+
+Rowan, M. S., Neymotin, S. A. and Lytton, W. W..
+Electrostimulation to reduce synaptic scaling driven progression
+of Alzheimer's disease. *Frontiers in Computational Neuroscience*
+8:39, 10.3389/fncom.2014.00039, 2014.
+
+Roy, A. and Narayanan, R.. Spatial information transfer in
+hippocampal place cells depends on trial-to-trial variability,
+symmetry of place-field firing, and biophysical heterogeneities.
+*Neural Networks* 142:636-660, 10.1016/j.neunet.2021.07.026, 2021.
+
+Royeck, M., Horstmann, M.-T., Remy, S., Reitze, M., Yaari, Y. and
+Beck, H.. Role of axonal NaV1.6 sodium channels in action
+potential initiation of CA1 pyramidal neurons. *Journal of
+Neurophysiology* 100:2361-2380, 2008.
+
+Royer, A. S. and Miller, R. F.. Dendritic impulse collisions and
+shifting sites of action potential initiation contract and extend
+the receptive field of an amacrine cell. *Visual Neuroscience*
+24:619-634, 2007.
+
+Rubin, D. B. and Cleland, T. A.. Dynamical mechanisms of odor
+processing in olfactory bulb mitral cells. *Journal of
+Neurophysiology* 96:555-568, 2006.
+
+Rudnicki, M. and Hemmert, W.. High entrainment constrains synaptic
+depression levels of an in vivo globular bushy cell model.
+*Frontiers in Computational Neuroscience* 11:16,
+10.3389/fncom.2017.00016, 2017.
+
+Rudolph, M. and Destexhe, A.. Correlation detection and resonance
+in neural systems with distributed noise sources. *Physical Review
+Letters* 86:3662-3665, 2001a.
+
+Rudolph, M. and Destexhe, A.. Do neocortical pyramidal neurons
+display stochastic resonance?. *Journal of Computational
+Neuroscience* 11:19-42, 2001b.
+
+Rudolph, M. and Destexhe, A.. Novel dynamics of dendritic
+integration in the high conductance state of cortical neurons.
+*Neurocomputing* 44-46:141-146, 2002a.
+
+Rudolph, M. and Destexhe, A.. Point-conductance models of cortical
+neurons with high discharge variability. *Neurocomputing*
+44-46:147-152, 2002b.
+
+Rudolph, M. and Destexhe, A.. A fast-conducting, stochastic
+integrative mode for neocortical neurons in vivo. *Journal of
+Neuroscience* 23:2466-2476, 2003a.
+
+Rudolph, M. and Destexhe, A.. Characterization of subthreshold
+voltage fluctuations in neuronal membranes. *Neural Computation*
+15:2577-2618, 2003b.
+
+Rudolph, M. and Destexhe, A.. The discharge variability of
+neocortical neurons during high-conductance states. *Neuroscience*
+119:855-873, 2003c.
+
+Rudolph, M. and Destexhe, A.. Tuning neocortical pyramidal neurons
+between integrators and coincidence detectors. *Journal of
+Computational Neuroscience* 14:239-251, 2003d.
+
+Rudolph, M. and Destexhe, A.. Inferring network activity from
+synaptic noise. *Journal of Physiology, Paris* 98:452-466, 2004.
+
+Rudolph, M. and Destexhe, A.. An extended analytic expression for
+the membrane potential distribution of conductance-based synaptic
+noise. *Neural Computation* 17:2301-2315, 2005a.
+
+Rudolph, M. and Destexhe, A.. Multi-channel shot noise and
+characterization of cortical network activity. *Neurocomputing*
+65:641-646, 2005b.
+
+Rudolph, M. and Destexhe, A.. Analytical integrate-and-fire neuron
+models with conductance-based dynamics for event-driven simulation
+strategies. *Neural Computation* 18:2146-2210, 2006a.
+
+Rudolph, M. and Destexhe, A.. Event-based simulation strategy for
+conductance-based synaptic interactions and plasticity.
+*Neurocomputing* 69:1130-1133, 2006b.
+
+Rudolph, M. and Destexhe, A.. On the use of analytical expressions
+for the voltage distribution to analyze intracellular recordings.
+*Neural Computation* 18:2917-2922, 2006c.
+
+Rudolph, M. and Destexhe, A.. How much can we trust neural
+simulation strategies?. *Neurocomputing* 70:1966-1969, 2007.
+
+Rudolph, M., Hô, N. and Destexhe, A.. Synaptic background activity
+affects the dynamics of dendritic integration in model neocortical
+pyramidal neurons. *Neurocomputing* 38-40:327-333, 2001.
+
+Rudolph, M., Pelletier, J. G., Pare, D. and Destexhe, A..
+Estimation of synaptic conductances and their variances from
+intracellular recordings of neocortical neurons in vivo.
+*Neurocomputing* 58-60:387-392, 2004a.
+
+Rudolph, M., Pelletier, J. G., Paré, D. and Destexhe, A..
+Characterization of synaptic conductances and integrative
+properties during electrically induced EEG-activated states in
+neocortical neurons in vivo. *Journal of Neurophysiology*
+94:2805-2821, 2005.
+
+Rudolph, M., Piwkowska, Z., Badoual, M., Bal, T. and Destexhe, A..
+A method to estimate synaptic conductances from membrane potential
+fluctuations. *Journal of Neurophysiology* 91:2884-2896, 2004b.
+
+Rudolph, M., Pospischil, M., Timofeev, I. and Destexhe, A..
+Inhibition determines membrane potential dynamics and controls
+action potential generation in awake and sleeping cat cortex.
+*Journal of Neuroscience* 27:5280-5290, 2007.
+
+Rudolph-Lilith, M., Dubois, M. and Destexhe, A.. Analytical
+integrate-and-fire neuron models with conductance-based dynamics
+and realistic postsynaptic potential time course for event-driven
+simulation strategies. *Neural Computation* 24:1426-1461,
+10.1162/NECO_a_00278, 2012.
+
+Ruff, C. A., Ye, H., Legasto, J. M., Stribbell, N. A., Wang, J.,
+Zhang, L. and Fehlings, M. G.. Effects of adult neural
+precursor-derived myelination on axonal function in the perinatal
+congenitally dysmyelinated brain: optimizing time of intervention,
+developing accurate prediction models, and enhancing performance.
+*Journal of Neuroscience* 33:11899-11915,
+10.1523/JNEUROSCI.1131-13.2013, 2013.
+
+Rumbell, T. and Kozloski, J.. Dimensions of control for
+subthreshold oscillations and spontaneous firing in dopamine
+neurons. *PLoS Computational Biology* 15:e1007375,
+10.1371/journal.pcbi.1007375, 2019.
+
+Rumbell, T. H., Draguljić, D., Yadav, A., Hof, P. R., Luebke, J.
+I. and Weaver, C. M.. Automated evolutionary optimization of ion
+channel conductances and kinetics in models of young and aged
+rhesus monkey pyramidal neurons. *Journal of Computational
+Neuroscience* 41:65-90, 10.1007/s10827-016-0605-9, 2016.
+
+Rumsey, C. C. and Abbott, L. F.. Equalization of synaptic efficacy
+by activity- and timing-dependent synaptic plasticity. *Journal of
+Neurophysiology* 91:2273-2280, 2004a.
+
+Rumsey, C. C. and Abbott, L. F.. Synaptic equalization by
+anti-STDP. *Neurocomputing* 58-60:359-364, 2004b.
+
+Rumsey, C. C. and Abbott, L. F.. Synaptic democracy in active
+dendrites. *Journal of Neurophysiology* 96:2307-2318, 2006.
+
+Rusakov, D. A., Savtchenko, L. P. and Latham, P. E.. Noisy
+synaptic conductance: bug or a feature?. *Trends in Neurosciences*
+2020.
+
+Rusakov, D. A., Richter-Levin, G., Stewart, M. G. and Bliss, T. V.
+P.. Reduction in spine density associated with long-term
+potentiation in the dentate gyrus suggests a spine
+fusion-and-branching model of potentiation. *Hippocampus*
+7:489-500, 1997a.
+
+Rusakov, D. A., Stewart, M. G. and Korogod, S. M.. Branching of
+active dendritic spines as a mechanism for controlling synaptic
+efficacy. *Neuroscience* 75:315-323, 1996.
+
+Rusakov, D. A., Stewart, M. G. and Korogod, S. M.. Subtle
+re-location of dendritic spine branches containing membrane with
+fast spiking mechanisms can alter synaptic efficacy.
+*Neurophysiology* 29:22-27, 1997b.
+
+Rusu, C. V., Murakami, M., Ziemann, U. and Triesch, J.. A model of
+TMS-induced I-waves in motor cortex. *Brain Stimulation*
+7:401-414, 10.1016/j.brs.2014.02.009, 2014.
+
+Ruz, I. D. and Schultz, S. R.. Localising and classifying neurons
+from high density MEA recordings. *Journal of Neuroscience
+Methods* 233:115 - 128,
+http://dx.doi.org/10.1016/j.jneumeth.2014.05.037, 2014.
+
+Ryglewski, S. and Duch, C.. Shaker and Shal mediate transient
+calcium-independent potassium current in a Drosophila flight
+motoneuron. *Journal of Neurophysiology* 102:3673-3688,
+10.1152/jn.00693.2009, 2009.
+
+Rzhepetskyy, Y., Lazniewska, J., Blesneac, I., Pamphlett, R. and
+Weiss, N.. CACNA1H missense mutations associated with amyotrophic
+lateral sclerosis alter Ca(v)3.2 T-type calcium channel activity
+and reticular thalamic neuron firing. *Channels* 10:466-477,
+10.1080/19336950.2016.1204497, 2016.
+
+Sadashivaiah, V., Sacre, P., Guan, Y., Anderson, W. S. and Sarma,
+S. V.. Modeling electrical stimulation of mammalian nerve fibers:
+a mechanistic versus probabilistic approach. *IEEE Engineering in
+Medicine and Biology Society. Annual Conference* 2017:3868-3871,
+10.1109/EMBC.2017.8037701, 2017.
+
+Sadashivaiah, V., Sacre, P., Guan, Y., Anderson, W. S. and Sarma,
+S. V.. Studying the interactions in a mammalian nerve fiber: a
+functional modeling approach. *IEEE Engineering in Medicine and
+Biology Society. Annual Conference* 2018:3525-3528,
+10.1109/EMBC.2018.8512975, 2018a.
+
+Sadashivaiah, V., Sacré, P., Guan, Y., Anderson, W. S. and Sarma,
+S. V.. Modeling the interactions between stimulation and
+physiologically induced APs in a mammalian nerve fiber: dependence
+on frequency and fiber diameter. *Journal of Computational
+Neuroscience* 45:193-206, 10.1007/s10827-018-0703-y, 2018b.
+
+Sadleir, R. J., Grant, S. C. and Woo, E. J.. Can high-field MREIT
+be used to directly detect neural activity? Theoretical
+considerations. *Neuroimage* 52:205-216,
+10.1016/j.neuroimage.2010.04.005, 2010.
+
+Sadoc, G., Le Masson, G., Foutry, B., Le Franc, Y., Piwkowska, Z.,
+Destexhe, A. and Bal, T.. Re-creating in vivo-like activity and
+investigating the signal transfer capabilities of neurons:
+dynamic-clamp applications using Real-time NEURON. In:
+*Dynamic-Clamp: From Principles to Applications*, edited by
+Destexhe, A. and Bal, T.. Springer, 2009, pp. 287-320.
+
+Safaryan, K., Maex, R., Davey, N., Adams, R. and Steuber, V..
+Nonspecific synaptic plasticity improves the recognition of sparse
+patterns degraded by local noise. *Scientific Reports* 7:46550,
+10.1038/srep46550, 2017.
+
+Safiulina, V. F., Caiati, M. D., Sivakumaran, S., Bisson, G.,
+Migliore, M. and Cherubini, E.. Control of GABA release at mossy
+fiber-CA3 connections in the developing hippocampus. *Frontiers in
+Synaptic Neuroscience* 2:1, 10.3389/neuro.19.001.2010, 2010.
+
+Safronov, B. V., Wolff, M. and Vogel, W.. Excitability of the soma
+in central nervous system neurons. *Biophysical Journal*
+78:2998-3010, 2000.
+
+Saftenku, E. E.. Modeling of slow glutamate diffusion and AMPA
+receptor activation in the cerebellar glomerulus. *Journal of
+Theoretical Biology* 234:363-82, 2005.
+
+Saftenku, E. E.. Computational study of non-homogeneous
+distribution of Ca2+ handling systems in cerebellar granule cells.
+*Journal of Theoretical Biology* 257:228-244, 2009.
+
+Saghatelyan, A., Roux, P., Migliore, M., Rochefort, C.,
+Desmaisons, D., Charneau, P., Shepherd, G. M. and Lledo, P. M..
+Activity-dependent adjustments of the inhibitory network in the
+olfactory bulb following early postnatal deprivation. *Neuron*
+46:103-116, 2005.
+
+Sah, P. and Bekkers, J. M.. Apical dendritic location of slow
+afterhyperpolarization current in hippocampal pyramidal neurons:
+implications for the integration of long-term potentiation.
+*Journal of Neuroscience* 16:4537-4542, 1996.
+
+Saha, R., Faramarzi, S., Bloom, R. P., Benally, O. J., Wu, K., di
+Girolamo, A., Tonini, D., Keirstead, S. A., Low, W. C., Netoff, T.
+I. and Wang, J.-P.. Strength-frequency curve for micromagnetic
+neurostimulation through excitatory postsynaptic potentials
+(EPSPs) on rat hippocampal neurons and numerical modeling of
+magnetic microcoil (μ coil).. *Journal of Neural Engineering*
+1910.1088/1741-2552/ac4baf, 2022.
+
+Sahin, M. and Durand, D. M.. Improved nerve cuff electrode
+recordings with subthreshold anodic currents. *IEEE Transactions
+on Biomedical Engineering* 45:1044-1050, 1998.
+
+Sailamul, P., Jang, J. and Paik, S.-B.. Synaptic convergence
+regulates synchronization-dependent spike transfer in feedforward
+neural networks. *Journal of Computational Neuroscience*
+43:189-202, 10.1007/s10827-017-0657-5, 2017.
+
+Saiz-Alia, M. and Reichenbach, T.. Computational modeling of the
+auditory brainstem response to continuous speech. *Journal of
+Neural Engineering* 10.1088/1741-2552/ab970d, 2020.
+
+Sajedi, S., Fellner, A., Werginz, P. and Rattay, F.. Block
+phenomena during electric micro-stimulation of pyramidal cells and
+retinal ganglion cells. *Frontiers in Cellular Neuroscience*
+15:771600, 10.3389/fncel.2021.771600, 2021.
+
+Sakurai, A., Calin-Jageman, R. J. and Katz, P. S.. Potentiation
+phase of spike timing-dependent neuromodulation by a serotonergic
+interneuron involves an increase in the fraction of transmitter
+release. *Journal of Neurophysiology* 98:1975-1987, 2007.
+
+Sakurai, A., Darghouth, N. R., Butera, R. J. and Katz, P. S..
+Serotonergic enhancement of a 4-AP-sensitive current mediates the
+synaptic depression phase of spike timing-dependent
+neuromodulation. *Journal of Neuroscience* 26:2010-2021, 2006.
+
+Salkim, E., Shiraz, A. and Demosthenous, A.. Impact of
+neuroanatomical variations and electrode orientation on stimulus
+current in a device for migraine: a computational study. *Journal
+of Neural Engineering* 17:016006, 10.1088/1741-2552/ab3d94, 2019a.
+
+Salkim, E., Shiraz, A. and Demosthenous, A.. Influence of cellular
+structures of skin on fiber activation thresholds and computation
+cost. *Biomedical Physics & Engineering Express*
+5{10.1088/2057-1976/aaeaad}, 2019b.
+
+Salkim, E., Shiraz, A. N. and Demosthenous, A.. Effect of nerve
+variations on the stimulus current level in a wearable
+neuromodulator for migraine: a modeling study [Online]. *2017 8th
+International IEEE/EMBS Conference on Neural Engineering*
+8:239-242, 2017.
+
+Salvador, R., Silva, S., Basser, P. J. and Miranda, P. C..
+Determining which mechanisms lead to activation in the motor
+cortex: A modeling study of transcranial magnetic stimulation
+using realistic stimulus waveforms and sulcal geometry. *Clinical
+Neurophysiology* 122:748-758, 10.1016/j.clinph.2010.09.022, 2011.
+
+Samoudi, A. M., Kampusch, S., Tanghe, E., Széles, J. C., Martens,
+L., Kaniusas, E. and Joseph, W.. Numerical modeling of
+percutaneous auricular vagus nerve stimulation: a realistic 3D
+model to evaluate sensitivity of neural activation to electrode
+position. *Medical & Biological Engineering & Computing*
+55:1763-1772, 10.1007/s11517-017-1629-7, 2017.
+
+de San Martin, J. Z., Jalil, A. and Trigo, F. F.. Impact of
+single-site axonal GABAergic synaptic events on cerebellar
+interneuron activity. *Journal of General Physiology* 146:477-493,
+10.1085/jgp.201511506, 2015.
+
+Sánchez, E., Barro, S., Mariño, J. and Canedo, A.. A computational
+model of cuneothalamic projection neurons. *Network* 14:211-231,
+2003a.
+
+Sánchez, E., Barro, S., Mariño, J. and Canedo, A.. Sleep and
+wakefulness in the cuneate nucleus: a computational study. In:
+*Computational Methods in Neural Modeling*, edited by Mira, J. and
+Álvarez, J.. Springer Berlin Heidelberg, 2003b, pp. 70-77.
+
+Sánchez, E., Barro, S., Mariño, J. and Canedo, A.. Cortical
+modulation of dorsal column nuclei: a computational study.
+*Journal of Computational Neuroscience* 21:21-33, 2006.
+
+Sanchez, G., Rodriguez, M. J., Pomata, P., Rela, L. and Murer, M.
+G.. Reduction of an afterhyperpolarization current increases
+excitability in striatal cholinergic interneurons in rat
+parkinsonism. *Journal of Neuroscience* 31:6553-6564,
+10.1523/JNEUROSCI.6345-10.2011, 2011.
+
+Sanchez, R. M., Surkis, A. and Leonard, C. S.. Voltage-clamp
+analysis and computer simulation of a novel cesium-resistant
+A-current in guinea pig laterodorsal tegmental neurons. *Journal
+of Neurophysiology* 79:3111-3126, 1998.
+
+Sandstrom, D. J.. Isoflurane reduces excitability of Drosophila
+larval motoneurons by activating a hyperpolarizing leak
+conductance. *Anesthesiology* 108:434-446, 2008.
+
+Sangrey, T. D., Friesen, W. O. and Levy, W. B.. Analysis of the
+optimal channel density of the squid giant axon using a
+reparameterized Hodgkin-Huxley model. *Journal of Neurophysiology*
+91:2541-2550, 2004.
+
+Sangrey, T. and Levy, W. B.. Conduction velocity costs energy.
+*Neurocomputing* 65:907-913, 2005.
+
+Sanjay, M., Neymotin, S. A. and Krothapalli, S. B.. Impaired
+dendritic inhibition leads to epileptic activity in a computer
+model of CA3. *Hippocampus* 25:1336-1350, 10.1002/hipo.22440,
+2015.
+
+Santaniello, S., Fiengo, G., Glielmo, L. and Grill, W. M..
+Closed-loop control of deep brain stimulation: a simulation study.
+*IEEE Transactions on Neural Systems and Rehabilitation
+Engineering* 19:15-24, 10.1109/TNSRE.2010.2081377, 2011.
+
+Santhakumar, V.. Modeling circuit alterations in epilepsy: a focus
+on mossy cell loss and mossy fiber sprouting in the dentate gyrus.
+In: *Computational Neuroscience in Epilepsy*, edited by Soltesz,
+I. and Staley, K.. Elsevier, 2008, pp. 89-111.
+
+Santhakumar, V., Aradi, I. and Soltesz, I.. Role of mossy fiber
+sprouting and mossy cell loss in hyperexcitability: a network
+model of the dentate gyrus incorporating cell types and axonal
+topography. *Journal of Neurophysiology* 93:437-453, 2005.
+
+Santos, J. P. G., Pajo, K., Trpevski, D., Stepaniuk, A., Eriksson,
+O., Nair, A. G., Keller, D., Hellgren Kotaleski, J. and Kramer,
+A.. A modular workflow for model building, analysis, and parameter
+estimation in systems biology and neuroscience. *Neuroinformatics*
+10.1007/s12021-021-09546-3, 2021.
+
+Santos, S. F. A., Luz, L. L., Szucs, P., Lima, D., Derkach, V. A.
+and Safronov, B. V.. Transmission efficacy and plasticity in
+glutamatergic synapses formed by excitatory interneurons of the
+substantia gelatinosa in the rat spinal cord. *PLoS ONE* 4:e8047,
+10.1371/journal.pone.0008047, 2009.
+
+Saraga, F., Balena, T., Wolansky, T., Dickson, C. T. and Woodin,
+M. A.. Inhibitory synaptic plasticity regulates pyramidal neuron
+spiking in the rodent hippocampus. *Neuroscience* 155:64-75, 2008.
+
+Saraga, F., Ng, L. and Skinner, F. K.. Distal gap junctions and
+active dendrites can tune network dynamics. *Journal of
+Neurophysiology* 95:1669-1682, 2006a.
+
+Saraga, F. and Skinner, F. K.. Dynamics and diversity in
+interneurons: a model exploration with slowly inactivating
+potassium currents. *Neuroscience* 113:193-203, 2002a.
+
+Saraga, F. and Skinner, F. K.. Slowly-inactivating potassium
+conductances in compartmental interneuron models. *Neurocomputing*
+44:161-166, 2002b.
+
+Saraga, F. and Skinner, F. K.. Spike initiation in a hippocampal
+interneuron model. *Neurocomputing* 52-54:185-189, 2003.
+
+Saraga, F. and Skinner, F. K.. Location, location, location (and
+density) of gap junctions in multi-compartment models.
+*Neurocomputing* 58-60:713-719, 2004.
+
+Saraga, F., Wu, C. P., Zhang, L. and Skinner, F. K.. Active
+dendrites and spike propagation in multi-compartment models of
+oriens-lacunosum/moleculare hippocampal interneurons. *Journal of
+Physiology* 552:673-689, 2003.
+
+Saraga, F., Zhang, X. L., Zhang, L., Carlen, P. L. and Skinner, F.
+K.. Exploring gap junction location and density in electrically
+coupled hippocampal oriens interneurons. *Neurocomputing*
+69:1048-1052, 2006b.
+
+Saravanan, V., Arabali, D., Jochems, A., Cui, A.-X.,
+Gootjes-Dreesbach, L., Cutsuridis, V. and Yoshida, M.. Transition
+between encoding and consolidation/replay dynamics via cholinergic
+modulation of CAN current: a modeling study. *Hippocampus*
+25:1052-1070, 10.1002/hipo.22429, 2015.
+
+Sáray, S., Rössert, C. A., Appukuttan, S., Migliore, R., Vitale,
+P., Lupascu, C. A., Bologna, L. L., Van Geit, W., Romani, A.,
+Davison, A. P., Muller, E., Freund, T. F. and Káli, S.. HippoUnit:
+a software tool for the automated testing and systematic
+comparison of detailed models of hippocampal neurons based on
+electrophysiological data. *PLoS Computational Biology*
+17:e1008114, 10.1371/journal.pcbi.1008114, 2021.
+
+Sarid, L., Bruno, R., Sakmann, B., Segev, I. and Feldmeyer, D..
+Modeling a layer 4-to-layer 2/3 module of a single-column in rat
+neocortex: interweaving in vitro and in vivo experimental
+observations. *Proceedings of the National Academy of Sciences of
+the United States of America* 104:16353-16358, 2007.
+
+Sarid, L., Feldmeyer, D., Gidon, A., Sakmann, B. and Segev, I..
+Contribution of intracolumnar layer 2/3-to-layer 2/3 excitatory
+connections in shaping the response to whisker deflection in rat
+barrel cortex. *Cerebral Cortex* 25:849-858,
+10.1093/cercor/bht268, 2015.
+
+Sarma, G. P., Lee, C. W., Portegys, T., Ghayoomie, V., Jacobs, T.,
+Alicea, B., Cantarelli, M., Currie, M., Gerkin, R. C., Gingell,
+S., Gleeson, P., Gordon, R., Hasani, R. M., Idili, G., Khayrulin,
+S., Lung, D., Palyanov, A., Watts, M. and Larson, S. D.. OpenWorm:
+overview and recent advances in integrative biological simulation
+of Caenorhabditis elegans. *Philosophical Transactions of the
+Royal Society B, Biological Sciences* 37310.1098/rstb.2017.0382,
+2018.
+
+Saudargiene, A., Cobb, S. and Graham, B. P.. A computational study
+on plasticity during theta cycles at Schaffer collateral synapses
+on CA1 pyramidal cells in the hippocampus. *Hippocampus*
+25:208-218, 10.1002/hipo.22365, 2015.
+
+Saudargienė, A. and Graham, B. P.. Inhibitory control of
+site-specific synaptic plasticity in a model CA1 pyramidal neuron.
+*Biosystems* 130:37-50, 10.1016/j.biosystems.2015.03.001, 2015.
+
+Saudargiene, A., Jackevicius, R. and Graham, B. P.. Interplay of
+STDP and dendritic plasticity in a hippocampal CA1 pyramidal
+neuron model. In: *Artificial Neural Networks and Machine Learning
+ICANN 2017*. Springer International Publishing, 2017, pp. 381-388.
+
+Savtchenko, L. P., Gogan, P. and Tyc-Dumont, S.. Dendritic spatial
+flicker of local membrane potential due to channel noise and
+probabilistic firing of hippocampal neurons in culture.
+*Neuroscience Research* 41:161-183, 2001.
+
+Savtchenko, L. P., Bard, L., Jensen, T. P., Reynolds, J. P.,
+Kraev, I., Medvedev, N., Stewart, M. G., Henneberger, C. and
+Rusakov, D. A.. Disentangling astroglial physiology with a
+realistic cell model in silico. *Nature Communications* 9:3554,
+10.1038/s41467-018-05896-w, 2018.
+
+Savtchenko, L. P. and Rusakov, D. A.. Regulation of rhythm genesis
+by volume-limited, astroglia-like signals in neural networks.
+*Philosophical Transactions of the Royal Society B: Biological
+Sciences* 369:20130614, 10.1098/rstb.2013.0614, 2014.
+
+Savtchenko, L. P., Sylantyev, S. and Rusakov, D. A.. Central
+synapses release a resource-efficient amount of glutamate. *Nature
+Neuroscience* 16:10-12, 10.1038/nn.3285, 2013.
+
+Schaefer, A. T., Helmstaedter, M., Sakmann, B. and Korngreen, A..
+Correction of conductance measurements in non-space-clamped
+structures: 1. Voltage-gated K+ channels. *Biophysical Journal*
+84:3508-3528, 2003a.
+
+Schaefer, A. T., Helmstaedter, M., Schmitt, A. C., Bar-Yehuda, D.,
+Almog, M., Ben-Porat, H., Sakmann, B. and Korngreen, A.. Dendritic
+voltage-gated K+ conductance gradient in pyramidal neurones of
+neocortical layer 5B from rats. *Journal of Physiology*
+579:737-752, 2007.
+
+Schaefer, A. T., Larkum, M. E., Sakmann, B. and Roth, A..
+Coincidence detection in pyramidal neurons is tuned by their
+dendritic branching pattern. *Journal of Neurophysiology*
+89:3143-3154, 2003b.
+
+Schaworonkow, N. and Triesch, J.. Ongoing brain rhythms shape
+I-wave properties in a computational model. *Brain Stimulation*
+11:828-838, 10.1016/j.brs.2018.03.010, 2018.
+
+Scheuer, T., dem Brinke, E. A., Grosser, S., Wolf, S. A., Mattei,
+D., Sharkovska, Y., Barthel, P. C., Endesfelder, S., Friedrich,
+V., Bührer, C., Vida, I. and Schmitz, T.. Reduction of cortical
+parvalbumin-expressing GABAergic interneurons in a rodent
+hyperoxia model of preterm birth brain injury with deficits in
+social behavior and cognition. *Development*
+14810.1242/dev.198390, 2021.
+
+Schierwagen, A., Alpár, A. and Gärtner, U.. Scaling properties of
+pyramidal neurons in mice neocortex. *Mathematical Biosciences*
+207:352-364, 2007.
+
+Schierwagen, A. and Claus, C.. Dendritic morphology and signal
+delay in superior colliculus neurons. *Neurocomputing*
+38-40:343-350, 2001.
+
+Schiller, J., Major, G., Koester, H. J. and Schiller, Y.. NMDA
+spikes in basal dendrites of cortical pyramidal neurons. *Nature*
+404:285-289, 2000.
+
+Schindler, K. A., Bernasconi, C. A., Stoop, R., Goodman, P. H. and
+Douglas, R. J.. Chaotic spike patterns evoked by periodic
+inhibition of rat cortical neurons. *Zeitschrift für
+Naturforschung A* 52:509-512, 1997.
+
+Schmidt, C., Dunn, E., Lowery, M. and van Rienen, U.. Uncertainty
+quantification of oscillation suppression during DBS in a coupled
+finite element and network model. *IEEE Transactions on Neural
+Systems and Rehabilitation Engineering* 26:281-290,
+10.1109/TNSRE.2016.2608925, 2018.
+
+Schmidt, C., Grant, P., Lowery, M. and van Rienen, U.. Influence
+of uncertainties in the material properties of brain tissue on the
+probabilistic volume of tissue activated. *IEEE Transactions on
+Biomedical Engineering* 60:1378-1387, 10.1109/TBME.2012.2235835,
+2013.
+
+Schmidt, C. and van Rienen, U.. Adaptive estimation of the neural
+activation extent in computational volume conductor models of deep
+brain stimulation. *IEEE Transactions on Bio-Medical Engineering*
+65:1828-1839, 10.1109/TBME.2017.2758324, 2018.
+
+Schmidt, S. L., Brocker, D. T., Swan, B. D., Turner, D. A. and
+Grill, W. M.. Evoked potentials reveal neural circuits engaged by
+human deep brain stimulation. *Brain Stimulation* 13:1706-1718,
+10.1016/j.brs.2020.09.028, 2020.
+
+Schmidt-Hieber, C. and Bischofberger, J.. Fast sodium channel
+gating supports localized and efficient axonal action potential
+initiation. *Journal of Neuroscience* 30:10233-10242,
+10.1523/JNEUROSCI.6335-09.2010, 2010.
+
+Schmidt-Hieber, C. and Häusser, M.. Cellular mechanisms of spatial
+navigation in the medial entorhinal cortex. *Nature Neuroscience*
+16:325-331, 10.1038/nn.3340, 2013.
+
+Schmidt-Hieber, C., Jonas, P. and Bischofberger, J.. Subthreshold
+dendritic signal processing and coincidence detection in dentate
+gyrus granule cells. *Journal of Neuroscience* 27:8430-8441, 2007.
+
+Schmidt-Hieber, C., Jonas, P. and Bischofberger, J.. Action
+potential initiation and propagation in hippocampal mossy fibre
+axons.. *Journal of Physiology* 586:1849-1857,
+10.1113/jphysiol.2007.150151, 2008.
+
+Schmidt-Hieber, C., Toleikyte, G., Aitchison, L., Roth, A., Clark,
+B. A., Branco, T. and Häusser, M.. Active dendritic integration as
+a mechanism for robust and precise grid cell firing. *Nature
+Neuroscience* 20:1114-1121, 10.1038/nn.4582, 2017.
+
+Schneider, A. C., Fox, D., Itani, O., Golowasch, J., Bucher, D.
+and Nadim, F.. Frequency-dependent action of neuromodulation.
+*eNeuro* 810.1523/ENEURO.0338-21.2021, 2021.
+
+Schneider, C. J., Bezaire, M. and Soltesz, I.. Toward a full-scale
+computational model of the rat dentate gyrus. *Frontiers In Neural
+Circuits* 6:83, 10.3389/fncir.2012.00083, 2012.
+
+Schneider-Mizell, C. M., Bodor, A. L., Collman, F., Brittain, D.,
+Bleckert, A., Dorkenwald, S., Turner, N. L., Macrina, T., Lee, K.,
+Lu, R., Wu, J., Zhuang, J., Nandi, A., Hu, B., Buchanan, J.,
+Takeno, M. M., Torres, R., Mahalingam, G., Bumbarger, D. J., Li,
+Y., Chartrand, T., Kemnitz, N., Silversmith, W. M., Ih, D., Zung,
+J., Zlateski, A., Tartavull, I., Popovych, S., Wong, W., Castro,
+M., Jordan, C. S., Froudarakis, E., Becker, L., Suckow, S.,
+Reimer, J., Tolias, A. S., Anastassiou, C. A., Seung, H. S., Reid,
+R. C. and Costa, N. M. d.. Structure and function of axo-axonic
+inhibition. *eLife* 1010.7554/eLife.73783, 2021.
+
+Schofield, C. M. and Huguenard, J. R.. GABA affinity shapes IPSCs
+in thalamic nuclei. *Journal of Neuroscience* 27:7954-7962, 2007.
+
+Schomburg, E. W., Anastassiou, C. A., Buzsáki, G. and Koch, C..
+The spiking component of oscillatory extracellular potentials in
+the rat hippocampus. *Journal of Neuroscience* 32:11798-11811,
+10.1523/JNEUROSCI.0656-12.2012, 2012.
+
+Schoppa, N. E. and Westbrook, G. L.. AMPA autoreceptors drive
+correlated spiking in olfactory bulb glomeruli. *Nature
+Neuroscience* 5:1194-1202, 2002.
+
+Schreglmann, S. R., Wang, D., Peach, R. L., Li, J., Zhang, X.,
+Latorre, A., Rhodes, E., Panella, E., Cassara, A. M., Boyden, E.
+S., Barahona, M., Santaniello, S., Rothwell, J., Bhatia, K. P. and
+Grossman, N.. Non-invasive suppression of essential tremor via
+phase-locked disruption of its temporal coherence. *Nature
+Communications* 12:363, 10.1038/s41467-020-20581-7, 2021.
+
+Schreiber, S., Erchova, I., Heinemann, U. and Herz, A. V. M..
+Subthreshold resonance explains the frequency-dependent
+integration of periodic as well as random stimuli in the
+entorhinal cortex. *Journal of Neurophysiology* 92:408-415, 2004.
+
+Schreiber, S., Samengo, I. and Herz, A. V. M.. Two distinct
+mechanisms shape the reliability of neural responses. *Journal of
+Neurophysiology* 101:2239-2251, 2009.
+
+Schulz, J. M., Knoflach, F., Hernandez, M.-C. and Bischofberger,
+J.. Dendrite-targeting interneurons control synaptic NMDA-receptor
+activation via nonlinear α5-GABA-A receptors. *Nature
+Communications* 9:3576, 10.1038/s41467-018-06004-8, 2018.
+
+Schulz, P. E., Cook, E. P. and Johnston, D.. Changes in
+paired-pulse facilitation suggest presynaptic involvement in
+long-term potentiation. *Journal of Neuroscience* 14:5325-5337,
+1994.
+
+Scorcioni, R., Lazarewicz, M. T. and Ascoli, G. A.. Quantitative
+morphometry of hippocampal pyramidal cells: differences between
+anatomical classes and reconstructing laboratories. *Journal of
+Comparative Neurology* 473:177-193, 2004.
+
+Scott, L. L., Mathews, P. J. and Golding, N. L.. Perisomatic
+voltage-gated sodium channels actively maintain linear synaptic
+integration in principal neurons of the medial superior olive.
+*Journal of Neuroscience* 30:2039-2050,
+10.1523/JNEUROSCI.2385-09.2010, 2010.
+
+Scurfield, A. and Latimer, D. C.. A computational study of the
+impact of inhomogeneous internodal lengths on conduction velocity
+in myelinated neurons. *PLoS ONE* 13:e0191106,
+10.1371/journal.pone.0191106, 2018.
+
+Scuri, R., Lombardo, P., Cataldo, E., Ristori, C. and Brunelli,
+M.. Inhibition of Na+/K+ ATPase potentiates synaptic transmission
+in tactile sensory neurons of the leech. *European Journal of
+Neuroscience* 25:159-167, 2007.
+
+Seay, M. J., Natan, R. G., Geffen, M. N. and Buonomano, D. V..
+Differential short-term plasticity of PV and SST neurons accounts
+for adaptation and facilitation of cortical neurons to auditory
+tones. *Journal of Neuroscience* 40:9224-9235,
+10.1523/JNEUROSCI.0686-20.2020, 2020.
+
+Seely, J. and Crotty, P.. Optimization of the leak conductance in
+the squid giant axon. *Physical Review E* 82:021906,
+10.1103/PhysRevE.82.021906, 2010.
+
+Seenivasan, P. and Narayanan, R.. Efficient phase coding in
+hippocampal place cells. *Physical Review Research* 2:033393,
+10.1103/PhysRevResearch.2.033393, 2020.
+
+Segev, D. and Korngreen, A.. Kinetics of two voltage-gated K+
+conductances in substantia nigra dopaminergic neurons. *Brain
+Research* 1173:27-35, 2007.
+
+Segev, I. and Burke, R. E.. Compartmental models of complex
+neurons. In: *Methods in Neuronal Modeling*, edited by Koch, C.
+and Segev, I.. Cambridge, MA: Cambridge, MA, MIT Press, 1998, pp.
+93-129.
+
+Segev, I., Friedman, A., White, E. L. and Gutnick, M. J..
+Electrical consequences of spine dimensions in a model of a
+cortical spiny stellate cell completely reconstructed from serial
+thin sections. *Journal of Computational Neuroscience* 2:117-130,
+1995.
+
+Segev, I. and London, M.. A theoretical view of passive and active
+dendrites. In: *Dendrites*, edited by Stuart, G., Spruston, N. and
+Häusser, M.. NY: NY, Oxford University Press, 1999, pp. 205-230.
+
+Segev, I. and London, M.. Untangling dendrites with quantitative
+models. *Science* 290:744-750, 2000.
+
+Sekulić, V., Chen, T.-C., Lawrence, J. J. and Skinner, F. K..
+Dendritic distributions of Ih channels in experimentally-derived
+multi-compartment models of oriens-lacunosum/moleculare (O-LM)
+hippocampal interneurons. *Frontiers in Synaptic Neuroscience*
+7:2, 10.3389/fnsyn.2015.00002, 2015.
+
+Sekulić, V., Lawrence, J. J. and Skinner, F. K.. Using
+multi-compartment ensemble modeling as an investigative tool of
+spatially distributed biophysical balances: application to
+hippocampal oriens-lacunosum/moleculare (O-LM) cells. *PLoS ONE*
+9:e106567, 10.1371/journal.pone.0106567, 2014.
+
+Sekulić, V. and Skinner, F. K.. Computational models of O-LM cells
+are recruited by low or high theta frequency inputs depending on
+h-channel distributions. *eLife* 6:e22962, 10.7554/eLife.22962,
+2017.
+
+Sekulić, V., Yi, F., Garrett, T., Guet-McCreight, A., Lawrence, J.
+J. and Skinner, F. K.. Integration of within-cell experimental
+data with multi-compartmental modeling predicts h-channel
+densities and distributions in hippocampal OLM cells. *Frontiers
+in Cellular Neuroscience* 14:277, 10.3389/fncel.2020.00277, 2020.
+
+Sengupta, N., Brain, K. L. and Manchanda, R.. Spatiotemporal
+dynamics of synaptic drive in urinary bladder syncytium: a
+computational investigation [Online]. *2015 37th Annual
+International Conference of the IEEE Engineering in Medicine and
+Biology Society*, 10.1109/embc.2015.7320267, 2015.
+
+Sengupta, N., Brain, K. L. and Manchanda, R.. Cellular environment
+in a bundle modulates SEJP characteristics in detrusor smooth
+muscle [Online]. *2018 40th Annual International Conference of the
+IEEE Engineering in Medicine and Biology Society*,
+10.1109/embc.2018.8513621, 2018.
+
+Sengupta, N. and Manchanda, R.. Spontaneous synaptic drive in
+detrusor smooth muscle: computational investigation and
+implications for urinary bladder function. *Journal of
+Computational Neuroscience* 47:167-189,
+10.1007/s10827-019-00731-7, 2019.
+
+Senk, J., Carde, C., Hagen, E., Kuhlen, T. W., Diesmann, M. and
+Weyers, B.. VIOLA-a multi-purpose and web-based visualization tool
+for neuronal-network simulation output. *Frontiers in
+Neuroinformatics* 12:75, 10.3389/fninf.2018.00075, 2018.
+
+Senkow, T. L., Theis, N. D., Quindlen-Hotek, J. C. and Barocas, V.
+H.. Computational and psychophysical experiments on the Pacinian
+corpuscle's ability to discriminate complex stimuli. *IEEE
+Transactions on Haptics* 12:635-644, 10.1109/TOH.2019.2903500,
+2019.
+
+Seo, H. and Jun, S. C.. Relation between the electric field and
+activation of cortical neurons in transcranial electrical
+stimulation. *Brain Stimulation* 12:275-289,
+10.1016/j.brs.2018.11.004, 2019.
+
+Seo, H., Kim, D. and Jun, S. C.. Computational study of subdural
+cortical stimulation: effects of simulating anisotropic
+conductivity on activation of cortical neurons. *PLoS ONE*
+10:e0128590, 10.1371/journal.pone.0128590, 2015.
+
+Seo, H., Kim, D. and Jun, S. C.. Effect of anatomically realistic
+full-head model on activation of cortical neurons in subdural
+cortical stimulation--a computational study. *Scientific Reports*
+62016a.
+
+Seo, H., Kim, D. and Jun, S. C.. Effects of electrode displacement
+in high-definition transcranial direct current stimulation: a
+computational study. *IEEE Engineering in Medicine and Biology
+Society. Annual Conference* 2016:4618-4621,
+10.1109/EMBC.2016.7591756, 2016b.
+
+Seo, H., Kim, H.-I. and Jun, S. C.. A computational study on
+effect of a transcranial channel as a skull/brain interface in the
+conventional rectangular patch-type transcranial direct current
+stimulation [Online]. *2017 39th Annual International Conference
+of the IEEE Engineering in Medicine and Biology Society*,
+10.1109/embc.2017.8037230, 2017a.
+
+Seo, H., Kim, H.-I. and Jun, S. C.. The effect of a transcranial
+channel as a skull/brain interface in high-definition transcranial
+direct current stimulation-a computational study. *Scientific
+Reports* 7:40612, 10.1038/srep40612, 2017b.
+
+Seo, H., Schaworonkow, N., Jun, S. C. and Triesch, J.. A
+multi-scale computational model of the effects of TMS on motor
+cortex. *F1000Research* 5:1945, 10.12688/f1000research.9277.3,
+2016c.
+
+Sethupathy, P., Rubin, D. B., Li, G. and Cleland, T. A.. A model
+of electrophysiological heterogeneity in periglomerular cells.
+*Frontiers in Computational Neuroscience* 7:49,
+10.3389/fncom.2013.00049, 2013.
+
+Sethuramanujam, S., Yao, X., deRosenroll, G., Briggman, K. L.,
+Field, G. D. and Awatramani, G. B.. "Silent" NMDA synapses enhance
+motion sensitivity in a mature retinal circuit. *Neuron*
+96:1099-1111.e3, 10.1016/j.neuron.2017.09.058, 2017.
+
+Shabestari, P. S., Buccino, A. P., Kumar, S. S., Pedrocchi, A. and
+Hierlemann, A.. A modulated template-matching approach to improve
+spike sorting of bursting neurons. *IEEE Biomedical Circuits and
+Systems Conference* 202110.1109/BioCAS49922.2021.9644995, 2021.
+
+Shah, M. M., Migliore, M. and Brown, D. A.. Differential effects
+of Kv7 (M-) channels on synaptic integration in distinct
+subcellular compartments of rat hippocampal pyramidal neurons.
+*Journal of Physiology* 589:6029-6038,
+10.1113/jphysiol.2011.220913, 2011.
+
+Shah, M. M., Migliore, M., Valencia, I., Cooper, E. C. and Brown,
+D. A.. Functional significance of axonal Kv7 channels in
+hippocampal pyramidal neurons. *Proceedings of the National
+Academy of Sciences of the United States of America*
+105:7869-7874, 2008.
+
+Shai, A. S., Anastassiou, C. A., Larkum, M. E. and Koch, C..
+Physiology of layer 5 pyramidal neurons in mouse primary visual
+cortex: coincidence detection through bursting. *PLoS
+Computational Biology* 11:e1004090, 10.1371/journal.pcbi.1004090,
+2015.
+
+Shai, A. S., Koch, C. and Anastassiou, C. A.. Spike-timing control
+by dendritic plateau potentials in the presence of synaptic
+barrages. *Frontiers in Computational Neuroscience* 8:89,
+10.3389/fncom.2014.00089, 2014.
+
+Shao, J., Tsao, T. H. and Butera, R.. Bursting without slow
+kinetics: a role for a small world?. *Neural Computation*
+18:2029-2035, 2006.
+
+Shao, L. R., Halvorsrud, R., Borg-Graham, L. and Storm, J. F.. The
+role of BK-type Ca2+-dependent K+ channels in spike broadening
+during repetitive firing in rat hippocampal pyramidal cells.
+*Journal of Physiology* 521:135-146, 1999.
+
+Sharp, P. E., Blair, H. T. and Brown, M.. Neural network modeling
+of the hippocampal formation spatial signals and their possible
+role in navigation: a modular approach. *Hippocampus* 6:720-734,
+1996.
+
+Sheasby, B. W. and Fohlmeister, J. F.. Impulse encoding across the
+dendritic morphologies of retinal ganglion cells. *Journal of
+Neurophysiology* 81:1685-1698, 1999.
+
+Sheets, P. L., Jackson, J. O., Waxman, S. G., Dib-Hajj, S. D. and
+Cummins, T. R.. A Na(v)1.7 channel mutation associated with
+hereditary erythromelalgia contributes to neuronal
+hyperexcitability and displays reduced lidocaine sensitivity.
+*Journal of Physiology* 581:1019-1031, 2007.
+
+Sheffield, M. E. J., Best, T. K., Mensh, B. D., Kath, W. L. and
+Spruston, N.. Slow integration leads to persistent action
+potential firing in distal axons of coupled interneurons. *Nature
+Neuroscience* 14:200-207, 10.1038/nn.2728, 2011.
+
+Shehzad, D. and Bozkuş, Z.. Optimizing NEURON simulation
+environment using remote memory access with recursive doubling on
+distributed memory systems. *Computational Intelligence and
+Neuroscience* 2016:3676582, 10.1155/2016/3676582, 2016.
+
+Shen, G. Y. Y., Chen, W. R., Midtgaard, J., Shepherd, G. M. and
+Hines, M. L.. Computational analysis of action potential
+initiation in mitral cell soma and dendrites based on dual patch
+recordings. *Journal of Neurophysiology* 82:3006-3020, 1999.
+
+Shen, W. X., Hernandez-Lopez, S., Tkatch, T., Held, J. E. and
+Surmeier, D. J.. Kv1.2-containing K+ channels regulate
+subthreshold excitability of striatal medium spiny neurons.
+*Journal of Neurophysiology* 91:1337-1349, 2004.
+
+Sherif, M. A., Neymotin, S. A. and Lytton, W. W.. In silico
+hippocampal modeling for multi-target pharmacotherapy in
+schizophrenia. *NPJ Schizophrenia* 6:25,
+10.1038/s41537-020-00109-0, 2020.
+
+Sheroziya, M. G. and Egorov, A. V.. Effects of extracellular
+calcium on the volley activity of entorhinal cortex neurons in
+neonatal rats: computer simulation. *Neuroscience and Behavioral
+Physiology* 40:1-4, 10.1007/s11055-009-9229-0, 2010.
+
+Sheynikhovich, D., Otani, S. and Arleo, A.. Dopaminergic control
+of long-term depression/long-term potentiation threshold in
+prefrontal cortex.. *Journal of Neuroscience* 33:13914-13926,
+10.1523/JNEUROSCI.0466-13.2013, 2013.
+
+Shifman, A. R. and Lewis, J. E.. ELFENN: a generalized platform
+for modeling ephaptic coupling in spiking neuron models.
+*Frontiers In Neuroinformatics* 13:35, 10.3389/fninf.2019.00035,
+2019.
+
+Shilyansky, C., Karlsgodt, K. H., Cummings, D. M., Sidiropoulou,
+K., Hardt, M., James, A. S., Ehninger, D., Bearden, C. E.,
+Poirazi, P., Jentsch, J. D., Cannon, T. D., Levine, M. S. and
+Silva, A. J.. Neurofibromin regulates corticostriatal inhibitory
+networks during working memory performance. *Proceedings of the
+National Academy of Sciences of the United States of America*
+107:13141-13146, 10.1073/pnas.1004829107, 2010.
+
+Shimazaki, R., Boccaccio, A., Mazzatenta, A., Pinato, G.,
+Migliore, M. and Menini, A.. Electrophysiological properties and
+modeling of murine vomeronasal sensory neurons in acute slice
+preparations. *Chemical Senses* 31:425-435, 2006.
+
+Shimoura, R. O., Pena, R. F. O., Lima, V., Kamiji, N. L.,
+Girardi-Schappo, M. and Roque, A. C.. Building a model of the
+brain: from detailed connectivity maps to network organization.
+*European Physical Journal Special Topics* 230:2887-2909,
+10.1140/epjs/s11734-021-00152-7, 2021.
+
+Shinozaki, T., Cateau, H., Urakubo, H. and Okada, M.. Controlling
+synfire chain by inhibitory synaptic input. *Journal of the
+Physical Society of Japan* 76:044806 doi:10.1143/JPSJ.76.044806,
+2007.
+
+Shirinpour, S., Hananeia, N., Rosado, J., Tran, H., Galanis, C.,
+Vlachos, A., Jedlicka, P., Queisser, G. and Opitz, A.. Multi-scale
+modeling toolbox for single neuron and subcellular activity under
+transcranial magnetic stimulation. *Brain Stimulation*
+14:1470-1482, 10.1016/j.brs.2021.09.004, 2021.
+
+Shirke, A. M. and Malinow, R.. Mechanisms of potentiation by
+calcium-calmodulin kinase II of postsynaptic sensitivity in rat
+hippocampal CA1 neurons. *Journal of Neurophysiology*
+78:2682-2692, 1997.
+
+Short, S. M., Morse, T. M., McTavish, T. S., Shepherd, G. M. and
+Verhagen, J. V.. Respiration gates sensory input responses in the
+mitral cell layer of the olfactory bulb. *PLoS ONE* 11:e0168356,
+10.1371/journal.pone.0168356, 2016.
+
+Shrager, P.. Axonal coding of action-potentials in demyelinated
+nerve-fibers. *Brain Research* 619:278-290, 1993.
+
+Shrager, P. and Rubinstein, C. T.. Optical measurement of
+conduction in single demyelinated axons. *Journal of General
+Physiology* 95:867-889, 1990.
+
+Shu, Y., Duque, A., Yu, Y., Haider, B. and McCormick, D. A..
+Properties of action-potential initiation in neocortical pyramidal
+cells: evidence from whole cell axon recordings. *Journal of
+Neurophysiology* 97:746-760, 2007a.
+
+Shu, Y., Yu, Y., Yang, J. and McCormick, D. A.. Selective control
+of cortical axonal spikes by a slowly inactivating K+ current..
+*Proceedings of the National Academy of Sciences of the United
+States of America* 104:11453-11458, 10.1073/pnas.0702041104,
+2007b.
+
+Shuman, T., Aharoni, D., Cai, D. J., Lee, C. R., Chavlis, S.,
+Page-Harley, L., Vetere, L. M., Feng, Y., Yang, C. Y.,
+Mollinedo-Gajate, I., Chen, L., Pennington, Z. T., Taxidis, J.,
+Flores, S. E., Cheng, K., Javaherian, M., Kaba, C. C., Rao, N.,
+La-Vu, M., Pandi, I., Shtrahman, M., Bakhurin, K. I., Masmanidis,
+S. C., Khakh, B. S., Poirazi, P., Silva, A. J. and Golshani, P..
+Breakdown of spatial coding and interneuron synchronization in
+epileptic mice. *Nature Neuroscience* 23:229-238,
+10.1038/s41593-019-0559-0, 2020.
+
+Shvartsman, A., Kotler, O., Stoler, O., Khrapunsky, Y., Melamed,
+I. and Fleidervish, I. A.. Subcellular distribution of persistent
+sodium conductance in cortical pyramidal neurons. *Journal of
+Neuroscience* 10.1523/JNEUROSCI.2989-20.2021, 2021.
+
+Sidiropoulou, K., Joels, M. and Poirazi, P.. Modeling
+stress-induced adaptations in Ca2+ dynamics. *Neurocomputing*
+70:1640-1644, 2007.
+
+Sidiropoulou, K. and Poirazi, P.. Predictive features of
+persistent activity emergence in regular spiking and intrinsic
+bursting model neurons. *PLoS Computational Biology* 8:e1002489,
+10.1371/journal.pcbi.1002489, 2012.
+
+Sikora, M. A., Gottesman, J. and Miller, R. F.. A computational
+model of the ribbon synapse. *Journal of Neuroscience Methods*
+145:47-61, 2005.
+
+Silberberg, G. and Markram, H.. Disynaptic inhibition between
+neocortical pyramidal cells mediated by Martinotti cells. *Neuron*
+53:735-746, 2007.
+
+Silver, R. A.. Neuronal arithmetic. *Nature Reviews Neuroscience*
+11:474-489, 10.1038/nrn2864, 2010.
+
+Silverstein, D. N.. A computational investigation of feedforward
+and feedback processing in metacontrast backward masking.
+*Frontiers in Psychology* 6:6, 10.3389/fpsyg.2015.00006, 2015.
+
+Silverstein, D. N. and Lansner, A.. Is attentional blink a
+byproduct of neocortical attractors?. *Frontiers in Computational
+Neuroscience* 5:13, 10.3389/fncom.2011.00013, 2011.
+
+Simões de Souza, F. M. and De Schutter, E.. Robustness effect of
+gap junctions between Golgi cells on cerebellar cortex
+oscillations. *Neural Systems and Circuits* 1:7,
+10.1186/2042-1001-1-7, 2011.
+
+Simon, J. Z., Carr, C. E. and Shamma, S. A.. A dendritic model of
+coincidence detection in the avian brainstem. *Neurocomputing*
+26-27:263-269, 1999.
+
+Singh, C. and Levy, W. B.. A consensus layer V pyramidal neuron
+can sustain interpulse-interval coding. *PLoS ONE* 12:e0180839,
+10.1371/journal.pone.0180839, 2017.
+
+Sinha, M. and Narayanan, R.. HCN channels enhance spike phase
+coherence and regulate the phase of spikes and LFPs in the
+theta-frequency range. *Proceedings of the National Academy of
+Sciences of the United States of America* 112:E2207-E2216,
+10.1073/pnas.1419017112, 2015.
+
+Šišková, Z., Justus, D., Kaneko, H., Friedrichs, D., Henneberg,
+N., Beutel, T., Pitsch, J., Schoch, S., Becker, A., von der
+Kammer, H. and Remy, S.. Dendritic structural degeneration is
+functionally linked to cellular hyperexcitability in a mouse model
+of Alzheimer's disease. *Neuron* 84:1023-1033,
+10.1016/j.neuron.2014.10.024, 2014.
+
+Sittl, R., Lampert, A., Huth, T., Schuy, E. T., Link, A. S.,
+Fleckenstein, J., Alzheimer, C., Grafe, P. and Carr, R. W..
+Anticancer drug oxaliplatin induces acute cooling-aggravated
+neuropathy via sodium channel subtype Na(V)1.6-resurgent and
+persistent current. *Proceedings of the National Academy of
+Sciences of the United States of America* 109:6704-6709,
+10.1073/pnas.1118058109, 2012.
+
+Siu, D.. Activity-dependent hepatocyte growth factor expression
+and its role in organogenesis and cancer growth suppression.
+*Medical Hypotheses* 63:62-70, 2004.
+
+Sivagnanam, S., Gorman, W., Doherty, D., Neymotin, S. A., Fang,
+S., Hovhannisyan, H., Lytton, W. W. and Dura-Bernal, S..
+Simulating Large-scale Models of Brain Neuronal Circuits using
+Google Cloud Platform.. *PEARC20 : Practice and Experience in
+Advanced Research Computing 2020 : Catch the wave : July 27-31,
+2020, Portland, Or Virtual Conference. Practice and Experience in
+Advanced Research Computing (Conference) (2020 : Online)*
+2020:505-509, 10.1145/3311790.3399621, 2020.
+
+Sivagnanam, S., Majumdar, A., Yoshimoto, K., Astakhov, V.,
+Bandrowski, A., Martone, M. E. and Carnevale, N. T.. Introducing
+the Neuroscience Gateway [Online]. *Proceedings of the 5th
+International Workshop on Science Gateways* 993, 2013.
+
+Sjöström, P. J. and Häusser, M.. A cooperative switch determines
+the sign of synaptic plasticity in distal dendrites of neocortical
+pyramidal neurons. *Neuron* 51:227-238, 2006.
+
+Skaar, J.-E. W., Stasik, A. J., Hagen, E., Ness, T. V. and
+Einevoll, G. T.. Estimation of neural network model parameters
+from local field potentials (LFPs). *PLoS Computational Biology*
+16:e1007725, 10.1371/journal.pcbi.1007725, 2020.
+
+Skach, J., Conway, C., Barrett, L. and Ye, H.. Axonal blockage
+with microscopic magnetic stimulation. *Scientific Reports*
+10:18030, 10.1038/s41598-020-74891-3, 2020.
+
+Skinner, F. and Saraga, F.. Single neuron models: interneurons.
+In: *Hippocampal Microcircuits*. New York, NY: Springer New York,
+2010, pp. 399-422.
+
+Slopsema, J. P., Peña, E., Patriat, R., Lehto, L. J., Gröhn, O.,
+Mangia, S., Harel, N., Michaeli, S. and Johnson, M. D.. Clinical
+deep brain stimulation strategies for orientation-selective
+pathway activation. *Journal of Neural Engineering* 15:056029,
+10.1088/1741-2552/aad978, 2018.
+
+Smith, S. L., Smith, I. T., Branco, T. and Häusser, M.. Dendritic
+spikes enhance stimulus selectivity in cortical neurons in vivo.
+*Nature* 503:115-120, 10.1038/nature12600, 2013.
+
+Softky, W.. Sub-millisecond coincidence detection in active
+dendritic trees. *Neuroscience* 58:13-41, 1994.
+
+Softky, W. R. and Koch, C.. Cortical cells should fire regularly,
+but do not. *Neural Computation* 4:643-646, 1992.
+
+Softky, W. R. and Koch, C.. The highly irregular firing of
+cortical cells is inconsistent with temporal integration of random
+EPSPs. *Journal of Neuroscience* 13:334-350, 1993.
+
+Sohal, V. S., Cox, C. L. and Huguenard, J. R.. Localization of CCK
+receptors in thalamic reticular neurons: a modeling study.
+*Journal of Neurophysiology* 79:2820-2824, 1998.
+
+Sohal, V. S. and Huguenard, J. R.. Long-range connections
+synchronize rather than spread intrathalamic oscillations:
+computational modeling and in vitro electrophysiology. *Journal of
+Neurophysiology* 80:1736-1751, 1998.
+
+Sohal, V. S. and Huguenard, J. R.. Reciprocal inhibition controls
+the oscillatory state in thalamic networks. *Neurocomputing*
+44:653-659, 2002.
+
+Sohal, V. S. and Huguenard, J. R.. Inhibitory interconnections
+control burst pattern and emergent network synchrony in reticular
+thalamus. *Journal of Neuroscience* 23:8978-8988, 2003.
+
+Sohal, V. S. and Huguenard, J. R.. Inhibitory coupling
+specifically generates emergent gamma oscillations in diverse cell
+types. *Proceedings of the National Academy of Sciences of the
+United States of America* 102:18638-18643, 2005.
+
+Sohal, V. S., Huntsman, M. M. and Huguenard, J. R.. Reciprocal
+inhibitory connections produce desynchronizing phase lags during
+intrathalamic oscillations. *Neurocomputing* 32:509-516, 2000a.
+
+Sohal, V. S., Huntsman, M. M. and Huguenard, J. R.. Reciprocal
+inhibitory connections regulate the spatiotemporal properties of
+intrathalamic oscillations. *Journal of Neuroscience*
+20:1735-1745, 2000b.
+
+Sohal, V. S., Pangratz-Fuehrer, S., Rudolph, U. and Huguenard, J.
+R.. Intrinsic and synaptic dynamics interact to generate emergent
+patterns of rhythmic bursting in thalamocortical neurons..
+*Journal of Neuroscience* 26:4247-4255,
+10.1523/JNEUROSCI.3812-05.2006, 2006.
+
+Sokolova, I. V., Schneider, C. J., Bezaire, M., Soltesz, I.,
+Vlkolinsky, R. and Nelson, G. A.. Proton radiation alters
+intrinsic and synaptic properties of CA1 pyramidal neurons of the
+mouse hippocampus. *Radiation Research* 183:208-218,
+10.1667/RR13785.1, 2015.
+
+Solbrå, A., Bergersen, A. W., van den Brink, J., Malthe-Sørenssen,
+A., Einevoll, G. T. and Halnes, G.. A Kirchhoff-Nernst-Planck
+framework for modeling large scale extracellular electrodiffusion
+surrounding morphologically detailed neurons. *PLoS Computational
+Biology* 14:e1006510, 10.1371/journal.pcbi.1006510, 2018.
+
+Soldado-Magraner, S., Brandalise, F., Honnuraiah, S., Pfeiffer,
+M., Moulinier, M., Gerber, U. and Douglas, R.. Conditioning by
+subthreshold synaptic input changes the intrinsic firing pattern
+of CA3 hippocampal neurons. *Journal of Neurophysiology*
+123:90-106, 10.1152/jn.00506.2019, 2020.
+
+Solinas, S., Forti, L., Cesana, E., Mapelli, J., De Schutter, E.
+and D'Angelo, E.. Computational reconstruction of pacemaking and
+intrinsic electroresponsiveness in cerebellar golgi cells.
+*Frontiers in Cellular Neuroscience* 1:2,
+10.3389/neuro.03.002.2007, 2007a.
+
+Solinas, S., Forti, L., Cesana, E., Mapelli, J., De Schutter, E.
+and D'Angelo, E.. Fast-reset of pacemaking and theta-frequency
+resonance patterns in cerebellar golgi cells: simulations of their
+impact in vivo. *Frontiers in Cellular Neuroscience* 1:4,
+10.3389/neuro.03.004.2007, 2007b.
+
+Solinas, S., Nieus, T. and D'Angelo, E.. A realistic large-scale
+model of the cerebellum granular layer predicts circuit
+spatio-temporal filtering properties. *Frontiers in Cellular
+Neuroscience* 4:12, 10.3389/fncel.2010.00012, 2010.
+
+Solinas, S. M. G., Edelmann, E., Leßmann, V. and Migliore, M.. A
+kinetic model for brain-derived neurotrophic factor mediated spike
+timing-dependent LTP. *PLoS Computational Biology* 15:e1006975,
+10.1371/journal.pcbi.1006975, 2019.
+
+Soltesz, I., Smetters, D. K. and Mody, I.. Tonic inhibition
+originates from synapses close to the soma. *Neuron* 14:1273-1283,
+1995.
+
+Somjen, G. G.. Mechanisms of spreading depression and hypoxic
+spreading depression-like depolarization. *Physiological Reviews*
+81:1065-1096, 2001.
+
+Somjen, G. G.. *Ions in the Brain*. New York, NY: address, Oxford
+University Press, 2004.
+
+Somjen, G. G., Kager, H. and Wadman, W. J.. Computer simulations
+of neuron-glia interactions mediated by ion flux. *Journal of
+Computational Neuroscience* 25:349-365, 2008.
+
+Somjen, G. G., Kager, H. and Wadman, W. J.. Calcium sensitive
+non-selective cation current promotes seizure-like discharges and
+spreading depression in a model neuron. *Journal of Computational
+Neuroscience* 26:139-147, 2009.
+
+Somogyi, A., Katonai, Z., Alpár, A. and Wolf, E.. A novel form of
+compensation in the Tg2576 amyloid mouse model of Alzheimer's
+disease. *Frontiers in Cellular Neuroscience* 10:152,
+10.3389/fncel.2016.00152, 2016.
+
+Somogyi, A. and Wolf, E.. Increased signal delays and unaltered
+synaptic input pattern recognition in layer III neocortical
+pyramidal neurons of the rTg4510 mouse model of tauopathy: a
+computer simulation study with passive membrane. *Frontiers in
+Neuroscience* 15:721773, 10.3389/fnins.2021.721773, 2021.
+
+Somogyvari, Z., Zalanyi, L., Ulbert, I. and Erdi, P.. Model-based
+source localization of extracellular action potentials. *Journal
+of Neuroscience Methods* 147:126-137, 2005.
+
+Song, D., Wang, Z. and Berger, T. W.. Contribution of T-type VDCC
+to TEA-induced long-term synaptic modification in hippocampal CA1
+and dentate gyrus. *Hippocampus* 12:689-697, 2002.
+
+Song, W., Kerr, C. C., Lytton, W. W. and Francis, J. T.. Cortical
+plasticity induced by spike-triggered microstimulation in primate
+somatosensory cortex. *PLoS ONE* 8:e57453,
+10.1371/journal.pone.0057453, 2013.
+
+Song, W. H., Xiao, Y. C., Chen, H. Y., Ashpole, N. M., Piekarz, A.
+D., Ma, P. L., Hudmon, A., Cummins, T. R. and Shou, W. N. A.. The
+human Nav1.5 F1486 deletion associated with long QT syndrome leads
+to impaired sodium channel inactivation and reduced lidocaine
+sensitivity. *Journal of Physiology* 590:5123-5139,
+10.1113/jphysiol.2012.235374, 2012.
+
+Sotiropoulos, S. N. and Steinmetz, P. N.. Assessing the direct
+effects of deep brain stimulation using embedded axon models.
+*Journal of Neural Engineering* 4:107-119, 2007.
+
+de Sousa, G., Maex, R., Adams, R., Davey, N. and Steuber, V..
+Dendritic morphology predicts pattern recognition performance in
+multi-compartmental model neurons with and without active
+conductances. *Journal of Computational Neuroscience* 38:221-234,
+10.1007/s10827-014-0537-1, 2015.
+
+Sousa, M. and Aguiar, P.. Building, simulating and visualizing
+large spiking neural networks with NeuralSyns. *Neurocomputing*
+123:372-380, 2014.
+
+Sousa, M., Szucs, P., Lima, D. and Aguiar, P.. The pronociceptive
+dorsal reticular nucleus contains mostly tonic neurons and shows a
+high prevalence of spontaneous activity in block preparation.
+*Journal of Neurophysiology* 111:1507-1518, 10.1152/jn.00440.2013,
+2014.
+
+Spaak, E., Zeitler, M. and Gielen, S.. Hippocampal theta
+modulation of neocortical spike times and gamma rhythm: a
+biophysical model study. *PLoS ONE* 7:e45688,
+10.1371/journal.pone.0045688, 2012.
+
+Spampanato, J., Aradi, I., Soltesz, I. and Goldin, A. L..
+Increased neuronal firing in computer simulations of sodium
+channel mutations that cause generalized epilepsy with febrile
+seizures plus. *Journal of Neurophysiology* 91:2040-2050, 2004a.
+
+Spampanato, J. and Goldin, A. L.. Computer simulations of sodium
+channel mutations that cause generalized epilepsy with febrile
+seizures plus. In: *Computational Neuroscience in Epilepsy*.
+Elsevier, 2008, pp. 143-154.
+
+Spampanato, J., Kearney, J. A., de Haan, G., McEwen, D. P.,
+Escayg, A., Aradi, I., MacDonald, B. T., Levin, S. I., Soltesz,
+I., Benna, P., Montalenti, E., Isom, L. L., Goldin, A. L. and
+Meisler, M. H.. A novel epilepsy mutation in the sodium channel
+SCN1A identifies a cytoplasmic domain for beta subunit
+interaction. *Journal of Neuroscience* 24:10022-10034, 2004b.
+
+Spencer, M. J., Grayden, D. B., Bruce, I. C., Meffin, H. and
+Burkitt, A. N.. An investigation of dendritic delay in octopus
+cells of the mammalian cochlear nucleus. *Frontiers in
+Computational Neuroscience* 6:83, 10.3389/fncom.2012.00083, 2012.
+
+Spera, E., Migliore, M., Unsworth, N. and Tegolo, D.. On the
+cellular mechanisms underlying working memory capacity in humans.
+*Neural Network World* 26:335-350, 10.14311/NNW.2016.26.019, 2016.
+
+Spiga, S., Lintas, A., Migliore, M. and Diana, M.. Altered
+architecture and functional consequences of the mesolimbic
+dopamine system in cannabis dependence. *Addiction Biology*
+15:266-276, 10.1111/j.1369-1600.2010.00218.x, 2010.
+
+Spiros, A., Roberts, P. and Geerts, H.. A quantitative systems
+pharmacology computer model for schizophrenia efficacy and
+extrapyramidal side effects. *Drug Development Research*
+73:196-213, 10.1002/ddr.21008, 2012.
+
+Spirou, G. A., Chirila, F. V., von Gersdorff, H. and Manis, P. B..
+Heterogeneous Ca2+ influx along the adult calyx of held: A
+structural and computational study. *Neuroscience* 154:171-185,
+2008.
+
+Spirou, G. A., Rager, J. and Manis, P. B.. Convergence of
+auditory-nerve fiber projections onto globular bushy cells.
+*Neuroscience* 136:843-863, 2005.
+
+Spoleti, E., Krashia, P., La Barbera, L., Nobili, A., Lupascu, C.
+A., Giacalone, E., Keller, F., Migliore, M., Renzi, M. and
+D'Amelio, M.. Early derailment of firing properties in CA1
+pyramidal cells of the ventral hippocampus in an Alzheimer's
+disease mouse model. *Experimental Neurology* 350:113969,
+10.1016/j.expneurol.2021.113969, 2022.
+
+Spratt, P. W. E., Alexander, R. P. D., Ben-Shalom, R., Sahagun,
+A., Kyoung, H., Keeshen, C. M., Sanders, S. J. and Bender, K. J..
+Paradoxical hyperexcitability from NaV1.2 sodium channel loss in
+neocortical pyramidal cells.. *Cell Reports* 36:109483,
+10.1016/j.celrep.2021.109483, 2021.
+
+Spratt, P. W. E., Ben-Shalom, R., Keeshen, C. M., Burke, K. J.,
+Clarkson, R. L., Sanders, S. J. and Bender, K. J.. The
+autism-associated gene SCN2a contributes to dendritic excitability
+and synaptic function in the prefrontal cortex. *Neuron*
+103:673-685.e5, 10.1016/j.neuron.2019.05.037, 2019.
+
+Spruston, N., Jaffe, D. B. and Johnston, D.. Dendritic attenuation
+of synaptic potentials and currents: the role of passive membrane
+properties. *Trends in Neurosciences* 17:161-166, 1994.
+
+Spruston, N., Jaffe, D. B., Williams, S. H. and Johnston, D..
+Voltage- and space-clamp errors associated with measurement of
+electrotonically remote synaptic events. *Journal of
+Neurophysiology* 70:781-802, 1993.
+
+Spruston, N. and Johnston, D.. Perforated patch-clamp analysis of
+the passive membrane properties of three classes of hippocampal
+neurons. *Journal of Neurophysiology* 67:508-529, 1992.
+
+Spruston, N., Jonas, P. and Sakmann, B.. Dendritic glutamate
+receptor channels in rat hippocampal CA3 and CA1 pyramidal
+neurons. *Journal of Physiology* 482:325-352, 1995.
+
+Spruston, N., Stuart, G. and Häusser, M.. Dendritic integration.
+In: *Computational Neuroscience*, edited by De Schutter, E.. Boca
+Raton, FL: Boca Raton, FL, CRC Press, 2001, pp. 231-270.
+
+Squair, J. W., Gautier, M., Mahe, L., Soriano, J. E., Rowald, A.,
+Bichat, A., Cho, N., Anderson, M. A., James, N. D., Gandar, J.,
+Incognito, A. V., Schiavone, G., Sarafis, Z. K., Laskaratos, A.,
+Bartholdi, K., Demesmaeker, R., Komi, S., Moerman, C., Vaseghi,
+B., Scott, B., Rosentreter, R., Kathe, C., Ravier, J., McCracken,
+L., Kang, X., Vachicouras, N., Fallegger, F., Jelescu, I., Cheng,
+Y., Li, Q., Buschman, R., Buse, N., Denison, T., Dukelow, S.,
+Charbonneau, R., Rigby, I., Boyd, S. K., Millar, P. J., Moraud, E.
+M., Capogrosso, M., Wagner, F. B., Barraud, Q., Bezard, E.,
+Lacour, S. P., Bloch, J., Courtine, G. and Phillips, A. A..
+Neuroprosthetic baroreflex controls haemodynamics after spinal
+cord injury. *Nature* 590:308-314, 10.1038/s41586-020-03180-w,
+2021.
+
+Srikanth, S. and Narayanan, R.. Variability state-dependent
+plasticity of intrinsic properties during cell-autonomous
+self-regulation of calcium homeostasis in hippocampal model
+neurons. *eNeuro* 2:ENEURO.0053-15.2015,
+10.1523/ENEURO.0053-15.2015, 2015.
+
+Srinivas, K. V., Buss, E. W., Sun, Q., Santoro, B., Takahashi, H.,
+Nicholson, D. A. and Siegelbaum, S. A.. The dendrites of Ca2 and
+Ca1 pyramidal neurons differentially regulate information flow in
+the cortico-hippocampal circuit. *Journal of Neuroscience*
+37:3276-3293, 10.1523/JNEUROSCI.2219-16.2017, 2017.
+
+Srinivas, K. V. and Sikdar, S. K.. Epileptiform activity induces
+distance-dependent alterations of the Ca2+ extrusion mechanism in
+the apical dendrites of subicular pyramidal neurons. *European
+Journal of Neuroscience* 28:2195-2212, 2008.
+
+Stacey, R. G., Hilbert, L. and Quail, T.. Computational study of
+synchrony in fields and microclusters of ephaptically coupled
+neurons. *Journal of Neurophysiology* 113:3229-3241,
+10.1152/jn.00546.2014, 2015.
+
+Stacey, W. C. and Durand, D. M.. Stochastic resonance improves
+signal detection in hippocampal CA1 neurons. *Journal of
+Neurophysiology* 83:1394-1402, 2000.
+
+Stacey, W. C. and Durand, D. M.. Synaptic noise improves detection
+of subthreshold signals in hippocampal CA1 neurons. *Journal of
+Neurophysiology* 86:1104-1112, 2001.
+
+Stacey, W. C. and Durand, D. M.. Noise and coupling affect signal
+detection and bursting in a simulated physiological neural
+network. *Journal of Neurophysiology* 88:2598-2611, 2002.
+
+Stacey, W. C., Kellis, S., Patel, P. R., Greger, B. and Butson, C.
+R.. Signal distortion from microelectrodes in clinical EEG
+acquisition systems. *Journal of Neural Engineering* 9:056007,
+10.1088/1741-2560/9/5/056007, 2012.
+
+Stacey, W. C., Krieger, A. and Litt, B.. Network recruitment to
+coherent oscillations in a hippocampal computer model. *Journal of
+Neurophysiology* 105:1464-1481, 10.1152/jn.00643.2010, 2011.
+
+Stacey, W. C., Lazarewicz, M. T. and Litt, B.. Synaptic noise and
+physiological coupling generate high-frequency oscillations in a
+hippocampal computational model.. *Journal of Neurophysiology*
+102:2342-2357, 10.1152/jn.00397.2009, 2009.
+
+Stadler, K., Bierwirth, C., Stoenica, L., Battefeld, A., Reetz,
+O., Mix, E., Schuchmann, S., Velmans, T., Rosenberger, K., Bräuer,
+A. U., Lehnardt, S., Nitsch, R., Budt, M., Wolff, T., Kole, M. H.
+P. and Strauss, U.. Elevation in type I interferons inhibits HCN1
+and slows cortical neuronal oscillations. *Cerebral Cortex*
+24:199-210, 10.1093/cercor/bhs305, 2014.
+
+Stamboulian-Platel, S., Legendre, A., Chabrol, T., Platel, J.-C.,
+Pernot, F., Duveau, V., Roucard, C., Baudry, M. and Depaulis, A..
+Activation of GABAA receptors controls mesiotemporal lobe epilepsy
+despite changes in chloride transporters expression: In vivo and
+in silico approach. *Experimental Neurology* 284:11-28,
+10.1016/j.expneurol.2016.07.009, 2016.
+
+Stasheff, S. F., Hines, M. and Wilson, W. A.. Axon terminal
+hyperexcitability associated with epileptogenesis in vitro: I.
+Origin of ectopic spikes. *Journal of Neurophysiology* 70:961-975,
+1993.
+
+Steephen, J. E.. Excitability range of medium spiny neurons widens
+through the combined effects of inward rectifying potassium
+current inactivation and dopaminergic modulation. *Neurocomputing*
+74:3884-3897, 2011.
+
+Steephen, J. E.. HED: a computational model of affective
+adaptation and emotion dynamics. *IEEE Transactions On Affective
+Computing* 4:197-210, 10.1109/T-AFFC.2013.2, 2013.
+
+Steephen, J. E. and Manchanda, R.. Differences in biophysical
+properties of nucleus accumbens medium spiny neurons emerging from
+inactivation of inward rectifying potassium currents. *Journal of
+Computational Neuroscience* 27:453-470, 10.1007/s10827-009-0161-7,
+2009.
+
+Stefano, M., Cordella, F., Li Gioi, S. M. and Zollo, L..
+Electrical stimulation of the human median nerve: a comparison
+between anatomical and simplified simulation models [Online].
+*Proc. 10th Int. IEEE/EMBS Conf. Neural Engineering* :769-772,
+10.1109/NER49283.2021.9441187, 2021.
+
+Stefano, M., Cordella, F. and Zollo, L.. The intraneural
+electrical stimulation of human median nerve: a simulation study
+[Online]. *Proc. 29th IEEE Int. Conf. Robot and Human Interactive
+Communication* :671-676, 10.1109/RO-MAN47096.2020.9223448, 2020.
+
+Stein, R. B., Estabrooks, K. L., McGie, S., Roth, M. J. and Jones,
+K. E.. Quantifying the effects of voluntary contraction and
+inter-stimulus interval on the human soleus H-reflex.
+*Experimental Brain Research* 182:309-319,
+10.1007/s00221-007-0989-x, 2007.
+
+Steinmetz, P. N., Manwani, A., Koch, C., London, M. and Segev, I..
+Subthreshold voltage noise due to channel fluctuations in active
+neuronal membranes. *Journal of Computational Neuroscience*
+9:133-148, 2000.
+
+Stelescu, A., Sumegi, J., Weber, I., Birinyi, A. and Wolf, E..
+Somato-dendritic morphology and dendritic signal transfer
+properties differentiate between fore- and hindlimb innervating
+motoneurons in the frog Rana esculenta. *BMC Neuroscience* 13:68,
+10.1186/1471-2202-13-68, 2012.
+
+Stern, S., Agudelo-Toro, A., Rotem, A., Moses, E. and Neef, A..
+Chronaxie measurements in patterned neuronal cultures from rat
+hippocampus. *PLoS ONE* 10:e0132577, 10.1371/journal.pone.0132577,
+2015a.
+
+Stern, S., Sarkar, A., Galor, D., Stern, T., Mei, A., Stern, Y.,
+Mendes, A. P. D., Randolph-Moore, L., Rouleau, G., Bang, A. G.,
+Santos, R., Alda, M., Marchetto, M. C. and Gage, F. H.. A
+physiological instability displayed in hippocampal neurons derived
+from lithium-nonresponsive bipolar disorder patients. *Biological
+Psychiatry* 88:150-158, 10.1016/j.biopsych.2020.01.020, 2020.
+
+Stern, S., Segal, M. and Moses, E.. Involvement of potassium and
+cation channels in hippocampal abnormalities of embryonic Ts65Dn
+and Tc1 trisomic mice. *EBioMedicine* 2:1048-1062,
+10.1016/j.ebiom.2015.07.038, 2015b.
+
+Sterratt, D., Graham, B., Gillies, A. and Willishaw, D..
+*Principles of Computational Modelling in Neuroscience*.
+Cambridge, UK: address, Cambridge University Press, 2011.
+
+Sterratt, D. C. and van Ooyen, A.. Does a dendritic democracy need
+a ruler?. *Neurocomputing* 58-60:437-442, 2004.
+
+Sterratt, D. C., Groen, M. R., Meredith, R. M. and van Ooyen, A..
+Spine calcium transients induced by synaptically-evoked action
+potentials can predict synapse location and establish synaptic
+democracy. *PLoS Computational Biology* 8:e1002545,
+10.1371/journal.pcbi.1002545, 2012.
+
+Stiefel, K. M., Wespatat, V., Singer, W. and Tennigkeit, F.. A
+computational model of the interaction of membrane potential
+oscillations with inhibitory synaptic input in cortical cells.
+*Neurocomputing* 38:389-395, 2001.
+
+Stiefel, K. M., Englitz, B. and Sejnowski, T. J.. Origin of
+intrinsic irregular firing in cortical interneurons. *Proceedings
+of the National Academy of Sciences of the United States of
+America* 110:7886-7891, 10.1073/pnas.1305219110, 2013a.
+
+Stiefel, K. M., Fellous, J.-M., Thomas, P. J. and Sejnowski, T.
+J.. Intrinsic subthreshold oscillations extend the influence of
+inhibitory synaptic inputs on cortical pyramidal neurons.
+*European Journal of Neuroscience* 31:1019-1026,
+10.1111/j.1460-9568.2010.07146.x, 2010.
+
+Stiefel, K. M., Gutkin, B. S. and Sejnowski, T. J.. The effects of
+cholinergic neuromodulation on neuronal phase-response curves of
+modeled cortical neurons. *Journal of Computational Neuroscience*
+26:289-301, 2009.
+
+Stiefel, K. M. and Sejnowski, T. J.. Mapping function onto
+neuronal morphology. *Journal of Neurophysiology* 98:513-526,
+2007.
+
+Stiefel, K. M., Torben-Nielsen, B. and Coggan, J. S.. Proposed
+evolutionary changes in the role of myelin. *Frontiers in
+Neuroscience* 7:202, 10.3389/fnins.2013.00202, 2013b.
+
+Stiefel, K. M., Wespatat, V., Gutkin, R., Tennigkeit, F. and
+Singer, W.. Phase dependent sign changes of GABAergic synaptic
+input explored in-silicio and in-vitro. *Journal of Computational
+Neuroscience* 19:71-85, 2005.
+
+Stimberg, M., Hoch, T. and Obermayer, K.. The effect of background
+noise on the precision of pulse packet propagation in feed-forward
+networks. *Neurocomputing* 70:1824-1828,
+10.1016/j.neucom.2006.10.057, 2007.
+
+Stockton, D. B. and Santamaria, F.. NeuroManager: a workflow
+analysis based simulation management engine for computational
+neuroscience. *Frontiers in Neuroinformatics* 9:24,
+10.3389/fninf.2015.00024, 2015.
+
+Stockton, D. B. and Santamaria, F.. Automating NEURON simulation
+deployment in cloud resources. *Neuroinformatics* 15:51-70,
+10.1007/s12021-016-9315-8, 2017a.
+
+Stockton, D. B. and Santamaria, F.. Integrating the Allen Brain
+Institute cell types database into automated neuroscience
+workflow. *Neuroinformatics* 15:333-342,
+10.1007/s12021-017-9337-x, 2017b.
+
+Stokes, C. C. A., Teeter, C. M. and Isaacson, J. S.. Single
+dendrite-targeting interneurons generate branch-specific
+inhibition.. *Frontiers in Neural Circuits* 8:139,
+10.3389/fncir.2014.00139, 2014.
+
+Stoop, R., Blank, D., Kern, A., v.d. Vyver, J.-J., Christen, M.,
+Lecchini, S. and Wagner, C.. Collective bursting in layer IV -
+synchronization by small thalamic inputs and recurrent
+connections. *Cognitive Brain Research* 13:293-304, 2002.
+
+Strube, C., Saliba, L., Moubarak, E., Penalba, V.,
+Martin-Eauclaire, M.-F., Tell, F. and Clerc, N.. Kv4 channels
+underlie A-currents with highly variable inactivation time courses
+but homogeneous other gating properties in the nucleus tractus
+solitarii. *Pflügers Archiv-European Journal of Physiology*
+467:789-803, 10.1007/s00424-014-1533-z, 2015.
+
+Strüber, M., Sauer, J.-F., Jonas, P. and Bartos, M..
+Distance-dependent inhibition facilitates focality of gamma
+oscillations in the dentate gyrus. *Nature Communications* 8:758,
+10.1038/s41467-017-00936-3, 2017.
+
+Stuart, G. and Häusser, M.. Dendritic coincidence detection of
+EPSPs and action potentials. *Nature Neuroscience* 4:63-71, 2001.
+
+Stuart, G. J. and Kole, M. H. P.. Is action potential threshold
+lowest in the axon?. *Nature Neuroscience* 11:1253-1255, 2008.
+
+Stuart, G. and Spruston, N.. Determinants of voltage attenuation
+in neocortical pyramidal neuron dendrites. *Journal of
+Neuroscience* 18:3501-3510, 1998.
+
+Stuart, G., Spruston, N. and Häusser, M.. Dendritic integration.
+In: *Dendrites*, edited by Stuart, G., Spruston, N. and Häusser,
+M.. NY: NY, Oxford University Press, 1999, pp. 231-270.
+
+Subramaniyam, S., Solinas, S., Perin, P., Locatelli, F., Masetto,
+S. and D'Angelo, E.. Computational modeling predicts the ionic
+mechanism of late-onset responses in unipolar brush cells.
+*Frontiers in Cellular Neuroscience* 8:237,
+10.3389/fncel.2014.00237, 2014.
+
+Sudhakar, S. K., Choi, T. J. and Ahmed, O. J.. Biophysical
+modeling suggests optimal drug combinations for improving the
+efficacy of GABA agonists after traumatic brain injuries. *Journal
+of Neurotrauma* 36:1632-1645, 10.1089/neu.2018.6065, 2019.
+
+Sudhakar, S. K., Hong, S., Raikov, I., Publio, R., Lang, C.,
+Close, T., Guo, D., Negrello, M. and De Schutter, E..
+Spatiotemporal network coding of physiological mossy fiber inputs
+by the cerebellar granular layer. *PLoS Computational Biology*
+13:e1005754, 10.1371/journal.pcbi.1005754, 2017.
+
+Sudhakar, S. K., Torben-Nielsen, B. and De Schutter, E..
+Cerebellar nuclear neurons use time and rate coding to transmit
+purkinje neuron pauses. *PLoS Computational Biology* 11:e1004641,
+10.1371/journal.pcbi.1004641, 2015.
+
+Suffczynski, P., Gentiletti, D., Gnatkovsky, V. and de Curtis, M..
+Extracellular potassium and focal seizures--insight from in silico
+study. In: *Computational Neurology and Psychiatry*. Springer
+International Publishing, 2017, pp. 49-72.
+
+Suleimanova, A., Talanov, M., Gafurov, O., Gafarov, F., Koroleva,
+K., Virenque, A., Noe, F. M., Mikhailov, N., Nistri, A. and
+Giniatullin, R.. Modeling a nociceptive neuro-immune synapse
+activated by ATP and 5-HT in meninges: novel clues on transduction
+of chemical signals into persistent or rhythmic neuronal firing.
+*Frontiers in Cellular Neuroscience* 14:135,
+10.3389/fncel.2020.00135, 2020.
+
+Suleimanova, A., Talanov, M., van den Maagdenberg, A. M. J. M. and
+Giniatullin, R.. Deciphering in silico the role of mutated NaV1.1
+sodium channels in enhancing trigeminal nociception in familial
+hemiplegic migraine type 3. *Frontiers in Cellular Neuroscience*
+15:644047, 10.3389/fncel.2021.644047, 2021.
+
+Sun, Q., Srinivas, K. V., Sotayo, A. and Siegelbaum, S. A..
+Dendritic Na(+) spikes enable cortical input to drive action
+potential output from hippocampal CA2 pyramidal neurons. *eLife*
+3:e04551, 10.7554/eLife.04551, 2014.
+
+Sun, Q.-Q.. A novel role of dendritic gap junction and mechanisms
+underlying its interaction with thalamocortical conductance in
+fast spiking inhibitory neurons. *BMC Neuroscience* 10:131,
+10.1186/1471-2202-10-131, 2009a.
+
+Sun, Q.-Q.. Experience-dependent intrinsic plasticity in
+interneurons of barrel cortex layer IV.. *Journal of
+Neurophysiology* 102:2955-2973, 10.1152/jn.00562.2009, 2009b.
+
+Sun, W. J. and Dietrich, D.. Synaptic integration by NG2 cells.
+*Frontiers In Cellular Neuroscience* 7:255,
+10.3389/fncel.2013.00255, 2013.
+
+Sundt, D., Gamper, N. and Jaffe, D. B.. Spike propagation through
+the dorsal root ganglia in an unmyelinated sensory neuron: a
+modeling study. *Journal of Neurophysiology* 114:3140-3153,
+10.1152/jn.00226.2015, 2015.
+
+Surkis, A., Peskin, C. S., Tranchina, D. and Leonard, C. S..
+Recovery of cable properties through active and passive modeling
+of subthreshold membrane responses from laterodorsal tegmental
+neurons. *Journal of Neurophysiology* 80:2593-2607, 1998.
+
+Swan, B. D., Brocker, D. T., Gross, R. E., Turner, D. A. and
+Grill, W. M.. Effects of ramped-frequency thalamic deep brain
+stimulation on tremor and activity of modeled neurons. *Clinical
+Neurophysiology* 131:625-634, 10.1016/j.clinph.2019.11.060, 2019.
+
+Swan, B. D., Brocker, D. T., Hilliard, J. D., Tatter, S. B.,
+Gross, R. E., Turner, D. A. and Grill, W. M.. Short pauses in
+thalamic deep brain stimulation promote tremor and neuronal
+bursting. *Clinical Neurophysiology* 127:1551-1559,
+10.1016/j.clinph.2015.07.034, 2016.
+
+Sylantyev, S., Savtchenko, L. P., Ermolyuk, Y., Michaluk, P. and
+Rusakov, D. A.. Spike-driven glutamate electrodiffusion triggers
+synaptic potentiation via a homer-dependent mGluR-NMDAR link.
+*Neuron* 77:528-541, 10.1016/j.neuron.2012.11.026, 2013.
+
+Sylantyev, S., Savtchenko, L. P., Niu, Y. P., Ivanov, A. I.,
+Jensen, T. P., Kullmann, D. M., Xiao, M. Y. and Rusakov, D. A..
+Electric fields due to synaptic currents sharpen excitatory
+transmission. *Science* 319:1845-1849, 2008.
+
+Sylantyev, S., Savtchenko, L. P., O'Neill, N. and Rusakov, D. A..
+Extracellular GABA waves regulate coincidence detection in
+excitatory circuits. *Journal of Physiology* 598:4047-4062,
+10.1113/JP279744, 2020.
+
+Szalisznyo, K., Silverstein, D. N., Duffau, H. and Smits, A..
+Pathological neural attractor dynamics in slowly growing gliomas
+supports an optimal time frame for white matter plasticity. *PLoS
+ONE* 8:e69798, 10.1371/journal.pone.0069798, 2013.
+
+Szegedi, V., Paizs, M., Baka, J., Barzó, P., Molnár, G., Tamas, G.
+and Lamsa, K.. Robust perisomatic GABAergic self-innervation
+inhibits basket cells in the human and mouse supragranular
+neocortex. *eLife* 910.7554/eLife.51691, 2020.
+
+Szoboszlay, M., Lőrincz, A., Lanore, F., Vervaeke, K., Silver, R.
+A. and Nusser, Z.. Functional properties of dendritic gap
+junctions in cerebellar golgi cells. *Neuron* 90:1043-1056,
+10.1016/j.neuron.2016.03.029, 2016.
+
+Tajarenejad, H., Ansari, M. A., Akbari, S., Yazdanfar, H. and
+Hamidi, S. M.. Optical neural stimulation using the
+thermoplasmonic effect of gold nano-hexagon. *Biomedical Optics
+Express* 12:6013-6023, 10.1364/BOE.438593, 2021.
+
+Takagi, H. and Kawasaki, M.. Modeling of time disparity detection
+by the Hodgkin-Huxley equations. *Journal of Comparative
+Physiology. A, Neuroethology, Sensory, Neural, and Behavioral
+Physiology* 189:257-262, 2003.
+
+Takagi, H., Sato, R., Matsumoto, T., Saito, M., Ito, E. and
+Suzuki, H.. Time-sharing contributions of A- and D-type K+
+channels to the integration of high-frequency sequential
+excitatory post synaptic potentials at a model dendrite in rats.
+*Neuroscience Letters* 289:169-172, 2000.
+
+Takagi, H., Sato, R., Mori, M., Ito, E. and Suzuki, H.. Roles of
+A- and D-type K channels in EPSP integration at a model dendrite.
+*Neuroscience Letters* 254:165-168, 1998.
+
+Takahashi, H., Nakao, M. and Kaga, K.. Selective activation of
+distant nerve by surface electrode array. *IEEE Transactions on
+Biomedical Engineering* 54:563-569, 2007.
+
+Takahashi, H., Nakao, M. and Kaga, K.. Simulation of nerve bundle
+activation by simultaneous multipoint extracellular stimulation
+with surface electrodes. *Electronics and Communications in Japan*
+92:31-40, 10.1002/ecj.10064, 2009.
+
+Takayasu, M., Takayasu, H., Koizumi, A., Shiraishi, Y. and Kaneko,
+A.. The role of random dendrites and inhibitory pathways in
+retinal neuron networks. *Physica A-Statistical Mechanics and its
+Applications* 357:513-524, 2005.
+
+Tal, I., Neymotin, S., Bickel, S., Lakatos, P. and Schroeder, C.
+E.. Oscillatory bursting as a mechanism for temporal coupling and
+information coding. *Frontiers in Computational Neuroscience*
+14:82, 10.3389/fncom.2020.00082, 2020.
+
+Talanov, M., Leukhin, A., Suleimanova, A., Toschev, A. and Lavrov,
+I.. Oscillator motif as design pattern for the spinal cord
+circuitry reconstruction. *BioNanoScience* 10:649-653,
+10.1007/s12668-020-00743-z, 2020.
+
+Tanaka, T. and Nakamura, K. C.. Focal inputs are a potential
+origin of local field potential (LFP) in the brain regions without
+laminar structure. *PLoS ONE* 14:e0226028,
+10.1371/journal.pone.0226028, 2019.
+
+Tang, A. C., Bartels, A. M. and Sejnowski, T. J.. Effects of
+cholinergic modulation on responses of neocortical neurons to
+fluctuating input. *Cerebral Cortex* 7:502-509, 1997.
+
+Tang, A. C., Wolfe, J. and Bartels, A. M.. Cholinergic modulation
+of spike timing and spike rate. *Neurocomputing* 26-27:293-298,
+1999.
+
+Taylor, A. L., Goaillard, J. M. and Marder, E.. How multiple
+conductances determine electrophysiological properties in a
+multicompartment model. *Journal of Neuroscience* 29:5573-5586,
+2009.
+
+Taylor, W. R., Mittman, S. and Copenhagen, D. R.. Passive
+electrical cable properties and synaptic excitation of tiger
+salamander retinal ganglion cells. *Visual Neuroscience*
+13:979-990, 1996.
+
+Tejada, J., Arisi, G. M., García-Cairasco, N. and Roque, A. C..
+Morphological alterations in newly born dentate gyrus granule
+cells that emerge after status epilepticus contribute to make them
+less excitable. *PLoS ONE* 7:e40726, 10.1371/journal.pone.0040726,
+2012.
+
+Tejada, J., Garcia-Cairasco, N. and Roque, A. C.. Combined role of
+seizure-induced dendritic morphology alterations and spine loss in
+newborn granule cells with mossy fiber sprouting on the
+hyperexcitability of a computer model of the dentate gyrus. *PLoS
+Computational Biology* 10:e1003601, 10.1371/journal.pcbi.1003601,
+2014.
+
+Tejada, J. and Roque, A. C.. Conductance-based models and the
+fragmentation problem: a case study based on hippocampal CA1
+pyramidal cell models and epilepsy. *Epilepsy & Behavior* :106841,
+10.1016/j.yebeh.2019.106841, 2019.
+
+Telenczuk, B., Telenczuk, M. and Destexhe, A.. A kernel-based
+method to calculate local field potentials from networks of
+spiking neurons. *Journal of Neuroscience Methods* 344:108871,
+10.1016/j.jneumeth.2020.108871, 2020.
+
+Teleńczuk, M., Brette, R., Destexhe, A. and Teleńczuk, B..
+Contribution of the axon initial segment to action potentials
+recorded extracellularly. *eNeuro* 5:ENEURO.0068-18.201,
+10.1523/ENEURO.0068-18.2018, 2018.
+
+Teleńczuk, M., Fontaine, B. and Brette, R.. The basis of sharp
+spike onset in standard biophysical models. *PLoS ONE*
+12:e0175362, 10.1371/journal.pone.0175362, 2017.
+
+Teleńczuk, M., Teleńczuk, B. and Destexhe, A.. Modelling unitary
+fields and the single-neuron contribution to local field
+potentials in the hippocampus. *Journal of Physiology*
+10.1113/JP279452, 2020.
+
+Tennøe, S., Halnes, G. and Einevoll, G. T.. Uncertainpy: a Python
+toolbox for uncertainty quantification and sensitivity analysis in
+computational neuroscience. *Frontiers in Neuroinformatics* 12:49,
+10.3389/fninf.2018.00049, 2018.
+
+Teplitzky, B. A., Connolly, A. T., Bajwa, J. A. and Johnson, M.
+D.. Computational modeling of an endovascular approach to deep
+brain stimulation. *Journal of Neural Engineering* 11:026011,
+10.1088/1741-2560/11/2/026011, 2014.
+
+Teplitzky, B. A., Zitella, L. M., Xiao, Y. and Johnson, M. D..
+Model-based comparison of deep brain stimulation array
+functionality with varying number of radial electrodes and machine
+learning feature sets. *Frontiers in Computational Neuroscience*
+10:58, 10.3389/fncom.2016.00058, 2016.
+
+Tesfayesus, W. and Durand, D. M.. Blind source separation of
+peripheral nerve recordings. *Journal of Neural Engineering*
+4:S157-S167, 2007.
+
+Thomas, E. A. and Petrou, S.. Network-specific mechanisms may
+explain the paradoxical effects of carbamazepine and phenytoin.
+*Epilepsia* 54:1195-1202, 10.1111/epi.12172, 2013.
+
+Thomas, E. and Lytton, W. W.. Computer model of antiepileptic
+effects mediated by alterations in GABA(A)-mediated inhibition.
+*Neuroreport* 9:691-696, 1998.
+
+Thomas, M., Ranjith, G., Radhakrishnan, A. and Arun Anirudhan, V..
+Effects of HCN2 mutations on dendritic excitability and synaptic
+plasticity: a computational study. *Neuroscience* 423:148-161,
+10.1016/j.neuroscience.2019.10.019, 2019.
+
+Thome, C., Kelly, T., Yanez, A., Schultz, C., Engelhardt, M.,
+Cambridge, S. B., Both, M., Draguhn, A., Beck, H. and Egorov, A.
+V.. Axon-carrying dendrites convey privileged synaptic input in
+hippocampal neurons. *Neuron* 83:1418-1430,
+10.1016/j.neuron.2014.08.013, 2014.
+
+Thompson, C. H., Ben-Shalom, R., Bender, K. J. and George, A. L..
+Alternative splicing potentiates dysfunction of early-onset
+epileptic encephalopathy SCN2A variants. *Journal of General
+Physiology* 15210.1085/jgp.201912442, 2020.
+
+Thomson, A. M. and Destexhe, A.. Dual intracellular recordings and
+computational models of slow inhibitory postsynaptic potentials in
+rat neocortical and hippocampal slices. *Neuroscience*
+92:1193-1215, 1999.
+
+Thorbergsson, P. T., Garwicz, M., Schouenborg, J. and Johansson,
+A. J.. Computationally efficient simulation of extracellular
+recordings with multielectrode arrays. *Journal of Neuroscience
+Methods* 211:133-144, 10.1016/j.jneumeth.2012.08.011, 2012a.
+
+Thorbergsson, P. T., Garwicz, M., Schouenborg, J. and Johansson,
+A. J.. Spike-feature based estimation of electrode position in
+extracellular neural recordings [Online]. *IEEE Engineering in
+Medicine and Biology Society Proceedings* 34:3380-3383,
+10.1109/EMBC.2012.6346690, 2012b.
+
+Thorbergsson, P. T., Garwicz, M., Schouenborg, J. and Johansson,
+A. J.. Strategies for high-performance resource-efficient
+compression of neural spike recordings. *PLoS ONE* 9:e93779,
+10.1371/journal.pone.0093779, 2014.
+
+Thurbon, D., Lüscher, H.-R., Hofstetter, T. and Redman, S. J..
+Passive electrical properties of ventral horn neurons in rat
+spinal cord slices. *Journal of Neurophysiology* 80:2485-2502,
+1998.
+
+Tiesinga, P. H. E., Fellous, J.-M., Jose, J. V. and Sejnowski, T.
+J.. Computational model of carbachol-induced delta, theta, and
+gamma oscillations in the hippocampus. *Hippocampus* 11:251-274,
+2001.
+
+Tiganj, Z., Chevallier, S. and Monacelli, E.. Influence of
+extracellular oscillations on neural communication: a
+computational perspective. *Frontiers in Computational
+Neuroscience* 8:9, 10.3389/fncom.2014.00009, 2014.
+
+Tigerholm, J., Börjesson, S. I., Lundberg, L., Elinder, F. and
+Fransén, E.. Dampening of hyperexcitability in CA1 pyramidal
+neurons by polyunsaturated fatty acids acting on voltage-gated ion
+channels. *PLoS ONE* 7:e44388, 10.1371/journal.pone.0044388, 2012.
+
+Tigerholm, J. and Fransén, E.. Reversing nerve cell pathology by
+optimizing modulatory action on target ion channels. *Biophysical
+Journal* 101:1871-1879, 10.1016/j.bpj.2011.08.055, 2011.
+
+Tigerholm, J., Hoberg, T. N., Brønnum, D., Vittinghus, M., Frahm,
+K. S. and Mørch, C. D.. Small and large cutaneous fibers display
+different excitability properties to slowly increasing ramp
+pulses. *Journal of Neurophysiology* 124:883-894,
+10.1152/jn.00629.2019, 2020.
+
+Tigerholm, J., Migliore, M. and Fransén, E.. Integration of
+synchronous synaptic input in CA1 pyramidal neuron depends on
+spatial and temporal distributions of the input. *Hippocampus*
+23:87-99, 10.1002/hipo.22061, 2013.
+
+Tigerholm, J., Petersson, M. E., Obreja, O., Lampert, A., Carr,
+R., Schmelz, M. and Fransén, E.. Modeling activity-dependent
+changes of axonal spike conduction in primary afferent
+C-nociceptors. *Journal of Neurophysiology* 111:1721-1735,
+10.1152/jn.00777.2012, 2014.
+
+Tigerholm, J., Poulsen, A. H., Andersen, O. K. and Mørch, C. D..
+From perception threshold to ion channels--a computational study.
+*Biophysical Journal* 117:281-295, 10.1016/j.bpj.2019.04.041,
+2019.
+
+Tikidji-Hamburyan, R. A. and Canavier, C. C.. Shunting inhibition
+improves synchronization in heterogeneous inhibitory interneuronal
+networks with type 1 excitability whereas hyperpolarizing
+inhibition is better for type 2 excitability. *eNeuro*
+710.1523/ENEURO.0464-19.2020, 2020.
+
+Tikidji-Hamburyan, R. A., Leonik, C. A. and Canavier, C. C.. Phase
+response theory explains cluster formation in sparsely but
+strongly connected inhibitory neural networks and effects of
+jitter due to sparse connectivity. *Journal of Neurophysiology*
+121:1125-1142, 10.1152/jn.00728.2018, 2019.
+
+Tikidji-Hamburyan, R. A., Martínez, J. J., White, J. A. and
+Canavier, C. C.. Resonant interneurons can increase robustness of
+gamma oscillations. *Journal of Neuroscience* 35:15682-15695,
+10.1523/JNEUROSCI.2601-15.2015, 2015.
+
+Tikidji-Hamburyan, R. A., Narayana, V., Bozkus, Z. and El-Ghazawi,
+T. A.. Software for brain network simulations: a comparative
+study. *Frontiers in Neuroinformatics* 11:46,
+10.3389/fninf.2017.00046, 2017.
+
+Timofeeva, Y., Cox, S. J., Coombes, S. and Josi?, K..
+Democratization in a passive dendritic tree: an analytical
+investigation.. *Journal of Computational Neuroscience*
+25:228-244, 10.1007/s10827-008-0075-9, 2008.
+
+Timofeeva, Y., Lord, G. J. and Coombes, S.. Dendritic cable with
+active spines: a modelling study in the spike-diffuse-spike
+framework. *Neurocomputing* 69:1058-1061, 2006a.
+
+Timofeeva, Y., Lord, G. J. and Coombes, S.. Spatio-temporal
+filtering properties of a dendritic cable with active spines: A
+modeling study in the spike-diffuse-spike framework. *Journal of
+Computational Neuroscience* 21:293-306, 2006b.
+
+Timofeeva, Y. and Volynski, K. E.. Calmodulin as a major calcium
+buffer shaping vesicular release and short-term synaptic
+plasticity: facilitation through buffer dislocation. *Frontiers in
+Cellular Neuroscience* 9:239, 10.3389/fncel.2015.00239, 2015.
+
+Tingley, D. and Buzsáki, G.. Transformation of a spatial map
+across the hippocampal-lateral septal circuit. *Neuron*
+98:1229-1242.e5, 10.1016/j.neuron.2018.04.028, 2018.
+
+Tingley, D. and Buzsáki, G.. Routing of hippocampal ripples to
+subcortical structures via the lateral septum. *Neuron*
+105:138-149.e5, 10.1016/j.neuron.2019.10.012, 2020.
+
+Tissone, A. I., Vidal, V. B., Nadal, M. S., Mato, G. and Amarillo,
+Y.. Differential contribution of the subthreshold operating
+currents IT, Ih, and IKir to the resonance of thalamocortical
+neurons. *Journal of Neurophysiology* 126:561-574,
+10.1152/jn.00147.2021, 2021.
+
+Tobin, W. F., Wilson, R. I. and Lee, W.-C. A.. Wiring variations
+that enable and constrain neural computation in a sensory
+microcircuit. *eLife* 6:e24838, 10.7554/eLife.24838, 2017.
+
+Toloza, E. H. S., Negahbani, E. and Fröhlich, F.. Ih interacts
+with somato-dendritic structure to determine frequency response to
+weak alternating electric field stimulation. *Journal of
+Neurophysiology* 119:1029-1036, 10.1152/jn.00541.2017, 2018.
+
+Tominaga, Y., Ichikawa, M. and Tominaga, T.. Membrane potential
+response profiles of CA1 pyramidal cells probed with
+voltage-sensitive dye optical imaging in rat hippocampal slices
+reveal the impact of GABA(A)-mediated feed-forward inhibition in
+signal propagation. *Neuroscience Research* 64:152-161, 2009.
+
+Tomko, M., Benuskova, L. and Jedlicka, P.. A new
+reduced-morphology model for CA1 pyramidal cells and its
+validation and comparison with other models using HippoUnit.
+*Scientific Reports* 11:7615, 10.1038/s41598-021-87002-7, 2021.
+
+Tomko, M., Jedlička, P. and Beňušková, L.. Meta-STDP rule
+stabilizes synaptic weights under in vivo-like ongoing spontaneous
+activity in a computational model of CA1 pyramidal cell [Online].
+*Artificial Neural Networks and Machine Learning -- ICANN 2020*
+:670-680, 2020.
+
+Tomsett, R. J., Ainsworth, M., Thiele, A., Sanayei, M., Chen, X.,
+Gieselmann, M. A., Whittington, M. A., Cunningham, M. O. and
+Kaiser, M.. Virtual Electrode Recording Tool for EXtracellular
+potentials (VERTEX): comparing multi-electrode recordings from
+simulated and biological mammalian cortical tissue. *Brain
+Structure and Function* 220:2333-2353, 10.1007/s00429-014-0793-x,
+2015.
+
+Toporikova, N. and Chacron, M. J.. SK channels gate information
+processing in vivo by regulating an intrinsic bursting mechanism
+seen in vitro.. *Journal of Neurophysiology* 102:2273-2287,
+10.1152/jn.00282.2009, 2009.
+
+Toporikova, N., Tsao, T.-H., Wright, Jr., T. M. and Butera, Jr.,
+R. J.. Conflicting effects of excitatory synaptic and electric
+coupling on the dynamics of square-wave bursters. *Journal of
+Computational Neuroscience* 31:701-711, 10.1007/s10827-011-0340-1,
+2011.
+
+Torben-Nielsen, B., Segev, I. and Yarom, Y.. The generation of
+phase differences and frequency changes in a network model of
+inferior olive subthreshold oscillations. *PLoS Computational
+Biology* 8:e1002580, 10.1371/journal.pcbi.1002580, 2012.
+
+Torben-Nielsen, B. and Stiefel, K. M.. An inverse approach for
+elucidating dendritic function. *Frontiers in Computational
+Neuroscience* 4:128, 10.3389/fncom.2010.00128, 2010a.
+
+Torben-Nielsen, B. and Stiefel, K. M.. Wide-field motion
+integration in fly VS cells: insights from an inverse approach.
+*PLoS Computational Biology* 6:e1000932,
+10.1371/journal.pcbi.1000932, 2010b.
+
+Tort, A. B. L., Rotstein, H. G., Dugladze, T., Gloveli, T. and
+Kopell, N. J.. On the formation of gamma-coherent cell assemblies
+by oriens lacunosum-moleculare interneurons in the hippocampus.
+*Proceedings of the National Academy of Sciences of the United
+States of America* 104:13490-13495, 2007.
+
+Toth, T. I. and Crunelli, V.. Solution of the nerve cable equation
+using Chebyshev approximations. *Journal of Neuroscience Methods*
+87:119-136, 1999.
+
+Traboulsie, A., Chemin, J., Chevalier, M., Quignard, J. F.,
+Nargeot, J. and Lory, P.. Subunit-specific modulation of T-type
+calcium channels by zinc. *Journal of Physiology* 578:159-171,
+2007.
+
+Traboulsie, A., Chemin, J., Kupfer, E., Nargeot, J. and Lory, P..
+T-type calcium channels are inhibited by fluoxetine and its
+metabolite norfluoxetine. *Molecular Pharmacology* 69:1963-1968,
+2006.
+
+Tran, H., Ranta, R., Le Cam, S. and Louis-Dorr, V.. Fast
+simulation of extracellular action potential signatures based on a
+morphological filtering approximation. *Journal of Computational
+Neuroscience* 48:27-46, 10.1007/s10827-019-00735-3, 2020.
+
+Tran, H., Shirinpour, S. and Opitz, A.. Effects of transcranial
+alternating current stimulation on spiking activity in
+computational models of single neocortical neurons. *NeuroImage*
+250:118953, 10.1016/j.neuroimage.2022.118953, 2022.
+
+Tran-Van-Minh, A., Abrahamsson, T., Cathala, L. and DiGregorio, D.
+A.. Differential dendritic integration of synaptic potentials and
+calcium in cerebellar interneurons. *Neuron* 91:837-850,
+10.1016/j.neuron.2016.07.029, 2016.
+
+Trapani, A., Antonietti, A., Naldi, G., D'Angelo, E. and
+Pedrocchi, A.. Production and diffusion model of Nitric Oxide for
+bioinspired spiking neural networks [Online]. *Proc. 10th Int.
+IEEE/EMBS Conf. Neural Engineering* :457-460,
+10.1109/NER49283.2021.9441383, 2021.
+
+Traynelis, S. F., Silver, R. A. and Cull-Candy, S. G.. Estimated
+conductance of glutamate receptor channels activated during epscs
+at the cerebellar mossy fiber-granule cell synapse. *Neuron*
+11:279-289, 1993.
+
+Trevelyan, A. J. and Watkinson, O.. Does inhibition balance
+excitation in neocortex?. *Progress in Biophysics and Molecular
+Biology* 87:109-143, 2005.
+
+Triesch, J., Zrenner, C. and Ziemann, U.. Modeling TMS-induced
+I-waves in human motor cortex. *Progress in Brain Research*
+222:105-124, 10.1016/bs.pbr.2015.07.001, 2015.
+
+Tsai, D., Chen, S., Protti, D. A., Morley, J. W., Suaning, G. J.
+and Lovell, N. H.. Responses of retinal ganglion cells to
+extracellular electrical stimulation, from single cell to
+population: model-based analysis. *PLoS ONE* 7:e53357,
+10.1371/journal.pone.0053357, 2012.
+
+Tsai, D., Morley, J. W., Suaning, G. J. and Lovell, N. H.. Survey
+of electrically evoked responses in the retina - stimulus
+preferences and oscillation among neurons. *Scientific Reports*
+7:13802, 10.1038/s41598-017-14357-1, 2017.
+
+Tsai, K. Y., Carnevale, N. T. and Brown, T. H.. Hebbian learning
+is jointly controlled by electrotonic and input structure.
+*Network* 5:1-19, 1994a.
+
+Tsai, K. Y., Carnevale, N. T., Claiborne, B. J. and Brown, T. H..
+Efficient mapping from neuroanatomical to electrotonic space.
+*Network* 5:21-46, 1994b.
+
+Tsanov, M., Chah, E., Noor, M. S., Egan, C., Reilly, R. B.,
+Aggleton, J. P., Erichsen, J. T., Vann, S. D. and O'Mara, S. M..
+The irregular firing properties of thalamic head direction cells
+mediate turn-specific modulation of the directional tuning curve.
+*Journal of Neurophysiology* 112:2316-2331, 10.1152/jn.00583.2013,
+2014.
+
+Tsay, D., Dudman, J. T. and Siegelbaum, S. A.. HCN1 channels
+constrain synaptically evoked Ca2+ spikes in distal dendrites of
+CA1 pyramidal neurons. *Neuron* 56:1076-1089,
+10.1016/j.neuron.2007.11.015, 2007.
+
+Tsay, D. and Yuste, R.. Role of dendritic spines in action
+potential backpropagation: a numerical simulation study. *Journal
+of Neurophysiology* 88:2834-2845, 2002.
+
+Tscherter, A., David, F., Ivanova, T., Deleuze, C., Renger, J. J.,
+Uebele, V. N., Shin, H.-S., Bal, T., Leresche, N. and Lambert, R.
+C.. Minimal alterations in T-type calcium channel gating markedly
+modify physiological firing dynamics. *Journal of Physiology*
+589:1707-1724, 10.1113/jphysiol.2010.203836, 2011.
+
+Tseng, S. H., Tsai, L. Y. and Yeh, S. R.. Induction of
+high-frequency oscillations in a junction-coupled network.
+*Journal of Neuroscience* 28:7165-7173, 2008.
+
+Tsuchitani, C.. Input from the medial nucleus of trapezoid body to
+an interaural level detector. *Hearing Research* 105:211-224,
+1997.
+
+Tsutsui, H. and Oka, Y.. Effects of characteristic dendritic tip
+geometry on the electrical properties of teleost thalamic neurons.
+*Journal of Neurophysiology* 85:2289-2292, 2001.
+
+Tsutsui, H. and Oka, Y.. Slow removal of Na+ channel inactivation
+underlies the temporal filtering property in the teleost thalamic
+neurons. *Journal of Physiology* 539:743-753, 2002.
+
+Tucker, K. R., Huertas, M. A., Horn, J. P., Canavier, C. C. and
+Levitan, E. S.. Pacemaker rate and depolarization block in nigral
+dopamine neurons: a somatic sodium channel balancing act. *Journal
+of Neuroscience* 32:14519-14531, 10.1523/JNEUROSCI.1251-12.2012,
+2012.
+
+Tucker, T. R. and Katz, L. C.. Recruitment of local inhibitory
+networks by horizontal connections in layer 2/3 of ferret visual
+cortex. *Journal of Neurophysiology* 89:501-512, 2003.
+
+Tumulty, J. S., Royster, M. and Cruz, L.. Columnar grouping
+preserves synchronization in neuronal networks with
+distance-dependent time delays. *Physical Review E* 101:022408,
+10.1103/PhysRevE.101.022408, 2020.
+
+Turi, G. F., Li, W.-K., Chavlis, S., Pandi, I., O'Hare, J.,
+Priestley, J. B., Grosmark, A. D., Liao, Z., Ladow, M., Zhang, J.
+F., Zemelman, B. V., Poirazi, P. and Losonczy, A.. Vasoactive
+intestinal polypeptide-expressing interneurons in the hippocampus
+support goal-oriented spatial learning. *Neuron* 101:1150-1165.e8,
+10.1016/j.neuron.2019.01.009, 2019.
+
+Tyurikova, O., Shih, P.-Y., Dembitskaya, Y., Savtchenko, L. P.,
+McHugh, T. J., Rusakov, D. A. and Semyanov, A.. K+ efflux through
+postsynaptic NMDA receptors suppresses local astrocytic glutamate
+uptake. *Glia* 10.1002/glia.24150, 2022.
+
+Tzilivaki, A., Kastellakis, G. and Poirazi, P.. Challenging the
+point neuron dogma: FS basket cells as 2-stage nonlinear
+integrators. *Nature Communications* 10:3664,
+10.1038/s41467-019-11537-7, 2019.
+
+Uebachs, M., Opitz, T., Royeck, M., Dickhof, G., Horstmann, M.-T.,
+Isom, L. L. and Beck, H.. Efficacy loss of the anticonvulsant
+carbamazepine in mice lacking sodium channel beta subunits via
+paradoxical effects on persistent sodium currents. *Journal of
+Neuroscience* 30:8489-8501, 10.1523/JNEUROSCI.1534-10.2010, 2010.
+
+Uhlirova, H., Kılıç, K., Tian, P., Thunemann, M., Desjardins, M.,
+Saisan, P. A., Sakadžić, S., Ness, T. V., Mateo, C., Cheng, Q.,
+Weldy, K. L., Razoux, F., Vandenberghe, M., Cremonesi, J. A.,
+Ferri, C. G., Nizar, K., Sridhar, V. B., Steed, T. C., Abashin,
+M., Fainman, Y., Masliah, E., Djurovic, S., Andreassen, O. A.,
+Silva, G. A., Boas, D. A., Kleinfeld, D., Buxton, R. B., Einevoll,
+G. T., Dale, A. M. and Devor, A.. Cell type specificity of
+neurovascular coupling in cerebral cortex. *eLife* 5:e14315,
+10.7554/eLife.14315, 2016.
+
+Ujfalussy, B. B., Makara, J. K., Lengyel, M. and Branco, T..
+Global and multiplexed dendritic computations under in vivo-like
+conditions. *Neuron* 100:579-592.e5, 10.1016/j.neuron.2018.08.032,
+2018.
+
+Ullman, S., Roth, A., Thomson, A. and Linne, M. L.. Crete,
+channels, cells, circuits and computers. *Trends in Neurosciences*
+20:53-54, 1997.
+
+Urakubo, H., Aihara, T., Kuroda, S., Watanabe, M. and Kondo, S..
+Spatial localization of synapses required for supralinear
+summation of action potentials and EPSPs. *Journal of
+Computational Neuroscience* 16:251-265, 2004.
+
+Urban, N. N. and Castro, J. B.. Tuft calcium spikes in accessory
+olfactory bulb mitral cells. *Journal of Neuroscience*
+25:5024-5028, 2005.
+
+Vabnick, I., Trimmer, J. S., Schwarz, T. L., Levinson, S. R.,
+Risal, D. and Shrager, P.. Dynamic potassium channel distributions
+during axonal development prevent aberrant firing patterns.
+*Journal of Neuroscience* 19:747-758, 1999.
+
+Valente, P., Romei, A., Fadda, M., Sterlini, B., Lonardoni, D.,
+Forte, N., Fruscione, F., Castroflorio, E., Michetti, C.,
+Giansante, G., Valtorta, F., Tsai, J.-W., Zara, F., Nieus, T.,
+Corradi, A., Fassio, A., Baldelli, P. and Benfenati, F..
+Constitutive inactivation of the PRRT2 gene alters short-term
+synaptic plasticity and promotes network hyperexcitability in
+hippocampal neurons. *Cerebral Cortex* 29:2010-2033,
+10.1093/cercor/bhy079, 2018.
+
+Van de Steene, T., Tanghe, E., Tarnaud, T., Kampusch, S.,
+Kaniusas, E., Martens, L., Van Holen, R. and Joseph, W..
+Sensitivity study of neuronal excitation and cathodal blocking
+thresholds of myelinated axons for percutaneous auricular vagus
+nerve stimulation. *IEEE Transactions on Bio-Medical Engineering*
+67:3276-3287, 10.1109/TBME.2020.2982271, 2020.
+
+Van Geit, W., Gevaert, M., Chindemi, G., Rössert, C., Courcol,
+J.-D., Muller, E. B., Schürmann, F., Segev, I. and Markram, H..
+BluePyOpt: leveraging open source software and cloud
+infrastructure to optimise model parameters in neuroscience.
+*Frontiers in Neuroinformatics* 10:17, 10.3389/fninf.2016.00017,
+2016.
+
+Varela, J. A., Wang, J., Christianson, J. P., Maier, S. F. and
+Cooper, D. C.. Control over stress, but not stress per se
+increases prefrontal cortical pyramidal neuron excitability.
+*Journal of Neuroscience* 32:12848-12853,
+10.1523/JNEUROSCI.2669-12.2012, 2012.
+
+Vasilkov, V. A. and Tikidji-Hamburyan, R. A.. Accurate detection
+of interaural time differences by a population of slowly
+integrating neurons. *Physical Review Letters* 108:138104,
+10.1103/PhysRevLett.108.138104, 2012.
+
+Vazquez, Y., Mendez, B., Trueta, C. and De-Miguel, F. F..
+Summation of excitatory postsynaptic potentials in
+electrically-coupled neurones. *Neuroscience* 163:202-212, 2009.
+
+van der Velden, L., van Hooft, J. A. and Chameau, P.. Altered
+dendritic complexity affects firing properties of cortical layer
+2/3 pyramidal neurons in mice lacking the 5-HT3A receptor.
+*Journal of Neurophysiology* 108:1521-1528, 10.1152/jn.00829.2011,
+2012.
+
+Veletic, M., Floor, P. A., Babic, Z. and Balasingham, I..
+Peer-to-peer communication in neuronal nano-network. *IEEE
+Transactions on Communications* 64:1153-1166, 2016.
+
+Velte, T. J. and Miller, R. F.. Computer simulations of voltage
+clamping retinal ganglion cells through whole-cell electrodes in
+the soma. *Journal of Neurophysiology* 75:2129-2143, 1996.
+
+Velte, T. J. and Miller, R. F.. Spiking and nonspiking models of
+starburst amacrine cells in the rabbit retina. *Visual
+Neuroscience* 14:1073-1088, 1997.
+
+Velte, T. J., Yu, W. and Miller, R. F.. Estimating the
+contributions of NMDA and non-NMDA currents to EPSPs in retinal
+ganglion cells. *Visual Neuroscience* 14:999-1014, 1997.
+
+Venkadesh, S., Komendantov, A. O., Wheeler, D. W., Hamilton, D. J.
+and Ascoli, G. A.. Simple models of quantitative firing phenotypes
+in hippocampal neurons: comprehensive coverage of intrinsic
+diversity. *PLoS Computational Biology* 15:e1007462,
+10.1371/journal.pcbi.1007462, 2019.
+
+Vera, J., Pezzoli, M., Pereira, U., Bacigalupo, J. and Sanhueza,
+M.. Electrical resonance in the θ frequency range in olfactory
+amygdala neurons. *PLoS ONE* 9:e85826,
+10.1371/journal.pone.0085826, 2014.
+
+Verbist, C., Müller, M. G., Mansvelder, H. D., Legenstein, R. and
+Giugliano, M.. The location of the axon initial segment affects
+the bandwidth of spike initiation dynamics. *PLoS Computational
+Biology* 16:e1008087, 10.1371/journal.pcbi.1008087, 2020.
+
+Verma, N., Graham, R. D., Mudge, J., Trevathan, J. K., Franke, M.,
+Shoffstall, A. J., Williams, J., Dalrymple, A. N., Fisher, L. E.,
+Weber, D. J., Lempka, S. F. and Ludwig, K. A.. Augmented
+transcutaneous stimulation using an injectable electrode: a
+computational study. *Frontiers in Bioengineering and
+Biotechnology* 9:796042, 10.3389/fbioe.2021.796042, 2021.
+
+Veruki, M. L., Oltedal, L. and Hartveit, E.. Electrical synapses
+between AII amacrine cells: dynamic range and functional
+consequences of variation in junctional conductance. *Journal of
+Neurophysiology* 100:3305-3322, 2008.
+
+Vervaeke, K., Lorincz, A., Gleeson, P., Farinella, M., Nusser, Z.
+and Silver, R. A.. Rapid desynchronization of an electrically
+coupled interneuron network with sparse excitatory synaptic input.
+*Neuron* 67:435-451, 10.1016/j.neuron.2010.06.028, 2010.
+
+Vervaeke, K., Lorincz, A., Nusser, Z. and Silver, R. A.. Gap
+junctions compensate for sublinear dendritic integration in an
+inhibitory network. *Science* 335:1624-1628,
+10.1126/science.1215101, 2012.
+
+Vetter, P., Roth, A. and Häusser, M.. Propagation of action
+potentials in dendrites depends on dendritic morphology. *Journal
+of Neurophysiology* 85:926-937, 2001.
+
+Vida, I., Bartos, M. and Jonas, P.. Shunting inhibition improves
+robustness of gamma oscillations in hippocampal interneuron
+networks by homogenizing firing rates. *Neuron* 49:107-117, 2006.
+
+Vierling-Claassen, D., Cardin, J. A., Moore, C. I. and Jones, S.
+R.. Computational modeling of distinct neocortical oscillations
+driven by cell-type selective optogenetic drive: separable
+resonant circuits controlled by low-threshold spiking and
+fast-spiking interneurons.. *Frontiers in Human Neuroscience*
+4:198, 10.3389/fnhum.2010.00198, 2010.
+
+Vitale, P., Salgueiro-Pereira, A. R., Lupascu, C. A., Willem, M.,
+Migliore, R., Migliore, M. and Marie, H.. Analysis of
+age-dependent alterations in excitability properties of CA1
+pyramidal neurons in an APPPS1 model of Alzheimer's disease.
+*Frontiers in Aging Neuroscience* 13:668948,
+10.3389/fnagi.2021.668948, 2021.
+
+Vitko, I., Chen, Y. C., Arias, J. M., Shen, Y., Wu, X. R. and
+Perez-Reyes, E.. Functional characterization and neuronal modeling
+of the effects of childhood absence epilepsy variants of CACNA1H,
+a T-type calcium channel. *Journal of Neuroscience* 25:4844-4855,
+2005.
+
+Vlachos, A., Becker, D., Jedlicka, P., Winkels, R., Roeper, J. and
+Deller, T.. Entorhinal denervation induces homeostatic synaptic
+scaling of excitatory postsynapses of dentate granule cells in
+mouse organotypic slice cultures. *PLoS ONE* 7:e32883,
+10.1371/journal.pone.0032883, 2012.
+
+Vladimirov, N., Tu, Y. and Traub, R. D.. Shortest loops are
+pacemakers in random networks of electrically coupled axons.
+*Frontiers in Computational Neuroscience* 6:17,
+10.3389/fncom.2012.00017, 2012.
+
+Vladimirov, N., Tu, Y. and Traub, R. D.. Synaptic gating at axonal
+branches, and sharp-wave ripples with replay: a simulation study.
+*European Journal of Neuroscience* 38:3435-3447,
+10.1111/ejn.12342, 2013.
+
+Vlasits, A. L., Morrie, R. D., Tran-Van-Minh, A., Bleckert, A.,
+Gainer, C. F., DiGregorio, D. A. and Feller, M. B.. A role for
+synaptic input distribution in a dendritic computation of motion
+direction in the retina. *Neuron* 89:1317-1330,
+10.1016/j.neuron.2016.02.020, 2016.
+
+Volk, V. L., Hamilton, L. D., Hume, D. R., Shelburne, K. B. and
+Fitzpatrick, C. K.. Integration of neural architecture within a
+finite element framework for improved neuromusculoskeletal
+modeling. *Scientific Reports* 11:22983,
+10.1038/s41598-021-02298-9, 2021.
+
+Volman, V., Levine, H., Ben-Jacob, E. and Sejnowski, T. J..
+Locally balanced dendritic integration by short-term synaptic
+plasticity and active dendritic conductances. *Journal of
+Neurophysiology* 102:3234-3250, 10.1152/jn.00260.2009, 2009.
+
+Volman, V. and Ng, L. J.. Computer modeling of mild axonal injury:
+implications for axonal signal transmission. *Neural Computation*
+25:2646-2681, 10.1162/NECO_a_00491, 2013.
+
+Volman, V. and Ng, L. J.. Primary paranode demyelination modulates
+slowly developing axonal depolarization in a model of axonal
+injury. *Journal of Computational Neuroscience* 37:439 - 457,
+10.1007/s10827-014-0515-7, 2014.
+
+Volman, V. and Ng, L. J.. Perinodal glial swelling mitigates
+axonal degradation in a model of axonal injury. *Journal of
+Neurophysiology* 115:1003-1017, 10.1152/jn.00912.2015, 2016.
+
+Vyleta, N. P. and Jonas, P.. Loose coupling between Ca2+ channels
+and release sensors at a plastic hippocampal synapse. *Science*
+343:665-670, 10.1126/science.1244811, 2014.
+
+Wagner, F. B., Mignardot, J.-B., Le Goff-Mignardot, C. G.,
+Demesmaeker, R., Komi, S., Capogrosso, M., Rowald, A., Seáñez, I.,
+Caban, M., Pirondini, E., Vat, M., McCracken, L. A., Heimgartner,
+R., Fodor, I., Watrin, A., Seguin, P., Paoles, E., Van Den Keybus,
+K., Eberle, G., Schurch, B., Pralong, E., Becce, F., Prior, J.,
+Buse, N., Buschman, R., Neufeld, E., Kuster, N., Carda, S., von
+Zitzewitz, J., Delattre, V., Denison, T., Lambert, H., Minassian,
+K., Bloch, J. and Courtine, G.. Targeted neurotechnology restores
+walking in humans with spinal cord injury. *Nature* 563:65-71,
+10.1038/s41586-018-0649-2, 2018.
+
+Walckiers, G., Fuchs, B., Thiran, J.-P., Mosig, J. R. and Pollo,
+C.. Influence of the implanted pulse generator as reference
+electrode in finite element model of monopolar deep brain
+stimulation. *Journal of Neuroscience Methods* 186:90-96,
+10.1016/j.jneumeth.2009.10.012, 2010.
+
+Walsh, D. M., Landman, K. A. and Hughes, B. D.. What is the
+optimal distribution of myelin along a single axon?. *Neuroscience
+Letters* 658:97-101, 10.1016/j.neulet.2017.08.037, 2017.
+
+Wang, B., Aberra, A. S., Grill, W. M. and Peterchev, A. V..
+Modified cable equation incorporating transverse polarization of
+neuronal membranes for accurate coupling of electric fields.
+*Journal of Neural Engineering* 15:026003,
+10.1088/1741-2552/aa8b7c, 2018.
+
+Wang, H.-P., Garcia, J. W., Sabottke, C. F., Spencer, D. J. and
+Sejnowski, T. J.. Feedforward thalamocortical connectivity
+preserves stimulus timing information in sensory pathways.
+*Journal of Neuroscience* 39:7674-7688,
+10.1523/JNEUROSCI.3165-17.2019, 2019.
+
+Wang, H.-P., Spencer, D., Fellous, J.-M. and Sejnowski, T. J..
+Synchrony of thalamocortical inputs maximizes cortical
+reliability. *Science* 328:106-109, 10.1126/science.1183108, 2010.
+
+Wang, H.-S. and McKinnon, D.. Potassium currents in rat
+prevertebral and paravertebral sympathetic neurones: control of
+firing properties. *Journal of Physiology* 485:319-335, 1995.
+
+Wang, J., Chen, S., Nolan, M. F. and Siegelbaum, S. A..
+Activity-dependent regulation of HCN pacemaker channels by cyclic
+AMP: signaling through dynamic allosteric coupling. *Neuron*
+36:451-461, 2002a.
+
+Wang, J., Liu, S., Wang, H., Ju, N. and Zeng, Y.. A model-based
+analysis of physiological properties of the striatal medium spiny
+neuron. *Neurological Research* 37:1074-1081,
+10.1080/01616412.2015.1110304, 2015.
+
+Wang, K., Riera, J., Enjieu-Kadji, H. and Kawashima, R.. The role
+of extracellular conductivity profiles in compartmental models for
+neurons: particulars for layer 5 pyramidal cells.. *Neural
+Computation* 25:1807-1852, 10.1162/NECO_a_00458, 2013.
+
+Wang, L. and Colburn, H. S.. A modeling study of the responses of
+the lateral superior olive to ipsilateral sinusoidally
+amplitude-modulated tones. *Journal of the Association for
+Research in Otolaryngology* 13:249-267, 10.1007/s10162-011-0300-5,
+2012.
+
+Wang, L., Devore, S., Delgutte, B. and Colburn, H. S.. Dual
+sensitivity of inferior colliculus neurons to ITD in the envelopes
+of high-frequency sounds: experimental and modeling study.
+*Journal of Neurophysiology* 111:164-181, 10.1152/jn.00450.2013,
+2014a.
+
+Wang, L., Liu, S. and Ou, S.. Numerical simulation of neuronal
+spike patterns in a retinal network model. *Neural Regeneration
+Research* 6:1254-1260, 10.3969/j.issn.1673-5374.2011.16.010, 2011.
+
+Wang, L. and Liu, S.-Q.. Neural circuit and its functional roles
+in cerebellar cortex. *Neuroscience Bulletin* 27:173-184,
+10.1007/s12264-011-1044-2, 2011.
+
+Wang, X.-D., Hao, J., Poo, M.-M. and Zhang, X.-H.. How does a
+neuron perform subtraction? Arithmetic rules of synaptic
+integration of excitation and inhibition. In: *Advances in Neural
+Networks - ISNN 2006*, edited by Wang, J., Yi, Z., Zurada, J., Lu,
+B.-L. and Yin, H.. Springer Berlin Heidelberg, 2006, pp. 7-14.
+
+Wang, X.-L., Jiang, X.-D. and Liang, P.-J.. Intracellular calcium
+concentration changes initiated by N-methyl-D-aspartic acid
+receptors in retinal horizontal cells. *Neuroreport* 19:675-678,
+2008.
+
+Wang, Y., Toprani, S., Tang, Y., Vrabec, T. and Durand, D. M..
+Mechanism of highly synchronized bilateral hippocampal activity.
+*Experimental Neurology* 251:101-111,
+10.1016/j.expneurol.2013.11.014, 2014b.
+
+Wang, Z., Song, D. and Berger, T. W.. Contribution of NMDA
+receptor channels to the expression of LTP in the hippocampal
+dentate gyrus. *Hippocampus* 12:680-688, 2002b.
+
+Warashina, A.. Mode of mitochondrial Ca2+ clearance and its
+influence on secretory responses in stimulated chromaffin cells.
+*Cell Calcium* 39:35-46, 2006.
+
+Warashina, A. and Ogura, T.. Modeling of stimulation-secretion
+coupling in a chromaffin cell. *Pflügers Archiv-European Journal
+of Physiology* 448:161-174, 2004.
+
+Watanabe, S., Hoffman, D. A., Migliore, M. and Johnston, D..
+Dendritic K+ channels contribute to spike-timing dependent
+long-term potentiation in hippocampal pyramidal neurons.
+*Proceedings of the National Academy of Sciences of the United
+States of America* 99:8366-8371, 2002.
+
+Watanabe, T., Shimazaki, T. and Oda, Y.. Coordinated expression of
+two types of low-threshold K+ channels establishes unique single
+spiking of Mauthner cells among segmentally homologous neurons in
+the zebrafish hindbrain. *eNeuro* 4:ENEURO.0249-17.2017,
+10.1523/ENEURO.0249-17.2017, 2017.
+
+Waters, J. and Helmchen, F.. Background synaptic activity is
+sparse in neocortex. *Journal of Neuroscience* 26:8267-8277, 2006.
+
+Wathey, J. C., Lytton, W. W., Jester, J. M. and Sejnowski, T. J..
+Computer simulations of EPSP-spike (E-S) potentiation in
+hippocampal CA1 pyramidal cells. *Journal of Neuroscience*
+12:607-618, 1992.
+
+Weaver, C. M. and Wearne, S. L.. The role of action potential
+shape and parameter constraints in optimization of compartment
+models. *Neurocomputing* 69:1053-1057, 2006.
+
+Weaver, C. M. and Wearne, S. L.. Neuronal firing sensitivity to
+morphologic and active membrane parameters. *PLoS Computational
+Biology* 4:e11, 10.1371/journal.pcbi.0040011.eor, 2008.
+
+Weber, F., Eichner, H., Cuntz, H. and Borst, A.. Eigenanalysis of
+a neural network for optic flow processing. *New Journal of
+Physics* 10:015013, 2008.
+
+Wefelmeyer, W., Cattaert, D. and Burrone, J.. Activity-dependent
+mismatch between axo-axonic synapses and the axon initial segment
+controls neuronal output. *Proceedings of the National Academy of
+Sciences of the United States of America* 112:9757-9762,
+10.1073/pnas.1502902112, 2015.
+
+Wehr, M. and Zador, A. M.. Balanced inhibition underlies tuning
+and sharpens spike timing in auditory cortex. *Nature*
+426:442-446, 10.1038/nature02116, 2003.
+
+Wei, X. F. and Grill, W. M.. Analysis of high-perimeter planar
+electrodes for efficient neural stimulation.. *Frontiers in
+Neuroengineering* 2:15, 10.3389/neuro.16.015.2009, 2009.
+
+Weidel, P., Djurfeldt, M., Duarte, R. C. and Morrison, A.. Closed
+loop interactions between spiking neural network and robotic
+simulators based on MUSIC and ROS. *Frontiers in Neuroinformatics*
+10:31, 10.3389/fninf.2016.00031, 2016.
+
+Weissler, Y., Farah, N. and Shoham, S.. Simulation of
+morphologically structured photo-thermal neural stimulation.
+*Journal of Neural Engineering* 14:055001,
+10.1088/1741-2552/aa7805, 2017.
+
+Weisz, C. J. C., Glowatzki, E. and Fuchs, P. A.. Excitability of
+type II cochlear afferents. *Journal of Neuroscience*
+34:2365-2373, 10.1523/JNEUROSCI.3428-13.2014, 2014.
+
+Welday, A. C., Shlifer, I. G., Bloom, M. L., Zhang, K. and Blair,
+H. T.. Cosine directional tuning of theta cell burst frequencies:
+evidence for spatial coding by oscillatory interference. *Journal
+of Neuroscience* 31:16157-16176, 10.1523/JNEUROSCI.0712-11.2011,
+2011.
+
+van Welie, I., Remme, M. W., van Hooft, J. A. and Wadman, W. J..
+Different levels of Ih determine distinct temporal integration in
+bursting and regular-spiking neurons in rat subiculum. *Journal of
+Physiology* 576:203-214, 2006.
+
+Wenger, C., Paredes, L. and Rattay, F.. Current-distance relations
+for microelectrode stimulation of pyramidal cell. *Artificial
+Organs* 35:263-266, 10.1111/j.1525-1594.2011.01224.x, 2011.
+
+Wenning, G., Hoch, T. and Obermayer, K.. Detection of pulses in a
+colored noise setting. *Physical Review E* 71:021902, 2005.
+
+Wenning, G. and Obermayer, K.. Activity driven adaptive stochastic
+resonance. *Physical Review Letters* 90:120602, 2003.
+
+Wester, J. C. and Contreras, D.. Biophysical mechanism of spike
+threshold dependence on the rate of rise of the membrane potential
+by sodium channel inactivation or subthreshold axonal potassium
+current. *Journal of Computational Neuroscience* 35:1-17,
+10.1007/s10827-012-0436-2, 2013.
+
+Wetmore, D. Z., Mukamel, E. A. and Schnitzer, M. J.. Lock-and-key
+mechanisms of cerebellar memory recall based on rebound currents.
+*Journal of Neurophysiology* 100:2328-2347, 2008.
+
+de Wiljes, O. O., van Elburg, R. A. J., Biehl, M. and Keijzer, F.
+A.. Modeling spontaneous activity across an excitable epithelium:
+support for a coordination scenario of early neural evolution.
+*Frontiers in Computational Neuroscience* 9:110,
+10.3389/fncom.2015.00110, 2015.
+
+Williams, M. R., DeSpenza, Jr, T., Li, M., Gulledge, A. T. and
+Luikart, B. W.. Hyperactivity of newborn Pten knock-out neurons
+results from increased excitatory synaptic drive. *Journal of
+Neuroscience* 35:943-959, 10.1523/JNEUROSCI.3144-14.2015, 2015.
+
+Williams, S. R. and Stuart, G. J.. Dependence of EPSP efficacy on
+synapse location in neocortical pyramidal neurons. *Science*
+295:1907-1910, 2002.
+
+Williams, S. R. and Stuart, G. J.. Role of dendritic synapse
+location in the control of action potential output. *Trends in
+Neurosciences* 26:147-154, 2003.
+
+Wilmes, K. A., Schleimer, J.-H. and Schreiber, S.. Spike-timing
+dependent inhibitory plasticity to learn a selective gating of
+backpropagating action potentials. *European Journal of
+Neuroscience* 45:1032-1043, 10.1111/ejn.13326, 2017.
+
+Wilmes, K. A., Sprekeler, H. and Schreiber, S.. Inhibition as a
+binary switch for excitatory plasticity in pyramidal neurons.
+*PLoS Computational Biology* 12:e1004768,
+10.1371/journal.pcbi.1004768, 2016.
+
+Wimmer, V. C., Reid, C. A., Mitchell, S., Richards, K. L., Scaf,
+B. B., Leaw, B. T., Hill, E. L., Royeck, M., Horstmann, M.-T.,
+Cromer, B. A., Davies, P. J., Xu, R., Lerche, H., Berkovic, S. F.,
+Beck, H. and Petrou, S.. Axon initial segment dysfunction in a
+mouse model of genetic epilepsy with febrile seizures plus.
+*Journal of Clinical Investigation* 120:2661-2671,
+10.1172/JCI42219, 2010.
+
+Winkels, R., Jedlicka, P., Weise, F. K., Schultz, C., Deller, T.
+and Schwarzacher, S. W.. Reduced excitability in the dentate gyrus
+network of betaIV-spectrin mutant. *Hippocampus* 19:677-686, 2009.
+
+Winograd, M., Destexhe, A. and Sanchez-Vives, M. V..
+Hyperpolarization-activated graded persistent activity in the
+prefrontal cortex. *Proceedings of the National Academy of
+Sciences of the United States of America* 105:7298-7303, 2008.
+
+Winslow, J. L., Jou, S. E., Wang, S. and Wojtowicz, J. M.. Signals
+in stochastically generated neurons. *Journal of Computational
+Neuroscience* 6:5-26, 1999.
+
+Winters, B. D., Jin, S.-X., Ledford, K. R. and Golding, N. L..
+Amplitude normalization of dendritic epsps at the soma of binaural
+coincidence detector neurons of the medial superior olive.
+*Journal of Neuroscience* 37:3138-3149,
+10.1523/JNEUROSCI.3110-16.2017, 2017.
+
+Wissmann, R., Bildl, W., Oliver, D., Beyermann, M., Kalbitzer, H.
+R., Bentrop, D. and Fakler, B.. Solution structure and function of
+the "tandem inactivation domain" of the neuronal A-type potassium
+channel Kv1.4. *Journal of Biological Chemistry* 278:16142-16150,
+2003.
+
+Wittmeier, S., Song, G., Duffin, J. and Poon, C.-S.. Pacemakers
+handshake synchronization mechanism of mammalian respiratory
+rhythmogenesis. *Proceedings of the National Academy of Sciences
+of the United States of America* 105:18000-18005, 2008.
+
+Wlodarczyk, A. I., Xu, C., Song, I., Doronin, M., Wu, Y. W.,
+Walker, M. C. and Semyanov, A.. Tonic GABA(A) conductance
+decreases membrane time constant and increases EPSP-spike
+precision in hippocampal pyramidal neurons. *Frontiers In Neural
+Circuits* 7:205, 10.3389/fncir.2013.00205, 2013.
+
+Wolf, E., Birinyi, A. and Székely, G.. Simulation of the effect of
+synapses: the significance of the dendritic diameter in impulse
+propagation. *European Journal of Neuroscience* 4:1013-1021, 1992.
+
+Wolf, J. A., Moyer, J. T. and Finkel, L. H.. The role of NMDA
+currents in state transitions of the nucleus accumbens medium
+spiny neuron. *Neurocomputing* 65-66:565-570, 2005a.
+
+Wolf, J. A., Moyer, J. T., Lazarewicz, M. T., Contreras, D.,
+Benoit-Marand, M., O'Donnell, P. and Finkel, L. H.. NMDA/AMPA
+ratio impacts state transitions and entrainment to oscillations in
+a computational model of the nucleus accumbens medium spiny
+projection neuron. *Journal of Neuroscience* 25:9080-9095, 2005b.
+
+Wolfart, J., Debay, D., Le Masson, G., Destexhe, A. and Bal, T..
+Synaptic background activity controls spike transfer from thalamus
+to cortex. *Nature Neuroscience* 8:1760-1767, 2005.
+
+Wong, A. Y. C., Graham, B. P., Billups, B. and Forsythe, I. D..
+Distinguishing between presynaptic and postsynaptic mechanisms of
+short-term depression during action potential trains. *Journal of
+Neuroscience* 23:4868-4877, 2003.
+
+Wongsarnpigoon, A. and Grill, W. M.. Energy-efficient waveform
+shapes for neural stimulation revealed with a genetic algorithm.
+*Journal of Neural Engineering* 7:046009,
+10.1088/1741-2560/7/4/046009, 2010.
+
+Wongsarnpigoon, A. and Grill, W. M.. Computer-based model of
+epidural motor cortex stimulation: effects of electrode position
+and geometry on activation of cortical neurons. *Clinical
+Neurophysiology* 123:160-172, 10.1016/j.clinph.2011.06.005, 2012.
+
+Wongsarnpigoon, A., Woock, J. P. and Grill, W. M.. Efficiency
+analysis of waveform shape for electrical excitation of nerve
+fibers. *IEEE Transactions on Neural Systems and Rehabilitation
+Engineering* 18:319-328, 10.1109/TNSRE.2010.2047610, 2010.
+
+Woo, J., Kim, S. H., Han, K. and Choi, M.. Characterization of
+dynamics and information processing of integrate-and-fire neuron
+models. *Journal of Physics A: Mathematical and Theoretical*
+54:445601, 10.1088/1751-8121/ac2a54, 2021.
+
+Wu, S.-C. and Swindlehurst, A. L.. Direct feature extraction from
+multi-electrode recordings for spike sorting. *Digital Signal
+Processing* 75:222-231, 10.1016/j.dsp.2018.01.016, 2018.
+
+Wu, S.-C., Swindlehurst, A. L. and Nenadic, Z.. A novel framework
+for feature extraction in multi-sensor action potential sorting.
+*Journal of Neuroscience Methods* 253:262-271,
+10.1016/j.jneumeth.2015.07.003, 2015a.
+
+Wu, S.-N., Huang, Y.-M., Kao, C.-A., Chen, B.-S. and Lo, Y.-C..
+Investigations on contribution of glial inwardly-rectifying K(+)
+current to membrane potential and ion flux: an experimental and
+theoretical study. *Kaohsiung Journal of Medical Sciences*
+31:9-17, 10.1016/j.kjms.2014.10.006, 2015b.
+
+Wu, T., Fan, J., Lee, K. S. and Li, X.. Cortical neuron activation
+induced by electromagnetic stimulation: a quantitative analysis
+via modelling and simulation. *Journal of Computational
+Neuroscience* 40:51-64, 10.1007/s10827-015-0585-1, 2016.
+
+Wulff, P., Ponomarenko, A. A., Bartos, M., Korotkova, T. M.,
+Fuchs, E. C., Bahner, F., Both, M., Tort, A. B. L., Kopell, N. J.,
+Wisden, W. and Monyer, H.. Hippocampal theta rhythm and its
+coupling with gamma oscillations require fast inhibition onto
+parvalbumin-positive interneurons. *Proceedings of the National
+Academy of Sciences of the United States of America*
+106:3561-3566, 2009.
+
+Wybo, W. A., Jordan, J., Ellenberger, B., Marti Mengual, U.,
+Nevian, T. and Senn, W.. Data-driven reduction of dendritic
+morphologies with preserved dendro-somatic responses. *eLife*
+1010.7554/eLife.60936, 2021.
+
+Wybo, W. A. M., Boccalini, D., Torben-Nielsen, B. and Gewaltig,
+M.-O.. A sparse reformulation of the Green's function formalism
+allows efficient simulations of morphological neuron models.
+*Neural Computation* 27:2587-2622, 10.1162/NECO_a_00788, 2015.
+
+Wybo, W. A. M., Stiefel, K. M. and Torben-Nielsen, B.. The Green's
+function formalism as a bridge between single- and
+multi-compartmental modeling. *Biological Cybernetics*
+107:685-694, 10.1007/s00422-013-0568-0, 2013.
+
+Wybo, W. A. M., Torben-Nielsen, B., Nevian, T. and Gewaltig,
+M.-O.. Electrical compartmentalization in neurons. *Cell Reports*
+26:1759-1773.e7, 10.1016/j.celrep.2019.01.074, 2019.
+
+Xiang, Z. X., Huguenard, J. R. and Prince, D. A.. Synaptic
+inhibition of pyramidal cells evoked by different interneuronal
+subtypes in layer V of rat visual cortex. *Journal of
+Neurophysiology* 88:740-750, 2002.
+
+Xiao, Q., Zhong, Z., Lai, X. and Qin, H.. A multiple modulation
+synthesis method with high spatial resolution for noninvasive
+neurostimulation. *PLoS ONE* 14:e0218293,
+10.1371/journal.pone.0218293, 2019.
+
+Xiumin, L.. Signal integration on the dendrites of a pyramidal
+neuron model. *Cognitive Neurodynamics* 8:81-85,
+10.1007/s11571-013-9252-2, 2014.
+
+Xu, K., Maidana, J. P., Caviedes, M., Quero, D., Aguirre, P. and
+Orio, P.. Hyperpolarization-activated current induces
+period-doubling cascades and chaos in a cold thermoreceptor model.
+*Frontiers in Computational Neuroscience* 11:12,
+10.3389/fncom.2017.00012, 2017.
+
+Xu, N., Jiang, F., Tian, Y., Ye, J., Shi, F., Lv, H., Wang, Y.,
+Wrachtrup, J. and Du, J.. Wavelet-based fast time-resolved
+magnetic sensing with electronic spins in diamond. *Physical
+Review B* 932016.
+
+Xylouris, K. and Wittum, G.. A three-dimensional mathematical
+model for the signal propagation on a neuron's membrane.
+*Frontiers in Computational Neuroscience* 9:94,
+10.3389/fncom.2015.00094, 2015.
+
+Yaeger, D. B. and Trussell, L. O.. Single granule cells excite
+Golgi cells and evoke feedback inhibition in the cochlear nucleus.
+*Journal of Neuroscience* 35:4741-4750,
+10.1523/JNEUROSCI.3665-14.2015, 2015.
+
+Yamada, R. and Kuba, H.. Dendritic synapse geometry optimizes
+binaural computation in a sound localization circuit. *Science
+Advances* 7:eabh0024, 10.1126/sciadv.abh0024, 2021.
+
+Yamada, R., Okuda, H., Kuba, H., Nishino, E., Ishii, T. M. and
+Ohmori, H.. The cooperation of sustained and phasic inhibitions
+increases the contrast of ITD-tuning in low-frequency neurons of
+the chick nucleus laminaris. *Journal of Neuroscience*
+33:3927-3938, 10.1523/JNEUROSCI.2377-12.2013, 2013.
+
+Yamasaki, T., Isokawa, T., Matsui, N., Ikeno, H. and Kanzaki, R..
+Reconstruction and simulation for three-dimensional morphological
+structure of insect neurons. *Neurocomputing* 69:1043-1047, 2006.
+
+Yamashita, K., Sundaram, P., Uchida, T., Matsuo, T. and Wong, W..
+Modelling the visual response to an OUReP retinal prosthesis with
+photoelectric dye coupled to polyethylene film. *Journal of Neural
+Engineering* 1810.1088/1741-2552/abf892, 2021.
+
+Yang, C. Y., Tsai, D., Guo, T., Dokos, S., Suaning, G. J., Morley,
+J. W. and Lovell, N. H.. Differential electrical responses in
+retinal ganglion cell subtypes: effects of synaptic blockade and
+stimulating electrode location. *Journal of Neural Engineering*
+15:046020, 10.1088/1741-2552/aac315, 2018a.
+
+Yang, F., Anderson, M., He, S., Stephens, K., Zheng, Y., Chen, Z.,
+Raja, S. N., Aplin, F., Guan, Y. and Fridman, G.. Differential
+expression of voltage-gated sodium channels in afferent neurons
+renders selective neural block by ionic direct current. *Science
+Advances* 4:eaaq1438, 10.1126/sciadv.aaq1438, 2018b.
+
+Yang, G. R., Murray, J. D. and Wang, X.-J.. A dendritic
+disinhibitory circuit mechanism for pathway-specific gating.
+*Nature Communications* 7:12815, 10.1038/ncomms12815, 2016a.
+
+Yang, H. H., St-Pierre, F., Sun, X., Ding, X., Lin, M. Z. and
+Clandinin, T. R.. Subcellular imaging of voltage and calcium
+signals reveals neural processing in vivo. *Cell* 166:245-257,
+10.1016/j.cell.2016.05.031, 2016b.
+
+Yao, H. K., Guet-McCreight, A., Mazza, F., Moradi Chameh, H.,
+Prevot, T. D., Griffiths, J. D., Tripathy, S. J., Valiante, T. A.,
+Sibille, E. and Hay, E.. Reduced inhibition in depression impairs
+stimulus processing in human cortical microcircuits. *Cell
+Reports* 38:110232, 10.1016/j.celrep.2021.110232, 2022.
+
+Yaron-Jakoubovitch, A., Jacobson, G. A., Koch, C., Segev, I. and
+Yarom, Y.. A paradoxical isopotentiality: a spatially uniform
+noise spectrum in neocortical pyramidal cells. *Frontiers in
+Cellular Neuroscience* 2:3, 10.3389/neuro.03.003.2008, 2008.
+
+Yau, H.-J., Baranauskas, G. and Martina, M.. Flufenamic acid
+decreases neuronal excitability through modulation of
+voltage-gated sodium channel gating. *Journal of Physiology*
+588:3869-3882, 10.1113/jphysiol.2010.193037, 2010.
+
+Ye, H. and Barrett, L.. Somatic inhibition by microscopic magnetic
+stimulation. *Scientific Reports* 11:13591,
+10.1038/s41598-021-93114-x, 2021.
+
+Ye, M., Yang, J., Tian, C., Zhu, Q., Yin, L., Jiang, S., Yang, M.
+and Shu, Y.. Differential roles of NaV1.2 and NaV1.6 in regulating
+neuronal excitability at febrile temperature and distinct
+contributions to febrile seizures. *Scientific Reports* 8:753,
+10.1038/s41598-017-17344-8, 2018.
+
+Yi, G., Fan, Y. and Wang, J.. Metabolic cost of dendritic Ca2+
+action potentials in layer 5 pyramidal neurons. *Frontiers in
+Neuroscience* 13:1221, 10.3389/fnins.2019.01221, 2019a.
+
+Yi, G. and Grill, W. M.. Frequency-dependent antidromic activation
+in thalamocortical relay neurons: effects of synaptic inputs.
+*Journal of Neural Engineering* 15:056001,
+10.1088/1741-2552/aacbff, 2018.
+
+Yi, G. and Grill, W. M.. Average firing rate rather than temporal
+pattern determines metabolic cost of activity in thalamocortical
+relay neurons. *Scientific Reports* 9:6940,
+10.1038/s41598-019-43460-8, 2019.
+
+Yi, G. and Grill, W. M.. Kilohertz waveforms optimized to produce
+closed-state Na+ channel inactivation eliminate onset response in
+nerve conduction block. *PLoS Computational Biology* 16:e1007766,
+10.1371/journal.pcbi.1007766, 2020.
+
+Yi, G. and Wang, J.. Frequency-dependent energy demand of
+dendritic responses to deep brain stimulation in thalamic neurons:
+a model-based study. *IEEE Transactions on Neural Networks and
+Learning Systems* 32:3056-3068, 10.1109/TNNLS.2020.3009293, 2021.
+
+Yi, G., Wang, J., Wei, X. and Che, Y.. Energy cost of action
+potential generation and propagation in thalamocortical relay
+neurons during deep brain stimulation. *IEEE Transactions on
+Bio-Medical Engineering* 66:3457-3471, 10.1109/TBME.2019.2906114,
+2019b.
+
+Yi, G., Wei, X., Wang, J., Deng, B. and Che, Y.. Modulations of
+dendritic Ca2+ spike with weak electric fields in layer 5
+pyramidal cells. *Neural Networks* 110:8-18,
+10.1016/j.neunet.2018.10.013, 2019c.
+
+Yi, G.-S., Wang, J., Deng, B. and Wei, X.-L.. Morphology controls
+how hippocampal CA1 pyramidal neuron responds to uniform electric
+fields: a biophysical modeling study. *Scientific Reports* 7:3210,
+10.1038/s41598-017-03547-6, 2017.
+
+Yildirim, O., Ozcan, Z., Turhan, H. and Kayikcioglu, T.. Network
+Master: a versatile and user-friendly educational software for
+simulation of neural networks [Online]. *2018 Medical Technologies
+National Congress (TIPTEKNO)*, 10.1109/tiptekno.2018.8596865,
+2018.
+
+Yim, M. Y., Hanuschkin, A. and Wolfart, J.. Intrinsic rescaling of
+granule cells restores pattern separation ability of a dentate
+gyrus network model during epileptic hyperexcitability.
+*Hippocampus* 25:297-308, 10.1002/hipo.22373, 2015.
+
+Yin, L., Rasch, M. J., He, Q., Wu, S., Dou, F. and Shu, Y..
+Selective modulation of axonal sodium channel subtypes by 5-HT1A
+receptor in cortical pyramidal neuron. *Cerebral Cortex*
+27:509-521, 10.1093/cercor/bhv245, 2017.
+
+Yoo, P. B. and Durand, D. A.. Selective recording of the canine
+hypoglossal nerve using a multicontact flat interface nerve
+electrode. *IEEE Transactions on Biomedical Engineering*
+52:1461-1469, 2005.
+
+You, M. and Mou, Z.. Model study of combined electrical and
+near-infrared neural stimulation on the bullfrog sciatic nerve.
+*Lasers in Medical Science* 32:1163-1172,
+10.1007/s10103-017-2222-x, 2017.
+
+Young, C. C., Stegen, M., Bernard, R., Mueller, M., Bischofberger,
+J., Veh, R. W., Haas, C. A. and Wolfart, J.. Upregulation of
+inward rectifier K(+) (Kir2) channels in dentate gyrus granule
+cells in temporal lobe epilepsy. *Journal of Physiology*
+587:4213-4233, 10.1113/jphysiol.2009.170746, 2009.
+
+Young, H., Belbut, B., Baeta, M. and Petreanu, L..
+Laminar-specific cortico-cortical loops in mouse visual cortex.
+*eLife* 1010.7554/eLife.59551, 2021.
+
+Young, R. G., Castelfranco, A. M. and Hartline, D. K.. The "Lillie
+transition": models of the onset of saltatory conduction in
+myelinating axons. *Journal of Computational Neuroscience*
+34:533-546, 10.1007/s10827-012-0435-3, 2013.
+
+Yousif, N. A. B. and Denham, M.. Action potential backpropagation
+in a model thalamocortical relay cell. *Neurocomputing*
+58-60:393-400, 2004.
+
+Yu, G. J., Bouteiller, J.-M. C. and Berger, T. W.. Topographic
+organization of correlation along the longitudinal and transverse
+axes in rat hippocampal Ca3 due to excitatory afferents.
+*Frontiers in Computational Neuroscience* 14:588881,
+10.3389/fncom.2020.588881, 2020.
+
+Yu, G. J., Bouteiller, J.-M. C., Song, D. and Berger, T. W..
+Axonal anatomy optimizes spatial encoding in the rat
+entorhinal-dentate system: a computational study. *IEEE
+Transactions on Bio-Medical Engineering* online:ahead of print,
+10.1109/TBME.2019.2894410, 2019a.
+
+Yu, G. J., Feng, Z. and Berger, T. W.. Network activity due to
+topographic organization of schaffer collaterals in a large-scale
+model of rat Ca1. *Annual International Conference of the IEEE
+Engineering in Medicine and Biology Society* 2019:2977-2980,
+10.1109/EMBC.2019.8856799, 2019b.
+
+Yu, J., Proddutur, A., Elgammal, F. S., Ito, T. and Santhakumar,
+V.. Status epilepticus enhances tonic GABA currents and
+depolarizes GABA reversal potential in dentate fast-spiking basket
+cells. *Journal of Neurophysiology* 109:1746-1763,
+10.1152/jn.00891.2012, 2013a.
+
+Yu, J., Proddutur, A., Swietek, B., Elgammal, F. S. and
+Santhakumar, V.. Functional reduction in cannabinoid-sensitive
+heterotypic inhibition of dentate basket cells in epilepsy: impact
+on network rhythms. *Cerebral Cortex* 26:4229-4314,
+10.1093/cercor/bhv199, 2015.
+
+Yu, N. and Canavier, C. C.. A mathematical model of a midbrain
+dopamine neuron identifies two slow variables likely responsible
+for bursts evoked by SK channel antagonists and terminated by
+depolarization block. *Journal of Mathematical Neuroscience* 5:5,
+10.1186/s13408-015-0017-6, 2015.
+
+Yu, N., Tucker, K. R., Levitan, E. S., Shepard, P. D. and
+Canavier, C. C.. Implications of cellular models of dopamine
+neurons for schizophrenia. *Progress in Molecular Biology and
+Translational Science* 123:53-82,
+10.1016/B978-0-12-397897-4.00011-5, 2014a.
+
+Yu, Y., McTavish, T. S., Hines, M. L., Shepherd, G. M., Valenti,
+C. and Migliore, M.. Sparse distributed representation of odors in
+a large-scale olfactory bulb circuit. *PLoS Computational Biology*
+9:e1003014, 10.1371/journal.pcbi.1003014, 2013b.
+
+Yu, Y., Migliore, M., Hines, M. L. and Shepherd, G. M.. Sparse
+coding and lateral inhibition arising from balanced and unbalanced
+dendrodendritic excitation and inhibition. *Journal of
+Neuroscience* 34:13701-13713, 10.1523/JNEUROSCI.1834-14.2014,
+2014b.
+
+Yu, Y. G., Shu, Y. S. and McCormick, D. A.. Cortical action
+potential backpropagation explains spike threshold variability and
+rapid-onset kinetics. *Journal of Neuroscience* 28:7260-7272,
+2008.
+
+Zachariou, M., Dissanayake, D. W. N., Coombes, S., Owen, M. R. and
+Mason, R.. Sensory gating and its modulation by cannabinoids:
+electrophysiological, computational and mathematical analysis.
+*Cognitive Neurodynamics* 2:159-170, 2008.
+
+Zacksenhouse, M., Johnson, D., Williams, J. and Tsuchitani, C..
+Single-neuron modeling of LSO unit responses. *Journal of
+Neurophysiology* 79:3098-3110, 1998.
+
+Zador, A. and Koch, C.. Linearized models of calcium dynamics:
+formal equivalence to the cable equation. *Journal of
+Neuroscience* 14:4705-4715, 1994.
+
+Zagha, E., Lang, E. J. and Rudy, B.. Kv3.3 channels at the
+Purkinje cell soma are necessary for generation of the classical
+complex spike waveform. *Journal of Neuroscience* 28:1291-1300,
+2008.
+
+Zahid, T. and Skinner, F. K.. Predicting synchronous and
+asynchronous network groupings of hippocampal interneurons coupled
+with dendritic gap junctions. *Brain Research* 1262:115-129, 2009.
+
+Zaika, O., Lara, L. S., Gamper, N., Hilgemann, D., Jaffe, D. B.
+and Shapiro, M. S.. Angiotensin II regulates neuronal excitability
+via phosphatidylinositol 4,5-bisphosphate-dependent modulation of
+Kv7 (M-type) K+ channels. *Journal of Physiology* 575:49-67, 2006.
+
+Zaika, O., Tolstykh, G. P., Jaffe, D. B. and Shapiro, M. S..
+Inositol triphosphate-mediated Ca2+ signals direct purinergic P2Y
+receptor regulation of neuronal ion channels. *Journal of
+Neuroscience* 27:8914-8926, 2007.
+
+Zander, H. J., Graham, R. D., Anaya, C. J. and Lempka, S. F..
+Anatomical and technical factors affecting the neural response to
+epidural spinal cord stimulation. *Journal of Neural Engineering*
+17:036019, 10.1088/1741-2552/ab8fc4, 2020.
+
+Zander, H. J., Kowalski, K. E., DiMarco, A. F. and Lempka, S. F..
+Model-based optimization of spinal cord stimulation for
+inspiratory muscle activation. *Neuromodulation*
+10.1111/ner.13415, 2021.
+
+Zandt, B.-J., Veruki, M. L. and Hartveit, E.. Electrotonic signal
+processing in AII amacrine cells: compartmental models and passive
+membrane properties for a gap junction-coupled retinal neuron.
+*Brain Structure and Function* 223:3383-3410,
+10.1007/s00429-018-1696-z, 2018.
+
+Zang, Y. and De Schutter, E.. The cellular electrophysiological
+properties underlying multiplexed coding in Purkinje cells.
+*Journal of Neuroscience* 10.1523/JNEUROSCI.1719-20.2020, 2021.
+
+Zang, Y., Dieudonné, S. and De Schutter, E.. Voltage- and
+branch-specific climbing fiber responses in Purkinje cells. *Cell
+Reports* 24:1536-1549, 10.1016/j.celrep.2018.07.011, 2018.
+
+Zang, Y., Hong, S. and De Schutter, E.. Firing rate-dependent
+phase responses of Purkinje cells support transient oscillations.
+*eLife* 910.7554/eLife.60692, 2020.
+
+Zang, Y. and Marder, E.. Interactions among diameter, myelination,
+and the Na/K pump affect axonal resilience to high-frequency
+spiking. *Proceedings of the National Academy of Sciences*
+11810.1073/pnas.2105795118, 2021.
+
+Zbili, M. and Debanne, D.. Myelination increases the spatial
+extent of analog-digital modulation of synaptic transmission: a
+modeling study. *Frontiers in Cellular Neuroscience* 14:40,
+10.3389/fncel.2020.00040, 2020.
+
+Zbili, M., Rama, S., Yger, P., Inglebert, Y., Boumedine-Guignon,
+N., Fronzaroli-Moliniere, L., Brette, R., Russier, M. and Debanne,
+D.. Axonal Na+ channels detect and transmit levels of input
+synchrony in local brain circuits. *Science Advances* 6:eaay4313,
+10.1126/sciadv.aay4313, 2020.
+
+Zeitler, M., Fries, P. and Gielen, S.. Biased competition through
+variations in amplitude of gamma-oscillations. *Journal of
+Computational Neuroscience* 25:89-107, 2008.
+
+Zeldenrust, F., Chameau, P. and Wadman, W. J.. Spike and burst
+coding in thalamocortical relay cells. *PLoS Computational
+Biology* 14:e1005960, 10.1371/journal.pcbi.1005960, 2018.
+
+Zelechowski, M., Valle, G. and Raspopovic, S.. A computational
+model to design neural interfaces for lower-limb sensory
+neuroprostheses. *Journal of NeuroEngineering and Rehabilitation*
+17:24, 10.1186/s12984-020-00657-7, 2020.
+
+Zellmer, E. R., MacEwan, M. R. and Moran, D. W.. Modelling the
+impact of altered axonal morphometry on the response of
+regenerative nervous tissue to electrical stimulation through
+macro-sieve electrodes. *Journal of Neural Engineering* 15:026009,
+10.1088/1741-2552/aa9e96, 2018.
+
+Zeng, Y., Ferdous, Z. I., Zhang, W., Xu, M., Yu, A., Patel, D.,
+Post, V., Guo, X., Berdichevsky, Y. and Yan, Z.. Understanding the
+impact of neural variations and random connections on inference.
+*Frontiers in Computational Neuroscience* 15:612937,
+10.3389/fncom.2021.612937, 2021.
+
+Zenke, F. and Gerstner, W.. Limits to high-speed simulations of
+spiking neural networks using general-purpose computers.
+*Frontiers in Neuroinformatics* 8:76, 10.3389/fninf.2014.00076,
+2014.
+
+Zerlaut, Y. and Destexhe, A.. Heterogeneous firing responses
+predict diverse couplings to presynaptic activity in mice layer V
+pyramidal neurons. *PLoS Computational Biology* 13:e1005452,
+10.1371/journal.pcbi.1005452, 2017.
+
+Zerlaut, Y., Teleńczuk, B., Deleuze, C., Bal, T., Ouanounou, G.
+and Destexhe, A.. Heterogeneous firing rate response of mouse
+layer V pyramidal neurons in the fluctuation-driven regime.
+*Journal of Physiology* 594:3791-3808, 10.1113/JP272317, 2016.
+
+Zhang, M., Liu, Y., Wang, S.-z., Zhong, W., Liu, B.-h. and Tao, H.
+W.. Functional elimination of excitatory feedforward inputs
+underlies developmental refinement of visual receptive fields in
+zebrafish. *Journal of Neuroscience* 31:5460-5469,
+10.1523/JNEUROSCI.6220-10.2011, 2011.
+
+Zhang, Q. and Dai, Y.. A modeling study of spinal motoneuron
+recruitment regulated by ionic channels during fictive locomotion.
+*Journal of Computational Neuroscience* 48:409-428,
+10.1007/s10827-020-00763-4, 2020.
+
+Zhang, T. C. and Grill, W. M.. Modeling deep brain stimulation:
+point source approximation versus realistic representation of the
+electrode. *Journal of Neural Engineering* 7:066009,
+10.1088/1741-2560/7/6/066009, 2010.
+
+Zhang, T. C., Janik, J. J. and Grill, W. M.. Modeling the effects
+of spinal cord stimulation on wide dynamic range dorsal horn
+neurons: influence of stimulation frequency and GABAergic
+inhibition. *Journal of Neurophysiology* 112:552-567,
+10.1152/jn.00254.2014, 2014.
+
+Zhang, T. C., Janik, J. J., Peters, R. V., Chen, G., Ji, R.-R. and
+Grill, W. M.. Spinal sensory projection neuron responses to spinal
+cord stimulation are mediated by circuits beyond gate control.
+*Journal of Neurophysiology* 114:284-300, 10.1152/jn.00147.2015,
+2015.
+
+Zhang, W., Chen, P., Zhou, L., Qin, Z., Gao, K., Yao, J., Li, C.
+and Wang, P.. A biomimetic bioelectronic tongue: a switch for On-
+and Off- response of acid sensations. *Biosensors and
+Bioelectronics* 92:523-528, 10.1016/j.bios.2016.10.069, 2017a.
+
+Zhang, W., Fan, B., Agarwal, D., Li, T. and Yu, Y.. Axonal sodium
+and potassium conductance density determines spiking dynamical
+properties of regular- and fast-spiking neurons. *Nonlinear
+Dynamics* 95:1035-1052, 10.1007/s11071-018-4613-3, 2019.
+
+Zhang, X., Hancock, R. and Santaniello, S.. Transcranial direct
+current stimulation of cerebellum alters spiking precision in
+cerebellar cortex: a modeling study of cellular responses.. *PLoS
+Computational Biology* 17:e1009609, 10.1371/journal.pcbi.1009609,
+2021a.
+
+Zhang, X., Liu, S., Zhan, F., Wang, J. and Jiang, X.. The effects
+of medium spiny neuron morphologcial changes on basal ganglia
+network under external electric field: a computational modeling
+study. *Frontiers In Computational Neuroscience* 11:91,
+10.3389/fncom.2017.00091, 2017b.
+
+Zhang, X. and Santaniello, S.. Role of cerebellar GABAergic
+dysfunctions in the origins of essential tremor. *Proceedings of
+the National Academy of Sciences of the United States of America*
+116:13592-13601, 10.1073/pnas.1817689116, 2019.
+
+Zhang, X., Schlögl, A. and Jonas, P.. Selective routing of spatial
+information flow from input to output in hippocampal granule
+cells. *Neuron* 107:1212-1225.e7, 10.1016/j.neuron.2020.07.006,
+2020.
+
+Zhang, X., Schlögl, A., Vandael, D. and Jonas, P.. MOD: a novel
+machine-learning optimal-filtering method for accurate and
+efficient detection of subthreshold synaptic events in vivo.
+*Journal of Neuroscience Methods* 357:109125,
+10.1016/j.jneumeth.2021.109125, 2021b.
+
+Zhang, Y., Bucher, D. and Nadim, F.. Ionic mechanisms underlying
+history-dependence of conduction delay in an unmyelinated axon.
+*eLife* 6:e25382, 10.7554/eLife.25382, 2017c.
+
+Zhang, Y.-F., Reynolds, J. N. J. and Cragg, S. J.. Pauses in
+cholinergic interneuron activity are driven by excitatory input
+and delayed rectification, with dopamine modulation. *Neuron*
+98:918-925.e3, 10.1016/j.neuron.2018.04.027, 2018.
+
+Zhao, Y., Siri, S., Feng, B. and Pierce, D. M.. The macro- and
+micro-mechanics of the colon and rectum ii: theoretical and
+computational methods. *Bioengineering*
+710.3390/bioengineering7040152, 2020.
+
+Zheng, L., Feng, Z., Hu, H., Wang, Z., Yuan, Y. and Wei, X.. The
+appearance order of varying intervals introduces extra modulation
+effects on neuronal firing through non-linear dynamics of sodium
+channels during high-frequency stimulations. *Frontiers in
+Neuroscience* 14:397, 10.3389/fnins.2020.00397, 2020.
+
+Zheng, Y., Liu, P., Bai, L., Trimmer, J. S., Bean, B. P. and
+Ginty, D. D.. Deep sequencing of somatosensory neurons reveals
+molecular determinants of intrinsic physiological properties.
+*Neuron* 103:598-616.e7, 10.1016/j.neuron.2019.05.039, 2019.
+
+Zhou, S., Migliore, M. and Yu, Y.. Odor experience facilitates
+sparse representations of new odors in a large-scale olfactory
+bulb model.. *Frontiers in Neuroanatomy* 10:10,
+10.3389/fnana.2016.00010, 2016.
+
+Zhou, S.-L., Chu, H.-Y., Jin, G.-Z., Cui, J.-M. and Zhen, X.-C..
+Effects of SKF83959 on the excitability of hippocampal CA1
+pyramidal neurons: a modeling study. *Acta Pharmacologica Sinica*
+35:738-751, 10.1038/aps.2014.23, 2014.
+
+Zhou, Y., Carney, L. H. and Colburn, H. S.. A model for interaural
+time difference sensitivity in the medial superior olive:
+Interaction of excitatory and inhibitory synaptic inputs, channel
+dynamics, and cellular morphology. *Journal of Neuroscience*
+25:3046-3058, 2005.
+
+Zhou, Y. and Colburn, H. S.. A modeling study of the effects of
+membrane afterhyperpolarization on spike interval statistics and
+on ILD encoding in the lateral superior olive. *Journal of
+Neurophysiology* 103:2355-2371, 10.1152/jn.00385.2009, 2010.
+
+Zhou, Y., Liu, B.-h., Wu, G. K., Kim, Y.-J., Xiao, Z., Tao, H. W.
+and Zhang, L. I.. Preceding inhibition silences layer 6 neurons in
+auditory cortex. *Neuron* 65:706-717,
+10.1016/j.neuron.2010.02.021, 2010.
+
+Zhu, J. J., Lytton, W. W., Xue, J.-T. and Uhlrich, D. J.. An
+intrinsic oscillation in interneurons of the rat lateral
+geniculate nucleus. *Journal of Neurophysiology* 81:702-711,
+1999a.
+
+Zhu, J. J., Uhlrich, D. J. and Lytton, W. W.. Burst firing in
+identified rat geniculate interneurons. *Neuroscience*
+91:1445-1460, 1999b.
+
+Zhu, J. J., Uhlrich, D. J. and Lytton, W. W.. Properties of a
+hyperpolarization-activated cation current in interneurons in the
+rat lateral geniculate nucleus. *Neuroscience* 92:445-457, 1999c.
+
+Zhu, K., Li, L., Wei, X. and Sui, X.. A 3D computational model of
+transcutaneous electrical nerve stimulation for estimating Aβ
+tactile nerve fiber excitability. *Frontiers in Neuroscience*
+11:250, 10.3389/fnins.2017.00250, 2017.
+
+Zhuchkova, E., Remme, M. W. H. and Schreiber, S.. Somatic versus
+dendritic resonance: differential filtering of inputs through
+non-uniform distributions of active conductances. *PLoS ONE*
+8:e78908, 10.1371/journal.pone.0078908, 2013.
+
+Zhukov, O. A., Kazakova, T. A., Maksimov, G. V. and Brazhe, A. R..
+Cost of auditory sharpness: model-based estimate of energy use by
+auditory brainstem "octopus" neurons. *Journal of Theoretical
+Biology* 469:137-147, 10.1016/j.jtbi.2019.01.043, 2019.
+
+Ziegler, D. A., Pritchett, D. L., Hosseini-Varnamkhasti, P.,
+Corkin, S., Hämäläinen, M., Moore, C. I. and Jones, S. R..
+Transformations in oscillatory activity and evoked responses in
+primary somatosensory cortex in middle age: a combined
+computational neural modeling and MEG study. *Neuroimage*
+52:897-912, 10.1016/j.neuroimage.2010.02.004, 2010.
+
+Zippo, A. G. and Biella, G. E. M.. Quantifying the number of
+discriminable coincident dendritic input patterns through
+dendritic tree morphology. *Scientific Reports* 5:11543,
+10.1038/srep11543, 2015.
+
+Zitella, L. M., Mohsenian, K., Pahwa, M., Gloeckner, C. and
+Johnson, M. D.. Computational modeling of pedunculopontine nucleus
+deep brain stimulation. *Journal of Neural Engineering* 10:045005,
+10.1088/1741-2560/10/4/045005, 2013.
+
+Zitella, L. M., Teplitzky, B. A., Yager, P., Hudson, H. M.,
+Brintz, K., Duchin, Y., Harel, N., Vitek, J. L., Baker, K. B. and
+Johnson, M. D.. Subject-specific computational modeling of DBS in
+the PPTg area. *Frontiers in Computational Neuroscience* 9:93,
+10.3389/fncom.2015.00093, 2015.
+
+Zobeiri, M., Chaudhary, R., Blaich, A., Rottmann, M., Herrmann,
+S., Meuth, P., Bista, P., Kanyshkova, T., Lüttjohann, A.,
+Narayanan, V., Hundehege, P., Meuth, S. G., Romanelli, M. N.,
+Urbano, F. J., Pape, H.-C., Budde, T. and Ludwig, A.. The
+hyperpolarization-activated HCN4 channel is important for proper
+maintenance of oscillatory activity in the thalamocortical system.
+*Cerebral Cortex* 29:2291-2304, 10.1093/cercor/bhz047, 2019.
+
+Zobeiri, M., Chaudhary, R., Datunashvili, M., Heuermann, R. J.,
+Lüttjohann, A., Narayanan, V., Balfanz, S., Meuth, P., Chetkovich,
+D. M., Pape, H.-C., Baumann, A., van Luijtelaar, G. and Budde, T..
+Modulation of thalamocortical oscillations by TRIP8b, an auxiliary
+subunit for HCN channels. *Brain Structure and Function*
+223:1537-1564, 10.1007/s00429-017-1559-z, 2018.
+
+Zomorrodi, R., Ferecsko, A. S., Kovacs, K., Kroeger, H. and
+Timofeev, I.. Analysis of morphological features of
+thalamocortical neurons from the ventroposterolateral nucleus of
+the cat. *Journal of Comparative Neurology* 518:3541-3556,
+10.1002/cne.22413, 2010.
+
+Zomorrodi, R., Kröger, H. and Timofeev, I.. Modeling
+thalamocortical cell: Impact of Ca2+ channel distribution and cell
+geometry on firing pattern. *Frontiers in Computational
+Neuroscience* 2:5, doi:10.3389/neuro.10.005.2008, 2008.
+
+Zou, Q., Bornat, Y., Saighi, S., Tomas, J., Renaud, S. and
+Destexhe, A.. Analog-digital simulations of full conductance-based
+networks of spiking neurons with spike timing dependent
+plasticity. *Network* 17:211-233, 2006a.
+
+Zou, Q., Bornat, Y., Tomas, J., Renaud, S. and Destexhe, A..
+Real-time simulations of networks of Hodgkin-Huxley neurons using
+analog circuits. *Neurocomputing* 69:1137-1140, 2006b.
+
+Zou, Q. and Destexhe, A.. Kinetic models of spike-timing dependent
+plasticity and their functional consequences in detecting
+correlations. *Biological Cybernetics* 97:81-97, 2007.
+
+Zou, Q., Rudolph, M., Roy, N., Sanchez-Vives, M., Contreras, D.
+and Destexhe, A.. Reconstructing synaptic background activity from
+conductance measurements in vivo. *Neurocomputing* 65:673-678,
+2005.
+
+Zsiros, V., Aradi, I. and Maccaferri, G.. Propagation of
+postsynaptic currents and potentials via gap junctions in
+GABAergic networks of the rat hippocampus. *Journal of Physiology*
+578:527-544, 2007.
+
+Zuo, S., Heidari, H., Farina, D. and Nazarpour, K.. Miniaturized
+magnetic sensors for implantable magnetomyography. *Advanced
+Materials Technologies* :2000185, 10.1002/admt.202000185, 2020.
+
+Zupanc, G. K. H., Amaro, S. M., Lehotzky, D., Zupanc, F. B. and
+Leung, N. Y.. Glia-mediated modulation of extracellular potassium
+concentration determines the sexually dimorphic output frequency
+of a model brainstem oscillator. *Journal of Theoretical Biology*
+471:117-124, 10.1016/j.jtbi.2019.03.013, 2019.
+
+Zybura, A. S., Baucum, A. J., Rush, A. M., Cummins, T. R. and
+Hudmon, A.. CaMKII enhances voltage-gated sodium channel Nav1.6
+activity and neuronal excitability. *Journal of Biological
+Chemistry* 295:11845-11865, 10.1074/jbc.RA120.014062, 2020.
+
+Zylbertal, A., Kahan, A., Ben-Shaul, Y., Yarom, Y. and Wagner, S..
+Prolonged intracellular Na+ dynamics govern electrical activity in
+accessory olfactory bulb mitral cells. *PLoS Biology* 13:e1002319,
+10.1371/journal.pbio.1002319, 2015.
+
+Zylbertal, A., Yarom, Y. and Wagner, S.. Synchronous infra-slow
+bursting in the mouse accessory olfactory bulb emerge from
+interplay between intrinsic neuronal dynamics and network
+connectivity. *Journal of Neuroscience* 37:2656-2672,
+10.1523/JNEUROSCI.3107-16.2017, 2017a.
+
+Zylbertal, A., Yarom, Y. and Wagner, S.. The slow dynamics of
+intracellular sodium concentration increase the time window of
+neuronal integration: a simulation study. *Frontiers in
+Computational Neuroscience* 11:85, 10.3389/fncom.2017.00085,
+2017b.


### PR DESCRIPTION
Content converted from https://www.neuron.yale.edu/neuron/publications/neuron-bibliography

It ends up looking like:

<img width="1255" alt="image" src="https://user-images.githubusercontent.com/6668090/168132844-37b04bfd-7ea7-4eb4-a19b-d2ec9862a1ca.png">
