### PR TITLE
Change mcomplex.dat normalization to hh/5.

### DIFF
--- a/share/lib/hoc/loadbal.hoc
+++ b/share/lib/hoc/loadbal.hoc
@@ -554,6 +554,7 @@ sprint(cmd.s, "for (hoc_ac_, 0) hoc_obj_.append(new %s(hoc_ac_))", s.s)
 	}
 	// separate the zero-area_node and the capacitance
 	ct.setrow(0, ct.getrow(0).sub(ct.getrow(1)).div(ns-1)) // single zero-area-node
+
 	ct.setrow(1, ct.getrow(1).sub(ct.getrow(0).mul(2)).div(ns)) // single capacitance after subtract two zero nodes
 
 	// subtract ions from mechanisms
@@ -570,8 +571,11 @@ sprint(cmd.s, "for (hoc_ac_, 0) hoc_obj_.append(new %s(hoc_ac_))", s.s)
 
 	f = new File()
 	f.wopen("mcomplex.dat")
-	// scale to capacitance
-	j = ct.getrow(1).mean
+	// scale to hh/5 (We suspect that due to timing noise, capacitance
+	// could sometimes be negative after zero-area-node got subtracted
+	// from it. Or at least, if too small, could be a poor
+	// normalization factor.)
+	j = ct.getrow(7).mean()/5.0
 	for i=0, ct.nrow-1 {
 		// take average. negative is artificial and undone
 		k = ct.getrow(i).mean


### PR DESCRIPTION
 - i.e. rarely, capacitance could be negative due to timing noise.

Closes #1849 
Choose hh timing for normalization as it has sufficient complexity so that it is highly unlikely to suffer from serious timing noise.

Tested with:
```
 cat test.py
from neuron import h
h.load_file("loadbal.hoc")
lb = h.LoadBalance()
lb.ExperimentalMechComplex() # writes mcomplex.dat
```
And on my machine the first few lines of mcomplex.dat are (note: hh has a normalization of 5)
```
0.798655 zero_area_node
0.862487 capacitance
0.335661 pas
12.9228 extracellular
0.333914 fastpas
0.157212 na_ion
0.056141 k_ion
5 hh
1.08344 IClamp
1.14451 AlphaSynapse
```

