### PR TITLE
assert -> nrn_assert because of side-effects

### DIFF
--- a/src/modlunit/units.cpp
+++ b/src/modlunit/units.cpp
@@ -1,6 +1,7 @@
 #include <../../nmodlconf.h>
 /* /local/src/master/nrn/src/modlunit/units.c,v 1.5 1997/11/24 16:19:13 hines Exp */
 /* Mostly from Berkeley */
+#include "nrnassrt.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>
@@ -948,7 +949,7 @@ l0:
         y_or_n = get();
         assert(y_or_n == 'Y' || y_or_n == 'N');
         legacy = (y_or_n == 'Y') ? 1 : 0;
-        assert(get() == '@');
+        nrn_assert(get() == '@');
         if (dynam[legacy].table != table) { /* skip the line */
             while (c != '\n' && c != 0) {
                 c = get();


### PR DESCRIPTION
Without this, and with the "right" combination of build options (`-DNDEBUG` in the right places, maybe also dynamic units enabled -- I didn't check exhaustively) then `nocmodl` would complain about units with a message along the lines of
```
Need declaration in UNITS block of the form:
        (e)
```
when compiling built-in MOD files.