### PR TITLE
setup.exe installer must distribute env.exe

### DIFF
--- a/mingw_files/nrnmingwenv.sh
+++ b/mingw_files/nrnmingwenv.sh
@@ -28,7 +28,7 @@ cp $HOME/.inputrc $NM/etc/inputrc
 #cp /msys2.ini $NM
 #cp /msys2_shell.cmd $NM
 
-binprog="basename bash cat cp dirname echo find grep ls make mintty
+binprog="basename bash cat cp dirname echo env find git grep ls make mintty
   mkdir mv rebase rm sed sh sort unzip which cygpath cygcheck uname"
 for i in $binprog ; do
   echo $i


### PR DESCRIPTION
Many bash scripts begin with ```#!/usr/bin/env bash```

Given an imminent update of 8.2.0 #1939 it seems like a good time to add this as well.