### PR TITLE
mech_api.h: expose more declarations to translated MOD files

### DIFF
--- a/cmake/NeuronFileLists.cmake
+++ b/cmake/NeuronFileLists.cmake
@@ -14,6 +14,7 @@ set(HEADER_FILES_TO_INSTALL
     hocparse.h
     isoc99.h
     ivstream.h
+    mcran4.h
     md1redef.h
     md2redef.h
     mech_api.h

--- a/src/ivoc/oclist.cpp
+++ b/src/ivoc/oclist.cpp
@@ -11,6 +11,7 @@
 #include "oc2iv.h"
 #include "hoclist.h"
 #include "ocobserv.h"
+#include "oc_ansi.h"
 #if HAVE_IV
 #include <InterViews/adjust.h>
 #include <InterViews/hit.h>
@@ -29,7 +30,6 @@
 extern Object** hoc_temp_objptr(Object*);
 extern Symlist* hoc_top_level_symlist;
 int ivoc_list_count(Object*);
-extern "C" Object* ivoc_list_item(Object*, int);
 
 
 extern Object** (*nrnpy_gui_helper_)(const char* name, Object* obj);
@@ -429,7 +429,8 @@ int ivoc_list_count(Object* olist) {
     OcList* list = (OcList*) olist->u.this_pointer;
     return list->count();
 }
-extern "C" Object* ivoc_list_item(Object* olist, int i) {
+
+Object* ivoc_list_item(Object* olist, int i) {
     chk_list(olist);
     OcList* list = (OcList*) olist->u.this_pointer;
     if (i >= 0 && i < list->count()) {

--- a/src/ivoc/xmenu.cpp
+++ b/src/ivoc/xmenu.cpp
@@ -167,7 +167,6 @@ static String* xvalue_format;
 
 
 extern int units_on_flag_;
-extern "C" Symbol* hoc_get_symbol(const char*);
 extern Symbol* hoc_get_last_pointer_symbol();
 extern "C" double* nrn_recalc_ptr(double*);
 void hoc_notify_value() {

--- a/src/nrnoc/nrncvode.h
+++ b/src/nrnoc/nrncvode.h
@@ -1,27 +1,30 @@
-#ifndef nrncvode_h
-#define nrncvode_h
-
-
-extern "C" void cvode_fadvance(double);
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+void clear_event_queue(void);
+void cvode_fadvance(double);
+void nrn_random_play();
+#ifdef __cplusplus
+}
+extern bool nrn_use_bin_queue_;
+#endif
+struct Memb_list;
+struct NrnThread;
 extern void cvode_finitialize(double);
 extern void nrncvode_set_t(double);
-extern void deliver_net_events(NrnThread*);
-extern void nrn_deliver_events(NrnThread*);
-extern "C" void clear_event_queue(void);
+extern void deliver_net_events(struct NrnThread*);
+extern void nrn_deliver_events(struct NrnThread*);
 extern void init_net_events(void);
 extern void nrn_record_init(void);
 extern void nrn_play_init(void);
-extern void fixed_record_continuous(NrnThread* nt);
-extern void fixed_play_continuous(NrnThread* nt);
+extern void fixed_record_continuous(struct NrnThread* nt);
+extern void fixed_play_continuous(struct NrnThread* nt);
 extern void nrn_solver_prepare(void);
-extern "C" void nrn_random_play();
 extern void nrn_daspk_init_step(double, double, int);
 extern void nrndae_init(void);
 extern void nrndae_update(void);
-extern void nrn_update_2d(NrnThread*);
-extern void nrn_capacity_current(NrnThread* _nt, Memb_list* ml);
+extern void nrn_update_2d(struct NrnThread*);
+extern void nrn_capacity_current(struct NrnThread* _nt, struct Memb_list* ml);
 extern void nrn_spike_exchange_init(void);
-extern void nrn_spike_exchange(NrnThread* nt);
-extern bool nrn_use_bin_queue_;
-
-#endif
+extern void nrn_spike_exchange(struct NrnThread* nt);

--- a/src/nrnoc/secref.cpp
+++ b/src/nrnoc/secref.cpp
@@ -19,6 +19,7 @@ access s1.sec	// soma becomes the default section
 #include "section.h"
 #include "parse.hpp"
 #include "hoc_membf.h"
+#include "oc_ansi.h"
 #include <nrnpython_config.h>
 
 extern int hoc_return_type_code;
@@ -79,8 +80,6 @@ static double s_unname(void* v) {
     sec->prop->dparam[0].sym = (Symbol*) 0;
     return 1.;
 }
-
-extern "C" Object* ivoc_list_item(Object*, int);
 
 static double s_rename(void* v) {
     extern Objectdata* hoc_top_level_data;

--- a/src/oc/hocdec.h
+++ b/src/oc/hocdec.h
@@ -231,7 +231,11 @@ typedef struct Object {
         Objectdata* dataspace; /* Points to beginning of object's data */
         void* this_pointer;    /* the c++ object */
     } u;
+#if defined(__cplusplus)
     cTemplate* ctemplate;
+#else
+    cTemplate* template;
+#endif
     void* aliases; /* more convenient names for e.g. Vector or List elements dynamically created by
                       this object*/
     HocStruct hoc_Item* itm_me;  /* this object in the template list */

--- a/src/oc/hocdec.h
+++ b/src/oc/hocdec.h
@@ -231,11 +231,7 @@ typedef struct Object {
         Objectdata* dataspace; /* Points to beginning of object's data */
         void* this_pointer;    /* the c++ object */
     } u;
-#if defined(__cplusplus)
     cTemplate* ctemplate;
-#else
-    cTemplate* template;
-#endif
     void* aliases; /* more convenient names for e.g. Vector or List elements dynamically created by
                       this object*/
     HocStruct hoc_Item* itm_me;  /* this object in the template list */

--- a/src/oc/mcran4.h
+++ b/src/oc/mcran4.h
@@ -11,7 +11,7 @@ extern "C" {
 #endif
 
 extern void mcell_ran4_init(uint32_t);
-extern double mcell_ran4(uint32_t* idx1, double* x, unsigned int n, double range);
+extern double mcell_ran4(uint32_t* high, double* x, unsigned int n, double range);
 extern double mcell_ran4a(uint32_t* idx1);
 extern uint32_t mcell_iran4(uint32_t* idx1);
 extern double nrnRan4dbl(uint32_t* idx1, uint32_t idx2);

--- a/src/oc/mech_api.h
+++ b/src/oc/mech_api.h
@@ -10,6 +10,7 @@
  *        we leave to nocmodl.
  */
 #include "mcran4.h"
+#include "nrncvode.h"
 #include "nrnrandom.h"
 #include "nrnran123.h"
 #include "nrnversionmacros.h"

--- a/src/oc/mech_api.h
+++ b/src/oc/mech_api.h
@@ -9,6 +9,7 @@
  *        header has to be sandwiched between md1redef.h and md2redef.h, which
  *        we leave to nocmodl.
  */
+#include "mcran4.h"
 #include "nrnrandom.h"
 #include "nrnran123.h"
 #include "nrnversionmacros.h"

--- a/src/oc/oc_ansi.h
+++ b/src/oc/oc_ansi.h
@@ -63,6 +63,7 @@ extern void vector_resize(IvocVect*, int);
 #endif
 
 extern int nrnignore;
+Object* ivoc_list_item(Object*, int);
 
 #if defined(__cplusplus)
 extern "C" {

--- a/src/oc/oc_ansi.h
+++ b/src/oc/oc_ansi.h
@@ -63,7 +63,6 @@ extern void vector_resize(IvocVect*, int);
 #endif
 
 extern int nrnignore;
-Object* ivoc_list_item(Object*, int);
 
 #if defined(__cplusplus)
 extern "C" {
@@ -180,6 +179,7 @@ extern void hoc_fake_call(Symbol*);
 extern void hoc_last_init(void);
 extern void hoc_obj_notify(Object*);
 extern int ivoc_list_count(Object*);
+Object* ivoc_list_item(Object*, int);
 extern double hoc_func_table(void* functable, int n, double* args);
 extern void hoc_spec_table(void** pfunctable, int n);
 extern void* hoc_sec_internal_name2ptr(const char* s, int eflag);
@@ -272,6 +272,7 @@ extern void hoc_free_allobjects(cTemplate*, Symlist*, Objectdata*);
 extern int nrn_is_cable(void);
 extern int nrn_isdouble(double*, double, double);
 extern void* nrn_opaque_obj2pyobj(Object*);  // PyObject reference not incremented
+extern Symbol* hoc_get_symbol(const char* var);
 
 extern double hoc_Exp(double);
 extern int hoc_is_tempobj_arg(int narg);


### PR DESCRIPTION
Include more headers in `mech_api.h`. This means that when updating MOD files to be compatible with C++ / https://github.com/neuronsimulator/nrn/pull/1597 then we can assume that NEURON-internal methods do not need to be declared for versions >=8.2.

As a brief reminder of the plan:
- 8.2 comes from `master` after this PR is merged
- 9.0 comes from `master` after https://github.com/neuronsimulator/nrn/pull/1597 is merged

In this PR:
- `mcell_ran4_init`, `mcell_ran4`, ... are declared
  - Note that MOD files that include incorrect declarations of `mcell_ran4_init` exist in ModelDB (example: https://github.com/ModelDBRepository/106891/blob/7f825c80ef3a76fb181607a346de730b8f740005/stats.mod#L56), and exposing the correct declaration breaks compilation.
- `ivoc_list_item` is declared
- `hoc_get_symbol` is declared
  - As above, this breaks some MOD files (example: https://github.com/ModelDBRepository/116862/blob/02f5832973fbf15b5fad210e5e6afd8d0e5eb651/misc.h#L75) that included incorrect declarations of this method.
- `cvode_fadvance`, `clear_event_queue`, ... are declared

(description by @olupton, don't blame @alexsavulescu for it)