### PR TITLE
Fix clang-14 warnings flagged in CI

### DIFF
--- a/src/ivoc/gifimage.cpp
+++ b/src/ivoc/gifimage.cpp
@@ -31,7 +31,7 @@ static int LoadGIF(const char* fname, PICINFO*);
 
 
 Image* gif_image(const char* filename) {
-    Image* image;
+    Image* image{};
     pinfo_ = new PICINFO;
     if (LoadGIF(filename, pinfo_)) {
         image = new Image(pinfo_->raster);

--- a/src/ivoc/graph.cpp
+++ b/src/ivoc/graph.cpp
@@ -2301,7 +2301,7 @@ void Graph::new_axis() {
     }
     XYView* v = XYView::current_pick_view();
     erase_axis();
-    Coord x1, x2, y1, y2;
+    Coord x1{}, x2{}, y1{}, y2{};
     if (v) {
         v->zin(x1, y1, x2, y2);
     }

--- a/src/ivoc/grmanip.cpp
+++ b/src/ivoc/grmanip.cpp
@@ -62,7 +62,6 @@ class MoveLabelBand: public Rubberband {
     GLabel* label_;
     GlyphIndex index_;
     Allocation a_;
-    Cursor* cursor_;
     Coord x0_, y0_;
 };
 
@@ -514,10 +513,6 @@ void MoveLabelBand::press(Event&) {
     }
     x0_ -= x_begin();
     y0_ -= y_begin();
-#if 0 && !defined(WIN32)
-	cursor_ = canvas()->window()->cursor();
-	canvas()->window()->cursor(noCursor);
-#endif
 #if !defined(WIN32) && !MAC
     undraw(x(), y());  // so initial draw does not make it disappear
 #endif
@@ -548,9 +543,6 @@ void MoveLabelBand::release(Event&) {
     }
     // printf("move to %g %g\n", x1, y1);
     gr->move(index_, x1, y1);
-#if 0 && !defined(WIN32)
-	canvas()->window()->cursor(cursor_);
-#endif
 }
 
 void MoveLabelBand::draw(Coord x, Coord y) {

--- a/src/ivoc/ocdeck.cpp
+++ b/src/ivoc/ocdeck.cpp
@@ -309,7 +309,7 @@ void OcDeck::remove_last() {
     bi_->deck_->remove(last);
 }
 
-void OcDeck::remove(int i) {
+void OcDeck::remove(long i) {
     if (bi_->deck_->card() == i) {
         flip_to(-1);
     }

--- a/src/ivoc/ocdeck.h
+++ b/src/ivoc/ocdeck.h
@@ -17,7 +17,7 @@ class OcDeck: public OcGlyphContainer {
     virtual void save_action(const char*, Object*);
     virtual void flip_to(int);
     virtual void remove_last();
-    virtual void remove(int);
+    virtual void remove(long);
     virtual void move_last(int);  // make last item the i'th item
   private:
     OcDeckImpl* bi_;

--- a/src/ivoc/ocfile.h
+++ b/src/ivoc/ocfile.h
@@ -45,7 +45,9 @@ class OcFile {
   private:
     FileChooser* fc_;
     enum { N, R, W, A };
+#if HAVE_IV
     int chooser_type_;
+#endif
     CopyString filename_;
     CopyString dirname_;
     FILE* file_;

--- a/src/ivoc/symchoos.cpp
+++ b/src/ivoc/symchoos.cpp
@@ -72,7 +72,6 @@ class SymChooserImpl {
     SymChooserImpl(int nbrowser);
     ~SymChooserImpl();
 
-    String* name_;
     WidgetKit* kit_;
     SymChooser* fchooser_;
     int nbrowser_;
@@ -239,7 +238,6 @@ declareActionCallback(SymChooserImpl) implementActionCallback(SymChooserImpl)
 #endif
     }
     Resource::ref(dir);
-    //    fc.name_ = new CopyString(dir->name());
     fc.kit_ = kit;
     fc.init(this, s, a);
 }
@@ -309,7 +307,6 @@ void SymChooserImpl::init(SymChooser* chooser, Style* s, SymChooserAction* a) {
 }
 
 void SymChooserImpl::scfree() {
-    //    delete name_;
     for (int i = nbrowser_ - 1; i >= 0; --i) {
         Resource::unref(dir_[i]);
     }

--- a/src/ivoc/xmenu.h
+++ b/src/ivoc/xmenu.h
@@ -269,9 +269,7 @@ class HocEditorForItem: public FieldSEditor {
 
   private:
     HocValEditor* hve_;
-    Coord y_;
     int index_;
-    EventButton b_;
 };
 
 class HocValStepper: public Stepper {

--- a/src/modlunit/units.cpp
+++ b/src/modlunit/units.cpp
@@ -1183,8 +1183,7 @@ void nrnunit_dynamic_str(char* buf, const char* name, char* u1, char* u2) {
             name,
             name,
             modern,
-            legacy,
-            modern);
+            legacy);
 
 #else
 

--- a/src/nrniv/geometry3d.cpp
+++ b/src/nrniv/geometry3d.cpp
@@ -550,7 +550,7 @@ class geometry3d_Cone {
     double signed_distance(double px, double py, double pz);
 
   private:
-    double axisx, axisy, axisz, cx, cy, cz, h, rra, rrb, conelength;
+    double axisx, axisy, axisz, h, rra, rrb, conelength;
     double side1, side2, x0, y0, z0, r0, axislength;
 };
 
@@ -562,10 +562,7 @@ geometry3d_Cone::geometry3d_Cone(double x0,
                                  double y1,
                                  double z1,
                                  double r1)
-    : cx((x0 + x1) / 2.)
-    , cy((y0 + y1) / 2.)
-    , cz((z0 + z1) / 2.)
-    , rra(r0 * r0)
+    : rra(r0 * r0)
     , rrb(r1 * r1)
     , x0(x0)
     , y0(y0)

--- a/src/nrniv/nvector_nrnparallel_ld.cpp
+++ b/src/nrniv/nvector_nrnparallel_ld.cpp
@@ -913,7 +913,7 @@ static realtype VAllReduce_NrnParallelLD(realtype d, int op, MPI_Comm comm) {
      * The operation is over all processors in the communicator
      */
 
-    realtype out;
+    realtype out = 0.0;
 
 #if NRNMPI_DYNAMICLOAD
     nrnmpi_dbl_allreduce_vec(&d, &out, 1, op);

--- a/src/nrnoc/solve.cpp
+++ b/src/nrnoc/solve.cpp
@@ -226,7 +226,7 @@ double topol_distance(Section* sec1,
 static Section* origin_sec;
 
 void distance(void) {
-    double d, d_origin;
+    double d, d_origin{};
     int mode;
     Node* node;
     Section* sec;

--- a/src/oc/plot.cpp
+++ b/src/oc/plot.cpp
@@ -866,9 +866,7 @@ void vtplot(int mode, double x, double y) {
 #endif /*VT*/
 
 int set_color(int c) {
-    if (c >= 0 || c < 128) {
-        hoc_color = c;
-    }
+    hoc_color = c;
 #if defined(__TURBOC__)
     if (egagrph) {
         setcolor(hoc_color);

--- a/src/parallel/bbslocal.cpp
+++ b/src/parallel/bbslocal.cpp
@@ -56,14 +56,14 @@ void BBSLocal::perror(const char* s) {
 }
 
 int BBSLocal::upkint() {
-    int i;
+    int i{};
     if (!taking_ || taking_->upkint(&i))
         perror("upkint");
     return i;
 }
 
 double BBSLocal::upkdouble() {
-    double x;
+    double x{};
     if (!taking_ || taking_->upkdouble(&x)) {
         perror("upkdouble");
     }
@@ -77,7 +77,7 @@ void BBSLocal::upkvec(int n, double* x) {
 }
 
 char* BBSLocal::upkstr() {
-    int len;
+    int len{};
     char* s;
     if (!taking_ || taking_->upkint(&len)) {
         perror("upkstr length");
@@ -90,7 +90,7 @@ char* BBSLocal::upkstr() {
 }
 
 char* BBSLocal::upkpickle(size_t* n) {
-    int len;
+    int len{};
     char* s;
     if (!taking_ || taking_->upkint(&len)) {
         perror("upkpickle length");

--- a/src/parallel/bbslsrv.h
+++ b/src/parallel/bbslsrv.h
@@ -45,7 +45,6 @@ class MessageValue: public Resource {
     MessageItem* link();
 
   private:
-    int type_;
     MessageItem* first_;
     MessageItem* last_;
     MessageItem* unpack_;

--- a/src/sparse13/spfactor.c
+++ b/src/sparse13/spfactor.c
@@ -965,7 +965,7 @@ double fProduct;
         if ((*pMarkowitzRow > LARGEST_SHORT_INTEGER AND *pMarkowitzCol != 0) OR
             (*pMarkowitzCol > LARGEST_SHORT_INTEGER AND *pMarkowitzRow != 0))
         {   fProduct = (double)(*pMarkowitzRow++) * (double)(*pMarkowitzCol++);
-            if (fProduct >= LARGEST_LONG_INTEGER)
+            if (fProduct >= (double)LARGEST_LONG_INTEGER)
                 *pMarkowitzProduct++ = LARGEST_LONG_INTEGER;
             else
                 *pMarkowitzProduct++ = fProduct;
@@ -2910,7 +2910,7 @@ double Product;
         if ((MarkoRow[Row] > LARGEST_SHORT_INTEGER AND MarkoCol[Row] != 0) OR
             (MarkoCol[Row] > LARGEST_SHORT_INTEGER AND MarkoRow[Row] != 0))
         {   Product = MarkoCol[Row] * MarkoRow[Row];
-            if (Product >= LARGEST_LONG_INTEGER)
+            if (Product >= (double)LARGEST_LONG_INTEGER)
                 Matrix->MarkowitzProd[Row] = LARGEST_LONG_INTEGER;
             else
                 Matrix->MarkowitzProd[Row] = Product;
@@ -2928,7 +2928,7 @@ double Product;
         if ((MarkoRow[Col] > LARGEST_SHORT_INTEGER AND MarkoCol[Col] != 0) OR
             (MarkoCol[Col] > LARGEST_SHORT_INTEGER AND MarkoRow[Col] != 0))
         {   Product = MarkoCol[Col] * MarkoRow[Col];
-            if (Product >= LARGEST_LONG_INTEGER)
+            if (Product >= (double)LARGEST_LONG_INTEGER)
                 Matrix->MarkowitzProd[Col] = LARGEST_LONG_INTEGER;
             else
                 Matrix->MarkowitzProd[Col] = Product;

--- a/src/sundials/shared/nvector_parallel.c
+++ b/src/sundials/shared/nvector_parallel.c
@@ -882,7 +882,7 @@ static realtype VAllReduce_Parallel(realtype d, int op, MPI_Comm comm)
    * The operation is over all processors in the communicator 
    */
 
-  realtype out;
+  realtype out = 0.0;
 
 #if NRNMPI_DYNAMICLOAD
   nrnmpi_dbl_allreduce_vec(&d, &out, 1, op);


### PR DESCRIPTION
Fix the warnings in committed code that I saw with
```bash
cmake -G Ninja .. \
  -DCMAKE_C_COMPILER=clang-mp-14 \
  -DCMAKE_CXX_COMPILER=clang++-mp-14 \
  -DNRN_CLANG_FORMAT=ON \
  -DNRN_EXTRA_CXX_FLAGS="-Wall \
                         -Wno-char-subscripts \
                         -Wno-unknown-pragmas \
                         -Wno-unused-variable \
                         -Wno-unused-function \
                         -Wno-unused-but-set-variable \
                         -Wno-reorder \
                         -Wno-sign-compare \
                         -Wno-strict-aliasing \
                         -Wno-missing-braces \
                         -Wno-mismatched-tags"
```
which roughly matches the CI job that emits code annotations in PRs:
https://github.com/neuronsimulator/nrn/blob/f242cc8d4ddefb74f71f7f613a4b7b4043c2b641/.github/workflows/neuron-ci.yml#L230-L245