### PR TITLE
hack hocdomain.py for Sphinx 5.0.1

### DIFF
--- a/docs/domains/hocdomain.py
+++ b/docs/domains/hocdomain.py
@@ -147,7 +147,7 @@ def type_to_xref(
         reftype=reftype,
         reftarget=target,
         refspecific=refspecific,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -829,7 +829,7 @@ class HOCVariable(HOCObject):
                 "",
                 addnodes.desc_sig_punctuation("", ":"),
                 addnodes.desc_sig_space(),
-                *annotations
+                *annotations,
             )
 
         value = self.options.get("value")
@@ -1016,7 +1016,7 @@ class HOCAttribute(HOCObject):
                 "",
                 addnodes.desc_sig_punctuation("", ":"),
                 addnodes.desc_sig_space(),
-                *annotations
+                *annotations,
             )
 
         value = self.options.get("value")
@@ -1070,7 +1070,7 @@ class HOCProperty(HOCObject):
                 "",
                 addnodes.desc_sig_punctuation("", ":"),
                 addnodes.desc_sig_space(),
-                *annotations
+                *annotations,
             )
 
         return fullname, prefix

--- a/docs/domains/hocdomain.py
+++ b/docs/domains/hocdomain.py
@@ -1,13 +1,5 @@
-# generated from 'sphinx/domains/python.py' @ Sphinx 4.4.0
-"""
-    sphinx.domains.python
-    ~~~~~~~~~~~~~~~~~~~~~
-
-    The HOC domain.
-
-    :copyright: Copyright 2007-2022 by the Sphinx team, see AUTHORS.
-    :license: BSD, see LICENSE for details.
-"""
+# generated from 'sphinx/domains/python.py' @ Sphinx 5.0.1
+"""The HOC domain."""
 
 import builtins
 import inspect
@@ -16,18 +8,7 @@ import sys
 import typing
 import warnings
 from inspect import Parameter
-from typing import (
-    Any,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    NamedTuple,
-    Optional,
-    Tuple,
-    Type,
-    cast,
-)
+from typing import Any, Dict, Iterable, Iterator, List, NamedTuple, Optional, Tuple, Type, cast
 
 from docutils import nodes
 from docutils.nodes import Element, Node
@@ -38,7 +19,7 @@ from sphinx import addnodes
 from sphinx.addnodes import desc_signature, pending_xref, pending_xref_condition
 from sphinx.application import Sphinx
 from sphinx.builders import Builder
-from sphinx.deprecation import RemovedInSphinx50Warning, RemovedInSphinx60Warning
+from sphinx.deprecation import RemovedInSphinx60Warning
 from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain, Index, IndexEntry, ObjType
 from sphinx.environment import BuildEnvironment
