### PR TITLE
Eliminate ForAllSections macro so clang-format succeeds.

### DIFF
--- a/src/ivoc/datapath.cpp
+++ b/src/ivoc/datapath.cpp
@@ -442,13 +442,16 @@ void HocDataPathImpl::search_pysec() {
 #if USE_PYTHON
     CopyString cs("");
     hoc_Item* qsec;
-    ForAllSections(sec) if (sec->prop && sec->prop->dparam[PROP_PY_INDEX]._pvoid) {
-        cs = secname(sec);
-        strlist_.append((char*) cs.string());
-        search(sec);
-        strlist_.remove(strlist_.count() - 1);
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        if (sec->prop && sec->prop->dparam[PROP_PY_INDEX]._pvoid) {
+            cs = secname(sec);
+            strlist_.append((char*) cs.string());
+            search(sec);
+            strlist_.remove(strlist_.count() - 1);
+        }
     }
-}
 #endif
 }
 

--- a/src/ivoc/symdir.cpp
+++ b/src/ivoc/symdir.cpp
@@ -575,9 +575,12 @@ void SymDirectoryImpl::load_sectionlist() {
 #if CABLE && 0
     List* sl = od[sym->u.oboff].plist[hoc_array_index(sym, od)];
     Item* qsym;
-    ForAllSections(sec) Prop* p = sec->prop;
-    symbol_list_.append(new SymbolItem(p->dparam[0].sym, p->dparam[6].obj, prop->dparam[5].i));
-}
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        Prop* p = sec->prop;
+        symbol_list_.append(new SymbolItem(p->dparam[0].sym, p->dparam[6].obj, prop->dparam[5].i));
+    }
 #endif
 }
 

