### PR TITLE
Improve std::thread cleanup

### DIFF
--- a/src/nrnoc/init.cpp
+++ b/src/nrnoc/init.cpp
@@ -12,6 +12,7 @@
 #include "cabvars.h"
 #include "neuron.h"
 #include "membdef.h"
+#include "multicore.h"
 #include "nrnmpi.h"
 
 
@@ -295,8 +296,6 @@ void hoc_nrn_load_dll(void) {
     }
 }
 
-extern void nrn_threads_create(int, int);
-
 static DoubScal scdoub[] = {"t", &t, "dt", &dt, 0, 0};
 
 void hoc_last_init(void) {
@@ -305,7 +304,7 @@ void hoc_last_init(void) {
     Symbol* s;
 
     hoc_register_var(scdoub, (DoubVec*) 0, (VoidFunc*) 0);
-    nrn_threads_create(1, 0);  // single thread
+    nrn_threads_create(1, false);  // single thread
 
     if (nrnmpi_myid < 1)
         if (nrn_nobanner_ == 0) {

--- a/src/nrnoc/multicore.cpp
+++ b/src/nrnoc/multicore.cpp
@@ -239,10 +239,6 @@ void nrn_thread_error(const char* s) {
     }
 }
 
-void nrn_thread_stat() {
-}
-
-
 void nrn_threads_create(int n, int parallel) {
     int i, j;
     NrnThread* nt;

--- a/src/nrnoc/multicore.cpp
+++ b/src/nrnoc/multicore.cpp
@@ -59,7 +59,6 @@ extern void nrn_threads_free();
 extern void nrn_old_thread_save();
 extern double nrn_timeus();
 
-static int nrn_thread_parallel_;
 void nrn_mk_table_check();
 static int table_check_cnt_;
 static Datum* table_check_;
@@ -70,168 +69,178 @@ static void* nulljob(NrnThread* nt) {
 }
 
 int nrn_inthread_;
-#if NRN_ENABLE_THREADS
-static int interpreter_locked;
-static std::unique_ptr<std::mutex> _interpreter_lock;
 
 namespace nrn {
 std::unique_ptr<std::mutex> nmodlmutex;
 }
 
 namespace {
+bool interpreter_locked{false};
+std::unique_ptr<std::mutex> interpreter_lock;
+
+enum struct worker_flag { execute_job, exit, wait };
+using worker_job_t = void* (*) (NrnThread*);
+
 // With C++17 and alignment-aware allocators we could do something like
 // alignas(std::hardware_destructive_interference_size) here and then use a
 // regular vector.
 struct worker_conf_t {
-    int flag{};
-    int thread_id{};
     /* for nrn_solve etc.*/
-    void* (*job)(NrnThread*) = nullptr;
+    worker_job_t job{};
+    std::size_t thread_id{};
+    worker_flag flag{worker_flag::wait};
 };
-}  // namespace
 
-namespace {
-std::unique_ptr<std::condition_variable[]> cond;
-std::unique_ptr<std::mutex[]> mut;
-std::vector<std::thread> worker_threads;
-worker_conf_t* wc{};
-}  // namespace
-
-static void wait_for_workers() {
-    for (int i = 1; i < nrn_nthread; ++i) {
-        if (busywait_main_) {
-            while (wc[i].flag != 0) {
-                ;
-            }
-        } else {
-            std::unique_lock<std::mutex> lock{mut[i]};
-            cond[i].wait(lock, [&wc_i = wc[i]] { return wc_i.flag == 0; });
-        }
-    }
-}
-
-static void wait_for_workers_timeit() {
-    wait_for_workers();
-}
-
-static void send_job_to_slave(int i, void* (*job)(NrnThread*) ) {
-    {
-        std::lock_guard<std::mutex> _{mut[i]};
-        wc[i].job = job;
-        wc[i].flag = 1;
-    }
-    cond[i].notify_one();
-}
-
-static void worker_main(worker_conf_t* my_wc) {
-    auto& my_mut = mut[my_wc->thread_id];
-    auto& my_cond = cond[my_wc->thread_id];
+void worker_main(worker_conf_t* my_wc_ptr,
+                 std::condition_variable* my_cond_ptr,
+                 std::mutex* my_mut_ptr) {
+    assert(my_cond_ptr);
+    assert(my_mut_ptr);
+    assert(my_wc_ptr);
+    auto& cond{*my_cond_ptr};
+    auto& mut{*my_mut_ptr};
+    auto& wc{*my_wc_ptr};
     for (;;) {
         if (busywait_) {
-            while (my_wc->flag == 0) {
+            // WARNING: this branch has not been extensively tested after the
+            // std::thread migration.
+            while (wc.flag == worker_flag::wait) {
                 ;
             }
-            if (my_wc->flag == 1) {
-                (*my_wc->job)(nrn_threads + my_wc->thread_id);
-            } else {
+            if (wc.flag == worker_flag::exit) {
                 return;
             }
-            my_wc->flag = 0;
-            my_cond.notify_one();
+            assert(wc.flag == worker_flag::execute_job);
+            (*wc.job)(nrn_threads + wc.thread_id);
+            wc.flag = worker_flag::wait;
+            wc.job = nullptr;
+            cond.notify_one();
         } else {
+            worker_job_t job{};
+            NrnThread* job_arg{};
             {
-                std::unique_lock<std::mutex> lock{my_mut};
-                my_cond.wait(lock, [my_wc] { return my_wc->flag != 0; });
+                // Wait until we have a job to execute or we have been told to
+                // shut down.
+                std::unique_lock<std::mutex> lock{mut};
+                cond.wait(lock, [&wc] { return wc.flag != worker_flag::wait; });
+                // Received instructions from the coordinator thread.
+                assert(wc.flag == worker_flag::execute_job || wc.flag == worker_flag::exit);
+                if (wc.flag == worker_flag::exit) {
+                    return;
+                }
+                assert(wc.flag == worker_flag::execute_job);
+                // Save the workload + argument to local variables before
+                // releasing the mutex.
+                job = wc.job;
+                job_arg = nrn_threads + wc.thread_id;
             }
-            my_mut.lock();
-            if (my_wc->flag == 1) {
-                my_mut.unlock();
-                (*my_wc->job)(nrn_threads + my_wc->thread_id);
-            } else {
-                my_mut.unlock();
-                return;
-            }
+            // Execute the workload without keeping the mutex
+            (*job)(job_arg);
+            // Signal that the work is completed and this thread is becoming
+            // idle
             {
-                std::lock_guard<std::mutex> _{my_mut};
-                my_wc->flag = 0;
+                std::lock_guard<std::mutex> _{mut};
+                // Make sure we don't accidentally overwrite an exit signal from
+                // the coordinating thread.
+                if (wc.flag == worker_flag::execute_job) {
+                    assert(wc.job == job);
+                    wc.flag = worker_flag::wait;
+                    wc.job = nullptr;
+                }
             }
-            my_cond.notify_one();
+            // Notify the coordinating thread.
+            cond.notify_one();
         }
     }
-    return;
 }
 
-static void threads_create() {
-#if NRNMPI
-    if (nrn_nthread > 1 && nrnmpi_numprocs > 1 && nrn_cannot_use_threads_and_mpi == 1) {
-        if (nrnmpi_myid == 0) {
-            printf("This MPI is not threadsafe so threads are disabled.\n");
-        }
-        nrn_thread_parallel_ = 0;
-        return;
-    }
-#endif
-    if (nrn_nthread > 1) {
-        CACHELINE_ALLOC(wc, worker_conf_t, nrn_nthread);
-        // Cannot easily use std::vector because std::condition_variable is not
-        // moveable.
-        cond = std::make_unique<std::condition_variable[]>(nrn_nthread);
-        // Cannot easily use std::vector because std::mutex is not moveable.
-        mut = std::make_unique<std::mutex[]>(nrn_nthread);
-        worker_threads.reserve(nrn_nthread);
+// Using an instance of a custom type allows us to manage the teardown process
+// more easily. TODO: remove the pointless zeroth entry in the vectors/arrays.
+struct worker_threads_t {
+    worker_threads_t()
+        : m_cond{std::make_unique<std::condition_variable[]>(nrn_nthread)}
+        , m_mut{std::make_unique<std::mutex[]>(nrn_nthread)} {
+        // Note that this does not call the worker_conf_t constructor.
+        CACHELINE_ALLOC(m_wc, worker_conf_t, nrn_nthread);
+        m_worker_threads.reserve(nrn_nthread);
         // worker_threads[0] does not appear to be used
-        worker_threads.emplace_back();
-        for (int i = 1; i < nrn_nthread; ++i) {
-            wc[i].flag = 0;
-            wc[i].thread_id = i;
-            worker_threads.emplace_back(worker_main, &(wc[i]));
+        m_worker_threads.emplace_back();
+        for (std::size_t i = 1; i < nrn_nthread; ++i) {
+            m_wc[i].flag = worker_flag::wait;
+            m_wc[i].job = nullptr;
+            m_wc[i].thread_id = i;
+            m_worker_threads.emplace_back(worker_main, &(m_wc[i]), &(m_cond[i]), &(m_mut[i]));
         }
-        if (!_interpreter_lock) {
-            interpreter_locked = 0;
-            _interpreter_lock = std::make_unique<std::mutex>();
+        if (!interpreter_lock) {
+            interpreter_locked = false;
+            interpreter_lock = std::make_unique<std::mutex>();
         }
         if (!nrn::nmodlmutex) {
             nrn::nmodlmutex = std::make_unique<std::mutex>();
         }
-        nrn_thread_parallel_ = 1;
-    } else {
-        nrn_thread_parallel_ = 0;
     }
-}
 
-static void threads_free() {
-    if (!worker_threads.empty()) {
-        wait_for_workers();
-        for (int i = 1; i < nrn_nthread; ++i) {
+    ~worker_threads_t() {
+        assert(m_worker_threads.size() == nrn_nthread);
+        wait();
+        for (std::size_t i = 1; i < nrn_nthread; ++i) {
             {
-                std::lock_guard<std::mutex> _{mut[i]};
-                wc[i].flag = -1;
+                std::lock_guard<std::mutex> _{m_mut[i]};
+                m_wc[i].flag = worker_flag::exit;
             }
-            cond[i].notify_one();
-            worker_threads[i].join();
+            m_cond[i].notify_one();
+            m_worker_threads[i].join();
         }
-        cond.reset();
-        mut.reset();
-        worker_threads.clear();
-        free(std::exchange(wc, nullptr));
+        if (interpreter_lock) {
+            interpreter_lock.reset();
+            interpreter_locked = 0;
+        }
+        nrn::nmodlmutex.reset();
+        free(std::exchange(m_wc, nullptr));
     }
-    if (_interpreter_lock) {
-        _interpreter_lock.reset();
-        interpreter_locked = 0;
+
+    void assign_job(std::size_t worker, void* (*job)(NrnThread*) ) {
+        assert(worker > 0);
+        auto& cond = m_cond[worker];
+        auto& wc = m_wc[worker];
+        {
+            std::unique_lock<std::mutex> lock{m_mut[worker]};
+            // Wait until the worker is idle.
+            cond.wait(lock, [&wc] { return wc.flag == worker_flag::wait; });
+            assert(!wc.job);
+            assert(wc.thread_id == worker);
+            wc.job = job;
+            wc.flag = worker_flag::execute_job;
+        }
+        // Notify the worker that it has new work to do.
+        cond.notify_one();
     }
-    nrn::nmodlmutex.reset();
-    nrn_thread_parallel_ = 0;
-}
 
-#else  /* NRN_ENABLE_THREADS */
+    // Wait until all worker threads are waiting
+    void wait() const {
+        for (std::size_t i = 1; i < nrn_nthread; ++i) {
+            auto& wc{m_wc[i]};
+            if (busywait_main_) {
+                while (wc.flag != worker_flag::wait) {
+                    ;
+                }
+            } else {
+                std::unique_lock<std::mutex> lock{m_mut[i]};
+                m_cond[i].wait(lock, [&wc] { return wc.flag == worker_flag::wait; });
+            }
+        }
+    }
 
-static void threads_create() {
-    nrn_thread_parallel_ = 0;
-}
-static void threads_free() {
-    nrn_thread_parallel_ = 0;
-}
-#endif /* !NRN_ENABLE_THREADS */
+  private:
+    // Cannot easily use std::vector because std::condition_variable is not moveable.
+    std::unique_ptr<std::condition_variable[]> m_cond;
+    // Cannot easily use std::vector because std::mutex is not moveable.
+    std::unique_ptr<std::mutex[]> m_mut;
+    std::vector<std::thread> m_worker_threads;
+    worker_conf_t* m_wc{};
+};
+std::unique_ptr<worker_threads_t> worker_threads{};
+}  // namespace
 
 void nrn_thread_error(const char* s) {
     if (nrn_nthread != 1) {
@@ -239,12 +248,10 @@ void nrn_thread_error(const char* s) {
     }
 }
 
-void nrn_threads_create(int n, int parallel) {
+void nrn_threads_create(int n, bool parallel) {
     int i, j;
     NrnThread* nt;
     if (nrn_nthread != n) {
-        /*printf("sizeof(NrnThread)=%d   sizeof(Memb_list)=%d\n", sizeof(NrnThread),
-         * sizeof(Memb_list));*/
         nrn_threads_free();
         for (i = 0; i < nrn_nthread; ++i) {
             nt = nrn_threads + i;
@@ -292,13 +299,23 @@ void nrn_threads_create(int n, int parallel) {
         v_structure_change = 1;
         diam_changed = 1;
     }
-    if (nrn_thread_parallel_ != parallel) {
-        threads_free();
-        if (parallel) {
-            threads_create();
+#if NRN_ENABLE_THREADS
+    // Check if we are enabling/disabling parallelisation over threads
+    if (parallel != static_cast<bool>(worker_threads)) {
+        worker_threads.reset();
+#if NRNMPI
+        if (nrn_nthread > 1 && nrnmpi_numprocs > 1 && nrn_cannot_use_threads_and_mpi == 1) {
+            if (nrnmpi_myid == 0) {
+                printf("This MPI is not threadsafe so threads are disabled.\n");
+            }
+            return;
+        }
+#endif
+        if (parallel && nrn_nthread > 1) {
+            worker_threads = std::make_unique<worker_threads_t>();
         }
     }
-    /*printf("nrn_threads_create %d %d\n", nrn_nthread, nrn_thread_parallel_);*/
+#endif
 }
 
 /*
@@ -368,7 +385,7 @@ void nrn_fast_imem_alloc() {
 }
 
 void nrn_threads_free() {
-    threads_free();
+    worker_threads.reset();
     int it, i;
     for (it = 0; it < nrn_nthread; ++it) {
         NrnThread* nt = nrn_threads + it;
@@ -849,65 +866,60 @@ void nrn_thread_table_check() {
 void nrn_hoc_lock() {
 #if NRN_ENABLE_THREADS
     if (nrn_inthread_) {
-        _interpreter_lock->lock();
-        interpreter_locked = 1;
+        interpreter_lock->lock();
+        interpreter_locked = true;
     }
 #endif
 }
 void nrn_hoc_unlock() {
 #if NRN_ENABLE_THREADS
     if (interpreter_locked) {
-        interpreter_locked = 0;
-        _interpreter_lock->unlock();
+        interpreter_locked = false;
+        interpreter_lock->unlock();
     }
 #endif
 }
 
 void nrn_multithread_job(void* (*job)(NrnThread*) ) {
-    int i;
 #if NRN_ENABLE_THREADS
-    if (nrn_thread_parallel_) {
+    if (worker_threads) {
         nrn_inthread_ = 1;
-        for (i = 1; i < nrn_nthread; ++i) {
-            send_job_to_slave(i, job);
+        for (std::size_t i = 1; i < nrn_nthread; ++i) {
+            worker_threads->assign_job(i, job);
         }
         (*job)(nrn_threads);
-        wait_for_workers();
+        worker_threads->wait();
         nrn_inthread_ = 0;
-    } else { /* sequential */
-#else
-    {
-#endif
-        for (i = 1; i < nrn_nthread; ++i) {
-            (*job)(nrn_threads + i);
-        }
-        (*job)(nrn_threads);
+        return;
     }
+#endif
+    for (std::size_t i = 1; i < nrn_nthread; ++i) {
+        (*job)(nrn_threads + i);
+    }
+    (*job)(nrn_threads);
 }
 
 
 void nrn_onethread_job(int i, void* (*job)(NrnThread*) ) {
     assert(i >= 0 && i < nrn_nthread);
 #if NRN_ENABLE_THREADS
-    if (nrn_thread_parallel_) {
+    if (worker_threads) {
         if (i > 0) {
-            send_job_to_slave(i, job);
-            wait_for_workers();
+            worker_threads->assign_job(i, job);
+            worker_threads->wait();
         } else {
             (*job)(nrn_threads);
         }
-    } else {
-#else
-    {
-#endif
-        (*job)(nrn_threads + i);
+        return;
     }
+#endif
+    (*job)(nrn_threads + i);
 }
 
 void nrn_wait_for_threads() {
 #if NRN_ENABLE_THREADS
-    if (nrn_thread_parallel_) {
-        wait_for_workers();
+    if (worker_threads) {
+        worker_threads->wait();
     }
 #endif
 }
@@ -1006,14 +1018,14 @@ int nrn_user_partition() {
 
 void nrn_use_busywait(int b) {
 #if NRN_ENABLE_THREADS
-    if (allow_busywait_ && nrn_thread_parallel_) {
+    if (allow_busywait_ && worker_threads) {
         if (b == 0 && busywait_main_ == 1) {
             busywait_ = 0;
             nrn_multithread_job(nulljob);
             busywait_main_ = 0;
         } else if (b == 1 && busywait_main_ == 0) {
             busywait_main_ = 1;
-            wait_for_workers();
+            worker_threads->wait();
             busywait_ = 1;
             nrn_multithread_job(nulljob);
         }

--- a/src/nrnoc/multicore.h
+++ b/src/nrnoc/multicore.h
@@ -95,6 +95,7 @@ typedef struct NrnThread {
 
 extern int nrn_nthread;
 extern NrnThread* nrn_threads;
+void nrn_threads_create(int n, bool parallel);
 extern void nrn_thread_error(const char*);
 extern void nrn_multithread_job(void* (*) (NrnThread*) );
 extern void nrn_onethread_job(int, void* (*) (NrnThread*) );

--- a/src/parallel/ocbbs.cpp
+++ b/src/parallel/ocbbs.cpp
@@ -11,6 +11,7 @@
 #include "parse.hpp"
 #include "section.h"
 #include "membfunc.h"
+#include "multicore.h"
 #include "utils/profile/profiler_interface.h"
 #include <nrnmpi.h>
 #include <errno.h>
@@ -63,7 +64,6 @@ static void nrnmpi_dbl_broadcast(double*, int, int) {}
 #endif
 extern double* nrn_mech_wtime_;
 extern int nrn_nthread;
-extern void nrn_threads_create(int, int);
 extern void nrn_thread_partition(int, Object*);
 extern int nrn_allow_busywait(int);
 extern int nrn_how_many_processors();
@@ -914,11 +914,11 @@ static double broadcast(void*) {
 }
 
 static double nthrd(void*) {
-    int ip = 1;
+    bool ip{true};
     hoc_return_type_code = 1;  // integer
     if (ifarg(1)) {
         if (ifarg(2)) {
-            ip = int(chkarg(2, 0, 1));
+            ip = bool(chkarg(2, 0, 1));
         }
         nrn_threads_create(int(chkarg(1, 1, 1e5)), ip);
     }

--- a/src/parallel/ocbbs.cpp
+++ b/src/parallel/ocbbs.cpp
@@ -65,7 +65,6 @@ extern double* nrn_mech_wtime_;
 extern int nrn_nthread;
 extern void nrn_threads_create(int, int);
 extern void nrn_thread_partition(int, Object*);
-extern void nrn_thread_stat();
 extern int nrn_allow_busywait(int);
 extern int nrn_how_many_processors();
 extern size_t nrncore_write();
@@ -947,7 +946,7 @@ static double partition(void*) {
 }
 
 static double thread_stat(void*) {
-    nrn_thread_stat();
+    // nrn_thread_stat was called here but didn't do anything
     return 0.0;
 }
 

--- a/src/scopmath/sparse_thread.c
+++ b/src/scopmath/sparse_thread.c
@@ -64,8 +64,6 @@ static char RCSid[] = "sparse.c,v 1.7 1998/03/12 13:17:17 hines Exp";
 #else
 #define Free(arg)	myfree((char *)arg)
 #endif
-extern void nrn_malloc_lock();
-extern void nrn_malloc_unlock();
 extern void* nrn_pool_create(long count, int itemsize);
 extern void nrn_pool_delete(void* pool);
 extern void nrn_pool_freeall(void* pool);
@@ -717,9 +715,7 @@ static void delete(Item* item) {
 
 static void *emalloc(unsigned n) { /* check return from malloc */
 	void *p;
-	nrn_malloc_lock();
 	p = malloc(n);
-	nrn_malloc_unlock();
 	if (p == (void *)0) {
 		abort_run(LOWMEM);
 	}
@@ -727,9 +723,7 @@ static void *emalloc(unsigned n) { /* check return from malloc */
 }
 
 void myfree(void* ptr) {
-	nrn_malloc_lock();
 	free(ptr);
-	nrn_malloc_unlock();
 }
 
 static void check_assert(SparseObj* so) {
@@ -822,9 +816,7 @@ static SparseObj* create_sparseobj() {
 	SparseObj* so;
 
 	so = emalloc(sizeof(SparseObj));
-	nrn_malloc_lock();
 	so->elmpool = nrn_pool_create(100, sizeof(Elm));
-	nrn_malloc_unlock();
 	so->rowst = 0;
 	so->diag = 0;
 	so->neqn = 0;

--- a/test/unit_tests/unit_test.cpp
+++ b/test/unit_tests/unit_test.cpp
@@ -7,8 +7,6 @@
 #include <section.h>
 #include <neuron.h>
 
-extern void nrn_threads_create(int, int);
-extern void nrn_threads_free();
 extern int ivocmain_session(int, const char**, const char**, int);
 
 extern int nrn_main_launch;


### PR DESCRIPTION
- NEURON builds using NVHPC were failing after #1859 because worker threads were not always joined before shutdown.
  - It seems that NEURON does not deallocate its data structures at shutdown.
  - Unclear why this problem was specific to NVHPC
- See https://github.com/BlueBrain/CoreNeuron/pull/833#issuecomment-1164666281 for an example of a failing run.
- Reorganise code in `multicore.cpp` to join threads at shutdown before the `std::thread` objects are destroyed.
- Drop unused code with `BENCH*` macros
- Drop unused allocation function wrappers. [std::malloc](https://en.cppreference.com/w/cpp/memory/c/malloc) is specified to be thread-safe.
- The busywait branches have not been extensively tested, perhaps they can be dropped too?