@@ -58,24 +39,22 @@ logger = logging.getLogger(__name__)
 
 # REs for HOC signatures
 hoc_sig_re = re.compile(
-    r"""^ ([\w.]*\.)?            # class name(s)
+    r'''^ ([\w.]*\.)?            # class name(s)
           (\w+)  \s*             # thing name
           (?: \(\s*(.*)\s*\)     # optional: arguments
            (?:\s* -> \s* (.*))?  #           return annotation
           )? $                   # and nothing more
-          """,
-    re.VERBOSE,
-)
+          ''', re.VERBOSE)
 
 
 pairindextypes = {
-    "module": _("module"),
-    "keyword": _("keyword"),
-    "operator": _("operator"),
-    "object": _("object"),
-    "exception": _("exception"),
-    "statement": _("statement"),
-    "builtin": _("HOC built-in function"),
+    'module':    _('module'),
+    'keyword':   _('keyword'),
+    'operator':  _('operator'),
+    'object':    _('object'),
+    'exception': _('exception'),
+    'statement': _('statement'),
+    'builtin':   _('HOC built-in function'),
 }
 
 
@@ -94,43 +73,39 @@ class ModuleEntry(NamedTuple):
     deprecated: bool
 
 
-def parse_reftarget(
-    reftarget: str, suppress_prefix: bool = False
-) -> Tuple[str, str, str, bool]:
+def parse_reftarget(reftarget: str, suppress_prefix: bool = False
+                    ) -> Tuple[str, str, str, bool]:
     """Parse a type string and return (reftype, reftarget, title, refspecific flag)"""
     refspecific = False
-    if reftarget.startswith("."):
+    if reftarget.startswith('.'):
         reftarget = reftarget[1:]
         title = reftarget
         refspecific = True
-    elif reftarget.startswith("~"):
+    elif reftarget.startswith('~'):
         reftarget = reftarget[1:]
-        title = reftarget.split(".")[-1]
+        title = reftarget.split('.')[-1]
     elif suppress_prefix:
-        title = reftarget.split(".")[-1]
-    elif reftarget.startswith("typing."):
+        title = reftarget.split('.')[-1]
+    elif reftarget.startswith('typing.'):
         title = reftarget[7:]
     else:
         title = reftarget
 
-    if reftarget == "None" or reftarget.startswith("typing."):
+    if reftarget == 'None' or reftarget.startswith('typing.'):
         # typing module provides non-class types.  Obj reference is good to refer them.
-        reftype = "obj"
+        reftype = 'obj'
     else:
-        reftype = "class"
+        reftype = 'class'
 
     return reftype, reftarget, title, refspecific
 
 
-def type_to_xref(
-    target: str, env: BuildEnvironment = None, suppress_prefix: bool = False
-) -> addnodes.pending_xref:
+def type_to_xref(target: str, env: BuildEnvironment = None, suppress_prefix: bool = False
+                 ) -> addnodes.pending_xref:
     """Convert a type string to a cross reference node."""
     if env:
-        kwargs = {
-            "hoc:module": env.ref_context.get("hoc:module"),
-            "hoc:class": env.ref_context.get("hoc:class"),
-        }
+        kwargs = {'hoc:module': env.ref_context.get('hoc:module'),
+                  'hoc:class': env.ref_context.get('hoc:class')}
     else:
         kwargs = {}
 
@@ -140,28 +115,19 @@ def type_to_xref(
         # Note: It would be better to use qualname to describe the object to support support
         # nested classes.  But python domain can't access the real python object because this
         # module should work not-dynamically.
-        shortname = title.split(".")[-1]
-        contnodes: List[Node] = [
-            pending_xref_condition("", shortname, condition="resolved"),
-            pending_xref_condition("", title, condition="*"),
-        ]
+        shortname = title.split('.')[-1]
+        contnodes: List[Node] = [pending_xref_condition('', shortname, condition='resolved'),
+                                 pending_xref_condition('', title, condition='*')]
     else:
         contnodes = [nodes.Text(title)]
 
-    return pending_xref(
-        "",
-        *contnodes,
-        refdomain="hoc",
-        reftype=reftype,
-        reftarget=target,
-        refspecific=refspecific,
-        **kwargs,
-    )
+    return pending_xref('', *contnodes,
+                        refdomain='hoc', reftype=reftype, reftarget=target,
+                        refspecific=refspecific, **kwargs)
 
 
-def _parse_annotation(annotation: str, env: BuildEnvironment = None) -> List[Node]:
+def _parse_annotation(annotation: str, env: BuildEnvironment) -> List[Node]:
     """Parse type annotation."""
-
     def unparse(node: ast.AST) -> List[Node]:
         if isinstance(node, ast.Attribute):
             return [nodes.Text("%s.%s" % (unparse(node.value)[0], node.attr))]
@@ -171,20 +137,18 @@ def _parse_annotation(annotation: str, env: BuildEnvironment = None) -> List[Nod
             result.extend(unparse(node.right))
             return result
         elif isinstance(node, ast.BitOr):
-            return [
-                addnodes.desc_sig_space(),
-                addnodes.desc_sig_punctuation("", "|"),
-                addnodes.desc_sig_space(),
-            ]
+            return [addnodes.desc_sig_space(),
+                    addnodes.desc_sig_punctuation('', '|'),
+                    addnodes.desc_sig_space()]
         elif isinstance(node, ast.Constant):  # type: ignore
             if node.value is Ellipsis:
-                return [addnodes.desc_sig_punctuation("", "...")]
+                return [addnodes.desc_sig_punctuation('', "...")]
             elif isinstance(node.value, bool):
-                return [addnodes.desc_sig_keyword("", repr(node.value))]
+                return [addnodes.desc_sig_keyword('', repr(node.value))]
             elif isinstance(node.value, int):
-                return [addnodes.desc_sig_literal_number("", repr(node.value))]
+                return [addnodes.desc_sig_literal_number('', repr(node.value))]
             elif isinstance(node.value, str):
-                return [addnodes.desc_sig_literal_string("", repr(node.value))]
+                return [addnodes.desc_sig_literal_string('', repr(node.value))]
             else:
                 # handles None, which is further handled by type_to_xref later
                 # and fallback for other types that should be converted
@@ -194,20 +158,20 @@ def _parse_annotation(annotation: str, env: BuildEnvironment = None) -> List[Nod
         elif isinstance(node, ast.Index):
             return unparse(node.value)
         elif isinstance(node, ast.Invert):
-            return [addnodes.desc_sig_punctuation("", "~")]
+            return [addnodes.desc_sig_punctuation('', '~')]
         elif isinstance(node, ast.List):
-            result = [addnodes.desc_sig_punctuation("", "[")]
+            result = [addnodes.desc_sig_punctuation('', '[')]
             if node.elts:
                 # check if there are elements in node.elts to only pop the
                 # last element of result if the for-loop was run at least
                 # once
                 for elem in node.elts:
                     result.extend(unparse(elem))
-                    result.append(addnodes.desc_sig_punctuation("", ","))
+                    result.append(addnodes.desc_sig_punctuation('', ','))
                     result.append(addnodes.desc_sig_space())
                 result.pop()
                 result.pop()
-            result.append(addnodes.desc_sig_punctuation("", "]"))
+            result.append(addnodes.desc_sig_punctuation('', ']'))
             return result
         elif isinstance(node, ast.Module):
             return sum((unparse(e) for e in node.body), [])
@@ -215,15 +179,15 @@ def _parse_annotation(annotation: str, env: BuildEnvironment = None) -> List[Nod
             return [nodes.Text(node.id)]
         elif isinstance(node, ast.Subscript):
             result = unparse(node.value)
-            result.append(addnodes.desc_sig_punctuation("", "["))
+            result.append(addnodes.desc_sig_punctuation('', '['))
             result.extend(unparse(node.slice))
-            result.append(addnodes.desc_sig_punctuation("", "]"))
+            result.append(addnodes.desc_sig_punctuation('', ']'))
 
             # Wrap the Text nodes inside brackets by literal node if the subscript is a Literal
-            if result[0] in ("Literal", "typing.Literal"):
+            if result[0] in ('Literal', 'typing.Literal'):
                 for i, subnode in enumerate(result[1:], start=1):
                     if isinstance(subnode, nodes.Text):
-                        result[i] = nodes.literal("", "", subnode)
+                        result[i] = nodes.literal('', '', subnode)
             return result
         elif isinstance(node, ast.UnaryOp):
             return unparse(node.op) + unparse(node.operand)
@@ -232,38 +196,29 @@ def _parse_annotation(annotation: str, env: BuildEnvironment = None) -> List[Nod
                 result = []
                 for elem in node.elts:
                     result.extend(unparse(elem))
-                    result.append(addnodes.desc_sig_punctuation("", ","))
+                    result.append(addnodes.desc_sig_punctuation('', ','))
                     result.append(addnodes.desc_sig_space())
                 result.pop()
                 result.pop()
             else:
-                result = [
-                    addnodes.desc_sig_punctuation("", "("),
-                    addnodes.desc_sig_punctuation("", ")"),
-                ]
+                result = [addnodes.desc_sig_punctuation('', '('),
+                          addnodes.desc_sig_punctuation('', ')')]
 
             return result
         else:
             if sys.version_info < (3, 8):
                 if isinstance(node, ast.Bytes):
-                    return [addnodes.desc_sig_literal_string("", repr(node.s))]
+                    return [addnodes.desc_sig_literal_string('', repr(node.s))]
                 elif isinstance(node, ast.Ellipsis):
-                    return [addnodes.desc_sig_punctuation("", "...")]
+                    return [addnodes.desc_sig_punctuation('', "...")]
                 elif isinstance(node, ast.NameConstant):
                     return [nodes.Text(node.value)]
                 elif isinstance(node, ast.Num):
-                    return [addnodes.desc_sig_literal_string("", repr(node.n))]
+                    return [addnodes.desc_sig_literal_string('', repr(node.n))]
                 elif isinstance(node, ast.Str):
-                    return [addnodes.desc_sig_literal_string("", repr(node.s))]
+                    return [addnodes.desc_sig_literal_string('', repr(node.s))]
 
             raise SyntaxError  # unsupported syntax
-
-    if env is None:
-        warnings.warn(
-            "The env parameter for _parse_annotation becomes required now.",
-            RemovedInSphinx50Warning,
-            stacklevel=2,
-        )
 
     try:
         tree = ast_parse(annotation)
@@ -272,11 +227,8 @@ def _parse_annotation(annotation: str, env: BuildEnvironment = None) -> List[Nod
             if isinstance(node, nodes.literal):
                 result.append(node[0])
             elif isinstance(node, nodes.Text) and node.strip():
-                if (
-                    result
-                    and isinstance(result[-1], addnodes.desc_sig_punctuation)
-                    and result[-1].astext() == "~"
-                ):
+                if (result and isinstance(result[-1], addnodes.desc_sig_punctuation) and
+                        result[-1].astext() == '~'):
                     result.pop()
                     result.append(type_to_xref(str(node), env, suppress_prefix=True))
                 else:
@@ -288,67 +240,58 @@ def _parse_annotation(annotation: str, env: BuildEnvironment = None) -> List[Nod
         return [type_to_xref(annotation, env)]
 
 
-def _parse_arglist(
-    arglist: str, env: BuildEnvironment = None
-) -> addnodes.desc_parameterlist:
+def _parse_arglist(arglist: str, env: BuildEnvironment = None) -> addnodes.desc_parameterlist:
     """Parse a list of arguments using AST parser"""
     params = addnodes.desc_parameterlist(arglist)
-    sig = signature_from_str("(%s)" % arglist)
+    sig = signature_from_str('(%s)' % arglist)
     last_kind = None
     for param in sig.parameters.values():
         if param.kind != param.POSITIONAL_ONLY and last_kind == param.POSITIONAL_ONLY:
             # PEP-570: Separator for Positional Only Parameter: /
-            params += addnodes.desc_parameter(
-                "", "", addnodes.desc_sig_operator("", "/")
-            )
-        if param.kind == param.KEYWORD_ONLY and last_kind in (
-            param.POSITIONAL_OR_KEYWORD,
-            param.POSITIONAL_ONLY,
-            None,
-        ):
+            params += addnodes.desc_parameter('', '', addnodes.desc_sig_operator('', '/'))
+        if param.kind == param.KEYWORD_ONLY and last_kind in (param.POSITIONAL_OR_KEYWORD,
+                                                              param.POSITIONAL_ONLY,
+                                                              None):
             # PEP-3102: Separator for Keyword Only Parameter: *
-            params += addnodes.desc_parameter(
-                "", "", addnodes.desc_sig_operator("", "*")
-            )
+            params += addnodes.desc_parameter('', '', addnodes.desc_sig_operator('', '*'))
 
         node = addnodes.desc_parameter()
         if param.kind == param.VAR_POSITIONAL:
-            node += addnodes.desc_sig_operator("", "*")
-            node += addnodes.desc_sig_name("", param.name)
+            node += addnodes.desc_sig_operator('', '*')
+            node += addnodes.desc_sig_name('', param.name)
         elif param.kind == param.VAR_KEYWORD:
-            node += addnodes.desc_sig_operator("", "**")
-            node += addnodes.desc_sig_name("", param.name)
+            node += addnodes.desc_sig_operator('', '**')
+            node += addnodes.desc_sig_name('', param.name)
         else:
-            node += addnodes.desc_sig_name("", param.name)
+            node += addnodes.desc_sig_name('', param.name)
 
         if param.annotation is not param.empty:
             children = _parse_annotation(param.annotation, env)
-            node += addnodes.desc_sig_punctuation("", ":")
+            node += addnodes.desc_sig_punctuation('', ':')
             node += addnodes.desc_sig_space()
-            node += addnodes.desc_sig_name("", "", *children)  # type: ignore
+            node += addnodes.desc_sig_name('', '', *children)  # type: ignore
         if param.default is not param.empty:
             if param.annotation is not param.empty:
                 node += addnodes.desc_sig_space()
-                node += addnodes.desc_sig_operator("", "=")
+                node += addnodes.desc_sig_operator('', '=')
                 node += addnodes.desc_sig_space()
             else:
-                node += addnodes.desc_sig_operator("", "=")
-            node += nodes.inline(
-                "", param.default, classes=["default_value"], support_smartquotes=False
-            )
+                node += addnodes.desc_sig_operator('', '=')
+            node += nodes.inline('', param.default, classes=['default_value'],
+                                 support_smartquotes=False)
 
         params += node
         last_kind = param.kind
 
     if last_kind == Parameter.POSITIONAL_ONLY:
         # PEP-570: Separator for Positional Only Parameter: /
-        params += addnodes.desc_parameter("", "", addnodes.desc_sig_operator("", "/"))
+        params += addnodes.desc_parameter('', '', addnodes.desc_sig_operator('', '/'))
 
     return params
 
 
 def _pseudo_parse_arglist(signode: desc_signature, arglist: str) -> None:
-    """ "Parse" a list of arguments separated by commas.
+    """"Parse" a list of arguments separated by commas.
 
     Arguments can have "optional" annotations given by enclosing them in
     brackets.  Currently, this will split at any comma, even if it's inside a
@@ -357,26 +300,25 @@ def _pseudo_parse_arglist(signode: desc_signature, arglist: str) -> None:
     paramlist = addnodes.desc_parameterlist()
     stack: List[Element] = [paramlist]
     try:
-        for argument in arglist.split(","):
+        for argument in arglist.split(','):
             argument = argument.strip()
             ends_open = ends_close = 0
-            while argument.startswith("["):
+            while argument.startswith('['):
                 stack.append(addnodes.desc_optional())
                 stack[-2] += stack[-1]
                 argument = argument[1:].strip()
-            while argument.startswith("]"):
+            while argument.startswith(']'):
                 stack.pop()
                 argument = argument[1:].strip()
-            while argument.endswith("]") and not argument.endswith("[]"):
+            while argument.endswith(']') and not argument.endswith('[]'):
                 ends_close += 1
                 argument = argument[:-1].strip()
-            while argument.endswith("["):
+            while argument.endswith('['):
                 ends_open += 1
                 argument = argument[:-1].strip()
             if argument:
                 stack[-1] += addnodes.desc_parameter(
-                    "", "", addnodes.desc_sig_name(argument, argument)
-                )
+                    '', '', addnodes.desc_sig_name(argument, argument))
             while ends_open:
                 stack.append(addnodes.desc_optional())
                 stack[-2] += stack[-1]
@@ -400,38 +342,24 @@ def _pseudo_parse_arglist(signode: desc_signature, arglist: str) -> None:
 # This override allows our inline type specifiers to behave like :class: link
 # when it comes to handling "." and "~" prefixes.
 class HOCXrefMixin:
-    def make_xref(
-        self,
-        rolename: str,
-        domain: str,
-        target: str,
-        innernode: Type[TextlikeNode] = nodes.emphasis,
-        contnode: Node = None,
-        env: BuildEnvironment = None,
-        inliner: Inliner = None,
-        location: Node = None,
-    ) -> Node:
+    def make_xref(self, rolename: str, domain: str, target: str,
+                  innernode: Type[TextlikeNode] = nodes.emphasis,
+                  contnode: Node = None, env: BuildEnvironment = None,
+                  inliner: Inliner = None, location: Node = None) -> Node:
         # we use inliner=None to make sure we get the old behaviour with a single
         # pending_xref node
-        result = super().make_xref(
-            rolename,
-            domain,
-            target,  # type: ignore
-            innernode,
-            contnode,
-            env,
-            inliner=None,
-            location=None,
-        )
+        result = super().make_xref(rolename, domain, target,  # type: ignore
+                                   innernode, contnode,
+                                   env, inliner=None, location=None)
         if isinstance(result, pending_xref):
-            result["refspecific"] = True
-            result["hoc:module"] = env.ref_context.get("hoc:module")
-            result["hoc:class"] = env.ref_context.get("hoc:class")
+            result['refspecific'] = True
+            result['hoc:module'] = env.ref_context.get('hoc:module')
+            result['hoc:class'] = env.ref_context.get('hoc:class')
 
             reftype, reftarget, reftitle, _ = parse_reftarget(target)
             if reftarget != reftitle:
-                result["reftype"] = reftype
-                result["reftarget"] = reftarget
+                result['reftype'] = reftype
+                result['reftarget'] = reftarget
 
                 result.clear()
                 result += innernode(reftitle, reftitle)
@@ -439,28 +367,19 @@ class HOCXrefMixin:
                 children = result.children
                 result.clear()
 
-                shortname = target.split(".")[-1]
-                textnode = innernode("", shortname)
-                contnodes = [
-                    pending_xref_condition("", "", textnode, condition="resolved"),
-                    pending_xref_condition("", "", *children, condition="*"),
-                ]
+                shortname = target.split('.')[-1]
+                textnode = innernode('', shortname)
+                contnodes = [pending_xref_condition('', '', textnode, condition='resolved'),
+                             pending_xref_condition('', '', *children, condition='*')]
                 result.extend(contnodes)
 
         return result
 
-    def make_xrefs(
-        self,
-        rolename: str,
-        domain: str,
-        target: str,
-        innernode: Type[TextlikeNode] = nodes.emphasis,
-        contnode: Node = None,
-        env: BuildEnvironment = None,
-        inliner: Inliner = None,
-        location: Node = None,
-    ) -> List[Node]:
-        delims = r"(\s*[\[\]\(\),](?:\s*or\s)?\s*|\s+or\s+|\s*\|\s*|\.\.\.)"
+    def make_xrefs(self, rolename: str, domain: str, target: str,
+                   innernode: Type[TextlikeNode] = nodes.emphasis,
+                   contnode: Node = None, env: BuildEnvironment = None,
+                   inliner: Inliner = None, location: Node = None) -> List[Node]:
+        delims = r'(\s*[\[\]\(\),](?:\s*or\s)?\s*|\s+or\s+|\s*\|\s*|\.\.\.)'
         delims_re = re.compile(delims)
         sub_targets = re.split(delims, target)
 
@@ -475,20 +394,10 @@ class HOCXrefMixin:
             if in_literal or delims_re.match(sub_target):
                 results.append(contnode or innernode(sub_target, sub_target))
             else:
-                results.append(
-                    self.make_xref(
-                        rolename,
-                        domain,
-                        sub_target,
-                        innernode,
-                        contnode,
-                        env,
-                        inliner,
-                        location,
-                    )
-                )
+                results.append(self.make_xref(rolename, domain, sub_target,
+                                              innernode, contnode, env, inliner, location))
 
-            if sub_target in ("Literal", "typing.Literal"):
+            if sub_target in ('Literal', 'typing.Literal'):
                 in_literal = True
 
         return results
@@ -513,60 +422,31 @@ class HOCObject(ObjectDescription[Tuple[str, str]]):
     :cvar allow_nesting: Class is an object that allows for nested namespaces
     :vartype allow_nesting: bool
     """
-
     option_spec: OptionSpec = {
-        "noindex": directives.flag,
-        "noindexentry": directives.flag,
-        "module": directives.unchanged,
-        "canonical": directives.unchanged,
-        "annotation": directives.unchanged,
+        'noindex': directives.flag,
+        'noindexentry': directives.flag,
+        'module': directives.unchanged,
+        'canonical': directives.unchanged,
+        'annotation': directives.unchanged,
     }
 
     doc_field_types = [
-        HOCTypedField(
-            "parameter",
-            label=_("Parameters"),
-            names=(
-                "param",
-                "parameter",
-                "arg",
-                "argument",
-                "keyword",
-                "kwarg",
-                "kwparam",
-            ),
-            typerolename="class",
-            typenames=("paramtype", "type"),
-            can_collapse=True,
-        ),
-        HOCTypedField(
-            "variable",
-            label=_("Variables"),
-            names=("var", "ivar", "cvar"),
-            typerolename="class",
-            typenames=("vartype",),
-            can_collapse=True,
-        ),
-        HOCGroupedField(
-            "exceptions",
-            label=_("Raises"),
-            rolename="exc",
-            names=("raises", "raise", "exception", "except"),
-            can_collapse=True,
-        ),
-        Field(
-            "returnvalue",
-            label=_("Returns"),
-            has_arg=False,
-            names=("returns", "return"),
-        ),
-        HOCField(
-            "returntype",
-            label=_("Return type"),
-            has_arg=False,
-            names=("rtype",),
-            bodyrolename="class",
-        ),
+        HOCTypedField('parameter', label=_('Parameters'),
+                     names=('param', 'parameter', 'arg', 'argument',
+                            'keyword', 'kwarg', 'kwparam'),
+                     typerolename='class', typenames=('paramtype', 'type'),
+                     can_collapse=True),
+        HOCTypedField('variable', label=_('Variables'),
+                     names=('var', 'ivar', 'cvar'),
+                     typerolename='class', typenames=('vartype',),
+                     can_collapse=True),
+        HOCGroupedField('exceptions', label=_('Raises'), rolename='exc',
+                       names=('raises', 'raise', 'exception', 'except'),
+                       can_collapse=True),
+        Field('returnvalue', label=_('Returns'), has_arg=False,
+              names=('returns', 'return')),
+        HOCField('returntype', label=_('Return type'), has_arg=False,
+                names=('rtype',), bodyrolename='class'),
     ]
 
     allow_nesting = False
@@ -598,33 +478,34 @@ class HOCObject(ObjectDescription[Tuple[str, str]]):
         prefix, name, arglist, retann = m.groups()
 
         # determine module and class name (if applicable), as well as full name
-        modname = self.options.get("module", self.env.ref_context.get("hoc:module"))
-        classname = self.env.ref_context.get("hoc:class")
+        modname = self.options.get('module', self.env.ref_context.get('hoc:module'))
+        classname = self.env.ref_context.get('hoc:class')
         if classname:
             add_module = False
-            if prefix and (prefix == classname or prefix.startswith(classname + ".")):
+            if prefix and (prefix == classname or
+                           prefix.startswith(classname + ".")):
                 fullname = prefix + name
                 # class name is given again in the signature
-                prefix = prefix[len(classname) :].lstrip(".")
+                prefix = prefix[len(classname):].lstrip('.')
             elif prefix:
                 # class name is given in the signature, but different
                 # (shouldn't happen)
-                fullname = classname + "." + prefix + name
+                fullname = classname + '.' + prefix + name
             else:
                 # class name is not given in the signature
-                fullname = classname + "." + name
+                fullname = classname + '.' + name
         else:
             add_module = True
             if prefix:
-                classname = prefix.rstrip(".")
+                classname = prefix.rstrip('.')
                 fullname = prefix + name
             else:
-                classname = ""
+                classname = ''
                 fullname = name
 
-        signode["module"] = modname
-        signode["class"] = classname
-        signode["fullname"] = fullname
+        signode['module'] = modname
+        signode['class'] = classname
+        signode['fullname'] = fullname
 
         sig_prefix = self.get_signature_prefix(sig)
         if sig_prefix:
@@ -634,18 +515,16 @@ class HOCObject(ObjectDescription[Tuple[str, str]]):
                     " returning a string is deprecated."
                     " It must now return a list of nodes."
                     " Return value was '{}'.".format(sig_prefix),
-                    RemovedInSphinx60Warning,
-                )
-                signode += addnodes.desc_annotation(
-                    sig_prefix, "", nodes.Text(sig_prefix)  # type: ignore
-                )  # type: ignore
+                    RemovedInSphinx60Warning)
+                signode += addnodes.desc_annotation(sig_prefix, '',  # type: ignore
+                                                    nodes.Text(sig_prefix))  # type: ignore
             else:
-                signode += addnodes.desc_annotation(str(sig_prefix), "", *sig_prefix)
+                signode += addnodes.desc_annotation(str(sig_prefix), '', *sig_prefix)
 
         if prefix:
             signode += addnodes.desc_addname(prefix, prefix)
         elif modname and add_module and self.env.config.add_module_names:
-            nodetext = modname + "."
+            nodetext = modname + '.'
             signode += addnodes.desc_addname(nodetext, nodetext)
 
         signode += addnodes.desc_name(name, name)
@@ -657,9 +536,8 @@ class HOCObject(ObjectDescription[Tuple[str, str]]):
                 # it supports to represent optional arguments (ex. "func(foo [, bar])")
                 _pseudo_parse_arglist(signode, arglist)
             except NotImplementedError as exc:
-                logger.warning(
-                    "could not parse arglist (%r): %s", arglist, exc, location=signode
-                )
+                logger.warning("could not parse arglist (%r): %s", arglist, exc,
+                               location=signode)
                 _pseudo_parse_arglist(signode, arglist)
         else:
             if self.needs_arglist():
@@ -668,50 +546,40 @@ class HOCObject(ObjectDescription[Tuple[str, str]]):
 
         if retann:
             children = _parse_annotation(retann, self.env)
-            signode += addnodes.desc_returns(retann, "", *children)
+            signode += addnodes.desc_returns(retann, '', *children)
 
-        anno = self.options.get("annotation")
+        anno = self.options.get('annotation')
         if anno:
-            signode += addnodes.desc_annotation(
-                " " + anno, "", addnodes.desc_sig_space(), nodes.Text(anno)
-            )
+            signode += addnodes.desc_annotation(' ' + anno, '',
+                                                addnodes.desc_sig_space(),
+                                                nodes.Text(anno))
 
         return fullname, prefix
 
     def get_index_text(self, modname: str, name: Tuple[str, str]) -> str:
         """Return the text for the index entry of the object."""
-        raise NotImplementedError("must be implemented in subclasses")
+        raise NotImplementedError('must be implemented in subclasses')
 
-    def add_target_and_index(
-        self, name_cls: Tuple[str, str], sig: str, signode: desc_signature
-    ) -> None:
-        modname = self.options.get("module", self.env.ref_context.get("hoc:module"))
-        fullname = (modname + "." if modname else "") + name_cls[0]
-        node_id = make_id(self.env, self.state.document, "", fullname)
-        signode["ids"].append(node_id)
-
-        # Assign old styled node_id(fullname) not to break old hyperlinks (if possible)
-        # Note: Will removed in Sphinx-5.0  (RemovedInSphinx50Warning)
-        if node_id != fullname and fullname not in self.state.document.ids:
-            signode["ids"].append(fullname)
-
+    def add_target_and_index(self, name_cls: Tuple[str, str], sig: str,
+                             signode: desc_signature) -> None:
+        modname = self.options.get('module', self.env.ref_context.get('hoc:module'))
+        fullname = (modname + '.' if modname else '') + name_cls[0]
+        node_id = make_id(self.env, self.state.document, '', fullname)
+        signode['ids'].append(node_id)
         self.state.document.note_explicit_target(signode)
 
-        domain = cast(HOCDomain, self.env.get_domain("hoc"))
+        domain = cast(HOCDomain, self.env.get_domain('hoc'))
         domain.note_object(fullname, self.objtype, node_id, location=signode)
 
-        canonical_name = self.options.get("canonical")
+        canonical_name = self.options.get('canonical')
         if canonical_name:
-            domain.note_object(
-                canonical_name, self.objtype, node_id, aliased=True, location=signode
-            )
+            domain.note_object(canonical_name, self.objtype, node_id, aliased=True,
+                               location=signode)
 
-        if "noindexentry" not in self.options:
+        if 'noindexentry' not in self.options:
             indextext = self.get_index_text(modname, name_cls)
             if indextext:
-                self.indexnode["entries"].append(
-                    ("single", indextext, node_id, "", None)
-                )
+                self.indexnode['entries'].append(('single', indextext, node_id, '', None))
 
     def before_content(self) -> None:
         """Handle object nesting before content
@@ -735,16 +603,16 @@ class HOCObject(ObjectDescription[Tuple[str, str]]):
             if self.allow_nesting:
                 prefix = fullname
             elif name_prefix:
-                prefix = name_prefix.strip(".")
+                prefix = name_prefix.strip('.')
         if prefix:
-            self.env.ref_context["hoc:class"] = prefix
+            self.env.ref_context['hoc:class'] = prefix
             if self.allow_nesting:
-                classes = self.env.ref_context.setdefault("hoc:classes", [])
+                classes = self.env.ref_context.setdefault('hoc:classes', [])
                 classes.append(prefix)
-        if "module" in self.options:
-            modules = self.env.ref_context.setdefault("hoc:modules", [])
-            modules.append(self.env.ref_context.get("hoc:module"))
-            self.env.ref_context["hoc:module"] = self.options["module"]
+        if 'module' in self.options:
+            modules = self.env.ref_context.setdefault('hoc:modules', [])
+            modules.append(self.env.ref_context.get('hoc:module'))
+            self.env.ref_context['hoc:module'] = self.options['module']
 
     def after_content(self) -> None:
         """Handle object de-nesting after content
@@ -756,55 +624,54 @@ class HOCObject(ObjectDescription[Tuple[str, str]]):
         be altered as we didn't affect the nesting levels in
         :py:meth:`before_content`.
         """
-        classes = self.env.ref_context.setdefault("hoc:classes", [])
+        classes = self.env.ref_context.setdefault('hoc:classes', [])
         if self.allow_nesting:
             try:
                 classes.pop()
             except IndexError:
                 pass
-        self.env.ref_context["hoc:class"] = classes[-1] if len(classes) > 0 else None
-        if "module" in self.options:
-            modules = self.env.ref_context.setdefault("hoc:modules", [])
+        self.env.ref_context['hoc:class'] = (classes[-1] if len(classes) > 0
+                                            else None)
+        if 'module' in self.options:
+            modules = self.env.ref_context.setdefault('hoc:modules', [])
             if modules:
-                self.env.ref_context["hoc:module"] = modules.pop()
+                self.env.ref_context['hoc:module'] = modules.pop()
             else:
-                self.env.ref_context.pop("hoc:module")
+                self.env.ref_context.pop('hoc:module')
 
 
 class HOCFunction(HOCObject):
     """Description of a function."""
 
     option_spec: OptionSpec = HOCObject.option_spec.copy()
-    option_spec.update(
-        {
-            "async": directives.flag,
-        }
-    )
+    option_spec.update({
+        'async': directives.flag,
+    })
 
     def get_signature_prefix(self, sig: str) -> List[nodes.Node]:
-        if "async" in self.options:
-            return [addnodes.desc_sig_keyword("", "async"), addnodes.desc_sig_space()]
+        if 'async' in self.options:
+            return [addnodes.desc_sig_keyword('', 'async'),
+                    addnodes.desc_sig_space()]
         else:
             return []
 
     def needs_arglist(self) -> bool:
         return True
 
-    def add_target_and_index(
-        self, name_cls: Tuple[str, str], sig: str, signode: desc_signature
-    ) -> None:
+    def add_target_and_index(self, name_cls: Tuple[str, str], sig: str,
+                             signode: desc_signature) -> None:
         super().add_target_and_index(name_cls, sig, signode)
-        if "noindexentry" not in self.options:
-            modname = self.options.get("module", self.env.ref_context.get("hoc:module"))
-            node_id = signode["ids"][0]
+        if 'noindexentry' not in self.options:
+            modname = self.options.get('module', self.env.ref_context.get('hoc:module'))
+            node_id = signode['ids'][0]
 
             name, cls = name_cls
             if modname:
-                text = _("%s() (in module %s)") % (name, modname)
-                self.indexnode["entries"].append(("single", text, node_id, "", None))
+                text = _('%s() (in module %s)') % (name, modname)
+                self.indexnode['entries'].append(('single', text, node_id, '', None))
             else:
-                text = "%s; %s()" % (pairindextypes["builtin"], name)
-                self.indexnode["entries"].append(("pair", text, node_id, "", None))
+                text = '%s; %s()' % (pairindextypes['builtin'], name)
+                self.indexnode['entries'].append(('pair', text, node_id, '', None))
 
     def get_index_text(self, modname: str, name_cls: Tuple[str, str]) -> str:
         # add index in own add_target_and_index() instead.
@@ -816,12 +683,12 @@ class HOCDecoratorFunction(HOCFunction):
 
     def run(self) -> List[Node]:
         # a decorator function is a function after all
-        self.name = "hoc:function"
+        self.name = 'hoc:function'
         return super().run()
 
     def handle_signature(self, sig: str, signode: desc_signature) -> Tuple[str, str]:
         ret = super().handle_signature(sig, signode)
-        signode.insert(0, addnodes.desc_addname("@", "@"))
+        signode.insert(0, addnodes.desc_addname('@', '@'))
         return ret
 
     def needs_arglist(self) -> bool:
@@ -832,46 +699,37 @@ class HOCVariable(HOCObject):
     """Description of a variable."""
 
     option_spec: OptionSpec = HOCObject.option_spec.copy()
-    option_spec.update(
-        {
-            "type": directives.unchanged,
-            "value": directives.unchanged,
-        }
-    )
+    option_spec.update({
+        'type': directives.unchanged,
+        'value': directives.unchanged,
+    })
 
     def handle_signature(self, sig: str, signode: desc_signature) -> Tuple[str, str]:
         fullname, prefix = super().handle_signature(sig, signode)
 
-        typ = self.options.get("type")
+        typ = self.options.get('type')
         if typ:
             annotations = _parse_annotation(typ, self.env)
-            signode += addnodes.desc_annotation(
-                typ,
-                "",
-                addnodes.desc_sig_punctuation("", ":"),
-                addnodes.desc_sig_space(),
-                *annotations,
-            )
+            signode += addnodes.desc_annotation(typ, '',
+                                                addnodes.desc_sig_punctuation('', ':'),
+                                                addnodes.desc_sig_space(), *annotations)
 
-        value = self.options.get("value")
+        value = self.options.get('value')
         if value:
-            signode += addnodes.desc_annotation(
-                value,
-                "",
-                addnodes.desc_sig_space(),
-                addnodes.desc_sig_punctuation("", "="),
-                addnodes.desc_sig_space(),
-                nodes.Text(value),
-            )
+            signode += addnodes.desc_annotation(value, '',
+                                                addnodes.desc_sig_space(),
+                                                addnodes.desc_sig_punctuation('', '='),
+                                                addnodes.desc_sig_space(),
+                                                nodes.Text(value))
 
         return fullname, prefix
 
     def get_index_text(self, modname: str, name_cls: Tuple[str, str]) -> str:
         name, cls = name_cls
         if modname:
-            return _("%s (HOC in module %s)") % (name, modname)
+            return _('%s (HOC in module %s)') % (name, modname)
         else:
-            return _("%s (HOC built-in variable)") % name
+            return _('%s (HOC built-in variable)') % name
 
 
 class HOCClasslike(HOCObject):
@@ -880,99 +738,91 @@ class HOCClasslike(HOCObject):
     """
 
     option_spec: OptionSpec = HOCObject.option_spec.copy()
-    option_spec.update(
-        {
-            "final": directives.flag,
-        }
-    )
+    option_spec.update({
+        'final': directives.flag,
+    })
 
     allow_nesting = True
 
     def get_signature_prefix(self, sig: str) -> List[nodes.Node]:
-        if "final" in self.options:
-            return [
-                nodes.Text("final"),
-                addnodes.desc_sig_space(),
-                nodes.Text(self.objtype),
-                addnodes.desc_sig_space(),
-            ]
+        if 'final' in self.options:
+            return [nodes.Text('final'), addnodes.desc_sig_space(),
+                    nodes.Text(self.objtype), addnodes.desc_sig_space()]
         else:
             return [nodes.Text(self.objtype), addnodes.desc_sig_space()]
 
     def get_index_text(self, modname: str, name_cls: Tuple[str, str]) -> str:
-        if self.objtype == "class":
+        if self.objtype == 'class':
             if not modname:
-                return _("%s (HOC built-in class)") % name_cls[0]
-            return _("%s (HOC class in %s)") % (name_cls[0], modname)
-        elif self.objtype == "exception":
+                return _('%s (HOC built-in class)') % name_cls[0]
+            return _('%s (HOC class in %s)') % (name_cls[0], modname)
+        elif self.objtype == 'exception':
             return name_cls[0]
         else:
-            return ""
+            return ''
 
 
 class HOCMethod(HOCObject):
     """Description of a method."""
 
     option_spec: OptionSpec = HOCObject.option_spec.copy()
-    option_spec.update(
-        {
-            "abstractmethod": directives.flag,
-            "async": directives.flag,
-            "classmethod": directives.flag,
-            "final": directives.flag,
-            "property": directives.flag,
-            "staticmethod": directives.flag,
-        }
-    )
+    option_spec.update({
+        'abstractmethod': directives.flag,
+        'async': directives.flag,
+        'classmethod': directives.flag,
+        'final': directives.flag,
+        'property': directives.flag,
+        'staticmethod': directives.flag,
+    })
 
     def needs_arglist(self) -> bool:
-        if "property" in self.options:
+        if 'property' in self.options:
             return False
         else:
             return True
 
     def get_signature_prefix(self, sig: str) -> List[nodes.Node]:
         prefix: List[nodes.Node] = []
-        if "final" in self.options:
-            prefix.append(nodes.Text("final"))
+        if 'final' in self.options:
+            prefix.append(nodes.Text('final'))
             prefix.append(addnodes.desc_sig_space())
-        if "abstractmethod" in self.options:
-            prefix.append(nodes.Text("abstract"))
+        if 'abstractmethod' in self.options:
+            prefix.append(nodes.Text('abstract'))
             prefix.append(addnodes.desc_sig_space())
-        if "async" in self.options:
-            prefix.append(nodes.Text("async"))
+        if 'async' in self.options:
+            prefix.append(nodes.Text('async'))
             prefix.append(addnodes.desc_sig_space())
-        if "classmethod" in self.options:
-            prefix.append(nodes.Text("classmethod"))
+        if 'classmethod' in self.options:
+            prefix.append(nodes.Text('classmethod'))
             prefix.append(addnodes.desc_sig_space())
-        if "property" in self.options:
-            prefix.append(nodes.Text("property"))
+        if 'property' in self.options:
+            prefix.append(nodes.Text('property'))
             prefix.append(addnodes.desc_sig_space())
-        if "staticmethod" in self.options:
-            prefix.append(nodes.Text("static"))
+        if 'staticmethod' in self.options:
+            prefix.append(nodes.Text('static'))
             prefix.append(addnodes.desc_sig_space())
         return prefix
 
     def get_index_text(self, modname: str, name_cls: Tuple[str, str]) -> str:
         name, cls = name_cls
         try:
-            clsname, methname = name.rsplit(".", 1)
+            clsname, methname = name.rsplit('.', 1)
             if modname and self.env.config.add_module_names:
-                clsname = ".".join([modname, clsname])
+                clsname = '.'.join([modname, clsname])
         except ValueError:
             if modname:
-                return _("%s() (in module %s)") % (name, modname)
+                return _('%s() (in module %s)') % (name, modname)
             else:
-                return "%s()" % name
+                return '%s()' % name
 
-        if "classmethod" in self.options:
-            return _("%s() (HOC %s class method)") % (methname, clsname)
-        elif "property" in self.options:
-            return _("%s (HOC %s property)") % (methname, clsname)
-        elif "staticmethod" in self.options:
-            return _("%s() (HOC %s static method)") % (methname, clsname)
+        if 'classmethod' in self.options:
+            return _('%s() (HOC %s class method)') % (methname, clsname)
+        elif 'property' in self.options:
+            return _('%s (HOC %s property)') % (methname, clsname)
+        elif 'staticmethod' in self.options:
+            return _('%s() (HOC %s static method)') % (methname, clsname)
         else:
-            return _("%s() (HOC %s method)") % (methname, clsname)
+            return _('%s() (HOC %s method)') % (methname, clsname)
 
 
 class HOCClassMethod(HOCMethod):
@@ -981,8 +831,8 @@ class HOCClassMethod(HOCMethod):
     option_spec: OptionSpec = HOCObject.option_spec.copy()
 
     def run(self) -> List[Node]:
-        self.name = "hoc:method"
-        self.options["classmethod"] = True
+        self.name = 'hoc:method'
+        self.options['classmethod'] = True
 
         return super().run()
 
@@ -993,8 +843,8 @@ class HOCStaticMethod(HOCMethod):
     option_spec: OptionSpec = HOCObject.option_spec.copy()
 
     def run(self) -> List[Node]:
-        self.name = "hoc:method"
-        self.options["staticmethod"] = True
+        self.name = 'hoc:method'
+        self.options['staticmethod'] = True
 
         return super().run()
 
@@ -1003,12 +853,12 @@ class HOCDecoratorMethod(HOCMethod):
     """Description of a decoratormethod."""
 
     def run(self) -> List[Node]:
-        self.name = "hoc:method"
+        self.name = 'hoc:method'
         return super().run()
 
     def handle_signature(self, sig: str, signode: desc_signature) -> Tuple[str, str]:
         ret = super().handle_signature(sig, signode)
-        signode.insert(0, addnodes.desc_addname("@", "@"))
+        signode.insert(0, addnodes.desc_addname('@', '@'))
         return ret
 
     def needs_arglist(self) -> bool:
@@ -1019,139 +869,96 @@ class HOCAttribute(HOCObject):
     """Description of an attribute."""
 
     option_spec: OptionSpec = HOCObject.option_spec.copy()
-    option_spec.update(
-        {
-            "type": directives.unchanged,
-            "value": directives.unchanged,
-        }
-    )
+    option_spec.update({
+        'type': directives.unchanged,
+        'value': directives.unchanged,
+    })
 
     def handle_signature(self, sig: str, signode: desc_signature) -> Tuple[str, str]:
         fullname, prefix = super().handle_signature(sig, signode)
 
-        typ = self.options.get("type")
+        typ = self.options.get('type')
         if typ:
             annotations = _parse_annotation(typ, self.env)
-            signode += addnodes.desc_annotation(
-                typ,
-                "",
-                addnodes.desc_sig_punctuation("", ":"),
-                addnodes.desc_sig_space(),
-                *annotations,
-            )
+            signode += addnodes.desc_annotation(typ, '',
+                                                addnodes.desc_sig_punctuation('', ':'),
+                                                addnodes.desc_sig_space(),
+                                                *annotations)
 
-        value = self.options.get("value")
+        value = self.options.get('value')
         if value:
-            signode += addnodes.desc_annotation(
-                value,
-                "",
-                addnodes.desc_sig_space(),
-                addnodes.desc_sig_punctuation("", "="),
-                addnodes.desc_sig_space(),
-                nodes.Text(value),
-            )
+            signode += addnodes.desc_annotation(value, '',
+                                                addnodes.desc_sig_space(),
+                                                addnodes.desc_sig_punctuation('', '='),
+                                                addnodes.desc_sig_space(),
+                                                nodes.Text(value))
 
         return fullname, prefix
 
     def get_index_text(self, modname: str, name_cls: Tuple[str, str]) -> str:
         name, cls = name_cls
         try:
-            clsname, attrname = name.rsplit(".", 1)
+            clsname, attrname = name.rsplit('.', 1)
             if modname and self.env.config.add_module_names:
-                clsname = ".".join([modname, clsname])
+                clsname = '.'.join([modname, clsname])
         except ValueError:
             if modname:
-                return _("%s (HOC in module %s)") % (name, modname)
+                return _('%s (HOC in module %s)') % (name, modname)
             else:
                 return name
 
-        return _("%s (HOC %s attribute)") % (attrname, clsname)
+        return _('%s (HOC %s attribute)') % (attrname, clsname)
 
 
 class HOCProperty(HOCObject):
     """Description of an attribute."""
 
     option_spec = HOCObject.option_spec.copy()
-    option_spec.update(
-        {
-            "abstractmethod": directives.flag,
-            "classmethod": directives.flag,
-            "type": directives.unchanged,
-        }
-    )
+    option_spec.update({
+        'abstractmethod': directives.flag,
+        'classmethod': directives.flag,
+        'type': directives.unchanged,
+    })
 
     def handle_signature(self, sig: str, signode: desc_signature) -> Tuple[str, str]:
         fullname, prefix = super().handle_signature(sig, signode)
 
-        typ = self.options.get("type")
+        typ = self.options.get('type')
         if typ:
             annotations = _parse_annotation(typ, self.env)
-            signode += addnodes.desc_annotation(
-                typ,
-                "",
-                addnodes.desc_sig_punctuation("", ":"),
-                addnodes.desc_sig_space(),
-                *annotations,
-            )
+            signode += addnodes.desc_annotation(typ, '',
+                                                addnodes.desc_sig_punctuation('', ':'),
+                                                addnodes.desc_sig_space(),
+                                                *annotations)
 
         return fullname, prefix
 
     def get_signature_prefix(self, sig: str) -> List[nodes.Node]:
         prefix: List[nodes.Node] = []
-        if "abstractmethod" in self.options:
-            prefix.append(nodes.Text("abstract"))
+        if 'abstractmethod' in self.options:
+            prefix.append(nodes.Text('abstract'))
             prefix.append(addnodes.desc_sig_space())
-        if "classmethod" in self.options:
-            prefix.append(nodes.Text("class"))
+        if 'classmethod' in self.options:
+            prefix.append(nodes.Text('class'))
             prefix.append(addnodes.desc_sig_space())
 
-        prefix.append(nodes.Text("property"))
+        prefix.append(nodes.Text('property'))
         prefix.append(addnodes.desc_sig_space())
         return prefix
 
     def get_index_text(self, modname: str, name_cls: Tuple[str, str]) -> str:
         name, cls = name_cls
         try:
-            clsname, attrname = name.rsplit(".", 1)
+            clsname, attrname = name.rsplit('.', 1)
             if modname and self.env.config.add_module_names:
-                clsname = ".".join([modname, clsname])
+                clsname = '.'.join([modname, clsname])
         except ValueError:
             if modname:
-                return _("%s (HOC in module %s)") % (name, modname)
+                return _('%s (HOC in module %s)') % (name, modname)
             else:
                 return name
 
-        return _("%s (HOC %s property)") % (attrname, clsname)
-
-
-class HOCDecoratorMixin:
-    """
-    Mixin for decorator directives.
-    """
-
-    def handle_signature(self, sig: str, signode: desc_signature) -> Tuple[str, str]:
-        for cls in self.__class__.__mro__:
-            if cls.__name__ != "DirectiveAdapter":
-                warnings.warn(
-                    "HOCDecoratorMixin is deprecated. "
-                    "Please check the implementation of %s" % cls,
-                    RemovedInSphinx50Warning,
-                    stacklevel=2,
-                )
-                break
-        else:
-            warnings.warn(
-                "HOCDecoratorMixin is deprecated",
-                RemovedInSphinx50Warning,
-                stacklevel=2,
-            )
-
-        ret = super().handle_signature(sig, signode)  # type: ignore
-        signode.insert(0, addnodes.desc_addname("@", "@"))
-        return ret
-
-    def needs_arglist(self) -> bool:
-        return False
+        return _('%s (HOC %s property)') % (attrname, clsname)
 
 
 class HOCModule(SphinxDirective):
@@ -1164,47 +971,38 @@ class HOCModule(SphinxDirective):
     optional_arguments = 0
     final_argument_whitespace = False
     option_spec: OptionSpec = {
-        "platform": lambda x: x,
-        "synopsis": lambda x: x,
-        "noindex": directives.flag,
-        "deprecated": directives.flag,
+        'platform': lambda x: x,
+        'synopsis': lambda x: x,
+        'noindex': directives.flag,
+        'deprecated': directives.flag,
     }
 
     def run(self) -> List[Node]:
-        domain = cast(HOCDomain, self.env.get_domain("hoc"))
+        domain = cast(HOCDomain, self.env.get_domain('hoc'))
 
         modname = self.arguments[0].strip()
-        noindex = "noindex" in self.options
-        self.env.ref_context["hoc:module"] = modname
+        noindex = 'noindex' in self.options
+        self.env.ref_context['hoc:module'] = modname
         ret: List[Node] = []
         if not noindex:
             # note module to the domain
-            node_id = make_id(self.env, self.state.document, "module", modname)
-            target = nodes.target("", "", ids=[node_id], ismod=True)
+            node_id = make_id(self.env, self.state.document, 'module', modname)
+            target = nodes.target('', '', ids=[node_id], ismod=True)
             self.set_source_info(target)
-
-            # Assign old styled node_id not to break old hyperlinks (if possible)
-            # Note: Will removed in Sphinx-5.0  (RemovedInSphinx50Warning)
-            old_node_id = self.make_old_id(modname)
-            if node_id != old_node_id and old_node_id not in self.state.document.ids:
-                target["ids"].append(old_node_id)
-
             self.state.document.note_explicit_target(target)
 
-            domain.note_module(
-                modname,
-                node_id,
-                self.options.get("synopsis", ""),
-                self.options.get("platform", ""),
-                "deprecated" in self.options,
-            )
-            domain.note_object(modname, "module", node_id, location=target)
+            domain.note_module(modname,
+                               node_id,
+                               self.options.get('synopsis', ''),
+                               self.options.get('platform', ''),
+                               'deprecated' in self.options)
+            domain.note_object(modname, 'module', node_id, location=target)
 
             # the platform and synopsis aren't printed; in fact, they are only
             # used in the modindex currently
             ret.append(target)
-            indextext = "%s; %s" % (pairindextypes["module"], modname)
-            inode = addnodes.index(entries=[("pair", indextext, node_id, "", None)])
+            indextext = '%s; %s' % (pairindextypes['module'], modname)
+            inode = addnodes.index(entries=[('pair', indextext, node_id, '', None)])
             ret.append(inode)
         return ret
 
@@ -1216,7 +1014,7 @@ class HOCModule(SphinxDirective):
 
         .. note:: Old styled node_id was mainly used until Sphinx-3.0.
         """
-        return "module-%s" % name
+        return 'module-%s' % name
 
 
 class HOCCurrentModule(SphinxDirective):
@@ -1233,57 +1031,49 @@ class HOCCurrentModule(SphinxDirective):
 
     def run(self) -> List[Node]:
         modname = self.arguments[0].strip()
-        if modname == "None":
-            self.env.ref_context.pop("hoc:module", None)
+        if modname == 'None':
+            self.env.ref_context.pop('hoc:module', None)
         else:
-            self.env.ref_context["hoc:module"] = modname
+            self.env.ref_context['hoc:module'] = modname
         return []
 
 
 class HOCXRefRole(XRefRole):
-    def process_link(
-        self,
-        env: BuildEnvironment,
-        refnode: Element,
-        has_explicit_title: bool,
-        title: str,
-        target: str,
-    ) -> Tuple[str, str]:
-        refnode["hoc:module"] = env.ref_context.get("hoc:module")
-        refnode["hoc:class"] = env.ref_context.get("hoc:class")
+    def process_link(self, env: BuildEnvironment, refnode: Element,
+                     has_explicit_title: bool, title: str, target: str) -> Tuple[str, str]:
+        refnode['hoc:module'] = env.ref_context.get('hoc:module')
+        refnode['hoc:class'] = env.ref_context.get('hoc:class')
         if not has_explicit_title:
-            title = title.lstrip(".")  # only has a meaning for the target
-            target = target.lstrip("~")  # only has a meaning for the title
+            title = title.lstrip('.')    # only has a meaning for the target
+            target = target.lstrip('~')  # only has a meaning for the title
             # if the first character is a tilde, don't display the module/class
             # parts of the contents
-            if title[0:1] == "~":
+            if title[0:1] == '~':
                 title = title[1:]
-                dot = title.rfind(".")
+                dot = title.rfind('.')
                 if dot != -1:
-                    title = title[dot + 1 :]
+                    title = title[dot + 1:]
         # if the first character is a dot, search more specific namespaces first
         # else search builtins first
-        if target[0:1] == ".":
+        if target[0:1] == '.':
             target = target[1:]
-            refnode["refspecific"] = True
+            refnode['refspecific'] = True
         return title, target
 
 
-def filter_meta_fields(
-    app: Sphinx, domain: str, objtype: str, content: Element
-) -> None:
+def filter_meta_fields(app: Sphinx, domain: str, objtype: str, content: Element) -> None:
     """Filter ``:meta:`` field from its docstring."""
-    if domain != "hoc":
+    if domain != 'hoc':
         return
 
     for node in content:
         if isinstance(node, nodes.field_list):
             fields = cast(List[nodes.field], node)
-            for field in fields:
+            # removing list items while iterating the list needs reversed()
+            for field in reversed(fields):
                 field_name = cast(nodes.field_body, field[0]).astext().strip()
-                if field_name == "meta" or field_name.startswith("meta "):
+                if field_name == 'meta' or field_name.startswith('meta '):
                     node.remove(field)
-                    break
 
 
 class HOCModuleIndex(Index):
@@ -1291,23 +1081,21 @@ class HOCModuleIndex(Index):
     Index subclass to provide the HOC module index.
     """
 
-    name = "modindex"
-    localname = _("HOC Module Index")
-    shortname = _("modules")
+    name = 'modindex'
+    localname = _('HOC Module Index')
+    shortname = _('modules')
 
-    def generate(
-        self, docnames: Iterable[str] = None
-    ) -> Tuple[List[Tuple[str, List[IndexEntry]]], bool]:
+    def generate(self, docnames: Iterable[str] = None
+                 ) -> Tuple[List[Tuple[str, List[IndexEntry]]], bool]:
         content: Dict[str, List[IndexEntry]] = {}
         # list of prefixes to ignore
-        ignores: List[str] = self.domain.env.config["modindex_common_prefix"]
+        ignores: List[str] = self.domain.env.config['modindex_common_prefix']
         ignores = sorted(ignores, key=len, reverse=True)
         # list of all modules, sorted by module name
-        modules = sorted(
-            self.domain.data["modules"].items(), key=lambda x: x[0].lower()
-        )
+        modules = sorted(self.domain.data['modules'].items(),
+                         key=lambda x: x[0].lower())
         # sort out collapsible modules
-        prev_modname = ""
+        prev_modname = ''
         num_toplevels = 0
         for modname, (docname, node_id, synopsis, platforms, deprecated) in modules:
             if docnames and docname not in docnames:
@@ -1315,50 +1103,38 @@ class HOCModuleIndex(Index):
 
             for ignore in ignores:
                 if modname.startswith(ignore):
-                    modname = modname[len(ignore) :]
+                    modname = modname[len(ignore):]
                     stripped = ignore
                     break
             else:
-                stripped = ""
+                stripped = ''
 
             # we stripped the whole module name?
             if not modname:
-                modname, stripped = stripped, ""
+                modname, stripped = stripped, ''
 
             entries = content.setdefault(modname[0].lower(), [])
 
-            package = modname.split(".")[0]
+            package = modname.split('.')[0]
             if package != modname:
                 # it's a submodule
                 if prev_modname == package:
                     # first submodule - make parent a group head
                     if entries:
                         last = entries[-1]
-                        entries[-1] = IndexEntry(
-                            last[0], 1, last[2], last[3], last[4], last[5], last[6]
-                        )
+                        entries[-1] = IndexEntry(last[0], 1, last[2], last[3],
+                                                 last[4], last[5], last[6])
                 elif not prev_modname.startswith(package):
                     # submodule without parent in list, add dummy entry
-                    entries.append(
-                        IndexEntry(stripped + package, 1, "", "", "", "", "")
-                    )
+                    entries.append(IndexEntry(stripped + package, 1, '', '', '', '', ''))
                 subtype = 2
             else:
                 num_toplevels += 1
                 subtype = 0
 
-            qualifier = _("Deprecated") if deprecated else ""
-            entries.append(
-                IndexEntry(
-                    stripped + modname,
-                    subtype,
-                    docname,
-                    node_id,
-                    platforms,
-                    qualifier,
-                    synopsis,
-                )
-            )
+            qualifier = _('Deprecated') if deprecated else ''
+            entries.append(IndexEntry(stripped + modname, subtype, docname,
+                                      node_id, platforms, qualifier, synopsis))
             prev_modname = modname
 
         # apply heuristics when to collapse modindex at page load:
@@ -1374,51 +1150,50 @@ class HOCModuleIndex(Index):
 
 class HOCDomain(Domain):
     """HOC language domain."""
-
-    name = "hoc"
-    label = "HOC"
+    name = 'hoc'
+    label = 'HOC'
     object_types: Dict[str, ObjType] = {
-        "function": ObjType(_("function"), "func", "obj"),
-        "data": ObjType(_("data"), "data", "obj"),
-        "class": ObjType(_("class"), "class", "exc", "obj"),
-        "exception": ObjType(_("exception"), "exc", "class", "obj"),
-        "method": ObjType(_("method"), "meth", "obj"),
-        "classmethod": ObjType(_("class method"), "meth", "obj"),
-        "staticmethod": ObjType(_("static method"), "meth", "obj"),
-        "attribute": ObjType(_("attribute"), "attr", "obj"),
-        "property": ObjType(_("property"), "attr", "_prop", "obj"),
-        "module": ObjType(_("module"), "mod", "obj"),
+        'function':     ObjType(_('function'),      'func', 'obj'),
+        'data':         ObjType(_('data'),          'data', 'obj'),
+        'class':        ObjType(_('class'),         'class', 'exc', 'obj'),
+        'exception':    ObjType(_('exception'),     'exc', 'class', 'obj'),
+        'method':       ObjType(_('method'),        'meth', 'obj'),
+        'classmethod':  ObjType(_('class method'),  'meth', 'obj'),
+        'staticmethod': ObjType(_('static method'), 'meth', 'obj'),
+        'attribute':    ObjType(_('attribute'),     'attr', 'obj'),
+        'property':     ObjType(_('property'),      'attr', '_prop', 'obj'),
+        'module':       ObjType(_('module'),        'mod', 'obj'),
     }
 
     directives = {
-        "function": HOCFunction,
-        "data": HOCVariable,
-        "class": HOCClasslike,
-        "exception": HOCClasslike,
-        "method": HOCMethod,
-        "classmethod": HOCClassMethod,
-        "staticmethod": HOCStaticMethod,
-        "attribute": HOCAttribute,
-        "property": HOCProperty,
-        "module": HOCModule,
-        "currentmodule": HOCCurrentModule,
-        "decorator": HOCDecoratorFunction,
-        "decoratormethod": HOCDecoratorMethod,
+        'function':        HOCFunction,
+        'data':            HOCVariable,
+        'class':           HOCClasslike,
+        'exception':       HOCClasslike,
+        'method':          HOCMethod,
+        'classmethod':     HOCClassMethod,
+        'staticmethod':    HOCStaticMethod,
+        'attribute':       HOCAttribute,
+        'property':        HOCProperty,
+        'module':          HOCModule,
+        'currentmodule':   HOCCurrentModule,
+        'decorator':       HOCDecoratorFunction,
+        'decoratormethod': HOCDecoratorMethod,
     }
     roles = {
-        "data": HOCXRefRole(),
-        "exc": HOCXRefRole(),
-        "func": HOCXRefRole(fix_parens=True),
-        "class": HOCXRefRole(),
-        "const": HOCXRefRole(),
-        "attr": HOCXRefRole(),
-        "meth": HOCXRefRole(fix_parens=True),
-        "mod": HOCXRefRole(),
-        "obj": HOCXRefRole(),
+        'data':  HOCXRefRole(),
+        'exc':   HOCXRefRole(),
+        'func':  HOCXRefRole(fix_parens=True),
+        'class': HOCXRefRole(),
+        'const': HOCXRefRole(),
+        'attr':  HOCXRefRole(),
+        'meth':  HOCXRefRole(fix_parens=True),
+        'mod':   HOCXRefRole(),
+        'obj':   HOCXRefRole(),
     }
     initial_data: Dict[str, Dict[str, Tuple[Any]]] = {
-        "objects": {},  # fullname -> docname, objtype
-        "modules": {},  # modname -> docname, synopsis, platform, deprecated
+        'objects': {},  # fullname -> docname, objtype
+        'modules': {},  # modname -> docname, synopsis, platform, deprecated
     }
     indices = [
         HOCModuleIndex,
@@ -1426,16 +1201,10 @@ class HOCDomain(Domain):
 
     @property
     def objects(self) -> Dict[str, ObjectEntry]:
-        return self.data.setdefault("objects", {})  # fullname -> ObjectEntry
+        return self.data.setdefault('objects', {})  # fullname -> ObjectEntry
 
-    def note_object(
-        self,
-        name: str,
-        objtype: str,
-        node_id: str,
-        aliased: bool = False,
-        location: Any = None,
-    ) -> None:
+    def note_object(self, name: str, objtype: str, node_id: str,
+                    aliased: bool = False, location: Any = None) -> None:
         """Note a python object for cross reference.
 
         .. versionadded:: 2.1
@@ -1450,31 +1219,23 @@ class HOCDomain(Domain):
                 return
             else:
                 # duplicated
-                logger.warning(
-                    __(
-                        "duplicate object description of %s, "
-                        "other instance in %s, use :noindex: for one of them"
-                    ),
-                    name,
-                    other.docname,
-                    location=location,
-                )
+                logger.warning(__('duplicate object description of %s, '
+                                  'other instance in %s, use :noindex: for one of them'),
+                               name, other.docname, location=location)
         self.objects[name] = ObjectEntry(self.env.docname, node_id, objtype, aliased)
 
     @property
     def modules(self) -> Dict[str, ModuleEntry]:
-        return self.data.setdefault("modules", {})  # modname -> ModuleEntry
+        return self.data.setdefault('modules', {})  # modname -> ModuleEntry
 
-    def note_module(
-        self, name: str, node_id: str, synopsis: str, platform: str, deprecated: bool
-    ) -> None:
+    def note_module(self, name: str, node_id: str, synopsis: str,
+                    platform: str, deprecated: bool) -> None:
         """Note a python module for cross reference.
 
         .. versionadded:: 2.1
         """
-        self.modules[name] = ModuleEntry(
-            self.env.docname, node_id, synopsis, platform, deprecated
-        )
+        self.modules[name] = ModuleEntry(self.env.docname, node_id,
+                                         synopsis, platform, deprecated)
 
     def clear_doc(self, docname: str) -> None:
         for fullname, obj in list(self.objects.items()):
@@ -1486,27 +1247,21 @@ class HOCDomain(Domain):
 
     def merge_domaindata(self, docnames: List[str], otherdata: Dict) -> None:
         # XXX check duplicates?
-        for fullname, obj in otherdata["objects"].items():
+        for fullname, obj in otherdata['objects'].items():
             if obj.docname in docnames:
                 self.objects[fullname] = obj
-        for modname, mod in otherdata["modules"].items():
+        for modname, mod in otherdata['modules'].items():
             if mod.docname in docnames:
                 self.modules[modname] = mod
 
-    def find_obj(
-        self,
-        env: BuildEnvironment,
-        modname: str,
-        classname: str,
-        name: str,
-        type: str,
-        searchmode: int = 0,
-    ) -> List[Tuple[str, ObjectEntry]]:
+    def find_obj(self, env: BuildEnvironment, modname: str, classname: str,
+                 name: str, type: str, searchmode: int = 0
+                 ) -> List[Tuple[str, ObjectEntry]]:
         """Find a HOC object for "name", perhaps using the given module
         and/or classname.  Returns a list of (name, object entry) tuples.
         """
         # skip parens
-        if name[-2:] == "()":
+        if name[-2:] == '()':
             name = name[:-2]
 
         if not name:
@@ -1522,80 +1277,60 @@ class HOCDomain(Domain):
                 objtypes = self.objtypes_for_role(type)
             if objtypes is not None:
                 if modname and classname:
-                    fullname = modname + "." + classname + "." + name
-                    if (
-                        fullname in self.objects
-                        and self.objects[fullname].objtype in objtypes
-                    ):
+                    fullname = modname + '.' + classname + '.' + name
+                    if fullname in self.objects and self.objects[fullname].objtype in objtypes:
                         newname = fullname
                 if not newname:
-                    if (
-                        modname
-                        and modname + "." + name in self.objects
-                        and self.objects[modname + "." + name].objtype in objtypes
-                    ):
-                        newname = modname + "." + name
-                    elif (
-                        name in self.objects and self.objects[name].objtype in objtypes
-                    ):
+                    if modname and modname + '.' + name in self.objects and \
+                       self.objects[modname + '.' + name].objtype in objtypes:
+                        newname = modname + '.' + name
+                    elif name in self.objects and self.objects[name].objtype in objtypes:
                         newname = name
                     else:
                         # "fuzzy" searching mode
-                        searchname = "." + name
-                        matches = [
-                            (oname, self.objects[oname])
-                            for oname in self.objects
-                            if oname.endswith(searchname)
-                            and self.objects[oname].objtype in objtypes
-                        ]
+                        searchname = '.' + name
+                        matches = [(oname, self.objects[oname]) for oname in self.objects
+                                   if oname.endswith(searchname) and
+                                   self.objects[oname].objtype in objtypes]
         else:
             # NOTE: searching for exact match, object type is not considered
             if name in self.objects:
                 newname = name
-            elif type == "mod":
+            elif type == 'mod':
                 # only exact matches allowed for modules
                 return []
-            elif classname and classname + "." + name in self.objects:
-                newname = classname + "." + name
-            elif modname and modname + "." + name in self.objects:
-                newname = modname + "." + name
-            elif (
-                modname
-                and classname
-                and modname + "." + classname + "." + name in self.objects
-            ):
-                newname = modname + "." + classname + "." + name
+            elif classname and classname + '.' + name in self.objects:
+                newname = classname + '.' + name
+            elif modname and modname + '.' + name in self.objects:
+                newname = modname + '.' + name
+            elif modname and classname and \
+                    modname + '.' + classname + '.' + name in self.objects:
+                newname = modname + '.' + classname + '.' + name
         if newname is not None:
             matches.append((newname, self.objects[newname]))
         return matches
 
-    def resolve_xref(
-        self,
-        env: BuildEnvironment,
-        fromdocname: str,
-        builder: Builder,
-        type: str,
-        target: str,
-        node: pending_xref,
-        contnode: Element,
-    ) -> Optional[Element]:
-        modname = node.get("hoc:module")
-        clsname = node.get("hoc:class")
-        searchmode = 1 if node.hasattr("refspecific") else 0
-        matches = self.find_obj(env, modname, clsname, target, type, searchmode)
+    def resolve_xref(self, env: BuildEnvironment, fromdocname: str, builder: Builder,
+                     type: str, target: str, node: pending_xref, contnode: Element
+                     ) -> Optional[Element]:
+        modname = node.get('hoc:module')
+        clsname = node.get('hoc:class')
+        searchmode = 1 if node.hasattr('refspecific') else 0
+        matches = self.find_obj(env, modname, clsname, target,
+                                type, searchmode)
 
-        if not matches and type == "attr":
+        if not matches and type == 'attr':
             # fallback to meth (for property; Sphinx-2.4.x)
             # this ensures that `:attr:` role continues to refer to the old property entry
             # that defined by ``method`` directive in old reST files.
-            matches = self.find_obj(env, modname, clsname, target, "meth", searchmode)
-        if not matches and type == "meth":
+            matches = self.find_obj(env, modname, clsname, target, 'meth', searchmode)
+        if not matches and type == 'meth':
             # fallback to attr (for property)
             # this ensures that `:meth:` in the old reST files can refer to the property
             # entry that defined by ``property`` directive.
             #
             # Note: _prop is a secret role only for internal look-up.
-            matches = self.find_obj(env, modname, clsname, target, "_prop", searchmode)
+            matches = self.find_obj(env, modname, clsname, target, '_prop', searchmode)
 
         if not matches:
             return None
@@ -1604,21 +1339,16 @@ class HOCDomain(Domain):
             if len(canonicals) == 1:
                 matches = canonicals
             else:
-                logger.warning(
-                    __("more than one target found for cross-reference %r: %s"),
-                    target,
-                    ", ".join(match[0] for match in matches),
-                    type="ref",
-                    subtype="hoc",
-                    location=node,
-                )
+                logger.warning(__('more than one target found for cross-reference %r: %s'),
+                               target, ', '.join(match[0] for match in matches),
+                               type='ref', subtype='hoc', location=node)
         name, obj = matches[0]
 
-        if obj[2] == "module":
+        if obj[2] == 'module':
             return self._make_module_refnode(builder, fromdocname, name, contnode)
         else:
             # determine the content of the reference by conditions
-            content = find_pending_xref_condition(node, "resolved")
+            content = find_pending_xref_condition(node, 'resolved')
             if content:
                 children = content.children
             else:
@@ -1627,69 +1357,53 @@ class HOCDomain(Domain):
 
             return make_refnode(builder, fromdocname, obj[0], obj[1], children, name)
 
-    def resolve_any_xref(
-        self,
-        env: BuildEnvironment,
-        fromdocname: str,
-        builder: Builder,
-        target: str,
-        node: pending_xref,
-        contnode: Element,
-    ) -> List[Tuple[str, Element]]:
-        modname = node.get("hoc:module")
-        clsname = node.get("hoc:class")
+    def resolve_any_xref(self, env: BuildEnvironment, fromdocname: str, builder: Builder,
+                         target: str, node: pending_xref, contnode: Element
+                         ) -> List[Tuple[str, Element]]:
+        modname = node.get('hoc:module')
+        clsname = node.get('hoc:class')
         results: List[Tuple[str, Element]] = []
 
         # always search in "refspecific" mode with the :any: role
         matches = self.find_obj(env, modname, clsname, target, None, 1)
         for name, obj in matches:
-            if obj[2] == "module":
-                results.append(
-                    (
-                        "hoc:mod",
-                        self._make_module_refnode(builder, fromdocname, name, contnode),
-                    )
-                )
+            if obj[2] == 'module':
+                results.append(('hoc:mod',
+                                self._make_module_refnode(builder, fromdocname,
+                                                          name, contnode)))
             else:
                 # determine the content of the reference by conditions
-                content = find_pending_xref_condition(node, "resolved")
+                content = find_pending_xref_condition(node, 'resolved')
                 if content:
                     children = content.children
                 else:
                     # if not found, use contnode
                     children = [contnode]
 
-                results.append(
-                    (
-                        "hoc:" + self.role_for_objtype(obj[2]),
-                        make_refnode(
-                            builder, fromdocname, obj[0], obj[1], children, name
-                        ),
-                    )
-                )
+                results.append(('hoc:' + self.role_for_objtype(obj[2]),
+                                make_refnode(builder, fromdocname, obj[0], obj[1],
+                                             children, name)))
         return results
 
-    def _make_module_refnode(
-        self, builder: Builder, fromdocname: str, name: str, contnode: Node
-    ) -> Element:
+    def _make_module_refnode(self, builder: Builder, fromdocname: str, name: str,
+                             contnode: Node) -> Element:
         # get additional info for modules
         module = self.modules[name]
         title = name
         if module.synopsis:
-            title += ": " + module.synopsis
+            title += ': ' + module.synopsis
         if module.deprecated:
-            title += _(" (deprecated)")
+            title += _(' (deprecated)')
         if module.platform:
-            title += " (" + module.platform + ")"
-        return make_refnode(
-            builder, fromdocname, module.docname, module.node_id, contnode, title
-        )
+            title += ' (' + module.platform + ')'
+        return make_refnode(builder, fromdocname, module.docname, module.node_id,
+                            contnode, title)
 
     def get_objects(self) -> Iterator[Tuple[str, str, str, str, str, int]]:
         for modname, mod in self.modules.items():
-            yield (modname, modname, "module", mod.docname, mod.node_id, 0)
+            yield (modname, modname, 'module', mod.docname, mod.node_id, 0)
         for refname, obj in self.objects.items():
-            if obj.objtype != "module":  # modules are already handled
+            if obj.objtype != 'module':  # modules are already handled
                 if obj.aliased:
                     # aliased names are not full-text searchable.
                     yield (refname, refname, obj.objtype, obj.docname, obj.node_id, -1)
@@ -1697,32 +1411,30 @@ class HOCDomain(Domain):
                     yield (refname, refname, obj.objtype, obj.docname, obj.node_id, 1)
 
     def get_full_qualified_name(self, node: Element) -> Optional[str]:
-        modname = node.get("hoc:module")
-        clsname = node.get("hoc:class")
-        target = node.get("reftarget")
+        modname = node.get('hoc:module')
+        clsname = node.get('hoc:class')
+        target = node.get('reftarget')
         if target is None:
             return None
         else:
-            return ".".join(filter(None, [modname, clsname, target]))
+            return '.'.join(filter(None, [modname, clsname, target]))
 
 
-def builtin_resolver(
-    app: Sphinx, env: BuildEnvironment, node: pending_xref, contnode: Element
-) -> Element:
+def builtin_resolver(app: Sphinx, env: BuildEnvironment,
+                     node: pending_xref, contnode: Element) -> Element:
     """Do not emit nitpicky warnings for built-in types."""
-
     def istyping(s: str) -> bool:
-        if s.startswith("typing."):
-            s = s.split(".", 1)[1]
+        if s.startswith('typing.'):
+            s = s.split('.', 1)[1]
 
-        return s in typing.__all__  # type: ignore
+        return s in typing.__all__
 
-    if node.get("refdomain") != "hoc":
+    if node.get('refdomain') != 'hoc':
         return None
-    elif node.get("reftype") in ("class", "obj") and node.get("reftarget") == "None":
+    elif node.get('reftype') in ('class', 'obj') and node.get('reftarget') == 'None':
         return contnode
-    elif node.get("reftype") in ("class", "obj", "exc"):
-        reftarget = node.get("reftarget")
+    elif node.get('reftype') in ('class', 'obj', 'exc'):
+        reftarget = node.get('reftarget')
         if inspect.isclass(getattr(builtins, reftarget, None)):
             # built-in class
             return contnode
@@ -1734,16 +1446,16 @@ def builtin_resolver(
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:
-    app.setup_extension("sphinx.directives")
+    app.setup_extension('sphinx.directives')
 
     app.add_domain(HOCDomain)
-    app.add_config_value("hoc_use_unqualified_type_names", False, "env")
-    app.connect("object-description-transform", filter_meta_fields)
-    app.connect("missing-reference", builtin_resolver, priority=900)
+    app.add_config_value('hoc_use_unqualified_type_names', False, 'env')
+    app.connect('object-description-transform', filter_meta_fields)
+    app.connect('missing-reference', builtin_resolver, priority=900)
 
     return {
-        "version": "builtin",
-        "env_version": 3,
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
+        'version': 'builtin',
+        'env_version': 3,
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
     }

--- a/docs/domains/hocdomain.py
+++ b/docs/domains/hocdomain.py
@@ -8,7 +8,18 @@ import sys
 import typing
 import warnings
 from inspect import Parameter
-from typing import Any, Dict, Iterable, Iterator, List, NamedTuple, Optional, Tuple, Type, cast
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Type,
+    cast,
+)
 
 from docutils import nodes
 from docutils.nodes import Element, Node
@@ -39,22 +50,24 @@ logger = logging.getLogger(__name__)
 
 # REs for HOC signatures
 hoc_sig_re = re.compile(
-    r'''^ ([\w.]*\.)?            # class name(s)
+    r"""^ ([\w.]*\.)?            # class name(s)
           (\w+)  \s*             # thing name
           (?: \(\s*(.*)\s*\)     # optional: arguments
            (?:\s* -> \s* (.*))?  #           return annotation
           )? $                   # and nothing more
-          ''', re.VERBOSE)
+          """,
+    re.VERBOSE,
+)
 
 
 pairindextypes = {
-    'module':    _('module'),
-    'keyword':   _('keyword'),
-    'operator':  _('operator'),
-    'object':    _('object'),
-    'exception': _('exception'),
-    'statement': _('statement'),
-    'builtin':   _('HOC built-in function'),
+    "module": _("module"),
+    "keyword": _("keyword"),
+    "operator": _("operator"),
+    "object": _("object"),
+    "exception": _("exception"),
+    "statement": _("statement"),
+    "builtin": _("HOC built-in function"),
 }
 
 