--- a/src/nrniv/bbsavestate.cpp
+++ b/src/nrniv/bbsavestate.cpp
@@ -1751,34 +1751,36 @@ static void pycell_name2sec_maps_clear() {
 static void pycell_name2sec_maps_fill() {
     pycell_name2sec_maps_clear();
     hoc_Item* qsec;
-    ForAllSections(sec)                                              // macro has the {
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
         if (sec->prop && sec->prop->dparam[PROP_PY_INDEX]._pvoid) {  // PythonSection
-        // Assume we can associate with a Python Cell
-        // Sadly, cannot use nrn_sec2cell Object* as the key because it
-        // is not unique and the map needs definite PyObject* keys.
-        Object* ho = nrn_sec2cell(sec);
-        if (ho) {
-            void* pycell = nrn_opaque_obj2pyobj(ho);
-            hoc_obj_unref(ho);
-            if (pycell) {
-                SecName2Sec& sn2s = pycell_name2sec_maps[pycell];
-                std::string name = secname(sec);
-                // basename is after the cell name component that ends in '.'.
-                size_t last_dot = name.rfind(".");
-                assert(last_dot != std::string::npos);
-                assert(name.size() > (last_dot + 1));
-                std::string basename = name.substr(last_dot + 1);
-                if (sn2s.find(basename) != sn2s.end()) {
-                    hoc_execerr_ext("Python Section name, %s, is not unique in the Python cell",
-                                    name.c_str());
+            // Assume we can associate with a Python Cell
+            // Sadly, cannot use nrn_sec2cell Object* as the key because it
+            // is not unique and the map needs definite PyObject* keys.
+            Object* ho = nrn_sec2cell(sec);
+            if (ho) {
+                void* pycell = nrn_opaque_obj2pyobj(ho);
+                hoc_obj_unref(ho);
+                if (pycell) {
+                    SecName2Sec& sn2s = pycell_name2sec_maps[pycell];
+                    std::string name = secname(sec);
+                    // basename is after the cell name component that ends in '.'.
+                    size_t last_dot = name.rfind(".");
+                    assert(last_dot != std::string::npos);
+                    assert(name.size() > (last_dot + 1));
+                    std::string basename = name.substr(last_dot + 1);
+                    if (sn2s.find(basename) != sn2s.end()) {
+                        hoc_execerr_ext("Python Section name, %s, is not unique in the Python cell",
+                                        name.c_str());
+                    }
+                    sn2s[basename] = sec;
+                    continue;
                 }
-                sn2s[basename] = sec;
-                continue;
             }
+            hoc_execerr_ext("Python Section, %s, not associated with Python Cell.", secname(sec));
         }
-        hoc_execerr_ext("Python Section, %s, not associated with Python Cell.", secname(sec));
     }
-}
 }
 
 static SecName2Sec& pycell_name2sec_map(Object* c) {

--- a/src/nrniv/kschan.cpp
+++ b/src/nrniv/kschan.cpp
@@ -2374,41 +2374,44 @@ void KSChan::ion_consist() {
         trans_[i].lig2pd(poff);
     }
     int ppsize = poff + 2 * nligand_;
-    ForAllSections(sec) for (i = 0; i < sec->nnode; ++i) {
-        nd = sec->pnode[i];
-        Prop *p, *pion;
-        for (p = nd->prop; p; p = p->next) {
-            if (p->type == mtype) {
-                break;
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        for (i = 0; i < sec->nnode; ++i) {
+            nd = sec->pnode[i];
+            Prop *p, *pion;
+            for (p = nd->prop; p; p = p->next) {
+                if (p->type == mtype) {
+                    break;
+                }
             }
-        }
-        if (!p) {
-            continue;
-        }
-        p->dparam = (Datum*) erealloc(p->dparam, ppsize * sizeof(Datum));
-        // printf("KSChan::ion_consist %s node %d mtype=%d ion_type=%d\n",
-        // secname(sec), i, mtype, ion_sym_->subtype);
-        if (ion_sym_) {
-            pion = needion(ion_sym_, nd, p);
-            if (cond_model_ == 0) {  // ohmic
-                nrn_promote(pion, 0, 1);
-            } else if (cond_model_ == 1) {  // nernst
-                nrn_promote(pion, 1, 0);
-            } else {  // ghk
-                nrn_promote(pion, 1, 0);
+            if (!p) {
+                continue;
             }
-            Datum* pp = p->dparam;
-            pp[ppoff_ + 0].pval = pion->param + 0;  // ena
-            pp[ppoff_ + 1].pval = pion->param + 3;  // ina
-            pp[ppoff_ + 2].pval = pion->param + 4;  // dinadv
-            pp[ppoff_ + 3].pval = pion->param + 1;  // nai
-            pp[ppoff_ + 4].pval = pion->param + 2;  // nao
-        }
-        for (j = 0; j < nligand_; ++j) {
-            ligand_consist(j, poff, p, nd);
+            p->dparam = (Datum*) erealloc(p->dparam, ppsize * sizeof(Datum));
+            // printf("KSChan::ion_consist %s node %d mtype=%d ion_type=%d\n",
+            // secname(sec), i, mtype, ion_sym_->subtype);
+            if (ion_sym_) {
+                pion = needion(ion_sym_, nd, p);
+                if (cond_model_ == 0) {  // ohmic
+                    nrn_promote(pion, 0, 1);
+                } else if (cond_model_ == 1) {  // nernst
+                    nrn_promote(pion, 1, 0);
+                } else {  // ghk
+                    nrn_promote(pion, 1, 0);
+                }
+                Datum* pp = p->dparam;
+                pp[ppoff_ + 0].pval = pion->param + 0;  // ena
+                pp[ppoff_ + 1].pval = pion->param + 3;  // ina
+                pp[ppoff_ + 2].pval = pion->param + 4;  // dinadv
+                pp[ppoff_ + 3].pval = pion->param + 1;  // nai
+                pp[ppoff_ + 4].pval = pion->param + 2;  // nao
+            }
+            for (j = 0; j < nligand_; ++j) {
+                ligand_consist(j, poff, p, nd);
+            }
         }
     }
-}
 }
 
 void KSChan::ligand_consist(int j, int poff, Prop* p, Node* nd) {
@@ -2427,36 +2430,39 @@ void KSChan::state_consist(int shift) {  // shift when Nsingle winks in and out 
     hoc_Item* qsec;
     int mtype = rlsym_->subtype;
     ns = soffset_ + 2 * nstate_;
-    ForAllSections(sec) for (i = 0; i < sec->nnode; ++i) {
-        nd = sec->pnode[i];
-        Prop* p;
-        for (p = nd->prop; p; p = p->next) {
-            if (p->type == mtype) {
-                if (p->param_size != ns) {
-                    v_structure_change = 1;
-                    double* oldp = p->param;
-                    p->param = (double*) erealloc(oldp, ns * sizeof(double));
-                    if (oldp != p->param || shift != 0) {
-                        // printf("KSChan::state_consist realloc changed location\n");
-                        notify_freed_val_array(oldp, p->param_size);
-                    }
-                    p->param_size = ns;
-                    if (shift == 1) {
-                        for (j = ns - 1; j > 0; --j) {
-                            p->param[j] = p->param[j - 1];
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        for (i = 0; i < sec->nnode; ++i) {
+            nd = sec->pnode[i];
+            Prop* p;
+            for (p = nd->prop; p; p = p->next) {
+                if (p->type == mtype) {
+                    if (p->param_size != ns) {
+                        v_structure_change = 1;
+                        double* oldp = p->param;
+                        p->param = (double*) erealloc(oldp, ns * sizeof(double));
+                        if (oldp != p->param || shift != 0) {
+                            // printf("KSChan::state_consist realloc changed location\n");
+                            notify_freed_val_array(oldp, p->param_size);
                         }
-                        p->param[0] = 1;
-                    } else if (shift == -1) {
-                        for (j = 1; j < ns; ++j) {
-                            p->param[j - 1] = p->param[j];
+                        p->param_size = ns;
+                        if (shift == 1) {
+                            for (j = ns - 1; j > 0; --j) {
+                                p->param[j] = p->param[j - 1];
+                            }
+                            p->param[0] = 1;
+                        } else if (shift == -1) {
+                            for (j = 1; j < ns; ++j) {
+                                p->param[j - 1] = p->param[j];
+                            }
                         }
                     }
+                    break;
                 }
-                break;
             }
         }
     }
-}
 }
 
 void KSChan::delete_schan_node_data() {

--- a/src/nrniv/pysecname2sec.cpp
+++ b/src/nrniv/pysecname2sec.cpp
@@ -28,11 +28,14 @@ static void activate() {
         // printf("first activation\n");
         activated = true;
         hoc_Item* qsec;
-        ForAllSections(sec) if (sec->prop && sec->prop->dparam[PROP_PY_INDEX]._pvoid) {
-            nrnpy_pysecname2sec_add(sec);
+        // ForAllSections(sec)
+        ITERATE(qsec, section_list) {
+            Section* sec = hocSEC(qsec);
+            if (sec->prop && sec->prop->dparam[PROP_PY_INDEX]._pvoid) {
+                nrnpy_pysecname2sec_add(sec);
+            }
         }
     }
-}
 #endif
 }
 

--- a/src/nrniv/rotate3d.cpp
+++ b/src/nrniv/rotate3d.cpp
@@ -240,59 +240,54 @@ void Rotate3Band::draw(Coord, Coord) {
 
     c->push_transform();
     c->transformer(transformer());
-#if 0
-	hoc_Item* qsec;
-	ForAllSections(sec) //{
-#else
     PolyGlyph* sg = ((ShapeScene*) XYView::current_pick_view()->scene())->shape_section_list();
     GlyphIndex cnt = sg->count();
     for (GlyphIndex i = 0; i < cnt; ++i) {
         Section* sec = ((ShapeSection*) sg->component(i))->section();
-#endif
-    if (sec->npt3d) {
-        float r[3];
-        int i = 0;
-        r[0] = sec->pt3d[i].x;
-        r[1] = sec->pt3d[i].y;
-        r[2] = sec->pt3d[i].z;
-        rot_->rotate(r, r);
-        c->move_to(r[0], r[1]);
-        i = sec->npt3d - 1;
-        r[0] = sec->pt3d[i].x;
-        r[1] = sec->pt3d[i].y;
-        r[2] = sec->pt3d[i].z;
-        rot_->rotate(r, r);
-        c->line_to(r[0], r[1]);
-        c->stroke(color(), brush());
+        if (sec->npt3d) {
+            float r[3];
+            int i = 0;
+            r[0] = sec->pt3d[i].x;
+            r[1] = sec->pt3d[i].y;
+            r[2] = sec->pt3d[i].z;
+            rot_->rotate(r, r);
+            c->move_to(r[0], r[1]);
+            i = sec->npt3d - 1;
+            r[0] = sec->pt3d[i].x;
+            r[1] = sec->pt3d[i].y;
+            r[2] = sec->pt3d[i].z;
+            rot_->rotate(r, r);
+            c->line_to(r[0], r[1]);
+            c->stroke(color(), brush());
+        }
     }
-}
-c->pop_transform();
+    c->pop_transform();
 
-x0 = x_begin();
-y0 = y_begin();
-c->push_transform();
-Transformer t;
-c->transformer(t);
-c->new_path();
-Coord w = canvas()->width() / 4;
-rot_->x_axis(x, y);
-// printf("x_axis %g %g\n", x, y);
-c->line(x0, y0, x0 + x * w, y0 + y * w, color(), brush());
+    x0 = x_begin();
+    y0 = y_begin();
+    c->push_transform();
+    Transformer t;
+    c->transformer(t);
+    c->new_path();
+    Coord w = canvas()->width() / 4;
+    rot_->x_axis(x, y);
+    // printf("x_axis %g %g\n", x, y);
+    c->line(x0, y0, x0 + x * w, y0 + y * w, color(), brush());
 #ifndef WIN32
-c->character(f, 'x', f->width('x'), color(), x0 + x * w * 1.1, y0 + y * w * 1.1);
+    c->character(f, 'x', f->width('x'), color(), x0 + x * w * 1.1, y0 + y * w * 1.1);
 #endif
-rot_->y_axis(x, y);
-// printf("y_axis %g %g\n", x, y);
-c->line(x0, y0, x0 + x * w, y0 + y * w, color(), brush());
+    rot_->y_axis(x, y);
+    // printf("y_axis %g %g\n", x, y);
+    c->line(x0, y0, x0 + x * w, y0 + y * w, color(), brush());
 #ifndef WIN32
-c->character(f, 'y', f->width('y'), color(), x0 + x * w * 1.1, y0 + y * w * 1.1);
+    c->character(f, 'y', f->width('y'), color(), x0 + x * w * 1.1, y0 + y * w * 1.1);
 #endif
-rot_->z_axis(x, y);
-// printf("z_axis %g %g\n", x, y);
-c->line(x0, y0, x0 + x * w, y0 + y * w, color(), brush());
+    rot_->z_axis(x, y);
+    // printf("z_axis %g %g\n", x, y);
+    c->line(x0, y0, x0 + x * w, y0 + y * w, color(), brush());
 #ifndef WIN32
-c->character(f, 'z', f->width('z'), color(), x0 + x * w * 1.1, y0 + y * w * 1.1);
+    c->character(f, 'z', f->width('z'), color(), x0 + x * w * 1.1, y0 + y * w * 1.1);
 #endif
-c->pop_transform();
+    c->pop_transform();
 }
 #endif

--- a/src/nrniv/savstate.cpp
+++ b/src/nrniv/savstate.cpp
@@ -292,95 +292,99 @@ bool SaveState::check(bool warn) {
     }
     if (nsec_ && ss_[0].sec == NULL) {  // got the data from a read
         isec = 0;
-        ForAllSections(sec) ss_[isec].sec = sec;
-        section_ref(ss_[isec].sec);
-        ++isec;
+        // ForAllSections(sec)
+        ITERATE(qsec, section_list) {
+            Section* sec = hocSEC(qsec);
+            ss_[isec].sec = sec;
+            section_ref(ss_[isec].sec);
+            ++isec;
+        }
     }
-}
-for (int i = 0, j = 0; i < n_memb_func; ++i)
-    if (nrn_is_artificial_[i]) {
-        if (!checkacell(acell_[j], i, warn)) {
+    for (int i = 0, j = 0; i < n_memb_func; ++i)
+        if (nrn_is_artificial_[i]) {
+            if (!checkacell(acell_[j], i, warn)) {
+                return false;
+            }
+            ++j;
+        }
+    for (int isec = 0; isec < nsec_; ++isec) {
+        SecState& ss = ss_[isec];
+        Section* sec = ss.sec;
+        if (!sec->prop || sec->nnode != ss.nnode) {
+            if (warn) {
+                if (!sec->prop) {
+                    fprintf(stderr, "SaveState warning: saved section no longer exists\n");
+                } else {
+                    fprintf(stderr,
+                            "SaveState warning: %s has %d nodes but saved %d\n",
+                            secname(sec),
+                            sec->nnode,
+                            ss.nnode);
+                }
+            }
             return false;
         }
-        ++j;
-    }
-for (int isec = 0; isec < nsec_; ++isec) {
-    SecState& ss = ss_[isec];
-    Section* sec = ss.sec;
-    if (!sec->prop || sec->nnode != ss.nnode) {
-        if (warn) {
-            if (!sec->prop) {
-                fprintf(stderr, "SaveState warning: saved section no longer exists\n");
-            } else {
-                fprintf(stderr,
-                        "SaveState warning: %s has %d nodes but saved %d\n",
-                        secname(sec),
-                        sec->nnode,
-                        ss.nnode);
-            }
-        }
-        return false;
-    }
-    for (int inode = 0; inode < ss.nnode; ++inode) {
-        NodeState& ns = ss.ns[inode];
-        Node* nd = sec->pnode[inode];
-        int i = 0;
-        Prop* p;
-        for (p = nd->prop; p; p = p->next) {
-            if (ssi[p->type].size == 0) {
-                continue;
-            }
-            if (i >= ns.nmemb) {
-                if (warn) {
-                    fprintf(stderr,
-                            "SaveState warning: \
+        for (int inode = 0; inode < ss.nnode; ++inode) {
+            NodeState& ns = ss.ns[inode];
+            Node* nd = sec->pnode[inode];
+            int i = 0;
+            Prop* p;
+            for (p = nd->prop; p; p = p->next) {
+                if (ssi[p->type].size == 0) {
+                    continue;
+                }
+                if (i >= ns.nmemb) {
+                    if (warn) {
+                        fprintf(stderr,
+                                "SaveState warning: \
 fewer mechanisms saved than exist at node %d of %s\n",
-                            inode,
-                            secname(sec));
+                                inode,
+                                secname(sec));
+                    }
+                    return false;
                 }
-                return false;
-            }
-            if (p->type != ns.type[i]) {
-                if (warn) {
-                    fprintf(stderr,
-                            "SaveState warning: mechanisms out of order at node %d of %s\n\
+                if (p->type != ns.type[i]) {
+                    if (warn) {
+                        fprintf(stderr,
+                                "SaveState warning: mechanisms out of order at node %d of %s\n\
 saved %s but need %s\n",
-                            inode,
-                            secname(sec),
-                            memb_func[i].sym->name,
-                            memb_func[p->type].sym->name);
+                                inode,
+                                secname(sec),
+                                memb_func[i].sym->name,
+                                memb_func[p->type].sym->name);
+                    }
+                    return false;
                 }
-                return false;
+                ++i;
             }
-            ++i;
-        }
-        if (i != ns.nmemb) {
-            if (warn) {
-                fprintf(stderr,
+            if (i != ns.nmemb) {
+                if (warn) {
+                    fprintf(
+                        stderr,
                         "SaveState warning: more mechanisms saved than exist at node %d of %s\n",
                         inode,
                         secname(sec));
-            }
-            return false;
-        }
-    }
-    if (!sec->parentsec || ss.root) {
-        if (sec->parentsec || !ss.root) {
-            if (warn) {
-                fprintf(stderr,
-                        "SaveState warning: Saved section and %s are not both root sections.\n",
-                        secname(sec));
+                }
+                return false;
             }
         }
-        if (!checknode(*ss.root, sec->parentnode, warn)) {
-            return false;
+        if (!sec->parentsec || ss.root) {
+            if (sec->parentsec || !ss.root) {
+                if (warn) {
+                    fprintf(stderr,
+                            "SaveState warning: Saved section and %s are not both root sections.\n",
+                            secname(sec));
+                }
+            }
+            if (!checknode(*ss.root, sec->parentnode, warn)) {
+                return false;
+            }
         }
     }
-}
-if (!checknet(warn)) {
-    return false;
-}
-return true;
+    if (!checknet(warn)) {
+        return false;
+    }
+    return true;
 }
 
 bool SaveState::checknode(NodeState& ns, Node* nd, bool warn) {
@@ -441,39 +445,42 @@ void SaveState::alloc() {
     }
     nroot_ = 0;
     isec = 0;
-    ForAllSections(sec) SecState& ss = ss_[isec];
-    ss.sec = sec;
-    section_ref(ss.sec);
-    ss.nnode = ss.sec->nnode;
-    ss.ns = new NodeState[ss.nnode];
-    for (inode = 0; inode < ss.nnode; ++inode) {
-        Node* nd = ss.sec->pnode[inode];
-        NodeState& ns = ss.ns[inode];
-        allocnode(ns, nd);
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        SecState& ss = ss_[isec];
+        ss.sec = sec;
+        section_ref(ss.sec);
+        ss.nnode = ss.sec->nnode;
+        ss.ns = new NodeState[ss.nnode];
+        for (inode = 0; inode < ss.nnode; ++inode) {
+            Node* nd = ss.sec->pnode[inode];
+            NodeState& ns = ss.ns[inode];
+            allocnode(ns, nd);
+        }
+        if (!sec->parentsec) {
+            assert(sec->parentnode);
+            ss.root = new NodeState;
+            allocnode(*ss.root, sec->parentnode);
+            ++nroot_;
+        } else {
+            ss.root = 0;
+        }
+        ++isec;
     }
-    if (!sec->parentsec) {
-        assert(sec->parentnode);
-        ss.root = new NodeState;
-        allocnode(*ss.root, sec->parentnode);
-        ++nroot_;
-    } else {
-        ss.root = 0;
+    assert(isec == section_count);
+    assert(nroot_ == nrn_global_ncell);
+    for (int i = 0, j = 0; i < n_memb_func; ++i)
+        if (nrn_is_artificial_[i]) {
+            allocacell(acell_[j], i);
+            ++j;
+        }
+    PlayRecList* prl = net_cvode_instance_prl();
+    nprs_ = prl->count();
+    if (nprs_) {
+        prs_ = new PlayRecordSave*[nprs_];
     }
-    ++isec;
-}
-assert(isec == section_count);
-assert(nroot_ == nrn_global_ncell);
-for (int i = 0, j = 0; i < n_memb_func; ++i)
-    if (nrn_is_artificial_[i]) {
-        allocacell(acell_[j], i);
-        ++j;
-    }
-PlayRecList* prl = net_cvode_instance_prl();
-nprs_ = prl->count();
-if (nprs_) {
-    prs_ = new PlayRecordSave*[nprs_];
-}
-allocnet();
+    allocnet();
 }
 
 void SaveState::allocnode(NodeState& ns, Node* nd) {

--- a/src/nrniv/secbrows.cpp
+++ b/src/nrniv/secbrows.cpp
@@ -131,7 +131,6 @@ OcSectionBrowser::OcSectionBrowser(Object* ob)
         scnt_ = 0;
         // ForAllSections(sec)  //{
         ITERATE(qsec, section_list) {
-            Section* sec = hocSEC(qsec);
             ++scnt_;
         }
         psec_ = new Section*[scnt_];

--- a/src/nrniv/secbrows.cpp
+++ b/src/nrniv/secbrows.cpp
@@ -129,21 +129,25 @@ OcSectionBrowser::OcSectionBrowser(Object* ob)
     } else {
         struct hoc_Item* qsec;
         scnt_ = 0;
-        ForAllSections(sec)  //{
-            ++ scnt_;
+        // ForAllSections(sec)  //{
+        ITERATE(qsec, section_list) {
+            Section* sec = hocSEC(qsec);
+            ++scnt_;
+        }
+        psec_ = new Section*[scnt_];
+        scnt_ = 0;
+        // ForAllSections(sec)  //{
+        ITERATE(qsec, section_list) {
+            Section* sec = hocSEC(qsec);
+            psec_[scnt_++] = sec;
+        }
     }
-    psec_ = new Section*[scnt_];
-    scnt_ = 0;
-    ForAllSections(sec)  //{
-        psec_[scnt_++] = sec;
-}
-}
-for (i = 0; i < scnt_; ++i) {
-    append_item(secname(psec_[i]));
-    section_ref(psec_[i]);
-}
-select_ = NULL;
-accept_ = NULL;
+    for (i = 0; i < scnt_; ++i) {
+        append_item(secname(psec_[i]));
+        section_ref(psec_[i]);
+    }
+    select_ = NULL;
+    accept_ = NULL;
 }
 
 OcSectionBrowser::~OcSectionBrowser() {
@@ -364,19 +368,23 @@ void BrowserAccept::execute() {
 SectionBrowserImpl::SectionBrowserImpl() {
     struct hoc_Item* qsec;
     scnt_ = 0;
-    ForAllSections(sec)  //{
-        ++ scnt_;
-}
-psec_ = new Section*[scnt_];
-scnt_ = 0;
-ForAllSections(sec)  //{
-    psec_[scnt_++] = sec;
-section_ref(sec);
-}
-ms_ = new MechSelector();
-ms_->ref();
-mvt_ = new MechVarType();
-mvt_->ref();
+    // ForAllSections(sec)  //{
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        ++scnt_;
+    }
+    psec_ = new Section*[scnt_];
+    scnt_ = 0;
+    // ForAllSections(sec)  //{
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        psec_[scnt_++] = sec;
+        section_ref(sec);
+    }
+    ms_ = new MechSelector();
+    ms_->ref();
+    mvt_ = new MechVarType();
+    mvt_->ref();
 }
 SectionBrowserImpl::~SectionBrowserImpl() {
     for (int i = 0; i < scnt_; ++i) {

--- a/src/nrniv/shape.cpp
+++ b/src/nrniv/shape.cpp
@@ -883,19 +883,22 @@ declareRubberCallback(ShapeScene) implementRubberCallback(ShapeScene)
         }
     } else {
         view_all_ = true;
-        ForAllSections(sec) gl = new ShapeSection(sec);
-        append(new FastGraphItem(gl, 0));
-        sg_->append(gl);
+        // ForAllSections(sec)
+        ITERATE(qsec, section_list) {
+            Section* sec = hocSEC(qsec);
+            gl = new ShapeSection(sec);
+            append(new FastGraphItem(gl, 0));
+            sg_->append(gl);
+        }
     }
-}
-recalc_diam();
-selected_ = NULL;
-volatile_ptr_ref = NULL;
-transform3d();
-if (shape_changed_) {
-    force();
-    flush();
-}
+    recalc_diam();
+    selected_ = NULL;
+    volatile_ptr_ref = NULL;
+    transform3d();
+    if (shape_changed_) {
+        force();
+        flush();
+    }
 }
 
 void ShapeScene::force() {

--- a/src/nrnoc/extcelln.cpp
+++ b/src/nrnoc/extcelln.cpp
@@ -521,100 +521,108 @@ void ext_con_coef(void) /* setup a and b */
     double* pd;
 
     /* temporarily store half segment resistances in rhs */
-    ForAllSections(sec) /*{*/
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
         if (sec->pnode[0]->extnode) {
-        dx = section_length(sec) / ((double) (sec->nnode - 1));
-        for (j = 0; j < sec->nnode - 1; j++) {
-            nde = sec->pnode[j]->extnode;
-            pd = nde->param;
-            for (k = 0; k < nlayer; ++k) {
-                *nde->_rhs[k] = 1e-4 * xraxial[k] * (dx / 2.); /*Megohms*/
+            dx = section_length(sec) / ((double) (sec->nnode - 1));
+            for (j = 0; j < sec->nnode - 1; j++) {
+                nde = sec->pnode[j]->extnode;
+                pd = nde->param;
+                for (k = 0; k < nlayer; ++k) {
+                    *nde->_rhs[k] = 1e-4 * xraxial[k] * (dx / 2.); /*Megohms*/
+                }
             }
-        }
-        /* last segment has 0 length. */
-        nde = sec->pnode[j]->extnode;
-        pd = nde->param;
-        for (k = 0; k < nlayer; ++k) {
-            *nde->_rhs[k] = 0.;
-            xc[k] = 0.;
-            xg[k] = 0.;
-        }
-        /* if owns a rootnode */
-        if (!sec->parentsec) {
-            nde = sec->parentnode->extnode;
+            /* last segment has 0 length. */
+            nde = sec->pnode[j]->extnode;
             pd = nde->param;
             for (k = 0; k < nlayer; ++k) {
                 *nde->_rhs[k] = 0.;
                 xc[k] = 0.;
                 xg[k] = 0.;
             }
+            /* if owns a rootnode */
+            if (!sec->parentsec) {
+                nde = sec->parentnode->extnode;
+                pd = nde->param;
+                for (k = 0; k < nlayer; ++k) {
+                    *nde->_rhs[k] = 0.;
+                    xc[k] = 0.;
+                    xg[k] = 0.;
+                }
+            }
         }
     }
-}
-/* assume that if only one connection at x=1, then they butte
-together, if several connections at x=1
-then last point is at x=1, has 0 area and other points are at
-centers of nnode-1 segments.
-If interior connection then child half
-section connects straight to the point*/
-/* for the near future we always have a last node at x=1 with
-no properties */
-ForAllSections(sec) /*{*/
-    if (sec->pnode[0]->extnode) {
-    /* node half resistances in general get added to the
-    node and to the node's "child node in the same section".
-    child nodes in different sections don't involve parent
-    node's resistance */
-    nde = sec->pnode[0]->extnode;
-    for (k = 0; k < nlayer; ++k) {
-        nde->_b[k] = *nde->_rhs[k];
-    }
-    for (j = 1; j < sec->nnode; j++) {
-        nde = sec->pnode[j]->extnode;
-        for (k = 0; k < nlayer; ++k) {
-            nde->_b[k] = *nde->_rhs[k] + *(sec->pnode[j - 1]->extnode->_rhs[k]); /*megohms*/
+    /* assume that if only one connection at x=1, then they butte
+    together, if several connections at x=1
+    then last point is at x=1, has 0 area and other points are at
+    centers of nnode-1 segments.
+    If interior connection then child half
+    section connects straight to the point*/
+    /* for the near future we always have a last node at x=1 with
+    no properties */
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        if (sec->pnode[0]->extnode) {
+            /* node half resistances in general get added to the
+            node and to the node's "child node in the same section".
+            child nodes in different sections don't involve parent
+            node's resistance */
+            nde = sec->pnode[0]->extnode;
+            for (k = 0; k < nlayer; ++k) {
+                nde->_b[k] = *nde->_rhs[k];
+            }
+            for (j = 1; j < sec->nnode; j++) {
+                nde = sec->pnode[j]->extnode;
+                for (k = 0; k < nlayer; ++k) {
+                    nde->_b[k] = *nde->_rhs[k] + *(sec->pnode[j - 1]->extnode->_rhs[k]); /*megohms*/
+                }
+            }
         }
     }
-}
-}
-ForAllSections(sec) /*{*/
-    if (sec->pnode[0]->extnode) {
-    /* convert to siemens/cm^2 for all nodes except last
-    and microsiemens for last.  This means that a*V = mamps/cm2
-    and a*v in last node = nanoamps. Note that last node
-    has no membrane properties and no area. It may perhaps recieve
-    current stimulus later */
-    /* first the effect of node on parent equation. Note That
-    last nodes have area = 1.e2 in dimensionless units so that
-    last nodes have units of microsiemens's */
-    pnd = sec->pnode;
-    nde = pnd[0]->extnode;
-    area = NODEAREA(sec->parentnode);
-    /* param[4] is rall_branch */
-    for (k = 0; k < nlayer; ++k) {
-        nde->_a[k] = -1.e2 * sec->prop->dparam[4].val / (nde->_b[k] * area);
-    }
-    for (j = 1; j < sec->nnode; j++) {
-        nde = pnd[j]->extnode;
-        area = NODEAREA(pnd[j - 1]);
-        for (k = 0; k < nlayer; ++k) {
-            nde->_a[k] = -1.e2 / (nde->_b[k] * area);
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        if (sec->pnode[0]->extnode) {
+            /* convert to siemens/cm^2 for all nodes except last
+            and microsiemens for last.  This means that a*V = mamps/cm2
+            and a*v in last node = nanoamps. Note that last node
+            has no membrane properties and no area. It may perhaps recieve
+            current stimulus later */
+            /* first the effect of node on parent equation. Note That
+            last nodes have area = 1.e2 in dimensionless units so that
+            last nodes have units of microsiemens's */
+            pnd = sec->pnode;
+            nde = pnd[0]->extnode;
+            area = NODEAREA(sec->parentnode);
+            /* param[4] is rall_branch */
+            for (k = 0; k < nlayer; ++k) {
+                nde->_a[k] = -1.e2 * sec->prop->dparam[4].val / (nde->_b[k] * area);
+            }
+            for (j = 1; j < sec->nnode; j++) {
+                nde = pnd[j]->extnode;
+                area = NODEAREA(pnd[j - 1]);
+                for (k = 0; k < nlayer; ++k) {
+                    nde->_a[k] = -1.e2 / (nde->_b[k] * area);
+                }
+            }
         }
     }
-}
-}
-/* now the effect of parent on node equation. */
-ForAllSections(sec) /*{*/
-    if (sec->pnode[0]->extnode) {
-    for (j = 0; j < sec->nnode; j++) {
-        nd = sec->pnode[j];
-        nde = nd->extnode;
-        for (k = 0; k < nlayer; ++k) {
-            nde->_b[k] = -1.e2 / (nde->_b[k] * NODEAREA(nd));
+    /* now the effect of parent on node equation. */
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        if (sec->pnode[0]->extnode) {
+            for (j = 0; j < sec->nnode; j++) {
+                nd = sec->pnode[j];
+                nde = nd->extnode;
+                for (k = 0; k < nlayer; ++k) {
+                    nde->_b[k] = -1.e2 / (nde->_b[k] * NODEAREA(nd));
+                }
+            }
         }
     }
-}
-}
 }
 
 #if 0

--- a/src/nrnoc/method3.cpp
+++ b/src/nrnoc/method3.cpp
@@ -331,43 +331,46 @@ method3_connection_coef() /* setup a and b */
         t = 0.;
     }
 
-    ForAllSections(sec) dx = section_length(sec) / ((double) (sec->nnode));
-    for (j = 0; j < sec->nnode; ++j) {
-        nd = sec->pnode[j];
-        p = nrn_mechanism(MORPHOLOGY, nd);
-        assert(p);
-        diam = p->param[0];
-        /* dv/(ra*dx) is nanoamps */
-        ra = nrn_ra(sec) * 4.e-2 / (PI * diam * diam);
-        /* coef*dx* mA/cm^2 should be nanoamps */
-        coef = PI * 1e-2 * diam;
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        dx = section_length(sec) / ((double) (sec->nnode));
+        for (j = 0; j < sec->nnode; ++j) {
+            nd = sec->pnode[j];
+            p = nrn_mechanism(MORPHOLOGY, nd);
+            assert(p);
+            diam = p->param[0];
+            /* dv/(ra*dx) is nanoamps */
+            ra = nrn_ra(sec) * 4.e-2 / (PI * diam * diam);
+            /* coef*dx* mA/cm^2 should be nanoamps */
+            coef = PI * 1e-2 * diam;
 
-        nd->area = 100.;
-        sec->parentnode->area = 100.;
+            nd->area = 100.;
+            sec->parentnode->area = 100.;
 
-        nd->toparent.coef0 = coef * r * dx / 12.;
-        nd->fromparent.coef0 = coef * r * dx / 12.;
-        nd->toparent.coefn = coef * s * dx / 12.;
-        nd->fromparent.coefn = coef * s * dx / 12.;
-        nd->toparent.coefjdot = t * ra * coef * dx * dx / 12.;
-        nd->fromparent.coefjdot = t * ra * coef * dx * dx / 12.;
-        nd->toparent.coefdg = t * coef * dx / 12.;
-        nd->fromparent.coefdg = t * coef * dx / 12.;
-        nd->toparent.coefj = 1. / (ra * dx);
-        nd->fromparent.coefj = 1. / (ra * dx);
-        nd->toparent.nd2 = 0;
-        nd->fromparent.nd2 = 0;
-    }
-    if (sec->nnode > 1) {
-        sec->pnode[0]->toparent.nd2 = sec->pnode[1];
-        if (sec->nnode > 2) {
-            sec->pnode[sec->nnode - 2]->fromparent.nd2 = sec->pnode[sec->nnode - 3];
-        } else {
-            sec->pnode[sec->nnode - 2]->fromparent.nd2 =
-                sec->parentsec->pnode[sec->parentsec->nnode - 1];
+            nd->toparent.coef0 = coef * r * dx / 12.;
+            nd->fromparent.coef0 = coef * r * dx / 12.;
+            nd->toparent.coefn = coef * s * dx / 12.;
+            nd->fromparent.coefn = coef * s * dx / 12.;
+            nd->toparent.coefjdot = t * ra * coef * dx * dx / 12.;
+            nd->fromparent.coefjdot = t * ra * coef * dx * dx / 12.;
+            nd->toparent.coefdg = t * coef * dx / 12.;
+            nd->fromparent.coefdg = t * coef * dx / 12.;
+            nd->toparent.coefj = 1. / (ra * dx);
+            nd->fromparent.coefj = 1. / (ra * dx);
+            nd->toparent.nd2 = 0;
+            nd->fromparent.nd2 = 0;
+        }
+        if (sec->nnode > 1) {
+            sec->pnode[0]->toparent.nd2 = sec->pnode[1];
+            if (sec->nnode > 2) {
+                sec->pnode[sec->nnode - 2]->fromparent.nd2 = sec->pnode[sec->nnode - 3];
+            } else {
+                sec->pnode[sec->nnode - 2]->fromparent.nd2 =
+                    sec->parentsec->pnode[sec->parentsec->nnode - 1];
+            }
         }
     }
-}
 }
 
 

--- a/src/nrnoc/multicore.cpp
+++ b/src/nrnoc/multicore.cpp
@@ -928,128 +928,137 @@ static void reorder_secorder() {
     hoc_List* sl;
     int order, isec, i, j, inode;
     /* count and allocate */
-    ForAllSections(sec) sec->order = -1;
-}
-order = 0;
-FOR_THREADS(_nt) {
-    /* roots of this thread */
-    sl = _nt->roots;
-    inode = 0;
-    ITERATE(qsec, sl) {
-        sec = hocSEC(qsec);
-        assert(sec->order == -1);
-        secorder[order] = sec;
-        sec->order = order;
-        ++order;
-        nd = sec->parentnode;
-        nd->_nt = _nt;
-        inode += 1;
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        sec->order = -1;
     }
-    /* all children of what is already in secorder */
-    for (isec = order - _nt->ncell; isec < order; ++isec) {
-        sec = secorder[isec];
-        /* to make it easy to fill in PreSyn.nt_*/
-        sec->prop->dparam[9]._pvoid = (void*) _nt;
-        for (j = 0; j < sec->nnode; ++j) {
-            nd = sec->pnode[j];
+    order = 0;
+    FOR_THREADS(_nt) {
+        /* roots of this thread */
+        sl = _nt->roots;
+        inode = 0;
+        ITERATE(qsec, sl) {
+            sec = hocSEC(qsec);
+            assert(sec->order == -1);
+            secorder[order] = sec;
+            sec->order = order;
+            ++order;
+            nd = sec->parentnode;
             nd->_nt = _nt;
             inode += 1;
         }
-        for (ch = sec->child; ch; ch = ch->sibling) {
-            assert(ch->order == -1);
-            secorder[order] = ch;
-            ch->order = order;
-            ++order;
+        /* all children of what is already in secorder */
+        for (isec = order - _nt->ncell; isec < order; ++isec) {
+            sec = secorder[isec];
+            /* to make it easy to fill in PreSyn.nt_*/
+            sec->prop->dparam[9]._pvoid = (void*) _nt;
+            for (j = 0; j < sec->nnode; ++j) {
+                nd = sec->pnode[j];
+                nd->_nt = _nt;
+                inode += 1;
+            }
+            for (ch = sec->child; ch; ch = ch->sibling) {
+                assert(ch->order == -1);
+                secorder[order] = ch;
+                ch->order = order;
+                ++order;
+            }
         }
+        _nt->end = inode;
+        CACHELINE_CALLOC(_nt->_actual_rhs, double, inode);
+        CACHELINE_CALLOC(_nt->_actual_d, double, inode);
+        CACHELINE_CALLOC(_nt->_actual_a, double, inode);
+        CACHELINE_CALLOC(_nt->_actual_b, double, inode);
+        CACHELINE_CALLOC(_nt->_v_node, Node*, inode);
+        CACHELINE_CALLOC(_nt->_v_parent, Node*, inode);
+        CACHELINE_CALLOC(_nt->_v_parent_index, int, inode);
     }
-    _nt->end = inode;
-    CACHELINE_CALLOC(_nt->_actual_rhs, double, inode);
-    CACHELINE_CALLOC(_nt->_actual_d, double, inode);
-    CACHELINE_CALLOC(_nt->_actual_a, double, inode);
-    CACHELINE_CALLOC(_nt->_actual_b, double, inode);
-    CACHELINE_CALLOC(_nt->_v_node, Node*, inode);
-    CACHELINE_CALLOC(_nt->_v_parent, Node*, inode);
-    CACHELINE_CALLOC(_nt->_v_parent_index, int, inode);
-}
-/* do it again and fill _v_node and _v_parent */
-/* index each cell section in relative order. Do offset later */
-ForAllSections(sec) sec->order = -1;
-}
-order = 0;
-FOR_THREADS(_nt) {
-    /* roots of this thread */
-    sl = _nt->roots;
-    inode = 0;
-    ITERATE(qsec, sl) {
-        sec = hocSEC(qsec);
-        assert(sec->order == -1);
-        secorder[order] = sec;
-        sec->order = order;
-        ++order;
-        nd = sec->parentnode;
-        nd->_nt = _nt;
-        _nt->_v_node[inode] = nd;
-        _nt->_v_parent[inode] = (Node*) 0;
-        _nt->_v_node[inode]->v_node_index = inode;
-        inode += 1;
+    /* do it again and fill _v_node and _v_parent */
+    /* index each cell section in relative order. Do offset later */
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        sec->order = -1;
     }
-    /* all children of what is already in secorder */
-    for (isec = order - _nt->ncell; isec < order; ++isec) {
-        sec = secorder[isec];
-        /* to make it easy to fill in PreSyn.nt_*/
-        sec->prop->dparam[9]._pvoid = (void*) _nt;
-        for (j = 0; j < sec->nnode; ++j) {
-            nd = sec->pnode[j];
+    order = 0;
+    FOR_THREADS(_nt) {
+        /* roots of this thread */
+        sl = _nt->roots;
+        inode = 0;
+        ITERATE(qsec, sl) {
+            sec = hocSEC(qsec);
+            assert(sec->order == -1);
+            secorder[order] = sec;
+            sec->order = order;
+            ++order;
+            nd = sec->parentnode;
             nd->_nt = _nt;
             _nt->_v_node[inode] = nd;
-            if (j) {
-                _nt->_v_parent[inode] = sec->pnode[j - 1];
-            } else {
-                _nt->_v_parent[inode] = sec->parentnode;
-            }
+            _nt->_v_parent[inode] = (Node*) 0;
             _nt->_v_node[inode]->v_node_index = inode;
             inode += 1;
         }
-        for (ch = sec->child; ch; ch = ch->sibling) {
-            assert(ch->order == -1);
-            secorder[order] = ch;
-            ch->order = order;
-            ++order;
+        /* all children of what is already in secorder */
+        for (isec = order - _nt->ncell; isec < order; ++isec) {
+            sec = secorder[isec];
+            /* to make it easy to fill in PreSyn.nt_*/
+            sec->prop->dparam[9]._pvoid = (void*) _nt;
+            for (j = 0; j < sec->nnode; ++j) {
+                nd = sec->pnode[j];
+                nd->_nt = _nt;
+                _nt->_v_node[inode] = nd;
+                if (j) {
+                    _nt->_v_parent[inode] = sec->pnode[j - 1];
+                } else {
+                    _nt->_v_parent[inode] = sec->parentnode;
+                }
+                _nt->_v_node[inode]->v_node_index = inode;
+                inode += 1;
+            }
+            for (ch = sec->child; ch; ch = ch->sibling) {
+                assert(ch->order == -1);
+                secorder[order] = ch;
+                ch->order = order;
+                ++order;
+            }
+        }
+        _nt->end = inode;
+    }
+    assert(order == section_count);
+    /*assert(inode == v_node_count);*/
+    /* not missing any */
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        assert(sec->order != -1);
+    }
+
+    /* here is where multisplit reorders the nodes. Afterwards
+      in either case, we can then point to v, d, rhs in proper
+      node order
+    */
+    FOR_THREADS(_nt) for (inode = 0; inode < _nt->end; ++inode) {
+        _nt->_v_node[inode]->_classical_parent = _nt->_v_parent[inode];
+    }
+    if (nrn_multisplit_setup_) {
+        /* classical order abandoned */
+        (*nrn_multisplit_setup_)();
+    }
+    /* make the Nodes point to the proper d, rhs */
+    FOR_THREADS(_nt) {
+        for (j = 0; j < _nt->end; ++j) {
+            Node* nd = _nt->_v_node[j];
+            nd->_d = _nt->_actual_d + j;
+            nd->_rhs = _nt->_actual_rhs + j;
         }
     }
-    _nt->end = inode;
-}
-assert(order == section_count);
-/*assert(inode == v_node_count);*/
-/* not missing any */
-ForAllSections(sec) assert(sec->order != -1);
-}
-
-/* here is where multisplit reorders the nodes. Afterwards
-  in either case, we can then point to v, d, rhs in proper
-  node order
-*/
-FOR_THREADS(_nt) for (inode = 0; inode < _nt->end; ++inode) {
-    _nt->_v_node[inode]->_classical_parent = _nt->_v_parent[inode];
-}
-if (nrn_multisplit_setup_) {
-    /* classical order abandoned */
-    (*nrn_multisplit_setup_)();
-}
-/* make the Nodes point to the proper d, rhs */
-FOR_THREADS(_nt) {
-    for (j = 0; j < _nt->end; ++j) {
-        Node* nd = _nt->_v_node[j];
-        nd->_d = _nt->_actual_d + j;
-        nd->_rhs = _nt->_actual_rhs + j;
+    /* because the d,rhs changed, if multisplit is used we need to update
+      the reduced tree gather/scatter pointers
+    */
+    if (nrn_multisplit_setup_) {
+        nrn_multisplit_ptr_update();
     }
-}
-/* because the d,rhs changed, if multisplit is used we need to update
-  the reduced tree gather/scatter pointers
-*/
-if (nrn_multisplit_setup_) {
-    nrn_multisplit_ptr_update();
-}
 }
 
 
@@ -1238,38 +1247,41 @@ int nrn_user_partition() {
         }
     }
 
-    ForAllSections(sec) sec->volatile_mark = 0;
-}
-/* fill in ncell and verify consistency */
-n = 0;
-for (it = 0; it < nrn_nthread; ++it) {
-    nt = nrn_threads + it;
-    sl = nt->roots;
-    nt->ncell = 0;
-    ITERATE(qsec, sl) {
-        sec = hocSEC(qsec);
-        ++nt->ncell;
-        ++n;
-        if (sec->parentsec) {
-            sprintf(buf, "in thread partition %d is not a root section", it);
-            hoc_execerror(secname(sec), buf);
-        }
-        if (sec->volatile_mark) {
-            sprintf(buf, "appeared again in partition %d", it);
-            hoc_execerror(secname(sec), buf);
-        }
-        sec->volatile_mark = 1;
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        sec->volatile_mark = 0;
     }
-}
-if (n != nrn_global_ncell) {
-    sprintf(
-        buf,
-        "The total number of cells, %d, is different than the number of user partition cells, %d\n",
-        nrn_global_ncell,
-        n);
-    hoc_execerror(buf, (char*) 0);
-}
-return 1;
+    /* fill in ncell and verify consistency */
+    n = 0;
+    for (it = 0; it < nrn_nthread; ++it) {
+        nt = nrn_threads + it;
+        sl = nt->roots;
+        nt->ncell = 0;
+        ITERATE(qsec, sl) {
+            sec = hocSEC(qsec);
+            ++nt->ncell;
+            ++n;
+            if (sec->parentsec) {
+                sprintf(buf, "in thread partition %d is not a root section", it);
+                hoc_execerror(secname(sec), buf);
+            }
+            if (sec->volatile_mark) {
+                sprintf(buf, "appeared again in partition %d", it);
+                hoc_execerror(secname(sec), buf);
+            }
+            sec->volatile_mark = 1;
+        }
+    }
+    if (n != nrn_global_ncell) {
+        sprintf(buf,
+                "The total number of cells, %d, is different than the number of user partition "
+                "cells, %d\n",
+                nrn_global_ncell,
+                n);
+        hoc_execerror(buf, (char*) 0);
+    }
+    return 1;
 }
 
 void nrn_use_busywait(int b) {

--- a/src/nrnoc/seclist.cpp
+++ b/src/nrnoc/seclist.cpp
@@ -132,13 +132,16 @@ static double allroots(void* v) {
     List* sl;
     Item* qsec;
     sl = (List*) v;
-    ForAllSections(sec) if (!sec->parentsec) {
-        lappendsec(sl, sec);
-        section_ref(sec);
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        if (!sec->parentsec) {
+            lappendsec(sl, sec);
+            section_ref(sec);
+        }
     }
-}
 
-return 1.;
+    return 1.;
 }
 
 static double seclist_remove(void* v) {

--- a/src/nrnoc/section.h
+++ b/src/nrnoc/section.h
@@ -315,11 +315,6 @@ extern Section* nrn_section_alloc();
 extern void nrn_section_free(Section*);
 extern int nrn_is_valid_section_ptr(void*);
 
-/* loop over sections. Must previously declare Item* qsec. Contains the {! */
-#define ForAllSections(sec)       \
-    ITERATE(qsec, section_list) { \
-        Section* sec = hocSEC(qsec);
-
 #if METHOD3
 extern int _method3;
 #endif

--- a/src/nrnoc/solve.cpp
+++ b/src/nrnoc/solve.cpp
@@ -880,8 +880,8 @@ void section_order(void) /* create a section order consistent */
     }
 
     for (isec = 0; isec < section_count; isec++) {
-        if (isec >= order) { /* there is a loop */
-                             // ForAllSections(sec)
+        if (isec >= order) {
+            // ForAllSections(sec)
             ITERATE(qsec, section_list) {
                 Section* sec = hocSEC(qsec);
                 Section *psec, *s = sec;

--- a/src/nrnoc/solve.cpp
+++ b/src/nrnoc/solve.cpp
@@ -881,6 +881,7 @@ void section_order(void) /* create a section order consistent */
 
     for (isec = 0; isec < section_count; isec++) {
         if (isec >= order) {
+            // Sections form a loop.
             // ForAllSections(sec)
             ITERATE(qsec, section_list) {
                 Section* sec = hocSEC(qsec);

--- a/src/nrnoc/solve.cpp
+++ b/src/nrnoc/solve.cpp
@@ -103,45 +103,51 @@ double debugsolve(void) /* returns solution error */
     /* save parts of matrix that will be destroyed */
     assert(0)
         /* need to save the rootnodes too */
-        ForAllSections(sec) assert(sec->pnode && sec->nnode);
-    for (inode = sec->nnode - 1; inode >= 0; inode--) {
-        nd = sec->pnode[inode];
-        nd->savd = NODED(nd);
-        nd->savrhs = NODERHS(nd);
+        // ForAllSections(sec)
+        ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        assert(sec->pnode && sec->nnode);
+        for (inode = sec->nnode - 1; inode >= 0; inode--) {
+            nd = sec->pnode[inode];
+            nd->savd = NODED(nd);
+            nd->savrhs = NODERHS(nd);
+        }
     }
-}
 
-triang(nrn_threads);
-bksub(nrn_threads);
+    triang(nrn_threads);
+    bksub(nrn_threads);
 
-err = 0.;
-/* need to check the rootnodes too */
-ForAllSections(sec) for (inode = sec->nnode - 1; inode >= 0; inode--) {
-    ndP = sec->pnode + inode;
-    nd = sec->pnode[inode];
-    /* a single internal current equation */
-    sum = nd->savd * NODERHS(nd);
-    if (inode > 0) {
-        sum += NODEB(nd) * NODERHS(nd - 1);
-    } else {
-        pnd = sec->parentnode;
-        sum += NODEB(nd) * NODERHS(pnd);
+    err = 0.;
+    /* need to check the rootnodes too */
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        for (inode = sec->nnode - 1; inode >= 0; inode--) {
+            ndP = sec->pnode + inode;
+            nd = sec->pnode[inode];
+            /* a single internal current equation */
+            sum = nd->savd * NODERHS(nd);
+            if (inode > 0) {
+                sum += NODEB(nd) * NODERHS(nd - 1);
+            } else {
+                pnd = sec->parentnode;
+                sum += NODEB(nd) * NODERHS(pnd);
+            }
+            if (inode < sec->nnode - 1) {
+                sum += NODEA(ndP[1]) * NODERHS(ndP[1]);
+            }
+            for (ch = nd->child; ch; ch = ch->sibling) {
+                psec = ch;
+                pnd = psec->pnode[0];
+                assert(pnd && psec->nnode);
+                sum += NODEA(pnd) * NODERHS(pnd);
+            }
+            sum -= nd->savrhs;
+            err += fabs(sum);
+        }
     }
-    if (inode < sec->nnode - 1) {
-        sum += NODEA(ndP[1]) * NODERHS(ndP[1]);
-    }
-    for (ch = nd->child; ch; ch = ch->sibling) {
-        psec = ch;
-        pnd = psec->pnode[0];
-        assert(pnd && psec->nnode);
-        sum += NODEA(pnd) * NODERHS(pnd);
-    }
-    sum -= nd->savrhs;
-    err += fabs(sum);
-}
-}
 
-return err;
+    return err;
 }
 #endif /*DEBUGSOLVE*/
 
@@ -452,8 +458,11 @@ void bksub(NrnThread* _nt) {
 
 void nrn_clear_mark(void) {
     hoc_Item* qsec;
-    ForAllSections(sec) sec->volatile_mark = 0;
-}
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        sec->volatile_mark = 0;
+    }
 }
 short nrn_increment_mark(Section* sec) {
     return sec->volatile_mark++;
@@ -845,51 +854,59 @@ void section_order(void) /* create a section order consistent */
     /* count the sections */
     section_count = 0;
     /*SUPPRESS 765*/
-    ForAllSections(sec) sec->order = -1;
-    ++section_count;
-}
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        sec->order = -1;
+        ++section_count;
+    }
 
-if (secorder) {
-    free((char*) secorder);
-    secorder = (Section**) 0;
-}
-if (section_count) {
-    secorder = (Section**) emalloc(section_count * sizeof(Section*));
-}
-order = 0;
-ForAllSections(sec) /* all the roots first */
-    if (!sec->parentsec) {
-    secorder[order] = sec;
-    sec->order = order;
-    ++order;
-}
-}
-
-for (isec = 0; isec < section_count; isec++) {
-    if (isec >= order) { /* there is a loop */
-        ForAllSections(sec) Section *psec, *s = sec;
-        for (psec = sec->parentsec; psec; s = psec, psec = psec->parentsec) {
-            if (!psec || s->order >= 0) {
-                break;
-            } else if (psec == sec) {
-                fprintf(stderr, "A loop exists consisting of:\n %s", secname(sec));
-                for (s = sec->parentsec; s != sec; s = s->parentsec) {
-                    fprintf(stderr, " %s", secname(s));
-                }
-                fprintf(stderr,
-                        " %s\nUse <section> disconnect() to break the loop\n ",
-                        secname(sec));
-                hoc_execerror("A loop exists involving section", secname(sec));
-            }
+    if (secorder) {
+        free((char*) secorder);
+        secorder = (Section**) 0;
+    }
+    if (section_count) {
+        secorder = (Section**) emalloc(section_count * sizeof(Section*));
+    }
+    order = 0;
+    // ForAllSections(sec) /* all the roots first */
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        if (!sec->parentsec) {
+            secorder[order] = sec;
+            sec->order = order;
+            ++order;
         }
     }
-}
-sec = secorder[isec];
-for (ch = sec->child; ch; ch = ch->sibling) {
-    secorder[order] = ch;
-    ch->order = order;
-    ++order;
-}
-}
-assert(order == section_count);
+
+    for (isec = 0; isec < section_count; isec++) {
+        if (isec >= order) { /* there is a loop */
+                             // ForAllSections(sec)
+            ITERATE(qsec, section_list) {
+                Section* sec = hocSEC(qsec);
+                Section *psec, *s = sec;
+                for (psec = sec->parentsec; psec; s = psec, psec = psec->parentsec) {
+                    if (!psec || s->order >= 0) {
+                        break;
+                    } else if (psec == sec) {
+                        fprintf(stderr, "A loop exists consisting of:\n %s", secname(sec));
+                        for (s = sec->parentsec; s != sec; s = s->parentsec) {
+                            fprintf(stderr, " %s", secname(s));
+                        }
+                        fprintf(stderr,
+                                " %s\nUse <section> disconnect() to break the loop\n ",
+                                secname(sec));
+                        hoc_execerror("A loop exists involving section", secname(sec));
+                    }
+                }
+            }
+        }
+        sec = secorder[isec];
+        for (ch = sec->child; ch; ch = ch->sibling) {
+            secorder[order] = ch;
+            ch->order = order;
+            ++order;
+        }
+    }
+    assert(order == section_count);
 }

--- a/src/nrnoc/treeset.cpp
+++ b/src/nrnoc/treeset.cpp
@@ -867,54 +867,62 @@ void connection_coef(void) /* setup a and b */
 #endif
     ++recalc_diam_count_;
     nrn_area_ri_nocount_ = 1;
-    ForAllSections(sec) nrn_area_ri(sec);
-}
-nrn_area_ri_nocount_ = 0;
-/* assume that if only one connection at x=1, then they butte
-together, if several connections at x=1
-then last point is at x=1, has 0 area and other points are at
-centers of nnode-1 segments.
-If interior connection then child half
-section connects straight to the point*/
-/* for the near future we always have a last node at x=1 with
-no properties */
-ForAllSections(sec)
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        nrn_area_ri(sec);
+    }
+    nrn_area_ri_nocount_ = 0;
+    /* assume that if only one connection at x=1, then they butte
+    together, if several connections at x=1
+    then last point is at x=1, has 0 area and other points are at
+    centers of nnode-1 segments.
+    If interior connection then child half
+    section connects straight to the point*/
+    /* for the near future we always have a last node at x=1 with
+    no properties */
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
 #if 1 /* unnecessary because they are unused, but help when looking at fmatrix */
-    if (!sec->parentsec) {
-    if (nrn_classicalNodeA(sec->parentnode)) {
-        ClassicalNODEA(sec->parentnode) = 0.0;
-    }
-    if (nrn_classicalNodeB(sec->parentnode)) {
-        ClassicalNODEB(sec->parentnode) = 0.0;
-    }
-}
+        if (!sec->parentsec) {
+            if (nrn_classicalNodeA(sec->parentnode)) {
+                ClassicalNODEA(sec->parentnode) = 0.0;
+            }
+            if (nrn_classicalNodeB(sec->parentnode)) {
+                ClassicalNODEB(sec->parentnode) = 0.0;
+            }
+        }
 #endif
-/* convert to siemens/cm^2 for all nodes except last
-and microsiemens for last.  This means that a*V = mamps/cm2
-and a*v in last node = nanoamps. Note that last node
-has no membrane properties and no area. It may perhaps receive
-current stimulus later */
-/* first the effect of node on parent equation. Note That
-last nodes have area = 1.e2 in dimensionless units so that
-last nodes have units of microsiemens */
-nd = sec->pnode[0];
-area = NODEAREA(sec->parentnode);
-/* dparam[4] is rall_branch */
-ClassicalNODEA(nd) = -1.e2 * sec->prop->dparam[4].val * NODERINV(nd) / area;
-for (j = 1; j < sec->nnode; j++) {
-    nd = sec->pnode[j];
-    area = NODEAREA(sec->pnode[j - 1]);
-    ClassicalNODEA(nd) = -1.e2 * NODERINV(nd) / area;
-}
-}
-/* now the effect of parent on node equation. */
-ForAllSections(sec) for (j = 0; j < sec->nnode; j++) {
-    nd = sec->pnode[j];
-    ClassicalNODEB(nd) = -1.e2 * NODERINV(nd) / NODEAREA(nd);
-}
-}
+        /* convert to siemens/cm^2 for all nodes except last
+        and microsiemens for last.  This means that a*V = mamps/cm2
+        and a*v in last node = nanoamps. Note that last node
+        has no membrane properties and no area. It may perhaps receive
+        current stimulus later */
+        /* first the effect of node on parent equation. Note That
+        last nodes have area = 1.e2 in dimensionless units so that
+        last nodes have units of microsiemens */
+        nd = sec->pnode[0];
+        area = NODEAREA(sec->parentnode);
+        /* dparam[4] is rall_branch */
+        ClassicalNODEA(nd) = -1.e2 * sec->prop->dparam[4].val * NODERINV(nd) / area;
+        for (j = 1; j < sec->nnode; j++) {
+            nd = sec->pnode[j];
+            area = NODEAREA(sec->pnode[j - 1]);
+            ClassicalNODEA(nd) = -1.e2 * NODERINV(nd) / area;
+        }
+    }
+    /* now the effect of parent on node equation. */
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        for (j = 0; j < sec->nnode; j++) {
+            nd = sec->pnode[j];
+            ClassicalNODEB(nd) = -1.e2 * NODERINV(nd) / NODEAREA(nd);
+        }
+    }
 #if EXTRACELLULAR
-ext_con_coef();
+    ext_con_coef();
 #endif
 }
 
