### PR TITLE
Export configuration options to Python

### DIFF
--- a/cmake/ConfigFileSetting.cmake
+++ b/cmake/ConfigFileSetting.cmake
@@ -60,11 +60,16 @@ endif()
 # separated 'option=value' where value differs from the default value.
 # ~~~
 set(neuron_config_args "cmake option default differences:")
+set(neuron_config_args_all)
 foreach(_name ${NRN_OPTION_NAME_LIST})
   if(NOT ("${${_name}}" STREQUAL "${${_name}_DEFAULT}"))
     string(APPEND neuron_config_args " '${_name}=${${_name}}'")
   endif()
+  string(REPLACE ";" "\\;" escaped_value "${${_name}}")
+  string(REPLACE "\"" "\\\"" escaped_value "${escaped_value}")
+  list(APPEND neuron_config_args_all "{\"${_name}\", \"${escaped_value}\"}")
 endforeach()
+string(JOIN ",\n  " neuron_config_args_all ${neuron_config_args_all})
 
 # =============================================================================
 # Platform specific options (get expanded to comments)

--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -142,6 +142,12 @@ import _neuron_section
 h = hoc.HocObject()
 version = h.nrnversion(5)
 __version__ = version
+
+# Initialise neuron.config.arguments
+from neuron import config
+
+config._parse_arguments(h)
+
 _original_hoc_file = None
 if not hasattr(hoc, "__file__"):
     # first try is to derive from neuron.__file__