@@ -73,39 +86,43 @@ class ModuleEntry(NamedTuple):
     deprecated: bool
 
 
-def parse_reftarget(reftarget: str, suppress_prefix: bool = False
-                    ) -> Tuple[str, str, str, bool]:
+def parse_reftarget(
+    reftarget: str, suppress_prefix: bool = False
+) -> Tuple[str, str, str, bool]:
     """Parse a type string and return (reftype, reftarget, title, refspecific flag)"""
     refspecific = False
-    if reftarget.startswith('.'):
+    if reftarget.startswith("."):
         reftarget = reftarget[1:]
         title = reftarget
         refspecific = True
-    elif reftarget.startswith('~'):
+    elif reftarget.startswith("~"):
         reftarget = reftarget[1:]
-        title = reftarget.split('.')[-1]
+        title = reftarget.split(".")[-1]
     elif suppress_prefix:
-        title = reftarget.split('.')[-1]
-    elif reftarget.startswith('typing.'):
+        title = reftarget.split(".")[-1]
+    elif reftarget.startswith("typing."):
         title = reftarget[7:]
     else:
         title = reftarget
 
-    if reftarget == 'None' or reftarget.startswith('typing.'):
+    if reftarget == "None" or reftarget.startswith("typing."):
         # typing module provides non-class types.  Obj reference is good to refer them.