@@ -1887,20 +1895,23 @@ extern "C" void nrn_complain(double* pp) {
     hoc_Item* qsec;
     int j;
     Prop* p;
-    ForAllSections(sec) for (j = 0; j < sec->nnode; ++j) {
-        nd = sec->pnode[j];
-        for (p = nd->prop; p; p = p->next) {
-            if (p->param == pp) {
-                fprintf(stderr,
-                        "Error at section location %s(%g)\n",
-                        secname(sec),
-                        nrn_arc_position(sec, nd));
-                return;
+    // ForAllSections(sec)
+    ITERATE(qsec, section_list) {
+        Section* sec = hocSEC(qsec);
+        for (j = 0; j < sec->nnode; ++j) {
+            nd = sec->pnode[j];
+            for (p = nd->prop; p; p = p->next) {
+                if (p->param == pp) {
+                    fprintf(stderr,
+                            "Error at section location %s(%g)\n",
+                            secname(sec),
+                            nrn_arc_position(sec, nd));
+                    return;
+                }
             }
         }
     }
-}
-fprintf(stderr, "Don't know the location of params at %p\n", pp);
+    fprintf(stderr, "Don't know the location of params at %p\n", pp);
 }
 
 void nrn_matrix_node_free(void) {


### PR DESCRIPTION
Closes #1808
All
```
ForAllSections(sec)
```
replaced by the old macro expansion. All fragments now similar to
```
// ForAllSections(sec)
ITERATE(qsec, section_list) {
    Section* sec = hocSEC(qsec);
```

Replaces #1820

Ideally it would be preferable to declare section_list as std::list. However, there are a number of places where a persistent pointer to an std::list element that wraps the Section* is saved and I did not know if that was supported.

Review should be simpler now as each fragment transformation is straightforward without the need for an extra closing brace. 