### PR TITLE
Fix -Wmismatched-tags warnings.

### DIFF
--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -238,8 +238,7 @@ jobs:
                                 -Wno-unused-but-set-variable \
                                 -Wno-reorder \
                                 -Wno-sign-compare \
-                                -Wno-strict-aliasing \
-                                -Wno-mismatched-tags" \
+                                -Wno-strict-aliasing" \
                              -DNRN_EXTRA_MECH_CXX_FLAGS="-Wno-sometimes-uninitialized \
                                 -Wno-missing-braces")
               fi

--- a/src/ivoc/graph.h
+++ b/src/ivoc/graph.h
@@ -11,7 +11,7 @@ class DataVec;
 class Color;
 class Brush;
 struct Symbol;
-class Symlist;
+struct Symlist;
 class GraphLine;
 class GLabel;
 class GPolyLine;

--- a/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.h
+++ b/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.h
@@ -20,8 +20,8 @@ typedef struct core2nrn_callback_t {
 // mechanism types of Memb_list(>0) or time(0) passed to CoreNeuron
 enum mech_type { voltage = -1, i_membrane_ = -2 };
 
-class Memb_list;
-class NrnThread;
+struct Memb_list;
+struct NrnThread;
 class CellGroup;
 class DatumIndices;
 

--- a/src/nrniv/nrncore_write/data/cell_group.h
+++ b/src/nrniv/nrncore_write/data/cell_group.h
@@ -10,7 +10,7 @@
 
 class PreSyn;
 class NetCon;
-class NrnThread;
+struct NrnThread;
 
 typedef std::pair<int, Memb_list*> MlWithArtItem;
 typedef std::vector<MlWithArtItem> MlWithArt;

--- a/src/nrniv/nrncore_write/io/nrncore_io.h
+++ b/src/nrniv/nrncore_write/io/nrncore_io.h
@@ -5,9 +5,9 @@
 #include <vector>
 
 class CellGroup;
-class NrnThread;
+struct NrnThread;
 union Datum;
-class NrnMappingInfo;
+struct NrnMappingInfo;
 
 void create_dir_path(const std::string& path);
 std::string get_write_path();

--- a/src/nrniv/nrncore_write/utils/nrncore_utils.h
+++ b/src/nrniv/nrncore_write/utils/nrncore_utils.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-class NrnThread;
+struct NrnThread;
 
 void model_ready();
 int count_distinct(double* data, int len);

--- a/src/nrnoc/multicore.h
+++ b/src/nrnoc/multicore.h
@@ -55,7 +55,7 @@ typedef struct _nrn_Fast_Imem {
  * NrnThread represent collection of cells or part of a cell computed
  * by single thread within NEURON process.
  */
-typedef struct NrnThread {
+struct NrnThread {
     double _t;
     double _dt;
     double cj;
@@ -89,8 +89,7 @@ typedef struct NrnThread {
     NrnThreadBAList* tbl[BEFORE_AFTER_SIZE]; /* wasteful since almost all empty */
     hoc_List* roots;                         /* ncell of these */
     Object* userpart; /* the SectionList if this is a user defined partition */
-
-} NrnThread;
+};
 
 
 extern int nrn_nthread;

--- a/src/nrnoc/nrnoc_ml.h
+++ b/src/nrnoc/nrnoc_ml.h
@@ -1,7 +1,7 @@
 #ifndef nrnoc_ml_h
 #define nrnoc_ml_h
 
-typedef struct Memb_list {
+struct Memb_list {
     Node** nodelist;
 #if CACHEVEC != 0
     /* nodeindices contains all nodes this extension is responsible for,
@@ -16,6 +16,6 @@ typedef struct Memb_list {
     Prop** prop;
     Datum* _thread; /* thread specific data (when static is no good) */
     int nodecount;
-} Memb_list;
+};
 
 #endif

--- a/src/oc/hocdec.h
+++ b/src/oc/hocdec.h
@@ -81,10 +81,10 @@ typedef struct Proc {
     int nobjauto;            /* the last of these are pointers to objects */
 } Proc;
 
-typedef struct Symlist {
+struct Symlist {
     HocStruct Symbol* first;
     HocStruct Symbol* last;
-} Symlist;
+};
 
 typedef char* Upoint;
 


### PR DESCRIPTION
This might help with a native windows build, based on Clang's warning message:
```
warning: struct 'Symlist' was previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
```