-        reftype = 'obj'
+        reftype = "obj"
     else:
-        reftype = 'class'
+        reftype = "class"
 
     return reftype, reftarget, title, refspecific
 
 
-def type_to_xref(target: str, env: BuildEnvironment = None, suppress_prefix: bool = False
-                 ) -> addnodes.pending_xref:
+def type_to_xref(
+    target: str, env: BuildEnvironment = None, suppress_prefix: bool = False
+) -> addnodes.pending_xref:
     """Convert a type string to a cross reference node."""
     if env:
-        kwargs = {'hoc:module': env.ref_context.get('hoc:module'),
-                  'hoc:class': env.ref_context.get('hoc:class')}
+        kwargs = {
+            "hoc:module": env.ref_context.get("hoc:module"),
+            "hoc:class": env.ref_context.get("hoc:class"),
+        }
     else:
         kwargs = {}
 
@@ -115,19 +132,28 @@ def type_to_xref(target: str, env: BuildEnvironment = None, suppress_prefix: boo
         # Note: It would be better to use qualname to describe the object to support support
         # nested classes.  But python domain can't access the real python object because this
         # module should work not-dynamically.
-        shortname = title.split('.')[-1]
-        contnodes: List[Node] = [pending_xref_condition('', shortname, condition='resolved'),
-                                 pending_xref_condition('', title, condition='*')]
+        shortname = title.split(".")[-1]
+        contnodes: List[Node] = [
+            pending_xref_condition("", shortname, condition="resolved"),
+            pending_xref_condition("", title, condition="*"),
+        ]
     else:
         contnodes = [nodes.Text(title)]
 
-    return pending_xref('', *contnodes,
-                        refdomain='hoc', reftype=reftype, reftarget=target,
-                        refspecific=refspecific, **kwargs)
+    return pending_xref(
+        "",
+        *contnodes,
+        refdomain="hoc",
+        reftype=reftype,
+        reftarget=target,
+        refspecific=refspecific,
+        **kwargs
+    )
 
 
 def _parse_annotation(annotation: str, env: BuildEnvironment) -> List[Node]:
     """Parse type annotation."""
+
     def unparse(node: ast.AST) -> List[Node]:
         if isinstance(node, ast.Attribute):
             return [nodes.Text("%s.%s" % (unparse(node.value)[0], node.attr))]
@@ -137,18 +163,20 @@ def _parse_annotation(annotation: str, env: BuildEnvironment) -> List[Node]:
             result.extend(unparse(node.right))
             return result
         elif isinstance(node, ast.BitOr):
-            return [addnodes.desc_sig_space(),
-                    addnodes.desc_sig_punctuation('', '|'),
-                    addnodes.desc_sig_space()]
+            return [
+                addnodes.desc_sig_space(),
+                addnodes.desc_sig_punctuation("", "|"),
+                addnodes.desc_sig_space(),
+            ]
         elif isinstance(node, ast.Constant):  # type: ignore
             if node.value is Ellipsis:
-                return [addnodes.desc_sig_punctuation('', "...")]
+                return [addnodes.desc_sig_punctuation("", "...")]
             elif isinstance(node.value, bool):
-                return [addnodes.desc_sig_keyword('', repr(node.value))]
+                return [addnodes.desc_sig_keyword("", repr(node.value))]
             elif isinstance(node.value, int):
-                return [addnodes.desc_sig_literal_number('', repr(node.value))]
+                return [addnodes.desc_sig_literal_number("", repr(node.value))]
             elif isinstance(node.value, str):
-                return [addnodes.desc_sig_literal_string('', repr(node.value))]
+                return [addnodes.desc_sig_literal_string("", repr(node.value))]
             else:
                 # handles None, which is further handled by type_to_xref later
                 # and fallback for other types that should be converted
@@ -158,20 +186,20 @@ def _parse_annotation(annotation: str, env: BuildEnvironment) -> List[Node]:
         elif isinstance(node, ast.Index):
             return unparse(node.value)
         elif isinstance(node, ast.Invert):
-            return [addnodes.desc_sig_punctuation('', '~')]
+            return [addnodes.desc_sig_punctuation("", "~")]
         elif isinstance(node, ast.List):
-            result = [addnodes.desc_sig_punctuation('', '[')]
+            result = [addnodes.desc_sig_punctuation("", "[")]
             if node.elts:
                 # check if there are elements in node.elts to only pop the
                 # last element of result if the for-loop was run at least
                 # once
                 for elem in node.elts:
                     result.extend(unparse(elem))
-                    result.append(addnodes.desc_sig_punctuation('', ','))
+                    result.append(addnodes.desc_sig_punctuation("", ","))
                     result.append(addnodes.desc_sig_space())
                 result.pop()
                 result.pop()
-            result.append(addnodes.desc_sig_punctuation('', ']'))
+            result.append(addnodes.desc_sig_punctuation("", "]"))
             return result
         elif isinstance(node, ast.Module):
             return sum((unparse(e) for e in node.body), [])
@@ -179,15 +207,15 @@ def _parse_annotation(annotation: str, env: BuildEnvironment) -> List[Node]:
             return [nodes.Text(node.id)]
         elif isinstance(node, ast.Subscript):
             result = unparse(node.value)
-            result.append(addnodes.desc_sig_punctuation('', '['))
+            result.append(addnodes.desc_sig_punctuation("", "["))
             result.extend(unparse(node.slice))
-            result.append(addnodes.desc_sig_punctuation('', ']'))
+            result.append(addnodes.desc_sig_punctuation("", "]"))
 
             # Wrap the Text nodes inside brackets by literal node if the subscript is a Literal
-            if result[0] in ('Literal', 'typing.Literal'):
+            if result[0] in ("Literal", "typing.Literal"):
                 for i, subnode in enumerate(result[1:], start=1):
                     if isinstance(subnode, nodes.Text):
-                        result[i] = nodes.literal('', '', subnode)
+                        result[i] = nodes.literal("", "", subnode)
             return result
         elif isinstance(node, ast.UnaryOp):
             return unparse(node.op) + unparse(node.operand)
@@ -196,27 +224,29 @@ def _parse_annotation(annotation: str, env: BuildEnvironment) -> List[Node]:
                 result = []
                 for elem in node.elts:
                     result.extend(unparse(elem))
-                    result.append(addnodes.desc_sig_punctuation('', ','))
+                    result.append(addnodes.desc_sig_punctuation("", ","))
                     result.append(addnodes.desc_sig_space())
                 result.pop()
                 result.pop()
             else:
-                result = [addnodes.desc_sig_punctuation('', '('),
-                          addnodes.desc_sig_punctuation('', ')')]
+                result = [
+                    addnodes.desc_sig_punctuation("", "("),
+                    addnodes.desc_sig_punctuation("", ")"),
+                ]
 
             return result
         else:
             if sys.version_info < (3, 8):
                 if isinstance(node, ast.Bytes):
-                    return [addnodes.desc_sig_literal_string('', repr(node.s))]
+                    return [addnodes.desc_sig_literal_string("", repr(node.s))]
                 elif isinstance(node, ast.Ellipsis):
-                    return [addnodes.desc_sig_punctuation('', "...")]
+                    return [addnodes.desc_sig_punctuation("", "...")]
                 elif isinstance(node, ast.NameConstant):
                     return [nodes.Text(node.value)]
                 elif isinstance(node, ast.Num):
-                    return [addnodes.desc_sig_literal_string('', repr(node.n))]
+                    return [addnodes.desc_sig_literal_string("", repr(node.n))]
                 elif isinstance(node, ast.Str):
-                    return [addnodes.desc_sig_literal_string('', repr(node.s))]
+                    return [addnodes.desc_sig_literal_string("", repr(node.s))]
 
             raise SyntaxError  # unsupported syntax
 
@@ -227,8 +257,11 @@ def _parse_annotation(annotation: str, env: BuildEnvironment) -> List[Node]:
             if isinstance(node, nodes.literal):
                 result.append(node[0])
             elif isinstance(node, nodes.Text) and node.strip():
-                if (result and isinstance(result[-1], addnodes.desc_sig_punctuation) and
-                        result[-1].astext() == '~'):
+                if (
+                    result
+                    and isinstance(result[-1], addnodes.desc_sig_punctuation)
+                    and result[-1].astext() == "~"
+                ):
                     result.pop()
                     result.append(type_to_xref(str(node), env, suppress_prefix=True))
                 else:
@@ -240,58 +273,67 @@ def _parse_annotation(annotation: str, env: BuildEnvironment) -> List[Node]:
         return [type_to_xref(annotation, env)]
 
 
-def _parse_arglist(arglist: str, env: BuildEnvironment = None) -> addnodes.desc_parameterlist:
+def _parse_arglist(
+    arglist: str, env: BuildEnvironment = None
+) -> addnodes.desc_parameterlist:
     """Parse a list of arguments using AST parser"""
     params = addnodes.desc_parameterlist(arglist)
-    sig = signature_from_str('(%s)' % arglist)
+    sig = signature_from_str("(%s)" % arglist)
     last_kind = None
     for param in sig.parameters.values():
         if param.kind != param.POSITIONAL_ONLY and last_kind == param.POSITIONAL_ONLY:
             # PEP-570: Separator for Positional Only Parameter: /
-            params += addnodes.desc_parameter('', '', addnodes.desc_sig_operator('', '/'))
-        if param.kind == param.KEYWORD_ONLY and last_kind in (param.POSITIONAL_OR_KEYWORD,
-                                                              param.POSITIONAL_ONLY,
-                                                              None):
+            params += addnodes.desc_parameter(
+                "", "", addnodes.desc_sig_operator("", "/")
+            )
+        if param.kind == param.KEYWORD_ONLY and last_kind in (
+            param.POSITIONAL_OR_KEYWORD,
+            param.POSITIONAL_ONLY,
+            None,
+        ):
             # PEP-3102: Separator for Keyword Only Parameter: *
-            params += addnodes.desc_parameter('', '', addnodes.desc_sig_operator('', '*'))
+            params += addnodes.desc_parameter(
+                "", "", addnodes.desc_sig_operator("", "*")
+            )
 
         node = addnodes.desc_parameter()
         if param.kind == param.VAR_POSITIONAL:
-            node += addnodes.desc_sig_operator('', '*')
-            node += addnodes.desc_sig_name('', param.name)
+            node += addnodes.desc_sig_operator("", "*")
+            node += addnodes.desc_sig_name("", param.name)
         elif param.kind == param.VAR_KEYWORD:
-            node += addnodes.desc_sig_operator('', '**')
-            node += addnodes.desc_sig_name('', param.name)
+            node += addnodes.desc_sig_operator("", "**")
+            node += addnodes.desc_sig_name("", param.name)
         else:
-            node += addnodes.desc_sig_name('', param.name)
+            node += addnodes.desc_sig_name("", param.name)
 
         if param.annotation is not param.empty:
             children = _parse_annotation(param.annotation, env)
-            node += addnodes.desc_sig_punctuation('', ':')
+            node += addnodes.desc_sig_punctuation("", ":")
             node += addnodes.desc_sig_space()
-            node += addnodes.desc_sig_name('', '', *children)  # type: ignore
+            node += addnodes.desc_sig_name("", "", *children)  # type: ignore
         if param.default is not param.empty:
             if param.annotation is not param.empty:
                 node += addnodes.desc_sig_space()
-                node += addnodes.desc_sig_operator('', '=')
+                node += addnodes.desc_sig_operator("", "=")
                 node += addnodes.desc_sig_space()
             else:
-                node += addnodes.desc_sig_operator('', '=')
-            node += nodes.inline('', param.default, classes=['default_value'],
-                                 support_smartquotes=False)
+                node += addnodes.desc_sig_operator("", "=")
+            node += nodes.inline(
+                "", param.default, classes=["default_value"], support_smartquotes=False
+            )
 
         params += node
         last_kind = param.kind
 
     if last_kind == Parameter.POSITIONAL_ONLY:
         # PEP-570: Separator for Positional Only Parameter: /
-        params += addnodes.desc_parameter('', '', addnodes.desc_sig_operator('', '/'))
+        params += addnodes.desc_parameter("", "", addnodes.desc_sig_operator("", "/"))
 
     return params
 
 
 def _pseudo_parse_arglist(signode: desc_signature, arglist: str) -> None:
-    """"Parse" a list of arguments separated by commas.
+    """ "Parse" a list of arguments separated by commas.
 
     Arguments can have "optional" annotations given by enclosing them in
     brackets.  Currently, this will split at any comma, even if it's inside a
@@ -300,25 +342,26 @@ def _pseudo_parse_arglist(signode: desc_signature, arglist: str) -> None:
     paramlist = addnodes.desc_parameterlist()
     stack: List[Element] = [paramlist]
     try:
-        for argument in arglist.split(','):
+        for argument in arglist.split(","):
             argument = argument.strip()
             ends_open = ends_close = 0
-            while argument.startswith('['):
+            while argument.startswith("["):
                 stack.append(addnodes.desc_optional())
                 stack[-2] += stack[-1]
                 argument = argument[1:].strip()
-            while argument.startswith(']'):
+            while argument.startswith("]"):
                 stack.pop()
                 argument = argument[1:].strip()
-            while argument.endswith(']') and not argument.endswith('[]'):
+            while argument.endswith("]") and not argument.endswith("[]"):
                 ends_close += 1
                 argument = argument[:-1].strip()
-            while argument.endswith('['):
+            while argument.endswith("["):
                 ends_open += 1
                 argument = argument[:-1].strip()
             if argument:
                 stack[-1] += addnodes.desc_parameter(
-                    '', '', addnodes.desc_sig_name(argument, argument))
+                    "", "", addnodes.desc_sig_name(argument, argument)
+                )
             while ends_open:
                 stack.append(addnodes.desc_optional())
                 stack[-2] += stack[-1]