--- a/share/lib/python/neuron/config.py
+++ b/share/lib/python/neuron/config.py
@@ -1,3 +1,23 @@
+def _convert_value(key, value):
+    """Convert a string representing a CMake variable value into a Python value.
+
+    This does some basic conversion of values that CMake interprets as boolean
+    values into Python's True/False, and includes some special cases for
+    variables that are known to represent lists. See also:
+    https://cmake.org/cmake/help/latest/command/if.html#basic-expressions.
+    """
+    if key.upper() in {"NRN_ENABLE_MODEL_TESTS"}:
+        return tuple(value.split(";"))
+    elif value.upper() in {"ON", "YES", "TRUE", "Y"}:
+        return True
+    elif value.upper() in {"OFF", "NO", "FALSE", "N"}:
+        return False
+    try:
+        return int(value)
+    except ValueError:
+        return value
+
+
 def _parse_arguments(h):
     """Map the C++ structure neuron::config::arguments into Python.
 
@@ -12,7 +32,4 @@ def _parse_arguments(h):
         key = h.nrn_get_config_key(i)
         val = h.nrn_get_config_val(i)
         assert key not in arguments
-        if key == "NRN_ENABLE_MODEL_TESTS":
-            val = tuple(val.split(";"))
-        val = {"ON": True, "OFF": False}.get(val, val)
-        arguments[key] = val
+        arguments[key] = _convert_value(key, val)

--- a/share/lib/python/neuron/config.py
+++ b/share/lib/python/neuron/config.py
@@ -1,0 +1,18 @@
+def _parse_arguments(h):
+    """Map the C++ structure neuron::config::arguments into Python.
+
+    The Python version is accessible as neuron.config.arguments.
+    """
+    global arguments
+    arguments = {}
+    num_keys_double = h.nrn_num_config_keys()
+    num_keys = int(num_keys_double)
+    assert float(num_keys) == num_keys_double
+    for i in range(num_keys):
+        key = h.nrn_get_config_key(i)
+        val = h.nrn_get_config_val(i)
+        assert key not in arguments
+        if key == "NRN_ENABLE_MODEL_TESTS":
+            val = tuple(val.split(";"))
+        val = {"ON": True, "OFF": False}.get(val, val)
+        arguments[key] = val

--- a/src/nrnoc/nrn_ansi.h
+++ b/src/nrnoc/nrn_ansi.h
@@ -1,5 +1,4 @@
-#ifndef nrn_ansi_h
-#define nrn_ansi_h
+#pragma once
 
 // nocpout.cpp
 extern void hoc_register_limits(int, HocParmLimits*);
@@ -161,4 +160,20 @@ extern void stor_pt3d(Section*, double x, double y, double z, double d);
 extern int nrn_netrec_state_adjust;
 extern int nrn_sparse_partrans;
 
-#endif
+char* nrn_version(int);
+
+/** @brief Get the number of NEURON configuration items.
+ */
+[[nodiscard]] std::size_t nrn_num_config_keys();
+
+/** @brief Get the ith NEURON configuration key.
+ *
+ * @param i Key index, must be less than nrn_num_config_keys().
+ */
+[[nodiscard]] char* nrn_get_config_key(std::size_t i);
+
+/** @brief Get the ith NEURON configuration value.
+ *
+ * @param i Key index, must be less than nrn_num_config_keys().
+ */
+[[nodiscard]] char* nrn_get_config_val(std::size_t i);

--- a/src/nrnoc/nrn_ansi.h
+++ b/src/nrnoc/nrn_ansi.h
@@ -1,4 +1,17 @@
 #pragma once
+#include "membfunc.h"  // nrn_bamech_t
+union Datum;
+struct Extnode;
+struct hoc_Item;
+struct HocParmLimits;
+struct HocParmUnits;
+struct HocStateTolerance;
+struct Node;
+struct Object;
+struct Point_process;
+struct Prop;
+struct Section;
+struct Symbol;
 
 // nocpout.cpp
 extern void hoc_register_limits(int, HocParmLimits*);

--- a/src/nrnoc/nrnconfigargs.h.in
+++ b/src/nrnoc/nrnconfigargs.h.in
@@ -1,7 +1,10 @@
-#ifndef nrnconfigargs_h
-#define nrnconfigargs_h
+#pragma once
+#include <map>
 
 /* define to the args passed to configure */
 #define NRN_CONFIG_ARGS "@neuron_config_args@"
 
-#endif
+namespace neuron::config {
+inline std::map<const char*, const char*> const arguments{
+  @neuron_config_args_all@};
+}

--- a/src/nrnoc/nrnversion.cpp
+++ b/src/nrnoc/nrnversion.cpp
@@ -1,11 +1,12 @@
 #include <../../nrnconf.h>
+#include "nrn_ansi.h"
+#include "nrnassrt.h"
+#include "nrnconfigargs.h"
+#include "nrnversion.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <nrnversion.h>
-#include <nrnconfigargs.h>
-#include <assert.h>
-#include "nrnassrt.h"
 
 
 extern int nrn_global_argc;
@@ -79,4 +80,18 @@ char* nrn_version(int i) {
     }
 
     return ver[i];
+}
+
+std::size_t nrn_num_config_keys() {
+    return neuron::config::arguments.size();
+}
+
+char* nrn_get_config_key(std::size_t i) {
+    nrn_assert(i < nrn_num_config_keys());
+    return const_cast<char*>(std::next(neuron::config::arguments.begin(), i)->first);
+}
+
+char* nrn_get_config_val(std::size_t i) {
+    nrn_assert(i < nrn_num_config_keys());
+    return const_cast<char*>(std::next(neuron::config::arguments.begin(), i)->second);
 }

--- a/src/oc/hoc_init.cpp
+++ b/src/oc/hoc_init.cpp
@@ -7,6 +7,7 @@
 #include "equation.h"
 #include "nrnunits_modern.h"
 
+#include "nrn_ansi.h"
 #include "ocfunc.h"
 
 
@@ -221,6 +222,7 @@ static struct { /* Builtin functions with multiple or variable args */
                  {"mcell_ran4_init", hoc_mcran4init},
                  {"nrn_feenableexcept", nrn_feenableexcept},
                  {"nrnmpi_init", hoc_nrnmpi_init},
+                 {"nrn_num_config_keys", hoc_num_config_keys},
 #if PVM
                  {"numprocs", numprocs},
                  {"myproc", myproc},
@@ -242,6 +244,8 @@ static struct { /* functions that return a string */
                     {"neuronhome", hoc_neuronhome},
                     {"getcwd", hoc_getcwd},
                     {"nrnversion", hoc_nrnversion},
+                    {"nrn_get_config_key", hoc_get_config_key},
+                    {"nrn_get_config_val", hoc_get_config_val},
                     {0, 0}};
 
 static struct { /* functions that return an object */
@@ -394,6 +398,28 @@ void hoc_nrnversion(void) {
     hoc_ret();
     *p = nrn_version(i);
     hoc_pushstr(p);
+}
+
+void hoc_get_config_key() {
+    nrn_assert(nrn_num_config_keys() > 0);
+    auto const i = static_cast<std::size_t>(chkarg(1, 0, nrn_num_config_keys() - 1));
+    char** p = hoc_temp_charptr();
+    hoc_ret();
+    *p = nrn_get_config_key(i);
+    hoc_pushstr(p);
+}
+
+void hoc_get_config_val() {
+    nrn_assert(nrn_num_config_keys() > 0);
+    auto const i = static_cast<std::size_t>(chkarg(1, 0, nrn_num_config_keys() - 1));
+    char** p = hoc_temp_charptr();
+    hoc_ret();
+    *p = nrn_get_config_val(i);
+    hoc_pushstr(p);
+}
+
+void hoc_num_config_keys() {
+    hoc_retpushx(nrn_num_config_keys());
 }
 
 void hoc_Execerror(void) {

--- a/src/oc/hocdec.h
+++ b/src/oc/hocdec.h
@@ -216,20 +216,20 @@ struct DoubVec { /* User Vectors */
     int index1;
 };
 
-typedef struct { /* recommended limits for symbol values */
+struct HocParmLimits { /* recommended limits for symbol values */
     const char* name;
     float bnd[2];
-} HocParmLimits;
+};
 
-typedef struct { /* recommended tolerance for CVODE */
+struct HocStateTolerance { /* recommended tolerance for CVODE */
     const char* name;
     float tolerance;
-} HocStateTolerance;
+};
 
-typedef struct { /* units for symbol values */
+struct HocParmUnits { /* units for symbol values */
     const char* name;
     char* units;
-} HocParmUnits;
+};
 
 #include "oc_ansi.h"
 

--- a/src/oc/ocfunc.h
+++ b/src/oc/ocfunc.h
@@ -37,6 +37,9 @@ extern void hoc_Setcolor(void);
 extern void hoc_init_space(void);
 extern void hoc_install_hoc_obj(void);
 extern void nrn_feenableexcept(void);
+void hoc_get_config_key();
+void hoc_get_config_val();
+void hoc_num_config_keys();
 extern int nrn_feenableexcept_;
 #if DOS
 extern void hoc_settext(void);

--- a/test/pynrn/test_basic.py
+++ b/test/pynrn/test_basic.py
@@ -4,7 +4,7 @@ from neuron.expect_hocerr import expect_hocerr, expect_err, set_quiet
 
 import numpy as np
 
-from neuron import h, hoc
+from neuron import config, h, hoc
 
 
 def test_soma():
@@ -382,13 +382,8 @@ def test_nosection():
 
 def test_nrn_mallinfo():
     # figure out if ASan was enabled, see comment in unit_test.cpp
-    cmake_args = h.nrnversion(6)
-    if re.search("'NRN_SANITIZERS=[a-z,]*address[a-z,]*'", cmake_args):
-        print(
-            "Skipping nrn_mallinfo checks because ASan was enabled ({})".format(
-                cmake_args
-            )
-        )
+    if "address" in config.arguments["NRN_SANITIZERS"]:
+        print("Skipping nrn_mallinfo checks because ASan was enabled")
         return
     assert h.nrn_mallinfo(0) > 0
 

--- a/test/pynrn/test_fast_imem.py
+++ b/test/pynrn/test_fast_imem.py
@@ -4,7 +4,7 @@
 import distutils.util
 import os
 
-from neuron import h
+from neuron import config, h
 
 h.load_file("stdrun.hoc")  # for h.cvode_active
 
@@ -209,9 +209,7 @@ def test_fastimem():
 
 
 def coreneuron_available():
-    if "NRN_ENABLE_CORENEURON=ON" not in h.nrnversion(6):
-        # Not ideal. Maybe someday it will be default ON and then
-        # will not appear in h.nrnversion(6)
+    if not config.arguments["NRN_ENABLE_CORENEURON"]:
         return False
     # But can it be loaded?
     cvode = h.CVode()

--- a/test/pynrn/test_multigid.py
+++ b/test/pynrn/test_multigid.py
@@ -2,7 +2,7 @@
 # pc.cell(gid, h.NetCon(cell.sec(x)._ref_v, None, sec=cell.sec))
 # It is an error to have multiple gids with the same reference.
 
-from neuron import h, coreneuron
+from neuron import config, h, coreneuron
 from neuron.expect_hocerr import expect_err
 from math import log10
 
@@ -11,9 +11,7 @@ pc = h.ParallelContext()
 
 
 def coreneuron_available():
-    if "NRN_ENABLE_CORENEURON=ON" not in h.nrnversion(6):
-        # Not ideal. Maybe someday it will be default ON and then
-        # will not appear in h.nrnversion(6)
+    if not config.arguments["NRN_ENABLE_CORENEURON"]:
         return False
     # But can it be loaded?
     cvode = h.CVode()

--- a/test/pynrn/test_netpar.py
+++ b/test/pynrn/test_netpar.py
@@ -7,7 +7,7 @@ import os, sys
 
 sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 
-from neuron import h
+from neuron import config, h
 
 pc = h.ParallelContext()
 
@@ -87,7 +87,7 @@ def err_test2():
     r.ncs[0].delay = h.dt
     pc.set_maxstep(h.dt)
     h.finitialize(-65)
-    if "'NRN_ENABLE_MPI=OFF'" not in h.nrnversion(6):
+    if config.arguments["NRN_ENABLE_MPI"]:
         # Fixed step method does not allow a mindelay < dt + 1e-10
         expect_err("pc.psolve(1.0)")  # wonder if this is too stringent an error
     else:


### PR DESCRIPTION
This PR exports the values of CMake configuration options to Python, so one can do
```python
from neuron import config
if config.arguments["NRN_ENABLE_MPI"]:
  # ...
```

The values of variables included in this list are available: https://github.com/neuronsimulator/nrn/blob/cc737a9defe8a2a744838f9befb9665c023feae4/cmake/BuildOptionDefaults.cmake#L49-L75

Changes hoisted out of https://github.com/neuronsimulator/nrn/pull/1922. Closes https://github.com/neuronsimulator/nrn/issues/1923.