### PR TITLE
Jupyter support for ModelView

### DIFF
--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -1729,7 +1729,6 @@ def _mview_html_tree(hlist, inside_mechanisms_in_use=0):
         return f"{''.join(items)}"
 
 
-
 # register our ModelView display formatter with Jupyter if available
 if _get_ipython() is not None:
     html_formatter = _get_ipython().display_formatter.formatters["text/html"]

--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -1677,3 +1677,60 @@ def clear_gui_callback():
         nrnpy_set_gui_callback(None)
     except:
         pass
+
+
+try:
+    from IPython import get_ipython as _get_ipython
+except:
+    _get_ipython = lambda *args: None
+
+
+def _hocobj_html(item):
+    try:
+        if item.hname().split("[")[0] == "ModelView":
+            return _mview_html_tree(item.display.top)
+        return None
+    except:
+        return None
+
+
+def _mview_html_tree(hlist, inside_mechanisms_in_use=0):
+    items = []
+    if inside_mechanisms_in_use:
+        miu_level = inside_mechanisms_in_use + 1
+    else:
+        miu_level = 0
+    my_miu_level = miu_level
+    for ho in hlist:
+        html = ho.s.lstrip(" *")
+        if ho.children:
+            if html == "Mechanisms in use":
+                my_miu_level = 1
+        if html or miu_level == 3:
+            if ho.children:
+                children_data = _mview_html_tree(
+                    ho.children, inside_mechanisms_in_use=my_miu_level
+                )
+                if miu_level == 3:
+                    items.append(html + children_data)
+                else:
+                    items.append(
+                        f"<div><details><summary style='cursor:pointer'>{html}</summary><div style='margin-left:1.06em'>{children_data}</div></div>"
+                    )
+            else:
+                if miu_level == 3:
+                    items.append(html)
+                else:
+                    items.append(f"<div style='margin-left:1.06em'>{html}</div>")
+
+    if miu_level == 3:
+        return f"{'<br>'.join(items)}"
+    else:
+        return f"{''.join(items)}"
+
+
+
+# register our ModelView display formatter with Jupyter if available
+if _get_ipython() is not None:
+    html_formatter = _get_ipython().display_formatter.formatters["text/html"]
+    html_formatter.for_type(hoc.HocObject, _hocobj_html)


### PR DESCRIPTION
Displaying a ModelView object inside a Jupyter notebook shows the expandable tree instead of e.g. `ModelView[0]`. This makes ModelView usable in e.g. Google Colab, even though it doesn't give the full information (as no shape plots are available).

<img width="465" alt="image" src="https://user-images.githubusercontent.com/6668090/177855949-38cf2e8d-ecaf-415a-9ed5-2ad760ddec34.png">

Importantly:
- collapsing and expanding list elements is done in pure HTML (no JavaScript), so there are no save/load security issues... it just works when you reopen the notebook
- the `repr` and `str` of the object are unchanged (so scripts analyzing ModelView objects are unaffected)
- the `ModelView` object itself is completely unchanged
- 
    the displaying behavior is unchanged inside a regular terminal or an IPython session
    
    <img width="261" alt="image" src="https://user-images.githubusercontent.com/6668090/177856740-2faaa474-1252-436d-863d-218513b6b377.png">