@@ -342,24 +385,38 @@ def _pseudo_parse_arglist(signode: desc_signature, arglist: str) -> None:
 # This override allows our inline type specifiers to behave like :class: link
 # when it comes to handling "." and "~" prefixes.
 class HOCXrefMixin:
-    def make_xref(self, rolename: str, domain: str, target: str,
-                  innernode: Type[TextlikeNode] = nodes.emphasis,
-                  contnode: Node = None, env: BuildEnvironment = None,
-                  inliner: Inliner = None, location: Node = None) -> Node:
+    def make_xref(
+        self,
+        rolename: str,
+        domain: str,
+        target: str,
+        innernode: Type[TextlikeNode] = nodes.emphasis,
+        contnode: Node = None,
+        env: BuildEnvironment = None,
+        inliner: Inliner = None,
+        location: Node = None,
+    ) -> Node:
         # we use inliner=None to make sure we get the old behaviour with a single
         # pending_xref node
-        result = super().make_xref(rolename, domain, target,  # type: ignore
-                                   innernode, contnode,
-                                   env, inliner=None, location=None)
+        result = super().make_xref(
+            rolename,
+            domain,
+            target,  # type: ignore
+            innernode,
+            contnode,
+            env,
+            inliner=None,
+            location=None,
+        )
         if isinstance(result, pending_xref):
