### PR TITLE
Remove some K&R syntax.

### DIFF
--- a/src/oc/hoc_init.cpp
+++ b/src/oc/hoc_init.cpp
@@ -26,12 +26,15 @@ extern void hoc_winio_show(int b);
 #endif
 
 #if MAC
-static double Fabs(x) double x;
-{ return (x > 0.) ? x : -x; }
-static double Erf(x) double x;
-{ return erf(x); }
-static double Erfc(x) double x;
-{ return erfc(x); }
+static double Fabs(double x) {
+    return (x > 0.) ? x : -x;
+}
+static double Erf(double x) {
+    return erf(x);
+}
+static double Erfc(double x) {
+    return erfc(x);
+}
 #endif
 
 static struct { /* Keywords */

--- a/src/oc/ocerf.cpp
+++ b/src/oc/ocerf.cpp
@@ -49,8 +49,7 @@ static char RCSid[] = "erf.cpp,v 1.5 1997/11/24 16:21:37 hines Exp";
 #define a3 1.421413741
 #define a4 -1.453152027
 #define a5 1.061405429
-double erf(z) double z;
-{
+double erf(double z) {
     double t, value;
 
     t = 1. / (1. + 0.3275911 * fabs(z));
@@ -62,7 +61,8 @@ double erf(z) double z;
         return (-value);
 }
 
-double erfc(z) double z;
-{ return 1. - erf(z); }
+double erfc(double z) {
+    return 1. - erf(z);
+}
 #endif
 #endif

--- a/src/oc/xred.cpp
+++ b/src/oc/xred.cpp
@@ -170,8 +170,7 @@ int hoc_sred(const char* prompt, char* defalt, char* charlist) {
 }
 
 #if !defined(HAVE_STRSTR)
-char *strstr(cs, ct) char *cs, *ct;
-{
+char* strstr(char* cs, char* ct) {
     char *strchr_ptr, *cs_ptr;
     int ct_len;
 


### PR DESCRIPTION
These lines were modified when I ran `ninja clang-format` using clang-format 13.0.0.
Hopefully the non-K&R versions will give the same results with 13.0.0 and the 12.0.1 we use in the CI.