### PR TITLE
First time declaration of section in template must be at command level.

### DIFF
--- a/src/nrnoc/cabcode.cpp
+++ b/src/nrnoc/cabcode.cpp
@@ -200,6 +200,13 @@ void add_section(void) /* symbol at pc+1, number of indices at pc+2 */
         hoc_freearay(sym);
     } else {
         assert(sym->type == UNDEF);
+        if (hoc_objectdata != hoc_top_level_data && hoc_thisobject) {
+            hoc_execerr_ext(
+                "First time declaration of Section %s in %s "
+                "must happen at command level (not in method)",
+                sym->name,
+                hoc_object_name(hoc_thisobject));
+        }
         sym->type = SECTION;
         hoc_install_object_data_index(sym);
     }

--- a/test/pynrn/test_template_err.py
+++ b/test/pynrn/test_template_err.py
@@ -1,0 +1,55 @@
+from neuron import h
+from neuron.expect_hocerr import expect_err
+
+
+def test_template_err():
+
+    h(
+        """
+begintemplate TestTemplateErr1
+proc init() {
+    create soma
+}
+endtemplate TestTemplateErr1
+    """
+    )
+
+    expect_err("m = h.TestTemplateErr1()")
+
+    h(
+        """
+begintemplate TestTemplateErr2
+proc init() {
+}
+proc setfoo() {
+    foo = 5 // 0 default if not called instead of UNDEF
+}
+endtemplate TestTemplateErr2
+    """
+    )
+
+    m = h.TestTemplateErr2()
+    expect_err('h.execute("create foo", m)')
+    assert m.foo == 0.0
+
+
+def test_template_err2():
+    h(
+        """
+proc test_template_err2() {
+    create test_template_err_sec
+}
+    """
+    )
+    h.test_template_err2()
+    s = h.test_template_err_sec
+    s.nseg = 3
+    s.insert("hh")
+    h.topology()
+    print(s.psection())
+    h.delete_section(sec=h.test_template_err_sec)
+
+
+if __name__ == "__main__":
+    test_template_err()
+    test_template_err2()


### PR DESCRIPTION
fixes #1910

the new ci test will generate the "expect_err" results.
```
NEURON: First time declaration of Section soma in TestTemplateErr1[0] must happen at command level (not in method)
 near line 0
     
     ^
        TestTemplateErr1[0].init()
NEURON: foo  already declared
 near line 1
 {create foo}
           ^
        execute("create foo", ...)
```