-            result['refspecific'] = True
-            result['hoc:module'] = env.ref_context.get('hoc:module')
-            result['hoc:class'] = env.ref_context.get('hoc:class')
+            result["refspecific"] = True
+            result["hoc:module"] = env.ref_context.get("hoc:module")
+            result["hoc:class"] = env.ref_context.get("hoc:class")
 
             reftype, reftarget, reftitle, _ = parse_reftarget(target)
             if reftarget != reftitle:
-                result['reftype'] = reftype
-                result['reftarget'] = reftarget
+                result["reftype"] = reftype
+                result["reftarget"] = reftarget
 
                 result.clear()
                 result += innernode(reftitle, reftitle)
@@ -367,19 +424,28 @@ class HOCXrefMixin:
                 children = result.children
                 result.clear()
 
-                shortname = target.split('.')[-1]
-                textnode = innernode('', shortname)
-                contnodes = [pending_xref_condition('', '', textnode, condition='resolved'),
-                             pending_xref_condition('', '', *children, condition='*')]
+                shortname = target.split(".")[-1]
+                textnode = innernode("", shortname)
+                contnodes = [
+                    pending_xref_condition("", "", textnode, condition="resolved"),
+                    pending_xref_condition("", "", *children, condition="*"),
+                ]
                 result.extend(contnodes)
 
         return result
 
-    def make_xrefs(self, rolename: str, domain: str, target: str,
-                   innernode: Type[TextlikeNode] = nodes.emphasis,
-                   contnode: Node = None, env: BuildEnvironment = None,
-                   inliner: Inliner = None, location: Node = None) -> List[Node]:
-        delims = r'(\s*[\[\]\(\),](?:\s*or\s)?\s*|\s+or\s+|\s*\|\s*|\.\.\.)'
+    def make_xrefs(
+        self,
+        rolename: str,
+        domain: str,
+        target: str,
+        innernode: Type[TextlikeNode] = nodes.emphasis,
+        contnode: Node = None,
+        env: BuildEnvironment = None,
+        inliner: Inliner = None,
+        location: Node = None,
+    ) -> List[Node]:
+        delims = r"(\s*[\[\]\(\),](?:\s*or\s)?\s*|\s+or\s+|\s*\|\s*|\.\.\.)"
         delims_re = re.compile(delims)
         sub_targets = re.split(delims, target)
 
@@ -394,10 +460,20 @@ class HOCXrefMixin:
             if in_literal or delims_re.match(sub_target):
                 results.append(contnode or innernode(sub_target, sub_target))
             else:
-                results.append(self.make_xref(rolename, domain, sub_target,
-                                              innernode, contnode, env, inliner, location))
+                results.append(
+                    self.make_xref(
+                        rolename,
+                        domain,
+                        sub_target,
+                        innernode,
+                        contnode,
+                        env,
+                        inliner,
+                        location,
+                    )
+                )
 
-            if sub_target in ('Literal', 'typing.Literal'):
+            if sub_target in ("Literal", "typing.Literal"):
                 in_literal = True
 
         return results
@@ -422,31 +498,60 @@ class HOCObject(ObjectDescription[Tuple[str, str]]):
     :cvar allow_nesting: Class is an object that allows for nested namespaces
     :vartype allow_nesting: bool
     """
+
     option_spec: OptionSpec = {
-        'noindex': directives.flag,
-        'noindexentry': directives.flag,
-        'module': directives.unchanged,
-        'canonical': directives.unchanged,
-        'annotation': directives.unchanged,
+        "noindex": directives.flag,
+        "noindexentry": directives.flag,
+        "module": directives.unchanged,
+        "canonical": directives.unchanged,
+        "annotation": directives.unchanged,
     }
 
     doc_field_types = [
-        HOCTypedField('parameter', label=_('Parameters'),
-                     names=('param', 'parameter', 'arg', 'argument',
-                            'keyword', 'kwarg', 'kwparam'),
-                     typerolename='class', typenames=('paramtype', 'type'),
-                     can_collapse=True),
-        HOCTypedField('variable', label=_('Variables'),
-                     names=('var', 'ivar', 'cvar'),
-                     typerolename='class', typenames=('vartype',),
-                     can_collapse=True),
-        HOCGroupedField('exceptions', label=_('Raises'), rolename='exc',
-                       names=('raises', 'raise', 'exception', 'except'),
-                       can_collapse=True),
-        Field('returnvalue', label=_('Returns'), has_arg=False,
-              names=('returns', 'return')),
-        HOCField('returntype', label=_('Return type'), has_arg=False,
-                names=('rtype',), bodyrolename='class'),
+        HOCTypedField(
+            "parameter",
+            label=_("Parameters"),
+            names=(
+                "param",
+                "parameter",
+                "arg",
+                "argument",
+                "keyword",
+                "kwarg",
+                "kwparam",
+            ),
+            typerolename="class",
+            typenames=("paramtype", "type"),
+            can_collapse=True,
+        ),
+        HOCTypedField(
+            "variable",
+            label=_("Variables"),
+            names=("var", "ivar", "cvar"),
+            typerolename="class",
+            typenames=("vartype",),
+            can_collapse=True,
+        ),
+        HOCGroupedField(
+            "exceptions",
+            label=_("Raises"),
+            rolename="exc",
+            names=("raises", "raise", "exception", "except"),
+            can_collapse=True,
+        ),
+        Field(
+            "returnvalue",
+            label=_("Returns"),
+            has_arg=False,
+            names=("returns", "return"),
+        ),
+        HOCField(
+            "returntype",
+            label=_("Return type"),
+            has_arg=False,
+            names=("rtype",),
+            bodyrolename="class",
+        ),
     ]
 
     allow_nesting = False
@@ -478,34 +583,33 @@ class HOCObject(ObjectDescription[Tuple[str, str]]):
         prefix, name, arglist, retann = m.groups()
 
         # determine module and class name (if applicable), as well as full name
-        modname = self.options.get('module', self.env.ref_context.get('hoc:module'))
-        classname = self.env.ref_context.get('hoc:class')
+        modname = self.options.get("module", self.env.ref_context.get("hoc:module"))
+        classname = self.env.ref_context.get("hoc:class")
         if classname:
             add_module = False
-            if prefix and (prefix == classname or
-                           prefix.startswith(classname + ".")):
+            if prefix and (prefix == classname or prefix.startswith(classname + ".")):
                 fullname = prefix + name
                 # class name is given again in the signature
-                prefix = prefix[len(classname):].lstrip('.')
+                prefix = prefix[len(classname) :].lstrip(".")
             elif prefix:
                 # class name is given in the signature, but different
                 # (shouldn't happen)
-                fullname = classname + '.' + prefix + name
+                fullname = classname + "." + prefix + name
             else:
                 # class name is not given in the signature
-                fullname = classname + '.' + name
+                fullname = classname + "." + name
         else:
             add_module = True
             if prefix:
-                classname = prefix.rstrip('.')
+                classname = prefix.rstrip(".")
                 fullname = prefix + name
             else:
-                classname = ''
+                classname = ""
                 fullname = name
 
-        signode['module'] = modname
-        signode['class'] = classname
-        signode['fullname'] = fullname
+        signode["module"] = modname
+        signode["class"] = classname
+        signode["fullname"] = fullname
 
         sig_prefix = self.get_signature_prefix(sig)
         if sig_prefix:
@@ -515,16 +619,18 @@ class HOCObject(ObjectDescription[Tuple[str, str]]):
                     " returning a string is deprecated."
                     " It must now return a list of nodes."
                     " Return value was '{}'.".format(sig_prefix),
-                    RemovedInSphinx60Warning)
-                signode += addnodes.desc_annotation(sig_prefix, '',  # type: ignore
-                                                    nodes.Text(sig_prefix))  # type: ignore
+                    RemovedInSphinx60Warning,
+                )
+                signode += addnodes.desc_annotation(
+                    sig_prefix, "", nodes.Text(sig_prefix)  # type: ignore
+                )  # type: ignore
             else:
-                signode += addnodes.desc_annotation(str(sig_prefix), '', *sig_prefix)
+                signode += addnodes.desc_annotation(str(sig_prefix), "", *sig_prefix)
 
         if prefix:
             signode += addnodes.desc_addname(prefix, prefix)
         elif modname and add_module and self.env.config.add_module_names:
-            nodetext = modname + '.'
+            nodetext = modname + "."
             signode += addnodes.desc_addname(nodetext, nodetext)
 
         signode += addnodes.desc_name(name, name)
@@ -536,8 +642,9 @@ class HOCObject(ObjectDescription[Tuple[str, str]]):
                 # it supports to represent optional arguments (ex. "func(foo [, bar])")
                 _pseudo_parse_arglist(signode, arglist)
             except NotImplementedError as exc:
-                logger.warning("could not parse arglist (%r): %s", arglist, exc,
-                               location=signode)
+                logger.warning(
+                    "could not parse arglist (%r): %s", arglist, exc, location=signode
+                )
                 _pseudo_parse_arglist(signode, arglist)
         else:
             if self.needs_arglist():
@@ -546,40 +653,44 @@ class HOCObject(ObjectDescription[Tuple[str, str]]):
 
         if retann:
             children = _parse_annotation(retann, self.env)
-            signode += addnodes.desc_returns(retann, '', *children)
+            signode += addnodes.desc_returns(retann, "", *children)
 
-        anno = self.options.get('annotation')
+        anno = self.options.get("annotation")
         if anno:
-            signode += addnodes.desc_annotation(' ' + anno, '',
-                                                addnodes.desc_sig_space(),
-                                                nodes.Text(anno))
+            signode += addnodes.desc_annotation(
+                " " + anno, "", addnodes.desc_sig_space(), nodes.Text(anno)
+            )
 
         return fullname, prefix
 
     def get_index_text(self, modname: str, name: Tuple[str, str]) -> str:
         """Return the text for the index entry of the object."""
-        raise NotImplementedError('must be implemented in subclasses')
+        raise NotImplementedError("must be implemented in subclasses")
 
-    def add_target_and_index(self, name_cls: Tuple[str, str], sig: str,
-                             signode: desc_signature) -> None:
-        modname = self.options.get('module', self.env.ref_context.get('hoc:module'))
-        fullname = (modname + '.' if modname else '') + name_cls[0]
-        node_id = make_id(self.env, self.state.document, '', fullname)
-        signode['ids'].append(node_id)
+    def add_target_and_index(
+        self, name_cls: Tuple[str, str], sig: str, signode: desc_signature
+    ) -> None:
+        modname = self.options.get("module", self.env.ref_context.get("hoc:module"))
+        fullname = (modname + "." if modname else "") + name_cls[0]
+        node_id = make_id(self.env, self.state.document, "", fullname)
+        signode["ids"].append(node_id)
         self.state.document.note_explicit_target(signode)
 
-        domain = cast(HOCDomain, self.env.get_domain('hoc'))
+        domain = cast(HOCDomain, self.env.get_domain("hoc"))
         domain.note_object(fullname, self.objtype, node_id, location=signode)
 
-        canonical_name = self.options.get('canonical')
+        canonical_name = self.options.get("canonical")
         if canonical_name:
-            domain.note_object(canonical_name, self.objtype, node_id, aliased=True,
-                               location=signode)
+            domain.note_object(
+                canonical_name, self.objtype, node_id, aliased=True, location=signode
+            )
 
-        if 'noindexentry' not in self.options:
+        if "noindexentry" not in self.options:
             indextext = self.get_index_text(modname, name_cls)
             if indextext:
-                self.indexnode['entries'].append(('single', indextext, node_id, '', None))
+                self.indexnode["entries"].append(
+                    ("single", indextext, node_id, "", None)
+                )
 
     def before_content(self) -> None:
         """Handle object nesting before content
@@ -603,16 +714,16 @@ class HOCObject(ObjectDescription[Tuple[str, str]]):
             if self.allow_nesting:
                 prefix = fullname
             elif name_prefix:
-                prefix = name_prefix.strip('.')
+                prefix = name_prefix.strip(".")
         if prefix:
-            self.env.ref_context['hoc:class'] = prefix
+            self.env.ref_context["hoc:class"] = prefix
             if self.allow_nesting:
-                classes = self.env.ref_context.setdefault('hoc:classes', [])
+                classes = self.env.ref_context.setdefault("hoc:classes", [])
                 classes.append(prefix)
-        if 'module' in self.options:
-            modules = self.env.ref_context.setdefault('hoc:modules', [])
-            modules.append(self.env.ref_context.get('hoc:module'))
-            self.env.ref_context['hoc:module'] = self.options['module']
+        if "module" in self.options:
+            modules = self.env.ref_context.setdefault("hoc:modules", [])
+            modules.append(self.env.ref_context.get("hoc:module"))
+            self.env.ref_context["hoc:module"] = self.options["module"]
 
     def after_content(self) -> None:
         """Handle object de-nesting after content
@@ -624,54 +735,55 @@ class HOCObject(ObjectDescription[Tuple[str, str]]):
         be altered as we didn't affect the nesting levels in
         :py:meth:`before_content`.
         """
-        classes = self.env.ref_context.setdefault('hoc:classes', [])
+        classes = self.env.ref_context.setdefault("hoc:classes", [])
         if self.allow_nesting:
             try:
                 classes.pop()
             except IndexError:
                 pass
-        self.env.ref_context['hoc:class'] = (classes[-1] if len(classes) > 0
-                                            else None)
-        if 'module' in self.options:
-            modules = self.env.ref_context.setdefault('hoc:modules', [])
+        self.env.ref_context["hoc:class"] = classes[-1] if len(classes) > 0 else None
+        if "module" in self.options:
+            modules = self.env.ref_context.setdefault("hoc:modules", [])
             if modules:
-                self.env.ref_context['hoc:module'] = modules.pop()
+                self.env.ref_context["hoc:module"] = modules.pop()
             else:
-                self.env.ref_context.pop('hoc:module')
+                self.env.ref_context.pop("hoc:module")
 
 
 class HOCFunction(HOCObject):
     """Description of a function."""
 
     option_spec: OptionSpec = HOCObject.option_spec.copy()
-    option_spec.update({
-        'async': directives.flag,
-    })
+    option_spec.update(
+        {
+            "async": directives.flag,
+        }
+    )
 
     def get_signature_prefix(self, sig: str) -> List[nodes.Node]:
-        if 'async' in self.options:
-            return [addnodes.desc_sig_keyword('', 'async'),
-                    addnodes.desc_sig_space()]
+        if "async" in self.options:
+            return [addnodes.desc_sig_keyword("", "async"), addnodes.desc_sig_space()]
         else:
             return []
 
     def needs_arglist(self) -> bool:
         return True
 
-    def add_target_and_index(self, name_cls: Tuple[str, str], sig: str,
-                             signode: desc_signature) -> None:
+    def add_target_and_index(
+        self, name_cls: Tuple[str, str], sig: str, signode: desc_signature
+    ) -> None:
         super().add_target_and_index(name_cls, sig, signode)
-        if 'noindexentry' not in self.options:
-            modname = self.options.get('module', self.env.ref_context.get('hoc:module'))
-            node_id = signode['ids'][0]
+        if "noindexentry" not in self.options:
+            modname = self.options.get("module", self.env.ref_context.get("hoc:module"))
+            node_id = signode["ids"][0]
 
             name, cls = name_cls
             if modname:
-                text = _('%s() (in module %s)') % (name, modname)
-                self.indexnode['entries'].append(('single', text, node_id, '', None))
+                text = _("%s() (in module %s)") % (name, modname)
+                self.indexnode["entries"].append(("single", text, node_id, "", None))
             else:
-                text = '%s; %s()' % (pairindextypes['builtin'], name)
-                self.indexnode['entries'].append(('pair', text, node_id, '', None))
+                text = "%s; %s()" % (pairindextypes["builtin"], name)
+                self.indexnode["entries"].append(("pair", text, node_id, "", None))
 
     def get_index_text(self, modname: str, name_cls: Tuple[str, str]) -> str:
         # add index in own add_target_and_index() instead.
@@ -683,12 +795,12 @@ class HOCDecoratorFunction(HOCFunction):
 
     def run(self) -> List[Node]:
         # a decorator function is a function after all
-        self.name = 'hoc:function'
+        self.name = "hoc:function"
         return super().run()
 
     def handle_signature(self, sig: str, signode: desc_signature) -> Tuple[str, str]:
         ret = super().handle_signature(sig, signode)
-        signode.insert(0, addnodes.desc_addname('@', '@'))
+        signode.insert(0, addnodes.desc_addname("@", "@"))
         return ret
 
     def needs_arglist(self) -> bool:
@@ -699,37 +811,46 @@ class HOCVariable(HOCObject):
     """Description of a variable."""
 
     option_spec: OptionSpec = HOCObject.option_spec.copy()
-    option_spec.update({
-        'type': directives.unchanged,
-        'value': directives.unchanged,
-    })
+    option_spec.update(
+        {
+            "type": directives.unchanged,
+            "value": directives.unchanged,
+        }
+    )
 
     def handle_signature(self, sig: str, signode: desc_signature) -> Tuple[str, str]:
         fullname, prefix = super().handle_signature(sig, signode)
 
-        typ = self.options.get('type')
+        typ = self.options.get("type")
         if typ:
             annotations = _parse_annotation(typ, self.env)
-            signode += addnodes.desc_annotation(typ, '',
-                                                addnodes.desc_sig_punctuation('', ':'),
-                                                addnodes.desc_sig_space(), *annotations)
+            signode += addnodes.desc_annotation(
+                typ,
+                "",
+                addnodes.desc_sig_punctuation("", ":"),
+                addnodes.desc_sig_space(),
+                *annotations
+            )
 
-        value = self.options.get('value')
+        value = self.options.get("value")
         if value:
-            signode += addnodes.desc_annotation(value, '',
-                                                addnodes.desc_sig_space(),
-                                                addnodes.desc_sig_punctuation('', '='),
-                                                addnodes.desc_sig_space(),
-                                                nodes.Text(value))
+            signode += addnodes.desc_annotation(
+                value,
+                "",
+                addnodes.desc_sig_space(),
+                addnodes.desc_sig_punctuation("", "="),
+                addnodes.desc_sig_space(),
+                nodes.Text(value),
+            )
 
         return fullname, prefix
 
     def get_index_text(self, modname: str, name_cls: Tuple[str, str]) -> str:
         name, cls = name_cls
         if modname:
-            return _('%s (HOC in module %s)') % (name, modname)
+            return _("%s (HOC in module %s)") % (name, modname)
         else:
-            return _('%s (HOC built-in variable)') % name
+            return _("%s (HOC built-in variable)") % name
 
 
 class HOCClasslike(HOCObject):
