### PR TITLE
basic NetCon graph in ModelView

### DIFF
--- a/share/lib/hoc/mview/mview1.hoc
+++ b/share/lib/hoc/mview/mview1.hoc
@@ -9,6 +9,7 @@ objref this, realcells_, tobj, tobj1, mt, rc_classes, dparm, allsec
 objref ms, display, storecm, cdis, adis, acview, ncv, appv, pdis, gui
 objref topcelldis, distinctvalues, tvi, tvi2, kst, ksth, xml
 objref seclists, pyobj
+objref mvncgrapher
 strdef tstr, tstr1, cond, name
 
 in_=0
@@ -112,7 +113,8 @@ proc init() {local i, n, icdis, ntop
 
 	tobj = new List("NetCon")
 	sprint(tstr, "%d NetCon objects", tobj.count)
-	display.top.append(new TreeViewItem(nil, tstr))
+	mvncgrapher = new ModelViewNetConGrapher(this)
+	display.top.append(new TreeViewItem(nil, tstr, mvncgrapher, 1.7))
 	if (tobj.count != 0) {
 		ncv = new ModelViewNetCon(tobj, display.top.object(display.top.count - 1), this)
 	}		

--- a/share/lib/hoc/mview/mviewgui.hoc
+++ b/share/lib/hoc/mview/mviewgui.hoc
@@ -1,15 +1,16 @@
 begintemplate ModelViewGUI
-public b, sh, selsub, selsec, selpp, selected, grph, pgrph
+public b, sh, selsub, selsec, selpp, selected, grph, pgrph, do_netcon_graph
 external nil, hoc_sf_
 
-objref modelview, this, b, sh, bsh, g, bg
-objref all, svec, xvec, psh, yvec, tobj, xpvec
+objref modelview, this, b, sh, bsh, g, bg, netcon_graph, bnetcon_graph
+objref all, svec, xvec, psh, yvec, tobj, xpvec, pyobj
 strdef tstr
 
 proc init() {
 	x = 0
 	j = 0
 	sh_map_ = 0
+	netcon_graph_map_ = 0
 	g_map_ = 0
 	spacepl_ = 0
 	modelview=$o1
@@ -20,6 +21,7 @@ proc init() {
 proc destroy() {
 	if (sh_map_) { sh_dismiss() }
 	if (g_map_) { g_dismiss() }
+	if (netcon_graph_map_) {netcon_graph_dismiss() }
 	modelview.destroy()
 	objref modelview, sh, bsh, g, bg
 	objref all, svec, xvec, psh, yvec, xpvec
@@ -125,6 +127,30 @@ proc lspsh() {
 proc sh_dismiss() {
 	sh_map_ = 0
 	bsh.unmap()
+}
+
+proc netcon_graph_dismiss() {
+	netcon_graph_map_ = 0
+	netcon_graph.unmap()
+}
+
+proc do_netcon_graph() {
+	has_python = nrnpython("import neuron")
+	if (has_python) {
+		pyobj = new PythonObject()
+		if (!netcon_graph_map_) {
+			bnetcon_graph = new VBox()
+			bnetcon_graph.save("")
+			bnetcon_graph.ref(this)
+			bnetcon_graph.intercept(1)
+			netcon_graph = new Graph()
+			bnetcon_graph.intercept(0)
+			bnetcon_graph.map("NetCon connections", 100, 100, 500, 500)
+			bnetcon_graph.dismiss_action("netcon_graph_dismiss()")
+			netcon_graph_map_ = 1
+		}
+		pyobj.neuron._show_cell_connectivity_grid(netcon_graph)
+	}
 }
 
 proc selsub() {

--- a/share/lib/hoc/mview/ncview.hoc
+++ b/share/lib/hoc/mview/ncview.hoc
@@ -86,3 +86,16 @@ proc selected() {
 }
 
 endtemplate ModelViewNetCon
+
+
+begintemplate ModelViewNetConGrapher
+public selected, mview
+objref mview
+proc init() {
+	mview = $o1
+}
+proc selected() {
+	print "ModelViewNetConGrapher selected", $2
+	mview.gui.do_netcon_graph()
+}
+endtemplate ModelViewNetConGrapher


### PR DESCRIPTION
Selecting the "### NetCon objects" in a ModelView shows a graph of the pre/post NetCon relationships by cell.

e.g. for the model of Short et al., 2016 (http://modeldb.yale.edu/183300)

<img width="1426" alt="image" src="https://user-images.githubusercontent.com/6668090/178179029-bc88db66-0370-4770-9dcc-ab3da9755bbb.png">

This works best for small networks. Cells of the same type are grouped together.

To do:
- [ ] Something reasonable when no cell object is specified; right now, these are lumped in with artifical cells, which is incorrect.
- [ ] Clicking a submenu ought to restrict the set of NetCons plotted to whatever was in the submenu... e.g. if there's a line that says "3 threshold = -20", clicking that ought to show us just those NetCons.