### PR TITLE
forum link in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ explore the `source code for over 750 NEURON models on ModelDB <https://senselab
    videos/index
    guide/index
    courses/exercises2018
+   The NEURON forum <https://neuron.yale.edu/phpBB>
    publications
    publications-using-neuron
    


### PR DESCRIPTION
Progress toward #1728

View at https://nrn.readthedocs.io/en/docs-update-1/

The link is correct. Unfortunately neither the NEURON server VM nor its host machine are working at the moment.