@@ -738,91 +859,99 @@ class HOCClasslike(HOCObject):
     """
 
     option_spec: OptionSpec = HOCObject.option_spec.copy()
-    option_spec.update({
-        'final': directives.flag,
-    })
+    option_spec.update(
+        {
+            "final": directives.flag,
+        }
+    )
 
     allow_nesting = True
 
     def get_signature_prefix(self, sig: str) -> List[nodes.Node]:
-        if 'final' in self.options:
-            return [nodes.Text('final'), addnodes.desc_sig_space(),
-                    nodes.Text(self.objtype), addnodes.desc_sig_space()]
+        if "final" in self.options:
+            return [
+                nodes.Text("final"),
+                addnodes.desc_sig_space(),
+                nodes.Text(self.objtype),
+                addnodes.desc_sig_space(),
+            ]
         else:
             return [nodes.Text(self.objtype), addnodes.desc_sig_space()]
 
     def get_index_text(self, modname: str, name_cls: Tuple[str, str]) -> str:
-        if self.objtype == 'class':
+        if self.objtype == "class":
             if not modname:
-                return _('%s (HOC built-in class)') % name_cls[0]
-            return _('%s (HOC class in %s)') % (name_cls[0], modname)
-        elif self.objtype == 'exception':
+                return _("%s (HOC built-in class)") % name_cls[0]
+            return _("%s (HOC class in %s)") % (name_cls[0], modname)
+        elif self.objtype == "exception":
             return name_cls[0]
         else:
-            return ''
+            return ""
 
 
 class HOCMethod(HOCObject):
     """Description of a method."""
 
     option_spec: OptionSpec = HOCObject.option_spec.copy()
-    option_spec.update({
-        'abstractmethod': directives.flag,
-        'async': directives.flag,
-        'classmethod': directives.flag,
-        'final': directives.flag,
-        'property': directives.flag,
-        'staticmethod': directives.flag,
-    })
+    option_spec.update(
+        {
+            "abstractmethod": directives.flag,
+            "async": directives.flag,
+            "classmethod": directives.flag,
+            "final": directives.flag,
+            "property": directives.flag,
+            "staticmethod": directives.flag,
+        }
+    )
 
     def needs_arglist(self) -> bool:
-        if 'property' in self.options:
+        if "property" in self.options:
             return False
         else:
             return True
 
     def get_signature_prefix(self, sig: str) -> List[nodes.Node]:
         prefix: List[nodes.Node] = []
-        if 'final' in self.options:
-            prefix.append(nodes.Text('final'))
+        if "final" in self.options:
+            prefix.append(nodes.Text("final"))
             prefix.append(addnodes.desc_sig_space())
-        if 'abstractmethod' in self.options:
-            prefix.append(nodes.Text('abstract'))
+        if "abstractmethod" in self.options:
+            prefix.append(nodes.Text("abstract"))
             prefix.append(addnodes.desc_sig_space())
-        if 'async' in self.options:
-            prefix.append(nodes.Text('async'))
+        if "async" in self.options:
+            prefix.append(nodes.Text("async"))
             prefix.append(addnodes.desc_sig_space())
-        if 'classmethod' in self.options:
-            prefix.append(nodes.Text('classmethod'))
+        if "classmethod" in self.options:
+            prefix.append(nodes.Text("classmethod"))
             prefix.append(addnodes.desc_sig_space())
-        if 'property' in self.options:
-            prefix.append(nodes.Text('property'))
+        if "property" in self.options:
+            prefix.append(nodes.Text("property"))
             prefix.append(addnodes.desc_sig_space())
-        if 'staticmethod' in self.options:
-            prefix.append(nodes.Text('static'))
+        if "staticmethod" in self.options:
+            prefix.append(nodes.Text("static"))
             prefix.append(addnodes.desc_sig_space())
         return prefix
 
     def get_index_text(self, modname: str, name_cls: Tuple[str, str]) -> str:
         name, cls = name_cls
         try:
-            clsname, methname = name.rsplit('.', 1)
+            clsname, methname = name.rsplit(".", 1)
             if modname and self.env.config.add_module_names:
-                clsname = '.'.join([modname, clsname])
+                clsname = ".".join([modname, clsname])
         except ValueError:
             if modname:
-                return _('%s() (in module %s)') % (name, modname)
+                return _("%s() (in module %s)") % (name, modname)
             else:
-                return '%s()' % name
+                return "%s()" % name
 
-        if 'classmethod' in self.options:
-            return _('%s() (HOC %s class method)') % (methname, clsname)
-        elif 'property' in self.options:
-            return _('%s (HOC %s property)') % (methname, clsname)
-        elif 'staticmethod' in self.options:
-            return _('%s() (HOC %s static method)') % (methname, clsname)
+        if "classmethod" in self.options:
+            return _("%s() (HOC %s class method)") % (methname, clsname)
+        elif "property" in self.options:
+            return _("%s (HOC %s property)") % (methname, clsname)
+        elif "staticmethod" in self.options:
+            return _("%s() (HOC %s static method)") % (methname, clsname)
         else:
-            return _('%s() (HOC %s method)') % (methname, clsname)
+            return _("%s() (HOC %s method)") % (methname, clsname)
 
 
 class HOCClassMethod(HOCMethod):
@@ -831,8 +960,8 @@ class HOCClassMethod(HOCMethod):
     option_spec: OptionSpec = HOCObject.option_spec.copy()
 
     def run(self) -> List[Node]:
-        self.name = 'hoc:method'
-        self.options['classmethod'] = True
+        self.name = "hoc:method"
+        self.options["classmethod"] = True
 
         return super().run()
 
@@ -843,8 +972,8 @@ class HOCStaticMethod(HOCMethod):
     option_spec: OptionSpec = HOCObject.option_spec.copy()
 
     def run(self) -> List[Node]:
-        self.name = 'hoc:method'
-        self.options['staticmethod'] = True
+        self.name = "hoc:method"
+        self.options["staticmethod"] = True
 
         return super().run()
 
@@ -853,12 +982,12 @@ class HOCDecoratorMethod(HOCMethod):
     """Description of a decoratormethod."""
 
     def run(self) -> List[Node]:
-        self.name = 'hoc:method'
+        self.name = "hoc:method"
         return super().run()
 
     def handle_signature(self, sig: str, signode: desc_signature) -> Tuple[str, str]:
         ret = super().handle_signature(sig, signode)
-        signode.insert(0, addnodes.desc_addname('@', '@'))
+        signode.insert(0, addnodes.desc_addname("@", "@"))
         return ret
 
     def needs_arglist(self) -> bool:
@@ -869,96 +998,109 @@ class HOCAttribute(HOCObject):
     """Description of an attribute."""
 
     option_spec: OptionSpec = HOCObject.option_spec.copy()
-    option_spec.update({
-        'type': directives.unchanged,
-        'value': directives.unchanged,
-    })
+    option_spec.update(
+        {
+            "type": directives.unchanged,
+            "value": directives.unchanged,
+        }
+    )
 
     def handle_signature(self, sig: str, signode: desc_signature) -> Tuple[str, str]:
         fullname, prefix = super().handle_signature(sig, signode)
 
-        typ = self.options.get('type')
+        typ = self.options.get("type")
         if typ:
             annotations = _parse_annotation(typ, self.env)
-            signode += addnodes.desc_annotation(typ, '',
-                                                addnodes.desc_sig_punctuation('', ':'),
-                                                addnodes.desc_sig_space(),
-                                                *annotations)
+            signode += addnodes.desc_annotation(
+                typ,
+                "",
+                addnodes.desc_sig_punctuation("", ":"),
+                addnodes.desc_sig_space(),
+                *annotations
+            )
 
-        value = self.options.get('value')
+        value = self.options.get("value")
         if value:
-            signode += addnodes.desc_annotation(value, '',
-                                                addnodes.desc_sig_space(),
-                                                addnodes.desc_sig_punctuation('', '='),
-                                                addnodes.desc_sig_space(),
-                                                nodes.Text(value))
+            signode += addnodes.desc_annotation(
+                value,
+                "",
+                addnodes.desc_sig_space(),
+                addnodes.desc_sig_punctuation("", "="),
+                addnodes.desc_sig_space(),
+                nodes.Text(value),
+            )
 
         return fullname, prefix
 
     def get_index_text(self, modname: str, name_cls: Tuple[str, str]) -> str:
         name, cls = name_cls
         try:
-            clsname, attrname = name.rsplit('.', 1)
+            clsname, attrname = name.rsplit(".", 1)
             if modname and self.env.config.add_module_names:
-                clsname = '.'.join([modname, clsname])
+                clsname = ".".join([modname, clsname])
         except ValueError:
             if modname:
-                return _('%s (HOC in module %s)') % (name, modname)
+                return _("%s (HOC in module %s)") % (name, modname)
             else:
                 return name
 
-        return _('%s (HOC %s attribute)') % (attrname, clsname)
+        return _("%s (HOC %s attribute)") % (attrname, clsname)
 
 
 class HOCProperty(HOCObject):
     """Description of an attribute."""
 
     option_spec = HOCObject.option_spec.copy()
-    option_spec.update({
-        'abstractmethod': directives.flag,
-        'classmethod': directives.flag,
-        'type': directives.unchanged,
-    })
+    option_spec.update(
+        {
+            "abstractmethod": directives.flag,
+            "classmethod": directives.flag,
+            "type": directives.unchanged,
+        }
+    )
 
     def handle_signature(self, sig: str, signode: desc_signature) -> Tuple[str, str]:
         fullname, prefix = super().handle_signature(sig, signode)
 
-        typ = self.options.get('type')
+        typ = self.options.get("type")
         if typ:
             annotations = _parse_annotation(typ, self.env)
-            signode += addnodes.desc_annotation(typ, '',
-                                                addnodes.desc_sig_punctuation('', ':'),
-                                                addnodes.desc_sig_space(),
-                                                *annotations)
+            signode += addnodes.desc_annotation(
+                typ,
+                "",
+                addnodes.desc_sig_punctuation("", ":"),
+                addnodes.desc_sig_space(),
+                *annotations
+            )
 
         return fullname, prefix
 
     def get_signature_prefix(self, sig: str) -> List[nodes.Node]:
         prefix: List[nodes.Node] = []
-        if 'abstractmethod' in self.options:
-            prefix.append(nodes.Text('abstract'))
+        if "abstractmethod" in self.options:
+            prefix.append(nodes.Text("abstract"))
             prefix.append(addnodes.desc_sig_space())
-        if 'classmethod' in self.options:
-            prefix.append(nodes.Text('class'))
+        if "classmethod" in self.options:
+            prefix.append(nodes.Text("class"))
             prefix.append(addnodes.desc_sig_space())
 
-        prefix.append(nodes.Text('property'))
+        prefix.append(nodes.Text("property"))
         prefix.append(addnodes.desc_sig_space())
         return prefix
 
     def get_index_text(self, modname: str, name_cls: Tuple[str, str]) -> str:
         name, cls = name_cls
         try:
-            clsname, attrname = name.rsplit('.', 1)
+            clsname, attrname = name.rsplit(".", 1)
             if modname and self.env.config.add_module_names:
-                clsname = '.'.join([modname, clsname])
+                clsname = ".".join([modname, clsname])
         except ValueError:
             if modname:
-                return _('%s (HOC in module %s)') % (name, modname)
+                return _("%s (HOC in module %s)") % (name, modname)
             else:
                 return name
 
-        return _('%s (HOC %s property)') % (attrname, clsname)
+        return _("%s (HOC %s property)") % (attrname, clsname)
 
 
 class HOCModule(SphinxDirective):
@@ -971,38 +1113,40 @@ class HOCModule(SphinxDirective):
     optional_arguments = 0
     final_argument_whitespace = False
     option_spec: OptionSpec = {
-        'platform': lambda x: x,
-        'synopsis': lambda x: x,
-        'noindex': directives.flag,
-        'deprecated': directives.flag,
+        "platform": lambda x: x,
+        "synopsis": lambda x: x,
+        "noindex": directives.flag,
+        "deprecated": directives.flag,
     }
 
     def run(self) -> List[Node]:
-        domain = cast(HOCDomain, self.env.get_domain('hoc'))
+        domain = cast(HOCDomain, self.env.get_domain("hoc"))
 
         modname = self.arguments[0].strip()
-        noindex = 'noindex' in self.options
-        self.env.ref_context['hoc:module'] = modname
+        noindex = "noindex" in self.options
+        self.env.ref_context["hoc:module"] = modname
         ret: List[Node] = []
         if not noindex:
             # note module to the domain
-            node_id = make_id(self.env, self.state.document, 'module', modname)
-            target = nodes.target('', '', ids=[node_id], ismod=True)
+            node_id = make_id(self.env, self.state.document, "module", modname)
+            target = nodes.target("", "", ids=[node_id], ismod=True)
             self.set_source_info(target)
             self.state.document.note_explicit_target(target)
 
-            domain.note_module(modname,
-                               node_id,
-                               self.options.get('synopsis', ''),
-                               self.options.get('platform', ''),
-                               'deprecated' in self.options)
-            domain.note_object(modname, 'module', node_id, location=target)
+            domain.note_module(
+                modname,
+                node_id,
+                self.options.get("synopsis", ""),
+                self.options.get("platform", ""),
+                "deprecated" in self.options,
+            )
+            domain.note_object(modname, "module", node_id, location=target)
 
             # the platform and synopsis aren't printed; in fact, they are only
             # used in the modindex currently
             ret.append(target)
-            indextext = '%s; %s' % (pairindextypes['module'], modname)
-            inode = addnodes.index(entries=[('pair', indextext, node_id, '', None)])
+            indextext = "%s; %s" % (pairindextypes["module"], modname)
+            inode = addnodes.index(entries=[("pair", indextext, node_id, "", None)])
             ret.append(inode)
         return ret
 
@@ -1014,7 +1158,7 @@ class HOCModule(SphinxDirective):
 
         .. note:: Old styled node_id was mainly used until Sphinx-3.0.
         """
-        return 'module-%s' % name
+        return "module-%s" % name
 
 
 class HOCCurrentModule(SphinxDirective):
@@ -1031,39 +1175,47 @@ class HOCCurrentModule(SphinxDirective):
 
     def run(self) -> List[Node]:
         modname = self.arguments[0].strip()
-        if modname == 'None':
-            self.env.ref_context.pop('hoc:module', None)
+        if modname == "None":
+            self.env.ref_context.pop("hoc:module", None)
         else:
-            self.env.ref_context['hoc:module'] = modname
+            self.env.ref_context["hoc:module"] = modname
         return []
 
 
 class HOCXRefRole(XRefRole):
-    def process_link(self, env: BuildEnvironment, refnode: Element,
-                     has_explicit_title: bool, title: str, target: str) -> Tuple[str, str]:
-        refnode['hoc:module'] = env.ref_context.get('hoc:module')
-        refnode['hoc:class'] = env.ref_context.get('hoc:class')
+    def process_link(
+        self,
+        env: BuildEnvironment,
+        refnode: Element,
+        has_explicit_title: bool,
+        title: str,
+        target: str,
+    ) -> Tuple[str, str]:
+        refnode["hoc:module"] = env.ref_context.get("hoc:module")
+        refnode["hoc:class"] = env.ref_context.get("hoc:class")
         if not has_explicit_title:
-            title = title.lstrip('.')    # only has a meaning for the target
-            target = target.lstrip('~')  # only has a meaning for the title
+            title = title.lstrip(".")  # only has a meaning for the target
+            target = target.lstrip("~")  # only has a meaning for the title
             # if the first character is a tilde, don't display the module/class
             # parts of the contents
-            if title[0:1] == '~':
+            if title[0:1] == "~":
                 title = title[1:]
-                dot = title.rfind('.')
+                dot = title.rfind(".")
                 if dot != -1:
-                    title = title[dot + 1:]
+                    title = title[dot + 1 :]
         # if the first character is a dot, search more specific namespaces first
         # else search builtins first
-        if target[0:1] == '.':
+        if target[0:1] == ".":
             target = target[1:]
-            refnode['refspecific'] = True
+            refnode["refspecific"] = True
         return title, target
 
 
-def filter_meta_fields(app: Sphinx, domain: str, objtype: str, content: Element) -> None:
+def filter_meta_fields(
+    app: Sphinx, domain: str, objtype: str, content: Element
+) -> None:
     """Filter ``:meta:`` field from its docstring."""
-    if domain != 'hoc':
+    if domain != "hoc":
         return
 
     for node in content:
@@ -1072,7 +1224,7 @@ def filter_meta_fields(app: Sphinx, domain: str, objtype: str, content: Element)
             # removing list items while iterating the list needs reversed()
             for field in reversed(fields):
                 field_name = cast(nodes.field_body, field[0]).astext().strip()
-                if field_name == 'meta' or field_name.startswith('meta '):
+                if field_name == "meta" or field_name.startswith("meta "):
                     node.remove(field)
 
 
@@ -1081,21 +1233,23 @@ class HOCModuleIndex(Index):
     Index subclass to provide the HOC module index.
     """
 
-    name = 'modindex'
-    localname = _('HOC Module Index')
-    shortname = _('modules')
+    name = "modindex"
+    localname = _("HOC Module Index")
+    shortname = _("modules")
 
-    def generate(self, docnames: Iterable[str] = None
-                 ) -> Tuple[List[Tuple[str, List[IndexEntry]]], bool]:
+    def generate(
+        self, docnames: Iterable[str] = None
+    ) -> Tuple[List[Tuple[str, List[IndexEntry]]], bool]:
         content: Dict[str, List[IndexEntry]] = {}
         # list of prefixes to ignore
-        ignores: List[str] = self.domain.env.config['modindex_common_prefix']
+        ignores: List[str] = self.domain.env.config["modindex_common_prefix"]
         ignores = sorted(ignores, key=len, reverse=True)
         # list of all modules, sorted by module name
-        modules = sorted(self.domain.data['modules'].items(),
-                         key=lambda x: x[0].lower())
+        modules = sorted(
+            self.domain.data["modules"].items(), key=lambda x: x[0].lower()
+        )
         # sort out collapsible modules
-        prev_modname = ''
+        prev_modname = ""
         num_toplevels = 0
         for modname, (docname, node_id, synopsis, platforms, deprecated) in modules:
             if docnames and docname not in docnames:
@@ -1103,38 +1257,50 @@ class HOCModuleIndex(Index):
 
             for ignore in ignores:
                 if modname.startswith(ignore):
-                    modname = modname[len(ignore):]
+                    modname = modname[len(ignore) :]
                     stripped = ignore
                     break
             else:
-                stripped = ''
+                stripped = ""
 
             # we stripped the whole module name?
             if not modname:
-                modname, stripped = stripped, ''
+                modname, stripped = stripped, ""
 
             entries = content.setdefault(modname[0].lower(), [])
 
-            package = modname.split('.')[0]
+            package = modname.split(".")[0]
             if package != modname:
                 # it's a submodule
                 if prev_modname == package:
                     # first submodule - make parent a group head
                     if entries:
                         last = entries[-1]
-                        entries[-1] = IndexEntry(last[0], 1, last[2], last[3],
-                                                 last[4], last[5], last[6])
+                        entries[-1] = IndexEntry(
+                            last[0], 1, last[2], last[3], last[4], last[5], last[6]
+                        )
                 elif not prev_modname.startswith(package):
                     # submodule without parent in list, add dummy entry
-                    entries.append(IndexEntry(stripped + package, 1, '', '', '', '', ''))
+                    entries.append(
+                        IndexEntry(stripped + package, 1, "", "", "", "", "")
+                    )
                 subtype = 2
             else:
                 num_toplevels += 1
                 subtype = 0
 
-            qualifier = _('Deprecated') if deprecated else ''
-            entries.append(IndexEntry(stripped + modname, subtype, docname,
-                                      node_id, platforms, qualifier, synopsis))
+            qualifier = _("Deprecated") if deprecated else ""
+            entries.append(
+                IndexEntry(
+                    stripped + modname,
+                    subtype,
+                    docname,
+                    node_id,
+                    platforms,
+                    qualifier,
+                    synopsis,
+                )
+            )
             prev_modname = modname
 
         # apply heuristics when to collapse modindex at page load:
@@ -1150,50 +1316,51 @@ class HOCModuleIndex(Index):
 
 class HOCDomain(Domain):
     """HOC language domain."""
-    name = 'hoc'
-    label = 'HOC'
+
+    name = "hoc"
+    label = "HOC"
     object_types: Dict[str, ObjType] = {
-        'function':     ObjType(_('function'),      'func', 'obj'),
-        'data':         ObjType(_('data'),          'data', 'obj'),
-        'class':        ObjType(_('class'),         'class', 'exc', 'obj'),
-        'exception':    ObjType(_('exception'),     'exc', 'class', 'obj'),
-        'method':       ObjType(_('method'),        'meth', 'obj'),
-        'classmethod':  ObjType(_('class method'),  'meth', 'obj'),
-        'staticmethod': ObjType(_('static method'), 'meth', 'obj'),
-        'attribute':    ObjType(_('attribute'),     'attr', 'obj'),
-        'property':     ObjType(_('property'),      'attr', '_prop', 'obj'),
-        'module':       ObjType(_('module'),        'mod', 'obj'),
+        "function": ObjType(_("function"), "func", "obj"),
+        "data": ObjType(_("data"), "data", "obj"),
+        "class": ObjType(_("class"), "class", "exc", "obj"),
+        "exception": ObjType(_("exception"), "exc", "class", "obj"),
+        "method": ObjType(_("method"), "meth", "obj"),
+        "classmethod": ObjType(_("class method"), "meth", "obj"),
+        "staticmethod": ObjType(_("static method"), "meth", "obj"),
+        "attribute": ObjType(_("attribute"), "attr", "obj"),
+        "property": ObjType(_("property"), "attr", "_prop", "obj"),
+        "module": ObjType(_("module"), "mod", "obj"),
     }
 
     directives = {
-        'function':        HOCFunction,
-        'data':            HOCVariable,
-        'class':           HOCClasslike,
-        'exception':       HOCClasslike,
-        'method':          HOCMethod,
-        'classmethod':     HOCClassMethod,
-        'staticmethod':    HOCStaticMethod,
-        'attribute':       HOCAttribute,
-        'property':        HOCProperty,
-        'module':          HOCModule,
-        'currentmodule':   HOCCurrentModule,
-        'decorator':       HOCDecoratorFunction,
-        'decoratormethod': HOCDecoratorMethod,
+        "function": HOCFunction,
+        "data": HOCVariable,
+        "class": HOCClasslike,
+        "exception": HOCClasslike,
+        "method": HOCMethod,
+        "classmethod": HOCClassMethod,
+        "staticmethod": HOCStaticMethod,
+        "attribute": HOCAttribute,
+        "property": HOCProperty,
+        "module": HOCModule,
+        "currentmodule": HOCCurrentModule,
+        "decorator": HOCDecoratorFunction,
+        "decoratormethod": HOCDecoratorMethod,
     }
     roles = {
-        'data':  HOCXRefRole(),
-        'exc':   HOCXRefRole(),
-        'func':  HOCXRefRole(fix_parens=True),
-        'class': HOCXRefRole(),
-        'const': HOCXRefRole(),
-        'attr':  HOCXRefRole(),
-        'meth':  HOCXRefRole(fix_parens=True),
-        'mod':   HOCXRefRole(),
-        'obj':   HOCXRefRole(),
+        "data": HOCXRefRole(),
+        "exc": HOCXRefRole(),
+        "func": HOCXRefRole(fix_parens=True),
+        "class": HOCXRefRole(),
+        "const": HOCXRefRole(),
+        "attr": HOCXRefRole(),
+        "meth": HOCXRefRole(fix_parens=True),
+        "mod": HOCXRefRole(),
+        "obj": HOCXRefRole(),
     }
     initial_data: Dict[str, Dict[str, Tuple[Any]]] = {
-        'objects': {},  # fullname -> docname, objtype
-        'modules': {},  # modname -> docname, synopsis, platform, deprecated
+        "objects": {},  # fullname -> docname, objtype
+        "modules": {},  # modname -> docname, synopsis, platform, deprecated
     }
     indices = [
         HOCModuleIndex,
@@ -1201,10 +1368,16 @@ class HOCDomain(Domain):
 
     @property
     def objects(self) -> Dict[str, ObjectEntry]:
-        return self.data.setdefault('objects', {})  # fullname -> ObjectEntry
+        return self.data.setdefault("objects", {})  # fullname -> ObjectEntry
 
-    def note_object(self, name: str, objtype: str, node_id: str,
-                    aliased: bool = False, location: Any = None) -> None:
+    def note_object(
+        self,
+        name: str,
+        objtype: str,
+        node_id: str,
+        aliased: bool = False,
+        location: Any = None,
+    ) -> None:
         """Note a python object for cross reference.
 
         .. versionadded:: 2.1
@@ -1219,23 +1392,31 @@ class HOCDomain(Domain):
                 return
             else:
                 # duplicated
-                logger.warning(__('duplicate object description of %s, '
-                                  'other instance in %s, use :noindex: for one of them'),
-                               name, other.docname, location=location)
+                logger.warning(
+                    __(
+                        "duplicate object description of %s, "
+                        "other instance in %s, use :noindex: for one of them"
+                    ),
+                    name,
+                    other.docname,
+                    location=location,
+                )
         self.objects[name] = ObjectEntry(self.env.docname, node_id, objtype, aliased)
 
     @property
     def modules(self) -> Dict[str, ModuleEntry]:
-        return self.data.setdefault('modules', {})  # modname -> ModuleEntry
+        return self.data.setdefault("modules", {})  # modname -> ModuleEntry
 
-    def note_module(self, name: str, node_id: str, synopsis: str,
-                    platform: str, deprecated: bool) -> None:
+    def note_module(
+        self, name: str, node_id: str, synopsis: str, platform: str, deprecated: bool
+    ) -> None:
         """Note a python module for cross reference.
 
         .. versionadded:: 2.1
         """
-        self.modules[name] = ModuleEntry(self.env.docname, node_id,
-                                         synopsis, platform, deprecated)
+        self.modules[name] = ModuleEntry(
+            self.env.docname, node_id, synopsis, platform, deprecated
+        )
 
     def clear_doc(self, docname: str) -> None:
         for fullname, obj in list(self.objects.items()):
@@ -1247,21 +1428,27 @@ class HOCDomain(Domain):
 
     def merge_domaindata(self, docnames: List[str], otherdata: Dict) -> None:
         # XXX check duplicates?
-        for fullname, obj in otherdata['objects'].items():
+        for fullname, obj in otherdata["objects"].items():
             if obj.docname in docnames:
                 self.objects[fullname] = obj
-        for modname, mod in otherdata['modules'].items():
+        for modname, mod in otherdata["modules"].items():
             if mod.docname in docnames:
                 self.modules[modname] = mod
 
-    def find_obj(self, env: BuildEnvironment, modname: str, classname: str,
-                 name: str, type: str, searchmode: int = 0
-                 ) -> List[Tuple[str, ObjectEntry]]:
+    def find_obj(
+        self,
+        env: BuildEnvironment,
+        modname: str,
+        classname: str,
+        name: str,
+        type: str,
+        searchmode: int = 0,
+    ) -> List[Tuple[str, ObjectEntry]]:
         """Find a HOC object for "name", perhaps using the given module
         and/or classname.  Returns a list of (name, object entry) tuples.
         """
         # skip parens
-        if name[-2:] == '()':
+        if name[-2:] == "()":
             name = name[:-2]
 
         if not name:
@@ -1277,60 +1464,80 @@ class HOCDomain(Domain):
                 objtypes = self.objtypes_for_role(type)
             if objtypes is not None:
                 if modname and classname:
-                    fullname = modname + '.' + classname + '.' + name
-                    if fullname in self.objects and self.objects[fullname].objtype in objtypes:
+                    fullname = modname + "." + classname + "." + name
+                    if (
+                        fullname in self.objects
+                        and self.objects[fullname].objtype in objtypes
+                    ):
                         newname = fullname
                 if not newname:
-                    if modname and modname + '.' + name in self.objects and \
-                       self.objects[modname + '.' + name].objtype in objtypes:
-                        newname = modname + '.' + name
-                    elif name in self.objects and self.objects[name].objtype in objtypes:
+                    if (
+                        modname
+                        and modname + "." + name in self.objects
+                        and self.objects[modname + "." + name].objtype in objtypes
+                    ):
+                        newname = modname + "." + name
+                    elif (
+                        name in self.objects and self.objects[name].objtype in objtypes
+                    ):
                         newname = name
                     else:
                         # "fuzzy" searching mode
-                        searchname = '.' + name
-                        matches = [(oname, self.objects[oname]) for oname in self.objects
-                                   if oname.endswith(searchname) and
-                                   self.objects[oname].objtype in objtypes]
+                        searchname = "." + name
+                        matches = [
+                            (oname, self.objects[oname])
+                            for oname in self.objects
+                            if oname.endswith(searchname)
+                            and self.objects[oname].objtype in objtypes
+                        ]
         else:
             # NOTE: searching for exact match, object type is not considered
             if name in self.objects:
                 newname = name
-            elif type == 'mod':
+            elif type == "mod":
                 # only exact matches allowed for modules
                 return []
-            elif classname and classname + '.' + name in self.objects:
-                newname = classname + '.' + name
-            elif modname and modname + '.' + name in self.objects:
-                newname = modname + '.' + name
-            elif modname and classname and \
-                    modname + '.' + classname + '.' + name in self.objects:
-                newname = modname + '.' + classname + '.' + name
+            elif classname and classname + "." + name in self.objects:
+                newname = classname + "." + name
+            elif modname and modname + "." + name in self.objects:
+                newname = modname + "." + name
+            elif (
+                modname
+                and classname
+                and modname + "." + classname + "." + name in self.objects
+            ):
+                newname = modname + "." + classname + "." + name
         if newname is not None:
             matches.append((newname, self.objects[newname]))
         return matches
 
-    def resolve_xref(self, env: BuildEnvironment, fromdocname: str, builder: Builder,
-                     type: str, target: str, node: pending_xref, contnode: Element
-                     ) -> Optional[Element]:
-        modname = node.get('hoc:module')
-        clsname = node.get('hoc:class')
-        searchmode = 1 if node.hasattr('refspecific') else 0
-        matches = self.find_obj(env, modname, clsname, target,
-                                type, searchmode)
+    def resolve_xref(
+        self,
+        env: BuildEnvironment,
+        fromdocname: str,
+        builder: Builder,
+        type: str,
+        target: str,
+        node: pending_xref,
+        contnode: Element,
+    ) -> Optional[Element]:
+        modname = node.get("hoc:module")
+        clsname = node.get("hoc:class")
+        searchmode = 1 if node.hasattr("refspecific") else 0
+        matches = self.find_obj(env, modname, clsname, target, type, searchmode)
 
-        if not matches and type == 'attr':
+        if not matches and type == "attr":
             # fallback to meth (for property; Sphinx-2.4.x)
             # this ensures that `:attr:` role continues to refer to the old property entry
             # that defined by ``method`` directive in old reST files.
-            matches = self.find_obj(env, modname, clsname, target, 'meth', searchmode)
-        if not matches and type == 'meth':
+            matches = self.find_obj(env, modname, clsname, target, "meth", searchmode)
+        if not matches and type == "meth":
             # fallback to attr (for property)
             # this ensures that `:meth:` in the old reST files can refer to the property
             # entry that defined by ``property`` directive.
             #
             # Note: _prop is a secret role only for internal look-up.
-            matches = self.find_obj(env, modname, clsname, target, '_prop', searchmode)
+            matches = self.find_obj(env, modname, clsname, target, "_prop", searchmode)
 
         if not matches:
             return None
@@ -1339,16 +1546,21 @@ class HOCDomain(Domain):
             if len(canonicals) == 1:
                 matches = canonicals
             else:
-                logger.warning(__('more than one target found for cross-reference %r: %s'),
-                               target, ', '.join(match[0] for match in matches),
-                               type='ref', subtype='hoc', location=node)
+                logger.warning(
+                    __("more than one target found for cross-reference %r: %s"),
+                    target,
+                    ", ".join(match[0] for match in matches),
+                    type="ref",
+                    subtype="hoc",
+                    location=node,
+                )
         name, obj = matches[0]
 
-        if obj[2] == 'module':
+        if obj[2] == "module":
             return self._make_module_refnode(builder, fromdocname, name, contnode)
         else:
             # determine the content of the reference by conditions
-            content = find_pending_xref_condition(node, 'resolved')
+            content = find_pending_xref_condition(node, "resolved")
             if content:
                 children = content.children
             else:
@@ -1357,53 +1569,69 @@ class HOCDomain(Domain):
 
             return make_refnode(builder, fromdocname, obj[0], obj[1], children, name)
 
-    def resolve_any_xref(self, env: BuildEnvironment, fromdocname: str, builder: Builder,
-                         target: str, node: pending_xref, contnode: Element
-                         ) -> List[Tuple[str, Element]]:
-        modname = node.get('hoc:module')
-        clsname = node.get('hoc:class')
+    def resolve_any_xref(
+        self,
+        env: BuildEnvironment,
+        fromdocname: str,
+        builder: Builder,
+        target: str,
+        node: pending_xref,
+        contnode: Element,
+    ) -> List[Tuple[str, Element]]:
+        modname = node.get("hoc:module")
+        clsname = node.get("hoc:class")
         results: List[Tuple[str, Element]] = []
 
         # always search in "refspecific" mode with the :any: role
         matches = self.find_obj(env, modname, clsname, target, None, 1)
         for name, obj in matches:
-            if obj[2] == 'module':
-                results.append(('hoc:mod',
-                                self._make_module_refnode(builder, fromdocname,
-                                                          name, contnode)))
+            if obj[2] == "module":
+                results.append(
+                    (
+                        "hoc:mod",
+                        self._make_module_refnode(builder, fromdocname, name, contnode),
+                    )
+                )
             else:
                 # determine the content of the reference by conditions
-                content = find_pending_xref_condition(node, 'resolved')
+                content = find_pending_xref_condition(node, "resolved")
                 if content:
                     children = content.children
                 else:
                     # if not found, use contnode
                     children = [contnode]
 
-                results.append(('hoc:' + self.role_for_objtype(obj[2]),
-                                make_refnode(builder, fromdocname, obj[0], obj[1],
-                                             children, name)))
+                results.append(
+                    (
+                        "hoc:" + self.role_for_objtype(obj[2]),
+                        make_refnode(
+                            builder, fromdocname, obj[0], obj[1], children, name
+                        ),
+                    )
+                )
         return results
 
-    def _make_module_refnode(self, builder: Builder, fromdocname: str, name: str,
-                             contnode: Node) -> Element:
+    def _make_module_refnode(
+        self, builder: Builder, fromdocname: str, name: str, contnode: Node
+    ) -> Element:
         # get additional info for modules
         module = self.modules[name]
         title = name
         if module.synopsis:
-            title += ': ' + module.synopsis
+            title += ": " + module.synopsis
         if module.deprecated:
-            title += _(' (deprecated)')
+            title += _(" (deprecated)")
         if module.platform:
-            title += ' (' + module.platform + ')'
-        return make_refnode(builder, fromdocname, module.docname, module.node_id,
-                            contnode, title)
+            title += " (" + module.platform + ")"
+        return make_refnode(
+            builder, fromdocname, module.docname, module.node_id, contnode, title
+        )
 
     def get_objects(self) -> Iterator[Tuple[str, str, str, str, str, int]]:
         for modname, mod in self.modules.items():
-            yield (modname, modname, 'module', mod.docname, mod.node_id, 0)
+            yield (modname, modname, "module", mod.docname, mod.node_id, 0)
         for refname, obj in self.objects.items():
-            if obj.objtype != 'module':  # modules are already handled
+            if obj.objtype != "module":  # modules are already handled
                 if obj.aliased:
                     # aliased names are not full-text searchable.
                     yield (refname, refname, obj.objtype, obj.docname, obj.node_id, -1)
@@ -1411,30 +1639,32 @@ class HOCDomain(Domain):
                     yield (refname, refname, obj.objtype, obj.docname, obj.node_id, 1)
 
     def get_full_qualified_name(self, node: Element) -> Optional[str]:
-        modname = node.get('hoc:module')
-        clsname = node.get('hoc:class')
-        target = node.get('reftarget')
+        modname = node.get("hoc:module")
+        clsname = node.get("hoc:class")
+        target = node.get("reftarget")
         if target is None:
             return None
         else:
-            return '.'.join(filter(None, [modname, clsname, target]))
+            return ".".join(filter(None, [modname, clsname, target]))
 
 
-def builtin_resolver(app: Sphinx, env: BuildEnvironment,
-                     node: pending_xref, contnode: Element) -> Element:
+def builtin_resolver(
+    app: Sphinx, env: BuildEnvironment, node: pending_xref, contnode: Element
+) -> Element:
     """Do not emit nitpicky warnings for built-in types."""
+
     def istyping(s: str) -> bool:
-        if s.startswith('typing.'):
-            s = s.split('.', 1)[1]
+        if s.startswith("typing."):
+            s = s.split(".", 1)[1]
 
         return s in typing.__all__
 
-    if node.get('refdomain') != 'hoc':
+    if node.get("refdomain") != "hoc":
         return None
-    elif node.get('reftype') in ('class', 'obj') and node.get('reftarget') == 'None':
+    elif node.get("reftype") in ("class", "obj") and node.get("reftarget") == "None":
         return contnode
-    elif node.get('reftype') in ('class', 'obj', 'exc'):
-        reftarget = node.get('reftarget')
+    elif node.get("reftype") in ("class", "obj", "exc"):
+        reftarget = node.get("reftarget")
         if inspect.isclass(getattr(builtins, reftarget, None)):
             # built-in class
             return contnode
@@ -1446,16 +1676,16 @@ def builtin_resolver(app: Sphinx, env: BuildEnvironment,
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:
-    app.setup_extension('sphinx.directives')
+    app.setup_extension("sphinx.directives")
 
     app.add_domain(HOCDomain)
-    app.add_config_value('hoc_use_unqualified_type_names', False, 'env')
-    app.connect('object-description-transform', filter_meta_fields)
-    app.connect('missing-reference', builtin_resolver, priority=900)
+    app.add_config_value("hoc_use_unqualified_type_names", False, "env")
+    app.connect("object-description-transform", filter_meta_fields)
+    app.connect("missing-reference", builtin_resolver, priority=900)
 
     return {
-        'version': 'builtin',
-        'env_version': 3,
-        'parallel_read_safe': True,
-        'parallel_write_safe': True,
+        "version": "builtin",
+        "env_version": 3,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
     }


### PR DESCRIPTION
Sphinx 5.0.1 is out:
```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/nrn/conda/latest/lib/python3.10/site-packages/sphinx/config.py", line 343, in eval_config_file
    exec(code, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/nrn/checkouts/latest/docs/conf.py", line 22, in <module>
    import hocdomain  # Sphinx HOC domain (hacked from the Python domain via docs/generate_hocdomain.py)
  File "/home/docs/checkouts/readthedocs.org/user_builds/nrn/checkouts/latest/docs/domains/hocdomain.py", line 41, in <module>
    from sphinx.deprecation import RemovedInSphinx50Warning, RemovedInSphinx60Warning
ImportError: cannot import name 'RemovedInSphinx50Warning' from 'sphinx.deprecation' (/home/docs/checkouts/readthedocs.org/user_builds/nrn/conda/latest/lib/python3.10/site-packages/sphinx/deprecation.py)
```
