### PR TITLE
Cleanup, prepare for more C++ use.

### DIFF
--- a/src/ivoc/datapath.cpp
+++ b/src/ivoc/datapath.cpp
@@ -491,7 +491,7 @@ void HocDataPathImpl::search(Node* nd, double x) {
 
     Prop* p;
     for (p = nd->prop; p; p = p->next) {
-        if (!memb_func[p->type].is_point) {
+        if (!memb_func[p->_type].is_point) {
             search(p, x);
         }
     }
@@ -505,7 +505,7 @@ void HocDataPathImpl::search(Point_process* pp, Symbol*) {
 
 void HocDataPathImpl::search(Prop* prop, double x) {
     char buf[200];
-    int type = prop->type;
+    int type = prop->_type;
     Symbol* sym = memb_func[type].sym;
     Symbol* psym;
     double* pd;

--- a/src/nrncvode/cvodeobj.cpp
+++ b/src/nrncvode/cvodeobj.cpp
@@ -431,7 +431,7 @@ static double tstop_event(void* v) {
         if (ifarg(3)) {
             ppobj = *hoc_objgetarg(3);
             if (!ppobj || ppobj->ctemplate->is_point_ <= 0 ||
-                nrn_is_artificial_[ob2pntproc(ppobj)->prop->type]) {
+                nrn_is_artificial_[ob2pntproc(ppobj)->prop->_type]) {
                 hoc_execerror(hoc_object_name(ppobj), "is not a POINT_PROCESS");
             }
             reinit = int(chkarg(4, 0, 1));

--- a/src/nrncvode/netcvode.cpp
+++ b/src/nrncvode/netcvode.cpp
@@ -1491,7 +1491,7 @@ void CvodeThreadData::delete_memb_list(CvMembList* cmlist) {
         if (memb_func[cml->index].hoc_mech) {
             delete[] ml->prop;
         } else {
-            delete[] ml->data;
+            delete[] ml->_data;
             delete[] ml->pdata;
         }
         delete cml;
@@ -1657,7 +1657,7 @@ bool NetCvode::init_global() {
                     if (mf->hoc_mech) {
                         cml->ml->prop = ml->prop;
                     } else {
-                        cml->ml->data = ml->data;
+                        cml->ml->_data = ml->_data;
                         cml->ml->pdata = ml->pdata;
                     }
                     cml->ml->_thread = ml->_thread;
@@ -1806,7 +1806,7 @@ bool NetCvode::init_global() {
                     if (memb_func[cml->index].hoc_mech) {
                         ml->prop = new Prop*[ml->nodecount];
                     } else {
-                        ml->data = new double*[ml->nodecount];
+                        ml->_data = new double*[ml->nodecount];
                         ml->pdata = new Datum*[ml->nodecount];
                     }
                     ml->nodecount = 0;
@@ -1836,7 +1836,7 @@ bool NetCvode::init_global() {
                         if (mf->hoc_mech) {
                             cml->ml->prop[cml->ml->nodecount] = ml->prop[j];
                         } else {
-                            cml->ml->data[cml->ml->nodecount] = ml->data[j];
+                            cml->ml->_data[cml->ml->nodecount] = ml->_data[j];
                             cml->ml->pdata[cml->ml->nodecount] = ml->pdata[j];
                         }
                         cml->ml->_thread = ml->_thread;

--- a/src/nrncvode/netcvode.cpp
+++ b/src/nrncvode/netcvode.cpp
@@ -666,7 +666,7 @@ static double nc_setpost(void* v) {
     }
     int cnt = 1;
     if (tar) {
-        cnt = pnt_receive_size[tar->prop->type];
+        cnt = pnt_receive_size[tar->prop->_type];
         d->target_ = tar;
 #if DISCRETE_EVENT_OBSERVER
         ObjObservable::Attach(otar, d);
@@ -718,7 +718,7 @@ static double nc_event(void* v) {
     if (ifarg(2)) {
         double flag = *getarg(2);
         Point_process* pnt = d->target_;
-        int type = pnt->prop->type;
+        int type = pnt->prop->_type;
         if (!nrn_is_artificial_[type]) {
             hoc_execerror("Can only send fake self-events to ARTIFICIAL_CELLs", 0);
         }
@@ -2822,7 +2822,7 @@ static PPArgs* ppargs;
 
 static void point_receive_job(NrnThread* nt) {
 	PPArgs* p = ppargs + nt->id;
-	(*pnt_receive[p->type])(p->pp, p->w, p->f);
+	(*pnt_receive[p->_type])(p->pp, p->w, p->f);
 }
 
 void NetCvode::point_receive(int type, Point_process* pp, double* w, double f) {
@@ -2834,7 +2834,7 @@ void NetCvode::point_receive(int type, Point_process* pp, double* w, double f) {
 	}else{
 		// marshall the args
 		PPArgs* p = ppargs + id;
-		p->type = type;
+		p->_type = type;
 		p->pp = pp;
 		p->w = w;
 		p->f = f;
@@ -3004,7 +3004,7 @@ void NetCvode::init_events() {
         Object* obj = OBJ(q);
         NetCon* d = (NetCon*) obj->u.this_pointer;
         if (d->target_) {
-            int type = d->target_->prop->type;
+            int type = d->target_->prop->_type;
             if (pnt_receive_init[type]) {
                 (*pnt_receive_init[type])(d->target_, d->weight_, 0);
             } else {
@@ -3171,7 +3171,7 @@ void NetCon::send(double tt, NetCvode* ns, NrnThread* nt) {
 
 void NetCon::deliver(double tt, NetCvode* ns, NrnThread* nt) {
     assert(target_);
-    int type = target_->prop->type;
+    int type = target_->prop->_type;
     std::string ss("net-receive-");
     ss += memb_func[type].sym->name;
     nrn::Instrumentor::phase p_get_pnt_receive(ss.c_str());
@@ -3214,7 +3214,7 @@ NrnThread* NetCon::thread() {
 
 void NetCon::pgvts_deliver(double tt, NetCvode* ns) {
     assert(target_);
-    int type = target_->prop->type;
+    int type = target_->prop->_type;
     STATISTICS(netcon_deliver_);
     POINT_RECEIVE(type, target_, weight_, 0);
     if (errno) {
@@ -3483,7 +3483,7 @@ void SelfEvent::savestate_write(FILE* f) {
             "%s %d %d %d %d %g\n",
             target_->ob->ctemplate->sym->name,
             target_->ob->index,
-            target_->prop->type,
+            target_->prop->_type,
             ncindex,
             moff,
             flag_);
@@ -3491,7 +3491,7 @@ void SelfEvent::savestate_write(FILE* f) {
 
 void SelfEvent::deliver(double tt, NetCvode* ns, NrnThread* nt) {
     Cvode* cv = (Cvode*) target_->nvi_;
-    int type = target_->prop->type;
+    int type = target_->prop->_type;
     assert(nt == PP2NT(target_));
     if (nrn_use_selfqueue_ && nrn_is_artificial_[type]) {  // handle possible earlier flag=1 self
                                                            // event
@@ -3527,9 +3527,9 @@ void SelfEvent::pgvts_deliver(double tt, NetCvode* ns) {
 }
 void SelfEvent::call_net_receive(NetCvode* ns) {
     STATISTICS(selfevent_deliver_);
-    POINT_RECEIVE(target_->prop->type, target_, weight_, flag_);
+    POINT_RECEIVE(target_->prop->_type, target_, weight_, flag_);
     if (errno) {
-        if (nrn_errno_check(target_->prop->type)) {
+        if (nrn_errno_check(target_->prop->_type)) {
             hoc_warning("errno set during SelfEvent deliver to NET_RECEIVE", (char*) 0);
         }
     }
@@ -4163,9 +4163,9 @@ void NetCvode::fornetcon_prepare() {
             const NetConPList& dil = ps->dil_;
             for (const auto& d1: dil) {
                 Point_process* pnt = d1->target_;
-                if (pnt && t2i[pnt->prop->type] > -1) {
+                if (pnt && t2i[pnt->prop->_type] > -1) {
                     ForNetConsInfo* fnc =
-                        (ForNetConsInfo*) pnt->prop->dparam[t2i[pnt->prop->type]]._pvoid;
+                        (ForNetConsInfo*) pnt->prop->dparam[t2i[pnt->prop->_type]]._pvoid;
                     assert(fnc);
                     fnc->size += 1;
                 }
@@ -4207,9 +4207,9 @@ void NetCvode::fornetcon_prepare() {
             const NetConPList& dil = ps->dil_;
             for (const auto& d1: dil) {
                 Point_process* pnt = d1->target_;
-                if (pnt && t2i[pnt->prop->type] > -1) {
+                if (pnt && t2i[pnt->prop->_type] > -1) {
                     ForNetConsInfo* fnc =
-                        (ForNetConsInfo*) pnt->prop->dparam[t2i[pnt->prop->type]]._pvoid;
+                        (ForNetConsInfo*) pnt->prop->dparam[t2i[pnt->prop->_type]]._pvoid;
                     fnc->argslist[fnc->size] = d1->weight_;
                     fnc->size += 1;
                 }
@@ -4690,7 +4690,7 @@ NetCon* NetCvode::install_deliver(double* dsrc,
         if (hoc_table_lookup("x", osrc->ctemplate->symtable)) {
             Point_process* pp = ob2pntproc(osrc);
             assert(pp && pp->prop);
-            if (!pnt_receive[pp->prop->type]) {  // only if no NET_RECEIVE block
+            if (!pnt_receive[pp->prop->_type]) {  // only if no NET_RECEIVE block
                 sprintf(buf, "%s.x", hoc_object_name(osrc));
                 psrc = hoc_val_pointer(buf);
             }
@@ -4836,10 +4836,10 @@ NetCon::NetCon(PreSyn* src, Object* target) {
 #if DISCRETE_EVENT_OBSERVER
     ObjObservable::Attach(target, this);
 #endif
-    if (!pnt_receive[target_->prop->type]) {
+    if (!pnt_receive[target_->prop->_type]) {
         hoc_execerror("No NET_RECEIVE in target PointProcess:", hoc_object_name(target));
     }
-    cnt_ = pnt_receive_size[target_->prop->type];
+    cnt_ = pnt_receive_size[target_->prop->_type];
     weight_ = nil;
     if (cnt_) {
         weight_ = new double[cnt_];
@@ -5506,7 +5506,7 @@ void WatchCondition::deliver(double tt, NetCvode* ns, NrnThread* nt) {
         STATISTICS(deliver_qthresh_);
     }
     Cvode* cv = (Cvode*) pnt_->nvi_;
-    int type = pnt_->prop->type;
+    int type = pnt_->prop->_type;
     if (cvode_active_ && cv) {
         ns->local_retreat(tt, cv);
         cv->set_init_flag();
@@ -5606,7 +5606,7 @@ void WatchCondition::pgvts_deliver(double tt, NetCvode* ns) {
         qthresh_ = nil;
         STATISTICS(deliver_qthresh_);
     }
-    int type = pnt_->prop->type;
+    int type = pnt_->prop->_type;
     STATISTICS(watch_deliver_);
     POINT_RECEIVE(type, pnt_, nil, nrflag_);
     if (errno) {
@@ -5622,7 +5622,7 @@ void STECondition::pgvts_deliver(double tt, NetCvode* ns) {
         qthresh_ = nil;
         STATISTICS(deliver_qthresh_);
     }
-    int type = pnt_->prop->type;
+    int type = pnt_->prop->_type;
     STATISTICS(watch_deliver_);
     stet_->event();
     if (errno) {

--- a/src/nrncvode/nrndaspk.cpp
+++ b/src/nrncvode/nrndaspk.cpp
@@ -501,7 +501,7 @@ for (i=0; i < z.nvsize_; ++i) {
             p = nt->_nrn_fast_imem->_nrn_sav_rhs;
         }
         for (i = 0; i < n; ++i) {
-            double* cd = ml->data[i];
+            double* cd = ml->_data[i];
             Node* nd = ml->nodelist[i];
             int j = nd->eqn_index_ - 1;
             Extnode* nde = nd->extnode;
@@ -534,7 +534,7 @@ for (i=0; i < z.nvsize_; ++i) {
         Memb_list* ml = z.cmlext_->ml;
         int n = ml->nodecount;
         for (i = 0; i < n; ++i) {
-            double* cd = ml->data[i];
+            double* cd = ml->_data[i];
             Node* nd = ml->nodelist[i];
             int j = nd->eqn_index_;
 #if EXTRACELLULAR

--- a/src/nrncvode/occvode.cpp
+++ b/src/nrncvode/occvode.cpp
@@ -261,7 +261,7 @@ printf("%d Cvode::init_eqn id=%d neq_v_=%d #nonvint=%d #nonvint_extra=%d nvsize=
                     (*s)(ieq,
                          z.pv_ + ieq,
                          z.pvdot_ + ieq,
-                         ml->data[j],
+                         ml->_data[j],
                          ml->pdata[j],
                          atv + ieq,
                          cml->index);
@@ -315,7 +315,7 @@ void Cvode::new_no_cap_memb(CvodeThreadData& z, NrnThread* _nt) {
         if (mf->hoc_mech) {
             ncm->ml->prop = new Prop*[n];
         } else {
-            ncm->ml->data = new double*[n];
+            ncm->ml->_data = new double*[n];
             ncm->ml->pdata = new Datum*[n];
         }
         ncm->ml->_thread = ml->_thread;  // can share this
@@ -330,7 +330,7 @@ void Cvode::new_no_cap_memb(CvodeThreadData& z, NrnThread* _nt) {
                 if (mf->hoc_mech) {
                     ncm->ml->prop[n] = ml->prop[i];
                 } else {
-                    ncm->ml->data[n] = ml->data[i];
+                    ncm->ml->_data[n] = ml->_data[i];
                     ncm->ml->pdata[n] = ml->pdata[i];
                 }
                 ++n;
@@ -437,7 +437,7 @@ void Cvode::daspk_init_eqn() {
                 (*s)(ieq,
                      z.pv_ + ieq,
                      z.pvdot_ + ieq,
-                     ml->data[j],
+                     ml->_data[j],
                      ml->pdata[j],
                      atv + ieq,
                      cml->index);
@@ -474,7 +474,7 @@ void Cvode::scatter_y(double* y, int tid) {
         if (mf->ode_synonym) {
             nrn_ode_synonym_t s = mf->ode_synonym;
             Memb_list* ml = cml->ml;
-            (*s)(ml->nodecount, ml->data, ml->pdata);
+            (*s)(ml->nodecount, ml->_data, ml->pdata);
         }
     }
     nrn_extra_scatter_gather(0, tid);
@@ -782,7 +782,7 @@ void Cvode::before_after(BAMechList* baml, NrnThread* nt) {
         nrn_bamech_t f = ba->bam->f;
         Memb_list* ml = ba->ml;
         for (i = 0; i < ml->nodecount; ++i) {
-            (*f)(ml->nodelist[i], ml->data[i], ml->pdata[i], ml->_thread, nt);
+            (*f)(ml->nodelist[i], ml->_data[i], ml->pdata[i], ml->_thread, nt);
         }
     }
 }

--- a/src/nrniv/bbsavestate.cpp
+++ b/src/nrniv/bbsavestate.cpp
@@ -1170,7 +1170,7 @@ static void tqcallback(const TQItem* tq, int i) {
             }
             if (sew->ncindex == -2) {  // ignore the self event
                 // printf("%d Ignoring a SelfEvent to %s\n", nrnmpi_myid,
-                // memb_func[pp->prop->type].sym->name);
+                // memb_func[pp->prop->_type].sym->name);
                 delete sew;
                 sew = 0;
             }
@@ -1933,8 +1933,8 @@ void BBSaveState::node(Node* nd) {
     // the section and marked IGNORE. So we need to count only the
     // non-ignored.
     for (i = 0, p = nd->prop; p; p = p->next) {
-        if (p->type > 3) {
-            if (memb_func[p->type].is_point) {
+        if (p->_type > 3) {
+            if (memb_func[p->_type].is_point) {
                 if (!ignored(p)) {
                     ++i;
                 }
@@ -1945,7 +1945,7 @@ void BBSaveState::node(Node* nd) {
     }
     f->i(i, 1);
     for (p = nd->prop; p; p = p->next) {
-        if (p->type > 3) {
+        if (p->_type > 3) {
             mech(p);
         }
     }
@@ -1969,7 +1969,7 @@ void BBSaveState::node01(Section* sec, Node* nd) {
     f->d(1, NODEV(nd));
     // count
     for (i = 0, p = nd->prop; p; p = p->next) {
-        if (memb_func[p->type].is_point) {
+        if (memb_func[p->_type].is_point) {
             Point_process* pp = (Point_process*) p->dparam[1]._pvoid;
             if (pp->sec == sec) {
                 if (!ignored(p)) {
@@ -1980,7 +1980,7 @@ void BBSaveState::node01(Section* sec, Node* nd) {
     }
     f->i(i, 1);
     for (p = nd->prop; p; p = p->next) {
-        if (memb_func[p->type].is_point) {
+        if (memb_func[p->_type].is_point) {
             Point_process* pp = (Point_process*) p->dparam[1]._pvoid;
             if (pp->sec == sec) {
                 mech(p);
@@ -1995,10 +1995,10 @@ void BBSaveState::node01(Section* sec, Node* nd) {
 
 void BBSaveState::mech(Prop* p) {
     if (debug) {
-        sprintf(dbuf, "Enter mech(prop type %d)", p->type);
+        sprintf(dbuf, "Enter mech(prop type %d)", p->_type);
         PDEBUG;
     }
-    int type = p->type;
+    int type = p->_type;
     if (memb_func[type].is_point && ignored(p)) {
         return;
     }
@@ -2006,18 +2006,18 @@ void BBSaveState::mech(Prop* p) {
     char buf[100];
     sprintf(buf, "//%s", memb_func[type].sym->name);
     f->s(buf, 1);
-    f->d(ssi[p->type].size, p->param + ssi[p->type].offset);
+    f->d(ssi[p->_type].size, p->param + ssi[p->_type].offset);
     Point_process* pp = 0;
-    if (memb_func[p->type].is_point) {
+    if (memb_func[p->_type].is_point) {
         pp = (Point_process*) p->dparam[1]._pvoid;
-        if (pnt_receive[p->type]) {
+        if (pnt_receive[p->_type]) {
             // associated NetCon and queue SelfEvent
             // if the NetCon has a unique non-gid source (art cell)
             // that source is save/restored as well.
             netrecv_pp(pp);
         }
     }
-    if (ssi[p->type].callback) {  // model author dependent info
+    if (ssi[p->_type].callback) {  // model author dependent info
         // the POINT_PROCESS or SUFFIX has a bbsavestate function
         sprintf(buf, "callback");
         f->s(buf, 1);
@@ -2027,11 +2027,11 @@ void BBSaveState::mech(Prop* p) {
 
         hoc_pushpx(&xdir);
         hoc_pushpx(xval);
-        if (memb_func[p->type].is_point) {
-            hoc_call_ob_proc(pp->ob, ssi[p->type].callback, narg);
+        if (memb_func[p->_type].is_point) {
+            hoc_call_ob_proc(pp->ob, ssi[p->_type].callback, narg);
             hoc_xpop();
         } else {
-            nrn_call_mech_func(ssi[p->type].callback, narg, p, p->type);
+            nrn_call_mech_func(ssi[p->_type].callback, narg, p, p->_type);
         }
         int sz = int(xdir);
         if (sz > 0) {
@@ -2042,19 +2042,19 @@ void BBSaveState::mech(Prop* p) {
             if (f->type() == BBSS_IO::IN) {  // restore
                 xdir = 1.;
                 f->d(sz, xval);
-                if (memb_func[p->type].is_point) {
-                    hoc_call_ob_proc(pp->ob, ssi[p->type].callback, narg);
+                if (memb_func[p->_type].is_point) {
+                    hoc_call_ob_proc(pp->ob, ssi[p->_type].callback, narg);
                     hoc_xpop();
                 } else {
-                    nrn_call_mech_func(ssi[p->type].callback, narg, p, p->type);
+                    nrn_call_mech_func(ssi[p->_type].callback, narg, p, p->_type);
                 }
             } else {
                 xdir = 0.;
-                if (memb_func[p->type].is_point) {
-                    hoc_call_ob_proc(pp->ob, ssi[p->type].callback, narg);
+                if (memb_func[p->_type].is_point) {
+                    hoc_call_ob_proc(pp->ob, ssi[p->_type].callback, narg);
                     hoc_xpop();
                 } else {
-                    nrn_call_mech_func(ssi[p->type].callback, narg, p, p->type);
+                    nrn_call_mech_func(ssi[p->_type].callback, narg, p, p->_type);
                 }
                 f->d(sz, xval);
             }
@@ -2062,14 +2062,14 @@ void BBSaveState::mech(Prop* p) {
         }
     }
     if (debug) {
-        sprintf(dbuf, "Leave mech(prop type %d)", p->type);
+        sprintf(dbuf, "Leave mech(prop type %d)", p->_type);
         PDEBUG;
     }
 }
 
 void BBSaveState::netrecv_pp(Point_process* pp) {
     if (debug) {
-        sprintf(dbuf, "Enter netrecv_pp(pp prop type %d)", pp->prop->type);
+        sprintf(dbuf, "Enter netrecv_pp(pp prop type %d)", pp->prop->_type);
         PDEBUG;
     }
     char buf[1000];
@@ -2207,7 +2207,7 @@ void BBSaveState::netrecv_pp(Point_process* pp) {
         }
     }
     if (debug) {
-        sprintf(dbuf, "Leave netrecv_pp(pp prop type %d)", pp->prop->type);
+        sprintf(dbuf, "Leave netrecv_pp(pp prop type %d)", pp->prop->_type);
         PDEBUG;
     }
 }

--- a/src/nrniv/cxprop.cpp
+++ b/src/nrniv/cxprop.cpp
@@ -58,7 +58,7 @@ called, how many needed for this thread
 // note that the pool chain order is the same as the thread order
 // there are nthread of the following lists
 cnt // number of mechanisms in thread
-type i seq // i is the tml->ml->data[i], seq is the allocation order
+type i seq // i is the tml->ml->_data[i], seq is the allocation order
 // ie we want
 
 Note that the overall memory allocation sequence has to be identical
@@ -365,9 +365,9 @@ int nrn_prop_is_cache_efficient() {
                     continue;
                 }
                 for (int j = 0; j < ml->nodecount; ++j) {
-                    if (p[i]->element(j) != ml->data[j]) {
+                    if (p[i]->element(j) != ml->_data[j]) {
                         // printf("thread %d mechanism %s instance %d  element %p data %p\n",
-                        // it, memb_func[i].sym->name, j, p[i]->element(j), (ml->data + j));
+                        // it, memb_func[i].sym->name, j, p[i]->element(j), (ml->_data + j));
                         r = 0;
                     }
                 }
@@ -461,17 +461,17 @@ static int in_place_data_realloc() {
                 newpool->grow(extra);
             }
             newpool->free_all();  // items in pool data order
-            // reset ml->data pointers to the new pool and copy the values
+            // reset ml->_data pointers to the new pool and copy the values
             FOR_THREADS(nt) {
                 for (NrnThreadMembList* tml = nt->tml; tml; tml = tml->next)
                     if (i == tml->index) {
                         Memb_list* ml = tml->ml;
                         for (int j = 0; j < ml->nodecount; ++j) {
-                            double* data = ml->data[j];
+                            double* data = ml->_data[j];
                             int ntget = newpool->ntget();
-                            ml->data[j] = newpool->alloc();
+                            ml->_data[j] = newpool->alloc();
                             for (int k = 0; k < newpool->d2(); ++k) {
-                                ml->data[j][k] = data[k];
+                                ml->_data[j][k] = data[k];
                             }
                             // store in old location enough info
                             // to construct a pointer to the new location
@@ -559,7 +559,7 @@ static int in_place_data_realloc() {
                     Memb_list* ml = mlmap[p->type];
                     assert(ml->nodelist[ml->nodecount] == nd);
                     if (!memb_func[p->type].hoc_mech) {
-                        p->param = ml->data[ml->nodecount];
+                        p->param = ml->_data[ml->nodecount];
                     }
                     ++ml->nodecount;
                 }

--- a/src/nrniv/cxprop.cpp
+++ b/src/nrniv/cxprop.cpp
@@ -554,11 +554,11 @@ static int in_place_data_realloc() {
         for (int i = 0; i < nt->end; ++i) {
             Node* nd = nt->_v_node[i];
             for (Prop* p = nd->prop; p; p = p->next) {
-                if (memb_func[p->type].current || memb_func[p->type].state ||
-                    memb_func[p->type].initialize) {
-                    Memb_list* ml = mlmap[p->type];
+                if (memb_func[p->_type].current || memb_func[p->_type].state ||
+                    memb_func[p->_type].initialize) {
+                    Memb_list* ml = mlmap[p->_type];
                     assert(ml->nodelist[ml->nodecount] == nd);
-                    if (!memb_func[p->type].hoc_mech) {
+                    if (!memb_func[p->_type].hoc_mech) {
                         p->param = ml->_data[ml->nodecount];
                     }
                     ++ml->nodecount;
@@ -666,14 +666,14 @@ void nrn_cache_prop_realloc() {
         for (i = 0; i < nt->end; ++i) {
             Node* nd = nt->_v_node[i];
             for (Prop* p = nd->prop; p; p = p->next) {
-                if (memb_func[p->type].current || memb_func[p->type].state ||
-                    memb_func[p->type].initialize) {
-                    Memb_list* ml = mlmap[p->type];
+                if (memb_func[p->_type].current || memb_func[p->_type].state ||
+                    memb_func[p->_type].initialize) {
+                    Memb_list* ml = mlmap[p->_type];
                     if (!ml || nd != ml->nodelist[ml->nodecount]) {
                         abort();
                     }
                     assert(ml && nd == ml->nodelist[ml->nodecount]);
-                    nrn_assert(fprintf(f, "%d %d %ld\n", p->type, ml->nodecount++, p->_alloc_seq) >
+                    nrn_assert(fprintf(f, "%d %d %ld\n", p->_type, ml->nodecount++, p->_alloc_seq) >
                                0);
                     ++cnt2;
                 }

--- a/src/nrniv/hocmech.cpp
+++ b/src/nrniv/hocmech.cpp
@@ -119,7 +119,7 @@ int special_pnt_call(Object* ob, Symbol* sym, int narg) {
 }
 
 static void alloc_mech(Prop* p) {
-    Symbol* mech = ((HocMech*) memb_func[p->type].hoc_mech)->mech;
+    Symbol* mech = ((HocMech*) memb_func[p->_type].hoc_mech)->mech;
     p->ob = hoc_newobj1(mech, 0);
     // printf("alloc_mech %s\n", hoc_object_name(p->ob));
 }
@@ -139,7 +139,7 @@ static void alloc_pnt(Prop* p) {
             p->ob = last_created_pp_ob_;
             // printf("p->ob comes from last_created %s\n", hoc_object_name(p->ob));
         } else {
-            Symbol* mech = ((HocMech*) memb_func[p->type].hoc_mech)->mech;
+            Symbol* mech = ((HocMech*) memb_func[p->_type].hoc_mech)->mech;
             skip_ = true;
             // printf("p->ob comes from hoc_newobj1 %s\n", mech->name);
             p->ob = hoc_newobj1(mech, 0);

--- a/src/nrniv/impedanc.cpp
+++ b/src/nrniv/impedanc.cpp
@@ -316,7 +316,7 @@ void Imp::setmat1() {
         NODERHS(_nt->_v_node[i]) = 0;
     }
     for (int i = 0; i < mlc->nodecount; ++i) {
-        NODERHS(mlc->nodelist[i]) = mlc->data[i][0];
+        NODERHS(mlc->nodelist[i]) = mlc->_data[i][0];
     }
 }
 

--- a/src/nrniv/kschan.cpp
+++ b/src/nrniv/kschan.cpp
@@ -66,7 +66,7 @@ static void nrn_alloc(Prop* prop) {
 static void nrn_init(NrnThread* nt, Memb_list* ml, int type) {
     // printf("nrn_init\n");
     KSChan* c = (*channels)[type];
-    c->init(ml->nodecount, ml->nodelist, ml->data, ml->pdata, nt);
+    c->init(ml->nodecount, ml->nodelist, ml->_data, ml->pdata, nt);
 }
 
 static void nrn_cur(NrnThread* nt, Memb_list* ml, int type) {
@@ -74,11 +74,11 @@ static void nrn_cur(NrnThread* nt, Memb_list* ml, int type) {
     KSChan* c = (*channels)[type];
 #if CACHEVEC
     if (use_cachevec) {
-        c->cur(ml->nodecount, ml->nodeindices, ml->data, ml->pdata, nt);
+        c->cur(ml->nodecount, ml->nodeindices, ml->_data, ml->pdata, nt);
     } else
 #endif /* CACHEVEC */
     {
-        c->cur(ml->nodecount, ml->nodelist, ml->data, ml->pdata);
+        c->cur(ml->nodecount, ml->nodelist, ml->_data, ml->pdata);
     }
 }
 
@@ -87,11 +87,11 @@ static void nrn_jacob(NrnThread* nt, Memb_list* ml, int type) {
     KSChan* c = (*channels)[type];
 #if CACHEVEC
     if (use_cachevec) {
-        c->jacob(ml->nodecount, ml->nodeindices, ml->data, ml->pdata, nt);
+        c->jacob(ml->nodecount, ml->nodeindices, ml->_data, ml->pdata, nt);
     } else
 #endif /* CACHEVEC */
     {
-        c->jacob(ml->nodecount, ml->nodelist, ml->data, ml->pdata);
+        c->jacob(ml->nodecount, ml->nodelist, ml->_data, ml->pdata);
     }
 }
 
@@ -100,11 +100,11 @@ static void nrn_state(NrnThread* nt, Memb_list* ml, int type) {
     KSChan* c = (*channels)[type];
 #if CACHEVEC
     if (use_cachevec) {
-        c->state(ml->nodecount, ml->nodeindices, ml->nodelist, ml->data, ml->pdata, nt);
+        c->state(ml->nodecount, ml->nodeindices, ml->nodelist, ml->_data, ml->pdata, nt);
     } else
 #endif /* CACHEVEC */
     {
-        c->state(ml->nodecount, ml->nodelist, ml->data, ml->pdata, nt);
+        c->state(ml->nodecount, ml->nodelist, ml->_data, ml->pdata, nt);
     }
 }
 
@@ -122,17 +122,17 @@ ode_map(int ieq, double** pv, double** pvdot, double* p, Datum* pd, double* atol
 static void ode_spec(NrnThread*, Memb_list* ml, int type) {
     // printf("ode_spec\n");
     KSChan* c = (*channels)[type];
-    c->spec(ml->nodecount, ml->nodelist, ml->data, ml->pdata);
+    c->spec(ml->nodecount, ml->nodelist, ml->_data, ml->pdata);
 }
 static void ode_matsol(NrnThread* nt, Memb_list* ml, int type) {
     // printf("ode_matsol\n");
     KSChan* c = (*channels)[type];
-    c->matsol(ml->nodecount, ml->nodelist, ml->data, ml->pdata, nt);
+    c->matsol(ml->nodecount, ml->nodelist, ml->_data, ml->pdata, nt);
 }
 static void singchan(NrnThread* nt, Memb_list* ml, int type) {
     // printf("singchan_\n");
     KSChan* c = (*channels)[type];
-    c->cv_sc_update(ml->nodecount, ml->nodelist, ml->data, ml->pdata, nt);
+    c->cv_sc_update(ml->nodecount, ml->nodelist, ml->_data, ml->pdata, nt);
 }
 static void* hoc_create_pnt(Object* ho) {
     return create_point_process(ho->ctemplate->is_point_, ho);

--- a/src/nrniv/kschan.cpp
+++ b/src/nrniv/kschan.cpp
@@ -59,7 +59,7 @@ static void check_table_thread_(double* p, Datum* ppvar, Datum* thread, NrnThrea
 }
 
 static void nrn_alloc(Prop* prop) {
-    KSChan* c = (*channels)[prop->type];
+    KSChan* c = (*channels)[prop->_type];
     c->alloc(prop);
 }
 
@@ -141,7 +141,7 @@ static void hoc_destroy_pnt(void* v) {
     // first free the KSSingleNodeData if it exists.
     Point_process* pp = (Point_process*) v;
     if (pp->prop) {
-        KSChan* c = (*channels)[pp->prop->type];
+        KSChan* c = (*channels)[pp->prop->_type];
         c->destroy_pnt(pp);
     }
 }
@@ -167,7 +167,7 @@ static double hoc_get_loc_pnt(void* v) {
 }
 static double hoc_nsingle(void* v) {
     Point_process* pp = (Point_process*) v;
-    KSChan* c = (*channels)[pp->prop->type];
+    KSChan* c = (*channels)[pp->prop->_type];
     if (ifarg(1)) {
         c->nsingle(pp, (int) chkarg(1, 1, 1e9));
     }
@@ -2236,7 +2236,7 @@ void KSChan::alloc(Prop* prop) {
         prop->param = nrn_point_prop_->param;
         prop->dparam = nrn_point_prop_->dparam;
     } else {
-        prop->param = nrn_prop_data_alloc(prop->type, prop->param_size, prop);
+        prop->param = nrn_prop_data_alloc(prop->_type, prop->param_size, prop);
         prop->param[gmaxoffset_] = gmax_deflt_;
         if (is_point()) {
             prop->param[NSingleIndex] = 1.;
@@ -2253,7 +2253,7 @@ void KSChan::alloc(Prop* prop) {
     }
     if (!is_point() || nrn_point_prop_ == 0) {
         if (ppsize > 0) {
-            prop->dparam = nrn_prop_datum_alloc(prop->type, ppsize, prop);
+            prop->dparam = nrn_prop_datum_alloc(prop->_type, ppsize, prop);
             if (is_point()) {
                 prop->dparam[2]._pvoid = NULL;
             }
@@ -2294,14 +2294,14 @@ Prop* KSChan::needion(Symbol* s, Node* nd, Prop* pm) {
     Prop *p, *pion;
     int type = s->subtype;
     for (p = nd->prop; p; p = p->next) {
-        if (p->type == type) {
+        if (p->_type == type) {
             break;
         }
     }
     pion = p;
     // printf("KSChan::needion %s\n", s->name);
     // printf("before ion rearrangement\n");
-    // for (p=nd->prop; p; p=p->next) {printf("\t%s\n", memb_func[p->type].sym->name);}
+    // for (p=nd->prop; p; p=p->next) {printf("\t%s\n", memb_func[p->_type].sym->name);}
     if (!pion) {
         pion = prop_alloc(&nd->prop, type, nd);
     } else {  // if after then move to beginning
@@ -2315,7 +2315,7 @@ Prop* KSChan::needion(Symbol* s, Node* nd, Prop* pm) {
         }
     }
     // printf("after ion rearrangement\n");
-    // for (p=nd->prop; p; p=p->next) {printf("\t%s\n", memb_func[p->type].sym->name);}
+    // for (p=nd->prop; p; p=p->next) {printf("\t%s\n", memb_func[p->_type].sym->name);}
     return pion;
 }
 
@@ -2340,7 +2340,7 @@ void KSChan::ion_consist() {
             nd = sec->pnode[i];
             Prop *p, *pion;
             for (p = nd->prop; p; p = p->next) {
-                if (p->type == mtype) {
+                if (p->_type == mtype) {
                     break;
                 }
             }
@@ -2395,7 +2395,7 @@ void KSChan::state_consist(int shift) {  // shift when Nsingle winks in and out 
             nd = sec->pnode[i];
             Prop* p;
             for (p = nd->prop; p; p = p->next) {
-                if (p->type == mtype) {
+                if (p->_type == mtype) {
                     if (p->param_size != ns) {
                         v_structure_change = 1;
                         double* oldp = p->param;

--- a/src/nrniv/ndatclas.cpp
+++ b/src/nrniv/ndatclas.cpp
@@ -25,7 +25,7 @@ extern Symlist* hoc_top_level_symlist;
 NrnPropertyImpl::NrnPropertyImpl(Prop* p) {
     p_ = p;
     iterator_ = -1;
-    sym_ = memb_func[p_->type].sym;
+    sym_ = memb_func[p_->_type].sym;
     del_ = false;
 }
 
@@ -113,11 +113,11 @@ const char* NrnProperty::name() const {
 }
 
 bool NrnProperty::is_point() const {
-    return memb_func[npi_->p_->type].is_point;
+    return memb_func[npi_->p_->_type].is_point;
 }
 
 int NrnProperty::type() const {
-    return npi_->p_->type;
+    return npi_->p_->_type;
 }
 
 Prop* NrnProperty::prop() const {
@@ -157,9 +157,9 @@ int NrnProperty::var_type(Symbol* sym) const {
 bool NrnProperty::assign(Prop* src, Prop* dest, int vartype) {
     int n;
     assert(vartype != NRNPOINTER);
-    if (src && dest && src != dest && src->type == dest->type) {
+    if (src && dest && src != dest && src->_type == dest->_type) {
         if (src->ob) {
-            Symbol* msym = memb_func[src->type].sym;
+            Symbol* msym = memb_func[src->_type].sym;
             int i, j, jmax, cnt = msym->s_varn;
             for (i = 0; i < cnt; ++i) {
                 Symbol* sym = msym->u.ppsym[i];
@@ -181,7 +181,7 @@ bool NrnProperty::assign(Prop* src, Prop* dest, int vartype) {
                     dest->param[i] = src->param[i];
                 }
             } else {
-                Symbol* msym = memb_func[src->type].sym;
+                Symbol* msym = memb_func[src->_type].sym;
                 int i, j, jmax, cnt = msym->s_varn;
                 for (i = 0; i < cnt; ++i) {
                     Symbol* sym = msym->u.ppsym[i];

--- a/src/nrniv/netpar.cpp
+++ b/src/nrniv/netpar.cpp
@@ -1600,7 +1600,7 @@ extern int* nrn_prop_param_size_;
 extern short* nrn_is_artificial_;
 static int weightcnt(NetCon* nc) {
     return nc->cnt_;
-    //  return nc->target_ ? pnt_receive_size[nc->target_->prop->type]: 1;
+    //  return nc->target_ ? pnt_receive_size[nc->target_->prop->_type]: 1;
 }
 
 size_t nrncore_netpar_bytes() {

--- a/src/nrniv/nonlinz.cpp
+++ b/src/nrniv/nonlinz.cpp
@@ -304,7 +304,7 @@ void NonLinImpRep::delta(double deltafac) {  // also defines pv_,pvdot_ map for 
         if (s && (cnt = (*s)(i)) > 0) {
             nrn_ode_map_t m = memb_func[i].ode_map;
             for (j = 0; j < nc; ++j) {
-                (*m)(ieq, pv_ + ieq, pvdot_ + ieq, ml->data[j], ml->pdata[j], deltavec_ + ieq, i);
+                (*m)(ieq, pv_ + ieq, pvdot_ + ieq, ml->_data[j], ml->pdata[j], deltavec_ + ieq, i);
                 ieq += cnt;
             }
         }
@@ -332,7 +332,7 @@ void NonLinImpRep::didv() {
     Memb_list* mlc = _nt->tml->ml;
     int n = mlc->nodecount;
     for (i = 0; i < n; ++i) {
-        double* cd = mlc->data[i];
+        double* cd = mlc->_data[i];
         j = mlc->nodelist[i]->v_node_index;
         diag_[v_index_[j] - 1][1] += .001 * cd[0] * omega_;
     }
@@ -569,7 +569,7 @@ void NonLinImpRep::current(int im, Memb_list* ml, int in) {  // assume there is 
     mfake.nodeindices = ml->nodeindices + in;
 #endif
     mfake.nodelist = ml->nodelist + in;
-    mfake.data = ml->data + in;
+    mfake._data = ml->_data + in;
     mfake.pdata = ml->pdata + in;
     mfake.prop = ml->prop ? ml->prop + in : nullptr;
     mfake.nodecount = 1;

--- a/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
+++ b/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
@@ -317,7 +317,7 @@ int nrnthread_dat2_2(int tid,
             Node* nd = nt._v_node[i];
             double diam = 0.0;
             for (Prop* p = nd->prop; p; p = p->next) {
-                if (p->type == MORPHOLOGY) {
+                if (p->_type == MORPHOLOGY) {
                     diam = p->param[0];
                     break;
                 }
@@ -743,7 +743,7 @@ void nrn2core_transfer_WatchCondition(WatchCondition* wc, void (*cb)(int, int, i
     Point_process* pnt = wc->pnt_;
     assert(pnt);
     int tid = ((NrnThread*) (pnt->_vnt))->id;
-    int pnttype = pnt->prop->type;
+    int pnttype = pnt->prop->_type;
     int watch_index = wc->watch_index_;
     int triggered = wc->flag_ ? 1 : 0;
     int pntindex = CellGroup::nrncore_pntindex_for_queue(pnt->prop->param, tid, pnttype);
@@ -829,7 +829,7 @@ static void set_info(TQItem* tqi,
     case SelfEventType: {  // 3
         SelfEvent* se = (SelfEvent*) de;
         Point_process* pnt = se->target_;
-        int type = pnt->prop->type;
+        int type = pnt->prop->_type;
         int movable_index = type2movable[type];
         double* wt = se->weight_;
 
@@ -1065,7 +1065,7 @@ static void core2nrn_SelfEvent_helper(int tid,
     }
 
     // Needs to be tested when permuted on CoreNEURON side.
-    assert(tar_type == pnt->prop->type);
+    assert(tar_type == pnt->prop->_type);
     //  assert(tar_index == CellGroup::nrncore_pntindex_for_queue(pnt->prop->param, tid, tar_type));
 
     int movable_index = type2movable[tar_type];

--- a/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
+++ b/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
@@ -168,13 +168,13 @@ size_t nrnthreads_type_return(int type, int tid, double*& data, double**& mdata)
     } else if (type > 0 && type < n_memb_func) {
         Memb_list* ml = nt._ml_list[type];
         if (ml) {
-            mdata = ml->data;
+            mdata = ml->_data;
             n = ml->nodecount;
         } else {
             // The single thread case is easy
             if (nrn_nthread == 1) {
                 ml = memb_list + type;
-                mdata = ml->data;
+                mdata = ml->_data;
                 n = ml->nodecount;
             } else {
                 // mk_tml_with_art() created a cgs[id].mlwithart which appended
@@ -185,7 +185,7 @@ size_t nrnthreads_type_return(int type, int tid, double*& data, double**& mdata)
                 // cellgroups_ portion (deleting it on return from nrncore_run).
                 auto& ml = CellGroup::deferred_type2artml_[tid][type];
                 n = size_t(ml->nodecount);
-                mdata = ml->data;
+                mdata = ml->_data;
             }
         }
     }
@@ -351,12 +351,12 @@ int nrnthread_dat2_mech(int tid,
     int n = ml->nodecount;
     int sz = nrn_prop_param_size_[type];
     double* data1;
-    if (isart) {                                       // data may not be contiguous
-        data1 = contiguous_art_data(ml->data, n, sz);  // delete after use
+    if (isart) {                                        // data may not be contiguous
+        data1 = contiguous_art_data(ml->_data, n, sz);  // delete after use
         nodeindices = NULL;
     } else {
         nodeindices = ml->nodeindices;  // allocated below if copy
-        data1 = ml->data[0];            // do not delete after use
+        data1 = ml->_data[0];           // do not delete after use
     }
     if (copy) {
         if (!isart) {
@@ -478,7 +478,7 @@ int nrnthread_dat2_corepointer_mech(int tid,
     // data size and allocate
     for (int i = 0; i < ml->nodecount; ++i) {
         (*nrn_bbcore_write_[type])(
-            NULL, NULL, &dcnt, &icnt, ml->data[i], ml->pdata[i], ml->_thread, &nt);
+            NULL, NULL, &dcnt, &icnt, ml->_data[i], ml->pdata[i], ml->_thread, &nt);
     }
     dArray = NULL;
     iArray = NULL;
@@ -492,7 +492,7 @@ int nrnthread_dat2_corepointer_mech(int tid,
     // data values
     for (int i = 0; i < ml->nodecount; ++i) {
         (*nrn_bbcore_write_[type])(
-            dArray, iArray, &dcnt, &icnt, ml->data[i], ml->pdata[i], ml->_thread, &nt);
+            dArray, iArray, &dcnt, &icnt, ml->_data[i], ml->pdata[i], ml->_thread, &nt);
     }
 
     return 1;
@@ -519,7 +519,7 @@ int core2nrn_corepointer_mech(int tid, int type, int icnt, int dcnt, int* iArray
     // data values
     for (int i = 0; i < ml->nodecount; ++i) {
         (*nrn_bbcore_read_[type])(
-            dArray, iArray, &dk, &ik, ml->data[i], ml->pdata[i], ml->_thread, &nt);
+            dArray, iArray, &dk, &ik, ml->_data[i], ml->pdata[i], ml->_thread, &nt);
     }
     assert(dk == dcnt);
     assert(ik == icnt);
@@ -690,9 +690,9 @@ int nrnthread_dat2_vecplay_inst(int tid,
                     }
                     Memb_list* ml = tml->ml;
                     int nn = nrn_prop_param_size_[tml->index] * ml->nodecount;
-                    if (pd >= ml->data[0] && pd < (ml->data[0] + nn)) {
+                    if (pd >= ml->_data[0] && pd < (ml->_data[0] + nn)) {
                         mtype = tml->index;
-                        ix = (pd - ml->data[0]);
+                        ix = (pd - ml->_data[0]);
                         sz = vector_capacity(vp->y_);
                         yvec = vector_vec(vp->y_);
                         tvec = vector_vec(vp->t_);

--- a/src/nrniv/nrncore_write/data/cell_group.cpp
+++ b/src/nrniv/nrncore_write/data/cell_group.cpp
@@ -160,7 +160,7 @@ CellGroup* CellGroup::mk_cellgroups(CellGroup* cgs) {
                                  1000 * static_cast<long>(nrncore_art2index(pnt->prop->param)));
                     } else {  // POINT_PROCESS with net_event
                         int sz = nrn_prop_param_size_[type];
-                        double* d1 = ml->data[0];
+                        double* d1 = ml->_data[0];
                         double* d2 = pnt->prop->param;
                         assert(d2 >= d1 && d2 < (d1 + (sz * ml->nodecount)));
                         long ix{(d2 - d1) / sz};
@@ -286,7 +286,7 @@ void CellGroup::datumindex_fill(int ith, CellGroup& cg, DatumIndices& di, Memb_l
     for (int i = 0; i < mcnt; ++i) {
         // Prop* datum instance arrays are not in cache efficient order
         // ie. ml->pdata[i] are not laid out end to end in memory.
-        // Also, ml->data for artificial cells is not in cache efficient order
+        // Also, ml->_data for artificial cells is not in cache efficient order
         // but in the artcell case there are no pointers to doubles and
         // the _actual_area pointer should be left unfilled.
         Datum* dparam = ml->pdata[i];
@@ -378,24 +378,24 @@ void CellGroup::datumindex_fill(int ith, CellGroup& cg, DatumIndices& di, Memb_l
             } else if (dmap[j] > 0 && dmap[j] < 1000) {  // double* into eion type data
                 Memb_list* eml = cg.type2ml[dmap[j]];
                 assert(eml);
-                if (dparam[j].pval < eml->data[0]) {
+                if (dparam[j].pval < eml->_data[0]) {
                     printf("%s dparam=%p data=%p j=%d etype=%d %s\n",
                            memb_func[di.type].sym->name,
                            dparam[j].pval,
-                           eml->data[0],
+                           eml->_data[0],
                            j,
                            dmap[j],
                            memb_func[dmap[j]].sym->name);
                     abort();
                 }
-                assert(dparam[j].pval >= eml->data[0]);
+                assert(dparam[j].pval >= eml->_data[0]);
                 etype = dmap[j];
                 if (dparam[j].pval >=
-                    (eml->data[0] + (nrn_prop_param_size_[etype] * eml->nodecount))) {
+                    (eml->_data[0] + (nrn_prop_param_size_[etype] * eml->nodecount))) {
                     printf("%s dparam=%p data=%p j=%d psize=%d nodecount=%d etype=%d %s\n",
                            memb_func[di.type].sym->name,
                            dparam[j].pval,
-                           eml->data[0],
+                           eml->_data[0],
                            j,
                            nrn_prop_param_size_[etype],
                            eml->nodecount,
@@ -403,8 +403,8 @@ void CellGroup::datumindex_fill(int ith, CellGroup& cg, DatumIndices& di, Memb_l
                            memb_func[etype].sym->name);
                 }
                 assert(dparam[j].pval <
-                       (eml->data[0] + (nrn_prop_param_size_[etype] * eml->nodecount)));
-                eindex = dparam[j].pval - eml->data[0];
+                       (eml->_data[0] + (nrn_prop_param_size_[etype] * eml->nodecount)));
+                eindex = dparam[j].pval - eml->_data[0];
             } else if (dmap[j] > 1000) {  // int* into ion dparam[xxx][0]
                 // store the actual ionstyle
                 etype = dmap[j];
@@ -475,7 +475,7 @@ void CellGroup::mk_cgs_netcon_info(CellGroup* cgs) {
                 // cache efficient so can calculate index from pointer
                 Memb_list* ml = cgs[ith].type2ml[type];
                 int sz = nrn_prop_param_size_[type];
-                double* d1 = ml->data[0];
+                double* d1 = ml->_data[0];
                 double* d2 = nc->target_->prop->param;
                 assert(d2 >= d1 && d2 < (d1 + (sz * ml->nodecount)));
                 int ix = (d2 - d1) / sz;
@@ -513,7 +513,7 @@ void CellGroup::mk_cgs_netcon_info(CellGroup* cgs) {
                         assert(nrn_has_net_event(type));
                         Memb_list* ml = cgs[ith].type2ml[type];
                         int sz = nrn_prop_param_size_[type];
-                        double* d1 = ml->data[0];
+                        double* d1 = ml->_data[0];
                         double* d2 = pnt->prop->param;
                         assert(d2 >= d1 && d2 < (d1 + (sz * ml->nodecount)));
                         int ix = (d2 - d1) / sz;
@@ -595,7 +595,7 @@ void CellGroup::mk_tml_with_art(CellGroup* cgs) {
                     ml->nodeindices = NULL;
                     ml->prop = NULL;
                     ml->_thread = NULL;
-                    ml->data = new double*[acnt[id]];
+                    ml->_data = new double*[acnt[id]];
                     ml->pdata = new Datum*[acnt[id]];
                 }
             }
@@ -608,9 +608,9 @@ void CellGroup::mk_tml_with_art(CellGroup* cgs) {
                 Point_process* pnt = (Point_process*) memb_list[i].pdata[j][1]._pvoid;
                 int id = ((NrnThread*) pnt->_vnt)->id;
                 Memb_list* ml = cgs[id].mlwithart.back().second;
-                ml->data[acnt[id]] = memb_list[i].data[j];
+                ml->_data[acnt[id]] = memb_list[i]._data[j];
                 ml->pdata[acnt[id]] = memb_list[i].pdata[j];
-                artdata2index_.insert(std::pair<double*, int>(ml->data[acnt[id]], acnt[id]));
+                artdata2index_.insert(std::pair<double*, int>(ml->_data[acnt[id]], acnt[id]));
                 ++acnt[id];
             }
         }
@@ -669,7 +669,7 @@ size_t CellGroup::get_mla_rankbytes(CellGroup* cellgroups_) {
 void CellGroup::clean_art(CellGroup* cgs) {
     // clean up the art Memb_list of CellGroup[].mlwithart
     // But if multithread and direct transfer mode, defer deletion of
-    // data for artificial cells, so that the artificial cell ml->data
+    // data for artificial cells, so that the artificial cell ml->_data
     // can be used when nrnthreads_type_return is called.
     if (corenrn_direct && nrn_nthread > 0) {
         deferred_type2artml_.resize(nrn_nthread);
@@ -683,7 +683,7 @@ void CellGroup::clean_art(CellGroup* cgs) {
                 if (!deferred_type2artml_.empty()) {
                     deferred_type2artml_[ith][type] = ml;
                 } else {
-                    delete[] ml->data;
+                    delete[] ml->_data;
                     delete[] ml->pdata;
                     delete ml;
                 }

--- a/src/nrniv/nrncore_write/data/cell_group.cpp
+++ b/src/nrniv/nrncore_write/data/cell_group.cpp
@@ -356,7 +356,7 @@ void CellGroup::datumindex_fill(int ith, CellGroup& cg, DatumIndices& di, Memb_l
                 Node* nd = ml->nodelist[i];
                 double* pdiam = NULL;
                 for (Prop* p = nd->prop; p; p = p->next) {
-                    if (p->type == MORPHOLOGY) {
+                    if (p->_type == MORPHOLOGY) {
                         pdiam = p->param;
                         break;
                     }
@@ -467,7 +467,7 @@ void CellGroup::mk_cgs_netcon_info(CellGroup* cgs) {
         cgs[ith].netcons[i] = nc;
 
         if (nc->target_) {
-            int type = nc->target_->prop->type;
+            int type = nc->target_->prop->_type;
             cgs[ith].netcon_pnttype[i] = type;
             if (nrn_is_artificial_[type]) {
                 cgs[ith].netcon_pntindex[i] = nrncore_art2index(nc->target_->prop->param);
@@ -505,7 +505,7 @@ void CellGroup::mk_cgs_netcon_info(CellGroup* cgs) {
                         }
                     }
                     Point_process* pnt = (Point_process*) ps->osrc_->u.this_pointer;
-                    int type = pnt->prop->type;
+                    int type = pnt->prop->_type;
                     if (nrn_is_artificial_[type]) {
                         int ix = nrncore_art2index(pnt->prop->param);
                         cgs[ith].netcon_srcgid[i] = -(type + 1000 * ix);

--- a/src/nrniv/nrncore_write/data/cell_group.h
+++ b/src/nrniv/nrncore_write/data/cell_group.h
@@ -67,8 +67,8 @@ class CellGroup {
         for (auto& th: deferred_type2artml_) {
             for (auto& p: th) {
                 Memb_list* ml = p.second;
-                if (ml->data) {
-                    delete[] ml->data;
+                if (ml->_data) {
+                    delete[] ml->_data;
                 }
                 if (ml->pdata) {
                     delete[] ml->pdata;
@@ -102,9 +102,9 @@ class CellGroup {
     static inline int nrncore_pntindex_for_queue(double* d, int tid, int type) {
         Memb_list* ml = nrn_threads[tid]._ml_list[type];
         if (ml) {
-            assert(d >= ml->data[0] &&
-                   d < (ml->data[0] + (ml->nodecount * nrn_prop_param_size_[type])));
-            return (d - ml->data[0]) / nrn_prop_param_size_[type];
+            assert(d >= ml->_data[0] &&
+                   d < (ml->_data[0] + (ml->nodecount * nrn_prop_param_size_[type])));
+            return (d - ml->_data[0]) / nrn_prop_param_size_[type];
         }
         return nrncore_art2index(d);
     }

--- a/src/nrniv/nrncore_write/utils/nrncore_utils.cpp
+++ b/src/nrniv/nrncore_write/utils/nrncore_utils.cpp
@@ -156,9 +156,9 @@ extern "C" int nrn_dblpntr2nrncore(double* pd, NrnThread& nt, int& type, int& in
             }
             Memb_list* ml1 = tml->ml;
             int nn = nrn_prop_param_size_[tml->index] * ml1->nodecount;
-            if (pd >= ml1->data[0] && pd < (ml1->data[0] + nn)) {
+            if (pd >= ml1->_data[0] && pd < (ml1->_data[0] + nn)) {
                 type = tml->index;
-                index = pd - ml1->data[0];
+                index = pd - ml1->_data[0];
                 break;
             }
         }

--- a/src/nrniv/nrncore_write/utils/nrncore_utils.cpp
+++ b/src/nrniv/nrncore_write/utils/nrncore_utils.cpp
@@ -20,7 +20,7 @@ namespace neuron::std {
 namespace filesystem = ::std::filesystem;
 }
 #else
-#include <experimental/filesystem>>
+#include <experimental/filesystem>
 namespace neuron::std {
 namespace filesystem = ::std::experimental::filesystem;
 }

--- a/src/nrniv/nrnmenu.cpp
+++ b/src/nrniv/nrnmenu.cpp
@@ -251,7 +251,7 @@ static void pnodemenu(Prop* p1, double x, int type, const char* path, MechSelect
         return;
     }
     pnodemenu(p1->next, x, type, path, ms); /*print in insert order*/
-    if (memb_func[p1->type].is_point) {
+    if (memb_func[p1->_type].is_point) {
         return;
     } else {
         mech_menu(p1, x, type, path, ms);
@@ -281,7 +281,7 @@ static void mech_menu(Prop* p1, double x, int type, const char* path, MechSelect
     char buf[200];
     bool deflt;
 
-    if (ms && !ms->is_selected(p1->type)) {
+    if (ms && !ms->is_selected(p1->_type)) {
         return;
     }
     if (type == nrnocCONST) {
@@ -289,7 +289,7 @@ static void mech_menu(Prop* p1, double x, int type, const char* path, MechSelect
     } else {
         deflt = false;
     }
-    sym = memb_func[p1->type].sym;
+    sym = memb_func[p1->_type].sym;
     if (sym->s_varn) {
         for (j = 0; j < sym->s_varn; j++) {
             vsym = sym->u.ppsym[j];
@@ -326,7 +326,7 @@ static void mech_menu(Prop* p1, double x, int type, const char* path, MechSelect
                             }
                         } else {
                             sprintf(buf, "%s(%g)", vsym->name, x);
-                            if (p1->type == MORPHOLOGY) {
+                            if (p1->_type == MORPHOLOGY) {
                                 Section* sec = chk_access();
                                 char buf2[200];
                                 sprintf(buf2, "%s.Ra += 0", secname(sec));
@@ -458,7 +458,7 @@ static void point_menu(Object* ob, int make_label) {
     } else if (make_label == -1) {  // i.e. do neither
         k = 0;
     }
-    psym = pointsym[pnt_map[pp->prop->type]];
+    psym = pointsym[pnt_map[pp->prop->_type]];
 
 #if 0
         switch (type) {
@@ -1195,7 +1195,7 @@ Point_process* MechanismType::pp_next() {
     Point_process* pp = NULL;
     bool done = mti_->p_iter_ == 0;
     while (!done) {
-        if (mti_->p_iter_->type == mti_->type_[mti_->select_]) {
+        if (mti_->p_iter_->_type == mti_->type_[mti_->select_]) {
             pp = (Point_process*) mti_->p_iter_->dparam[1]._pvoid;
             done = true;
             // but if it does not belong to this section

--- a/src/nrniv/partrans.cpp
+++ b/src/nrniv/partrans.cpp
@@ -1183,7 +1183,7 @@ static SetupTransferInfo* nrncore_transfer_info(int cn_nthread) {
             int tid = nt ? nt->id : 0;
             int type = pp->prop->type;
             Memb_list& ml = *(nrn_threads[tid]._ml_list[type]);
-            int ix = targets_[i] - ml.data[0];
+            int ix = targets_[i] - ml._data[0];
 
             auto& g = gi[tid];
             g.tar_sid.push_back(sid);
@@ -1209,7 +1209,7 @@ static SetupTransferInfo* nrncore_transfer_info(int cn_nthread) {
                 double* d = non_vsrc_update(nd, type, ix);
                 NrnThread* nt = nd->_nt ? nd->_nt : nrn_threads;
                 Memb_list& ml = *nt->_ml_list[type];
-                ix = d - ml.data[0];
+                ix = d - ml._data[0];
             } else {  // is a voltage source
                 ix = nd->_v - nrn_threads[tid]._actual_v;
                 assert(nd->extnode == NULL);  // only if v

--- a/src/nrniv/partrans.cpp
+++ b/src/nrniv/partrans.cpp
@@ -225,9 +225,9 @@ static void delete_imped_info() {
 static bool non_vsrc_setinfo(sgid_t ssid, Node* nd, double* pv) {
     for (Prop* p = nd->prop; p; p = p->next) {
         if (pv >= p->param && pv < (p->param + p->param_size)) {
-            non_vsrc_update_info_[ssid] = std::pair<int, int>(p->type, pv - p->param);
-            // printf("non_vsrc_setinfo %p %d %ld %s\n", pv, p->type, pv-p->param,
-            // memb_func[p->type].sym->name);
+            non_vsrc_update_info_[ssid] = std::pair<int, int>(p->_type, pv - p->param);
+            // printf("non_vsrc_setinfo %p %d %ld %s\n", pv, p->_type, pv-p->param,
+            // memb_func[p->_type].sym->name);
             return true;
         }
     }
@@ -236,7 +236,7 @@ static bool non_vsrc_setinfo(sgid_t ssid, Node* nd, double* pv) {
 
 static double* non_vsrc_update(Node* nd, int type, int ix) {
     for (Prop* p = nd->prop; p; p = p->next) {
-        if (type == p->type) {
+        if (type == p->_type) {
             return p->param + ix;
         }
     }
@@ -953,7 +953,7 @@ void pargap_jacobi_setup(int mode) {
                         "to the POINT_PROCESS",
                         0);
                 }
-                int type = pp->prop->type;
+                int type = pp->prop->_type;
                 if (imped_current_type_count_ == 0) {
                     imped_current_type_count_ = 1;
                     imped_current_type_ = new int[5];
@@ -1181,7 +1181,7 @@ static SetupTransferInfo* nrncore_transfer_info(int cn_nthread) {
             Point_process* pp = target_pntlist_[i];
             NrnThread* nt = (NrnThread*) pp->_vnt;
             int tid = nt ? nt->id : 0;
-            int type = pp->prop->type;
+            int type = pp->prop->_type;
             Memb_list& ml = *(nrn_threads[tid]._ml_list[type]);
             int ix = targets_[i] - ml._data[0];
 

--- a/src/nrniv/prcellstate.cpp
+++ b/src/nrniv/prcellstate.cpp
@@ -37,7 +37,7 @@ static void pr_memb(int type,
                 pnt2index.emplace(pp, pnt2index.size());
             }
             for (int j = 0; j < size; ++j) {
-                fprintf(f, " %d %d %.*g\n", cellnodes[inode], j, precision, ml->data[i][j]);
+                fprintf(f, " %d %d %.*g\n", cellnodes[inode], j, precision, ml->_data[i][j]);
             }
         }
     }

--- a/src/nrniv/prcellstate.cpp
+++ b/src/nrniv/prcellstate.cpp
@@ -83,7 +83,7 @@ static void pr_netcon(NrnThread& nt, FILE* f, const std::map<void*, int>& pnt2in
             } else {
                 fprintf(f, "%zd %d %d %.*g", i, srcgid, nc->active_ ? 1 : 0, precision, nc->delay_);
             }
-            int wcnt = pnt_receive_size[nc->target_->prop->type];
+            int wcnt = pnt_receive_size[nc->target_->prop->_type];
             for (int k = 0; k < wcnt; ++k) {
                 fprintf(f, " %.*g", precision, nc->weight_[k]);
             }

--- a/src/nrniv/savstate.cpp
+++ b/src/nrniv/savstate.cpp
@@ -669,7 +669,7 @@ void SaveState::saveacell(ACellState& ac, int type) {
     int sz = ssi[type].size;
     double* p = ac.state;
     for (int i = 0; i < ml.nodecount; ++i) {
-        double* d = ml.data[i];
+        double* d = ml._data[i];
         for (int j = 0; j < sz; ++j) {
             (*p++) = d[j];
         }
@@ -756,7 +756,7 @@ void SaveState::restoreacell(ACellState& ac, int type) {
     int sz = ssi[type].size;
     double* p = ac.state;
     for (int i = 0; i < ml.nodecount; ++i) {
-        double* d = ml.data[i];
+        double* d = ml._data[i];
         for (int j = 0; j < sz; ++j) {
             d[j] = (*p++);
         }

--- a/src/nrniv/savstate.cpp
+++ b/src/nrniv/savstate.cpp
@@ -330,7 +330,7 @@ bool SaveState::check(bool warn) {
             int i = 0;
             Prop* p;
             for (p = nd->prop; p; p = p->next) {
-                if (ssi[p->type].size == 0) {
+                if (ssi[p->_type].size == 0) {
                     continue;
                 }
                 if (i >= ns.nmemb) {
@@ -343,7 +343,7 @@ fewer mechanisms saved than exist at node %d of %s\n",
                     }
                     return false;
                 }
-                if (p->type != ns.type[i]) {
+                if (p->_type != ns.type[i]) {
                     if (warn) {
                         fprintf(stderr,
                                 "SaveState warning: mechanisms out of order at node %d of %s\n\
@@ -351,7 +351,7 @@ saved %s but need %s\n",
                                 inode,
                                 secname(sec),
                                 memb_func[i].sym->name,
-                                memb_func[p->type].sym->name);
+                                memb_func[p->_type].sym->name);
                     }
                     return false;
                 }
@@ -391,7 +391,7 @@ bool SaveState::checknode(NodeState& ns, Node* nd, bool warn) {
     int i = 0;
     Prop* p;
     for (p = nd->prop; p; p = p->next) {
-        if (ssi[p->type].size == 0) {
+        if (ssi[p->_type].size == 0) {
             continue;
         }
         if (i >= ns.nmemb) {
@@ -402,13 +402,13 @@ fewer mechanisms saved than exist at a root node\n");
             }
             return false;
         }
-        if (p->type != ns.type[i]) {
+        if (p->_type != ns.type[i]) {
             if (warn) {
                 fprintf(stderr,
                         "SaveState warning: mechanisms out of order at a rootnode\n\
 saved %s but need %s\n",
                         memb_func[i].sym->name,
-                        memb_func[p->type].sym->name);
+                        memb_func[p->_type].sym->name);
             }
             return false;
         }
@@ -490,11 +490,11 @@ void SaveState::allocnode(NodeState& ns, Node* nd) {
     ns.nstate = 0;
     Prop* p;
     for (p = nd->prop; p; p = p->next) {
-        if (ssi[p->type].size == 0) {
+        if (ssi[p->_type].size == 0) {
             continue;
         }
         ++ns.nmemb;
-        ns.nstate += ssi[p->type].size;
+        ns.nstate += ssi[p->_type].size;
     }
     if (ns.nmemb) {
         ns.type = new int[ns.nmemb];
@@ -504,10 +504,10 @@ void SaveState::allocnode(NodeState& ns, Node* nd) {
     }
     int i = 0;
     for (p = nd->prop; p; p = p->next) {
-        if (ssi[p->type].size == 0) {
+        if (ssi[p->_type].size == 0) {
             continue;
         }
-        ns.type[i] = p->type;
+        ns.type[i] = p->_type;
         ++i;
     }
 }
@@ -644,10 +644,10 @@ void SaveState::savenode(NodeState& ns, Node* nd) {
     int istate = 0;
     Prop* p;
     for (p = nd->prop; p; p = p->next) {
-        if (ssi[p->type].size == 0) {
+        if (ssi[p->_type].size == 0) {
             continue;
         }
-        int type = p->type;
+        int type = p->_type;
         int max = ssi[type].offset + ssi[type].size;
 #if EXTRACELLULAR
         if (type == EXTRACELL) {
@@ -731,10 +731,10 @@ void SaveState::restorenode(NodeState& ns, Node* nd) {
     int istate = 0;
     Prop* p;
     for (p = nd->prop; p; p = p->next) {
-        if (ssi[p->type].size == 0) {
+        if (ssi[p->_type].size == 0) {
             continue;
         }
-        int type = p->type;
+        int type = p->_type;
         int max = ssi[type].offset + ssi[type].size;
 #if EXTRACELLULAR
         if (type == EXTRACELL) {

--- a/src/nrniv/vrecord.cpp
+++ b/src/nrniv/vrecord.cpp
@@ -42,7 +42,7 @@ void nrn_vecsim_add(void* v, bool record) {
         iarg = 1;
         ppobj = *hoc_objgetarg(1);
         if (!ppobj || ppobj->ctemplate->is_point_ <= 0 ||
-            nrn_is_artificial_[ob2pntproc(ppobj)->prop->type]) {
+            nrn_is_artificial_[ob2pntproc(ppobj)->prop->_type]) {
             hoc_execerror("Optional first arg is not a POINT_PROCESS", 0);
         }
     }

--- a/src/nrnoc/cabcode.cpp
+++ b/src/nrnoc/cabcode.cpp
@@ -938,14 +938,14 @@ void mech_uninsert1(Section* sec, Symbol* s) {
     n = sec->nnode;
     for (i = 0; i < n; ++i) {
         mnext = sec->pnode[i]->prop;
-        if (mnext && mnext->type == type) {
+        if (mnext && mnext->_type == type) {
             sec->pnode[i]->prop = mnext->next;
             single_prop_free(mnext);
             continue;
         }
         for (m = mnext; m; m = mnext) {
             mnext = m->next;
-            if (mnext && mnext->type == type) {
+            if (mnext && mnext->_type == type) {
                 m->next = mnext->next;
                 single_prop_free(mnext);
                 break;
@@ -1079,7 +1079,7 @@ static int range_vec_indx(Symbol* s) {
 Prop* nrn_mechanism(int type, Node* nd) {
     Prop* m;
     for (m = nd->prop; m; m = m->next) {
-        if (m->type == type) {
+        if (m->_type == type) {
             break;
         }
     }
@@ -2064,9 +2064,9 @@ double* dprop(Symbol* s, int indx, Section* sec, short inode) {
 #if EXTRACELLULAR
 /* this does not handle vext(0) and vext(1) properly at this time */
 #if I_MEMBRANE
-    if (m->type == EXTRACELL && s->u.rng.index == 3 * (nlayer) + 2) {
+    if (m->_type == EXTRACELL && s->u.rng.index == 3 * (nlayer) + 2) {
 #else
-    if (m->type == EXTRACELL && s->u.rng.index == 3 * (nlayer) + 1) {
+    if (m->_type == EXTRACELL && s->u.rng.index == 3 * (nlayer) + 1) {
 #endif
         return sec->pnode[inode]->extnode->v + indx;
     }
@@ -2099,9 +2099,9 @@ double* nrnpy_dprop(Symbol* s, int indx, Section* sec, short inode, int* err) {
 #if EXTRACELLULAR
 /* this does not handle vext(0) and vext(1) properly at this time */
 #if I_MEMBRANE
-    if (m->type == EXTRACELL && s->u.rng.index == 3 * (nlayer) + 2) {
+    if (m->_type == EXTRACELL && s->u.rng.index == 3 * (nlayer) + 2) {
 #else
-    if (m->type == EXTRACELL && s->u.rng.index == 3 * (nlayer) + 1) {
+    if (m->_type == EXTRACELL && s->u.rng.index == 3 * (nlayer) + 1) {
 #endif
         return sec->pnode[inode]->extnode->v + indx;
     }
@@ -2237,7 +2237,7 @@ int has_membrane(char* mechanism_name, Section* sec) {
         section sec */
     Prop* p;
     for (p = sec->pnode[0]->prop; p; p = p->next) {
-        if (strcmp(memb_func[p->type].sym->name, mechanism_name) == 0) {
+        if (strcmp(memb_func[p->_type].sym->name, mechanism_name) == 0) {
             return (1);
         }
     }

--- a/src/nrnoc/capac.cpp
+++ b/src/nrnoc/capac.cpp
@@ -32,7 +32,7 @@ It used to be static but is now a thread data variable
 void nrn_cap_jacob(NrnThread* _nt, Memb_list* ml) {
     int count = ml->nodecount;
     Node** vnode = ml->nodelist;
-    double** vdata = ml->data;
+    double** vdata = ml->_data;
     int i;
     double cfac = .001 * _nt->cj;
 #if CACHEVEC
@@ -52,7 +52,7 @@ void nrn_cap_jacob(NrnThread* _nt, Memb_list* ml) {
 
 static void cap_init(NrnThread* _nt, Memb_list* ml, int type) {
     int count = ml->nodecount;
-    double** vdata = ml->data;
+    double** vdata = ml->_data;
     int i;
     for (i = 0; i < count; ++i) {
         i_cap = 0;
@@ -62,7 +62,7 @@ static void cap_init(NrnThread* _nt, Memb_list* ml, int type) {
 void nrn_capacity_current(NrnThread* _nt, Memb_list* ml) {
     int count = ml->nodecount;
     Node** vnode = ml->nodelist;
-    double** vdata = ml->data;
+    double** vdata = ml->_data;
     int i;
     double cfac = .001 * _nt->cj;
     /* since rhs is dvm for a full or half implicit step */
@@ -88,7 +88,7 @@ void nrn_capacity_current(NrnThread* _nt, Memb_list* ml) {
 void nrn_mul_capacity(NrnThread* _nt, Memb_list* ml) {
     int count = ml->nodecount;
     Node** vnode = ml->nodelist;
-    double** vdata = ml->data;
+    double** vdata = ml->_data;
     int i;
     double cfac = .001 * _nt->cj;
 #if CACHEVEC
@@ -109,7 +109,7 @@ void nrn_mul_capacity(NrnThread* _nt, Memb_list* ml) {
 void nrn_div_capacity(NrnThread* _nt, Memb_list* ml) {
     int count = ml->nodecount;
     Node** vnode = ml->nodelist;
-    double** vdata = ml->data;
+    double** vdata = ml->_data;
     int i;
 #if CACHEVEC
     if (use_cachevec) {

--- a/src/nrnoc/eion.cpp
+++ b/src/nrnoc/eion.cpp
@@ -559,7 +559,7 @@ void nrn_promote(Prop* p, int conc, int rev) {
 static void ion_cur(NrnThread* nt, Memb_list* ml, int type) {
     int count = ml->nodecount;
     Node** vnode = ml->nodelist;
-    double** pd = ml->data;
+    double** pd = ml->_data;
     Datum** ppd = ml->pdata;
     int i;
 /*printf("ion_cur %s\n", memb_func[type].sym->name);*/
@@ -581,7 +581,7 @@ static void ion_cur(NrnThread* nt, Memb_list* ml, int type) {
 static void ion_init(NrnThread* nt, Memb_list* ml, int type) {
     int count = ml->nodecount;
     Node** vnode = ml->nodelist;
-    double** pd = ml->data;
+    double** pd = ml->_data;
     Datum** ppd = ml->pdata;
     int i;
 /*printf("ion_init %s\n", memb_func[type].sym->name);*/
@@ -649,7 +649,7 @@ void second_order_cur(NrnThread* nt) {
                 ml = tml->ml;
                 i2 = ml->nodecount;
                 for (i = 0; i < i2; ++i) {
-                    ml->data[i][c] += ml->data[i][dc] * (NODERHS(ml->nodelist[i]));
+                    ml->_data[i][c] += ml->_data[i][dc] * (NODERHS(ml->nodelist[i]));
                 }
             }
     }

--- a/src/nrnoc/eion.cpp
+++ b/src/nrnoc/eion.cpp
@@ -428,22 +428,22 @@ void nrn_check_conc_write(Prop* p_ok, Prop* pion, int i) {
         }
     }
 
-    chk_conc_[2 * p_ok->type + i] |= ion_bit_[pion->type];
+    chk_conc_[2 * p_ok->_type + i] |= ion_bit_[pion->_type];
     if (pion->dparam[0].i & flag) {
         /* now comes the hard part. Is the possibility in fact actual.*/
         for (p = pion->next; p; p = p->next) {
             if (p == p_ok) {
                 continue;
             }
-            if (chk_conc_[2 * p->type + i] & ion_bit_[pion->type]) {
+            if (chk_conc_[2 * p->_type + i] & ion_bit_[pion->_type]) {
                 char buf[300];
                 sprintf(buf,
                         "%.*s%c is being written at the same location by %s and %s",
-                        (int) strlen(memb_func[pion->type].sym->name) - 4,
-                        memb_func[pion->type].sym->name,
+                        (int) strlen(memb_func[pion->_type].sym->name) - 4,
+                        memb_func[pion->_type].sym->name,
                         ((i == 1) ? 'i' : 'o'),
-                        memb_func[p_ok->type].sym->name,
-                        memb_func[p->type].sym->name);
+                        memb_func[p_ok->_type].sym->name,
+                        memb_func[p->_type].sym->name);
                 hoc_warning(buf, (char*) 0);
             }
         }
@@ -608,20 +608,20 @@ static void ion_alloc(Prop* p) {
     double* pd[1];
     int i = 0;
 
-    pd[0] = nrn_prop_data_alloc(p->type, nparm, p);
+    pd[0] = nrn_prop_data_alloc(p->_type, nparm, p);
     p->param_size = nparm;
 
     cur = 0.;
     dcurdv = 0.;
-    if (p->type == na_ion) {
+    if (p->_type == na_ion) {
         erev = DEF_ena;
         conci = DEF_nai;
         conco = DEF_nao;
-    } else if (p->type == k_ion) {
+    } else if (p->_type == k_ion) {
         erev = DEF_ek;
         conci = DEF_ki;
         conco = DEF_ko;
-    } else if (p->type == ca_ion) {
+    } else if (p->_type == ca_ion) {
         erev = DEF_eca;
         conci = DEF_cai;
         conco = DEF_cao;
@@ -632,7 +632,7 @@ static void ion_alloc(Prop* p) {
     }
     p->param = pd[0];
 
-    p->dparam = nrn_prop_datum_alloc(p->type, 1, p);
+    p->dparam = nrn_prop_datum_alloc(p->_type, 1, p);
     p->dparam->i = 0;
 }
 

--- a/src/nrnoc/extcelln.cpp
+++ b/src/nrnoc/extcelln.cpp
@@ -118,7 +118,7 @@ void nrn_update_2d(NrnThread* nt) {
 
 #if I_MEMBRANE
     for (i = 0; i < cnt; ++i) {
-        pd = ml->data[i];
+        pd = ml->_data[i];
         nd = ndlist[i];
         NODERHS(nd) -= *nd->extnode->_rhs[0];
         i_membrane = sav_g * (NODERHS(nd)) + sav_rhs;
@@ -189,7 +189,7 @@ static void extcell_alloc(Prop* p) {
 static void extcell_init(NrnThread* nt, Memb_list* ml, int type) {
     int ndcount = ml->nodecount;
     Node** ndlist = ml->nodelist;
-    double** data = ml->data;
+    double** data = ml->_data;
     int i, j;
     double* pd;
     if ((cvode_active_ > 0) && (nrn_use_daspk_ == 0)) {
@@ -334,7 +334,7 @@ void nrn_extcell_update_param(void) {
             for (i = 0; i < cnt; ++i) {
                 Node* nd = ndlist[i];
                 assert(nd->extnode);
-                nd->extnode->param = ml->data[i];
+                nd->extnode->param = ml->_data[i];
             }
         }
     }
@@ -375,7 +375,7 @@ void nrn_rhs_ext(NrnThread* _nt) {
         nde = nd->extnode;
         *nde->_rhs[0] -= NODERHS(nd);
 #if I_MEMBRANE
-        pd = ml->data[i];
+        pd = ml->_data[i];
         sav_rhs = *nde->_rhs[0];
         /* and for daspk this is the ionic current which can be
            combined later with i_cap before return from solve. */
@@ -464,7 +464,7 @@ void nrn_setup_ext(NrnThread* _nt) {
         *nde->_x12[0] -= d;
         *nde->_x21[0] -= d;
 #if I_MEMBRANE
-        pd = ml->data[i];
+        pd = ml->_data[i];
         sav_g = d;
 #endif
     }

--- a/src/nrnoc/extcelln.cpp
+++ b/src/nrnoc/extcelln.cpp
@@ -314,12 +314,12 @@ void extcell_node_create(Node* nd) {
         }
         nde->param = (double*) 0;
         for (p = nd->prop; p; p = p->next) {
-            if (p->type == EXTRACELL) {
+            if (p->_type == EXTRACELL) {
                 nde->param = p->param;
                 break;
             }
         }
-        assert(p && p->type == EXTRACELL);
+        assert(p && p->_type == EXTRACELL);
     }
 }
 

--- a/src/nrnoc/fadvance.cpp
+++ b/src/nrnoc/fadvance.cpp
@@ -851,7 +851,7 @@ int nrn_errno_check(Prop* p, int inode, Section* sec) {
                 "%d errno set at t=%g during call to mechanism %s at node %d in section %s\n",
                 nrnmpi_myid,
                 t,
-                memb_func[p->type].sym->name,
+                memb_func[p->_type].sym->name,
                 inode,
                 secname(sec));
     }

--- a/src/nrnoc/fadvance.cpp
+++ b/src/nrnoc/fadvance.cpp
@@ -1103,7 +1103,7 @@ void nrn_ba(NrnThread* nt, int bat) {
         int type = tbl->bam->type;
         Memb_list* ml = tbl->ml;
         for (i = 0; i < ml->nodecount; ++i) {
-            (*f)(ml->nodelist[i], ml->data[i], ml->pdata[i], ml->_thread, nt);
+            (*f)(ml->nodelist[i], ml->_data[i], ml->pdata[i], ml->_thread, nt);
         }
     }
 }

--- a/src/nrnoc/init.cpp
+++ b/src/nrnoc/init.cpp
@@ -1005,7 +1005,7 @@ void hoc_register_tolerance(int type, HocStateTolerance* tol, Symbol*** stol) {
                     into the p->param array */
                 assert(p);
                 /* need to find symbol for this */
-                msym = memb_func[p->type].sym;
+                msym = memb_func[p->_type].sym;
                 for (j = 0; j < msym->s_varn; ++j) {
                     vsym = msym->u.ppsym[j];
                     if (vsym->type == RANGEVAR && vsym->u.rng.index == index) {

--- a/src/nrnoc/ldifus.cpp
+++ b/src/nrnoc/ldifus.cpp
@@ -165,7 +165,7 @@ static void longdifus_diamchange(LongDifus* pld, int m, int sindex, Memb_list* m
         if (sindex < 0) {
             pld->state[i] = ml->pdata[mi][-sindex - 1].pval;
         } else {
-            pld->state[i] = ml->data[mi] + sindex;
+            pld->state[i] = ml->_data[mi] + sindex;
         }
         nd = ml->nodelist[mi];
         pindex = pld->pindex[i];
@@ -347,7 +347,7 @@ stagger(int m, ldifusfunc3_t diffunc, void** v, int ai, int sindex, int dindex, 
     ml = v2ml(v, _nt->id);
 
     n = ml->nodecount;
-    data = ml->data;
+    data = ml->_data;
     pdata = ml->pdata;
     thread = ml->_thread;
 
@@ -420,7 +420,7 @@ ode(int m, ldifusfunc3_t diffunc, void** v, int ai, int sindex, int dindex, NrnT
     ml = v2ml(v, _nt->id);
 
     n = ml->nodecount;
-    data = ml->data;
+    data = ml->_data;
     pdata = ml->pdata;
     thread = ml->_thread;
 
@@ -479,7 +479,7 @@ matsol(int m, ldifusfunc3_t diffunc, void** v, int ai, int sindex, int dindex, N
     ml = v2ml(v, _nt->id);
 
     n = ml->nodecount;
-    data = ml->data;
+    data = ml->_data;
     pdata = ml->pdata;
     thread = ml->_thread;
 

--- a/src/nrnoc/md1redef.h
+++ b/src/nrnoc/md1redef.h
@@ -17,14 +17,12 @@
 #undef pdata
 #undef prop
 #undef nodecount
-#undef type
 
 #define nodelist    _nodelist
 #define nodeindices _nodeindices
 #define pdata       _pdata
 #define prop        _prop
 #define nodecount   _nodecount
-#define type        _type
 #define pval        _pval
 #define id          _id
 

--- a/src/nrnoc/md1redef.h
+++ b/src/nrnoc/md1redef.h
@@ -14,7 +14,6 @@
 
 #undef nodelist
 #undef nodeindices
-#undef data
 #undef pdata
 #undef prop
 #undef nodecount
@@ -22,7 +21,6 @@
 
 #define nodelist    _nodelist
 #define nodeindices _nodeindices
-#define data        _data
 #define pdata       _pdata
 #define prop        _prop
 #define nodecount   _nodecount

--- a/src/nrnoc/md2redef.h
+++ b/src/nrnoc/md2redef.h
@@ -19,7 +19,6 @@
 #undef nodecount
 #undef pval
 
-#undef type
 #undef id
 
 #endif

--- a/src/nrnoc/md2redef.h
+++ b/src/nrnoc/md2redef.h
@@ -14,7 +14,6 @@
 
 #undef nodelist
 #undef nodeindices
-#undef data
 #undef pdata
 #undef prop
 #undef nodecount

--- a/src/nrnoc/method3.cpp
+++ b/src/nrnoc/method3.cpp
@@ -160,7 +160,7 @@ method3_setup_tree_matrix() /* construct diagonal elements */
             if (memb_func[i].vectorized) {
                 memb_func[i].current(memb_list[i].nodecount,
                                      memb_list[i].nodelist,
-                                     memb_list[i].data,
+                                     memb_list[i]._data,
                                      memb_list[i].pdata);
             } else {
                 int j, count;

--- a/src/nrnoc/multicore.cpp
+++ b/src/nrnoc/multicore.cpp
@@ -513,9 +513,9 @@ printf("thread_memblist_setup %lx v_node_count=%d ncell=%d end=%d\n", (long)nth,
     for (i = 0; i < _nt->end; ++i) {
         nd = _nt->_v_node[i];
         for (p = nd->prop; p; p = p->next) {
-            if (memb_func[p->type].current || memb_func[p->type].state ||
-                memb_func[p->type].initialize) {
-                ++mlcnt[p->type];
+            if (memb_func[p->_type].current || memb_func[p->_type].state ||
+                memb_func[p->_type].initialize) {
+                ++mlcnt[p->_type];
             }
         }
     }
@@ -565,12 +565,12 @@ printf("thread_memblist_setup %lx v_node_count=%d ncell=%d end=%d\n", (long)nth,
     for (i = 0; i < _nt->end; ++i) {
         nd = _nt->_v_node[i];
         for (p = nd->prop; p; p = p->next) {
-            if (memb_func[p->type].current || memb_func[p->type].state ||
-                memb_func[p->type].initialize) {
-                Memb_list* ml = mlmap[p->type];
+            if (memb_func[p->_type].current || memb_func[p->_type].state ||
+                memb_func[p->_type].initialize) {
+                Memb_list* ml = mlmap[p->_type];
                 ml->nodelist[ml->nodecount] = nd;
                 ml->nodeindices[ml->nodecount] = nd->v_node_index;
-                if (memb_func[p->type].hoc_mech) {
+                if (memb_func[p->_type].hoc_mech) {
                     ml->prop[ml->nodecount] = p;
                 } else {
                     ml->_data[ml->nodecount] = p->param;

--- a/src/nrnoc/multicore.cpp
+++ b/src/nrnoc/multicore.cpp
@@ -413,7 +413,7 @@ void nrn_threads_free() {
             if (memb_func[tml->index].hoc_mech) {
                 free((char*) ml->prop);
             } else {
-                free((char*) ml->data);
+                free((char*) ml->_data);
                 free((char*) ml->pdata);
             }
             if (ml->_thread) {
@@ -543,7 +543,7 @@ printf("thread_memblist_setup %lx v_node_count=%d ncell=%d end=%d\n", (long)nth,
             if (memb_func[i].hoc_mech) {
                 tml->ml->prop = (Prop**) emalloc(mlcnt[i] * sizeof(Prop*));
             } else {
-                CACHELINE_ALLOC(tml->ml->data, double*, mlcnt[i]);
+                CACHELINE_ALLOC(tml->ml->_data, double*, mlcnt[i]);
                 CACHELINE_ALLOC(tml->ml->pdata, Datum*, mlcnt[i]);
             }
             tml->ml->_thread = (Datum*) 0;
@@ -573,7 +573,7 @@ printf("thread_memblist_setup %lx v_node_count=%d ncell=%d end=%d\n", (long)nth,
                 if (memb_func[p->type].hoc_mech) {
                     ml->prop[ml->nodecount] = p;
                 } else {
-                    ml->data[ml->nodecount] = p->param;
+                    ml->_data[ml->nodecount] = p->param;
                     ml->pdata[ml->nodecount] = p->dparam;
                 }
                 ++ml->nodecount;
@@ -872,7 +872,7 @@ void nrn_thread_table_check() {
         NrnThreadMembList* tml = (NrnThreadMembList*) table_check_[i + 1]._pvoid;
         Memb_list* ml = tml->ml;
         (*memb_func[tml->index].thread_table_check_)(
-            ml->data[0], ml->pdata[0], ml->_thread, nt, tml->index);
+            ml->_data[0], ml->pdata[0], ml->_thread, nt, tml->index);
     }
 }
 

--- a/src/nrnoc/nrnnemo.cpp
+++ b/src/nrnoc/nrnnemo.cpp
@@ -119,7 +119,7 @@ static double diamval(Node* nd) {
     Prop* p;
 
     for (p = nd->prop; p; p = p->next) {
-        if (p->type == MORPHOLOGY) {
+        if (p->_type == MORPHOLOGY) {
             break;
         }
     }
@@ -186,7 +186,7 @@ static void file_func(Section* sec) {
 
     active = 0;
     for (p = nd->prop; p; p = p->next) {
-        if (p->type == hhtype) {
+        if (p->_type == hhtype) {
             active = 1;
         }
     }

--- a/src/nrnoc/nrnoc_ml.h
+++ b/src/nrnoc/nrnoc_ml.h
@@ -15,7 +15,7 @@ struct Memb_list {
      * cache-efficient */
     int* nodeindices;
 #endif /* CACHEVEC */
-    double** data;
+    double** _data;
     Datum** pdata;
     Prop** prop;
     Datum* _thread; /* thread specific data (when static is no good) */

--- a/src/nrnoc/passive0.cpp
+++ b/src/nrnoc/passive0.cpp
@@ -54,7 +54,7 @@ static void pas_jacob(NrnThread* nt, Memb_list* ml, int type) {
 
 static void pas_alloc(Prop* p) {
     double* pd;
-    pd = nrn_prop_data_alloc(p->type, nparm, p);
+    pd = nrn_prop_data_alloc(p->_type, nparm, p);
     p->param_size = nparm;
 #if defined(__MWERKS__)
     pd[0] = 5.e-4; /*DEF_g;*/

--- a/src/nrnoc/passive0.cpp
+++ b/src/nrnoc/passive0.cpp
@@ -25,7 +25,7 @@ extern "C" void passive0_reg_(void) {
 static void pas_cur(NrnThread* nt, Memb_list* ml, int type) {
     int count = ml->nodecount;
     Node** vnode = ml->nodelist;
-    double** vdata = ml->data;
+    double** vdata = ml->_data;
     Datum** vpdata = ml->pdata;
     int i;
 #if _CRAY
@@ -39,7 +39,7 @@ static void pas_cur(NrnThread* nt, Memb_list* ml, int type) {
 static void pas_jacob(NrnThread* nt, Memb_list* ml, int type) {
     int count = ml->nodecount;
     Node** vnode = ml->nodelist;
-    double** vdata = ml->data;
+    double** vdata = ml->_data;
     Datum** vpdata = ml->pdata;
     int i;
 #if _CRAY

--- a/src/nrnoc/point.cpp
+++ b/src/nrnoc/point.cpp
@@ -161,7 +161,7 @@ void nrn_relocate_old_points(Section* oldsec, Node* oldnode, Section* sec, Node*
     if (oldnode)
         for (p = oldnode->prop; p; p = pn) {
             pn = p->next;
-            if (memb_func[p->type].is_point) {
+            if (memb_func[p->_type].is_point) {
                 pnt = (Point_process*) p->dparam[1]._pvoid;
                 if (oldsec == pnt->sec) {
                     if (oldnode == node) {
@@ -171,11 +171,11 @@ void nrn_relocate_old_points(Section* oldsec, Node* oldnode, Section* sec, Node*
 double nrn_arc_position();
 char* secname();
 printf("relocating a %s to %s(%d)\n",
-memb_func[p->type].sym->name,
+memb_func[p->_type].sym->name,
 secname(sec), nrn_arc_position(sec, node)
 );
 #endif
-                        nrn_loc_point_process(pnt_map[p->type], pnt, sec, node);
+                        nrn_loc_point_process(pnt_map[p->_type], pnt, sec, node);
                     }
                 }
             }
@@ -240,7 +240,7 @@ double get_loc_point_process(void* v) {
     if (pnt->prop == (Prop*) 0) {
         hoc_execerror("point process not located in a section", (char*) 0);
     }
-    if (nrn_is_artificial_[pnt->prop->type]) {
+    if (nrn_is_artificial_[pnt->prop->_type]) {
         hoc_execerror("ARTIFICIAL_CELLs are not located in a section", (char*) 0);
     }
     sec = pnt->sec;
@@ -326,7 +326,7 @@ static void free_one_point(Point_process* pnt) /* must unlink from node property
     if (!p) {
         return;
     }
-    if (!nrn_is_artificial_[p->type]) {
+    if (!nrn_is_artificial_[p->_type]) {
         p1 = pnt->node->prop;
         if (p1 == p) {
             pnt->node->prop = p1->next;
@@ -342,14 +342,14 @@ static void free_one_point(Point_process* pnt) /* must unlink from node property
     { v_structure_change = 1; }
 #endif
     if (p->param) {
-        if (memb_func[p->type].destructor) {
-            memb_func[p->type].destructor(p);
+        if (memb_func[p->_type].destructor) {
+            memb_func[p->_type].destructor(p);
         }
         notify_freed_val_array(p->param, p->param_size);
-        nrn_prop_data_free(p->type, p->param);
+        nrn_prop_data_free(p->_type, p->param);
     }
     if (p->dparam) {
-        nrn_prop_datum_free(p->type, p->dparam);
+        nrn_prop_datum_free(p->_type, p->dparam);
     }
     free(p);
     pnt->prop = (Prop*) 0;
@@ -380,10 +380,10 @@ void clear_point_process_struct(Prop* p) /* called from prop_free */
         }
         if (p->param) {
             notify_freed_val_array(p->param, p->param_size);
-            nrn_prop_data_free(p->type, p->param);
+            nrn_prop_data_free(p->_type, p->param);
         }
         if (p->dparam) {
-            nrn_prop_datum_free(p->type, p->dparam);
+            nrn_prop_datum_free(p->_type, p->dparam);
         }
         free(p);
     }

--- a/src/nrnoc/psection.cpp
+++ b/src/nrnoc/psection.cpp
@@ -50,7 +50,7 @@ static void pnode(Prop* p1) {
         return;
     }
     pnode(p1->next); /*print in insert order*/
-    sym = memb_func[p1->type].sym;
+    sym = memb_func[p1->_type].sym;
     Printf("	insert %s {", sym->name);
     if (sym->s_varn) {
         for (j = 0; j < sym->s_varn; j++) {

--- a/src/nrnoc/seclist.cpp
+++ b/src/nrnoc/seclist.cpp
@@ -163,7 +163,7 @@ static double seclist_remove(void* v) {
         sec = nrn_secarg(1);
         ITERATE_REMOVE(q, q1, sl) /*{*/
         if (sec == q->element.sec) {
-            delete (q);
+            hoc_l_delete(q);
             section_unref(sec);
             return 1.;
         }
@@ -189,7 +189,7 @@ for (q = sl->next; q != sl; q = q1) {
     q1 = q->next;
     s = hocSEC(q);
     if (s->volatile_mark) {
-        delete (q);
+        hoc_l_delete(q);
         section_unref(s);
         ++i;
     }
@@ -213,7 +213,7 @@ for (q = sl->next; q != sl; q = q1) {
     q1 = q->next;
     s = hocSEC(q);
     if (s->volatile_mark++) {
-        delete (q);
+        hoc_l_delete(q);
         section_unref(s);
         ++i;
     }
@@ -307,7 +307,7 @@ void forall_sectionlist(void) {
         q1 = q->next;
         sec = q->element.sec;
         if (!sec->prop) {
-            delete (q);
+            hoc_l_delete(q);
             section_unref(sec);
             continue;
         }

--- a/src/nrnoc/section.h
+++ b/src/nrnoc/section.h
@@ -213,7 +213,7 @@ typedef struct Extnode {
 
 typedef struct Prop {
     struct Prop* next; /* linked list of properties */
-    short type;        /* type of membrane, e.g. passive, HH, etc. */
+    short _type;       /* type of membrane, e.g. passive, HH, etc. */
     short unused1;     /* gcc and borland need pairs of shorts to align the same.*/
     int param_size;    /* for notifying hoc_free_val_array */
     double* param;     /* vector of doubles for this property */

--- a/src/nrnoc/solve.cpp
+++ b/src/nrnoc/solve.cpp
@@ -698,13 +698,13 @@ static Node* node_clone(Node* nd1) {
 #endif
     NODEV(nd2) = NODEV(nd1);
     for (p1 = nd1->prop; p1; p1 = p1->next) {
-        if (!memb_func[p1->type].is_point) {
-            p2 = prop_alloc(&(nd2->prop), p1->type, nd2);
+        if (!memb_func[p1->_type].is_point) {
+            p2 = prop_alloc(&(nd2->prop), p1->_type, nd2);
             if (p2->ob) {
                 Symbol *s, *ps;
                 double *px, *py;
                 int j, jmax;
-                s = memb_func[p1->type].sym;
+                s = memb_func[p1->_type].sym;
                 jmax = s->s_varn;
                 for (j = 0; j < jmax; ++j) {
                     ps = s->u.ppsym[j];
@@ -725,12 +725,12 @@ static Node* node_clone(Node* nd1) {
     /* in case the user defined an explicit ion_style, make sure
        the new node has the same style for all ions. */
     for (p1 = nd1->prop; p1; p1 = p1->next) {
-        if (nrn_is_ion(p1->type)) {
+        if (nrn_is_ion(p1->_type)) {
             p2 = nd2->prop;
-            while (p2 && p2->type != p1->type) {
+            while (p2 && p2->_type != p1->_type) {
                 p2 = p2->next;
             }
-            assert(p2 && p1->type == p2->type);
+            assert(p2 && p1->_type == p2->_type);
             p2->dparam[0].i = p1->dparam[0].i;
         }
     }

--- a/src/nrnoc/treeset.cpp
+++ b/src/nrnoc/treeset.cpp
@@ -1657,7 +1657,7 @@ void v_setup_vectors(void) {
                 if (memb_func[i].hoc_mech) {
                     free(memb_list[i].prop);
                 } else {
-                    free(memb_list[i].data);
+                    free(memb_list[i]._data);
                     free(memb_list[i].pdata);
                 }
             }
@@ -1684,8 +1684,8 @@ void v_setup_vectors(void) {
                 if (memb_func[i].hoc_mech) {
                     memb_list[i].prop = (Prop**) emalloc(memb_list[i].nodecount * sizeof(Prop*));
                 } else {
-                    memb_list[i].data = (double**) emalloc(memb_list[i].nodecount *
-                                                           sizeof(double*));
+                    memb_list[i]._data = (double**) emalloc(memb_list[i].nodecount *
+                                                            sizeof(double*));
                     memb_list[i].pdata = (Datum**) emalloc(memb_list[i].nodecount * sizeof(Datum*));
                 }
                 memb_list[i].nodecount = 0; /* counted again below */
@@ -1753,7 +1753,7 @@ hoc_execerror(memb_func[i].sym->name, "is not thread safe");
                 Point_process* pnt = (Point_process*) obj->u.this_pointer;
                 p = pnt->prop;
                 memb_list[i].nodelist[j] = (Node*) 0;
-                memb_list[i].data[j] = p->param;
+                memb_list[i]._data[j] = p->param;
                 memb_list[i].pdata[j] = p->dparam;
                 /* for now, round robin all the artificial cells */
                 /* but put the non-threadsafe ones in thread 0 */
@@ -1849,7 +1849,7 @@ void node_data_values(void) {
             Pd(cnt);
         }
         for (j = 0; j < memb_list[i].nodecount; ++j) {
-            pd = memb_list[i].data[j];
+            pd = memb_list[i]._data[j];
             for (k = 0; k < cnt; ++k) {
                 Pg(pd[k]);
             }

--- a/src/nrnoc/treeset.cpp
+++ b/src/nrnoc/treeset.cpp
@@ -652,7 +652,7 @@ Prop* need_memb(Symbol* sym) {
     type = sym->subtype;
     mprev = (Prop*) 0; /* may need to relink m */
     for (m = *current_prop_list; m; mprev = m, m = m->next) {
-        if (m->type == type) {
+        if (m->_type == type) {
             break;
         }
     }
@@ -704,7 +704,7 @@ Prop* prop_alloc(Prop** pp, int type, Node* nd) {
 #endif
     current_prop_list = pp;
     p = (Prop*) emalloc(sizeof(Prop));
-    p->type = type;
+    p->_type = type;
     p->next = *pp;
     p->ob = nullptr;
     p->_alloc_seq = -1;
@@ -742,19 +742,19 @@ void single_prop_free(Prop* p) {
 #if VECTORIZE
     v_structure_change = 1;
 #endif
-    if (pnt_map[p->type]) {
+    if (pnt_map[p->_type]) {
         clear_point_process_struct(p);
         return;
     }
     if (p->param) {
         notify_freed_val_array(p->param, p->param_size);
-        nrn_prop_data_free(p->type, p->param);
+        nrn_prop_data_free(p->_type, p->param);
     }
     if (p->dparam) {
-        if (p->type == CABLESECTION) {
+        if (p->_type == CABLESECTION) {
             notify_freed_val_array(&p->dparam[2].val, 6);
         }
-        nrn_prop_datum_free(p->type, p->dparam);
+        nrn_prop_datum_free(p->_type, p->dparam);
     }
     if (p->ob) {
         hoc_obj_unref(p->ob);
@@ -793,7 +793,7 @@ void nrn_area_ri(Section* sec) {
     for (j = 0; j < sec->nnode - 1; j++) {
         nd = sec->pnode[j];
         for (p = nd->prop; p; p = p->next) {
-            if (p->type == MORPHOLOGY) {
+            if (p->_type == MORPHOLOGY) {
                 break;
             }
         }
@@ -2253,11 +2253,11 @@ void nrn_recalc_node_ptrs(void) {
         Datum* d;
         int dpend;
         for (p = nd->prop; p; p = p->next) {
-            if (memb_func[p->type].is_point && !nrn_is_artificial_[p->type]) {
+            if (memb_func[p->_type].is_point && !nrn_is_artificial_[p->_type]) {
                 p->dparam[0].pval = nt->_actual_area + i;
             }
-            dpend = nrn_dparam_ptr_end_[p->type];
-            for (j = nrn_dparam_ptr_start_[p->type]; j < dpend; ++j) {
+            dpend = nrn_dparam_ptr_end_[p->_type];
+            for (j = nrn_dparam_ptr_start_[p->_type]; j < dpend; ++j) {
                 double* pval = p->dparam[j].pval;
                 if (nrn_isdouble(pval, 0., (double) recalc_cnt_)) {
                     /* possible pointer to v */

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -1075,14 +1075,14 @@ static PyObject* NPyMechObj_name(NPyMechObj* self) {
     CHECK_SEC_INVALID(self->pyseg_->pysec_->sec_);
     PyObject* result = NULL;
     if (self->prop_) {
-        result = PyString_FromString(memb_func[self->prop_->type].sym->name);
+        result = PyString_FromString(memb_func[self->prop_->_type].sym->name);
     }
     return result;
 }
 
 static PyObject* NPyMechObj_is_ion(NPyMechObj* self) {
     CHECK_SEC_INVALID(self->pyseg_->pysec_->sec_);
-    if (self->prop_ && nrn_is_ion(self->prop_->type)) {
+    if (self->prop_ && nrn_is_ion(self->prop_->_type)) {
         Py_RETURN_TRUE;
     }
     Py_RETURN_FALSE;
@@ -1356,7 +1356,7 @@ static PyObject* seg_point_processes(NPySegObj* self) {
     Node* nd = node_exact(sec, self->x_);
     PyObject* result = PyList_New(0);
     for (Prop* p = nd->prop; p; p = p->next) {
-        if (memb_func[p->type].is_point) {
+        if (memb_func[p->_type].is_point) {
             Point_process* pp = (Point_process*) p->dparam[1]._pvoid;
             PyObject* item = nrnpy_ho2po(pp->ob);
             int err = PyList_Append(result, item);
@@ -1466,7 +1466,7 @@ static PyObject* seg_volume(NPySegObj* self) {
             // 0 or 1 3D points... so give cylinder volume
             Node* nd = node_exact(sec, x);
             for (Prop* p = nd->prop; p; p = p->next) {
-                if (p->type == MORPHOLOGY) {
+                if (p->_type == MORPHOLOGY) {
                     double diam = p->param[0];
                     a = M_PI * diam * diam / 4 * length;
                     break;
@@ -1501,8 +1501,8 @@ static Prop* mech_of_segment_prop(Prop* p) {
         if (!p) {
             break;
         }
-        // printf("segment_iter %d %s\n", p->type, memb_func[p->type].sym->name);
-        if (PyDict_GetItemString(pmech_types, memb_func[p->type].sym->name)) {
+        // printf("segment_iter %d %s\n", p->_type, memb_func[p->_type].sym->name);
+        if (PyDict_GetItemString(pmech_types, memb_func[p->_type].sym->name)) {
             // printf("segment_iter found\n");
             break;
         }
@@ -1764,7 +1764,7 @@ static PyObject* var_of_mech_iter(NPyMechObj* self) {
     }
     vmi->pymech_ = self;
     Py_INCREF(vmi->pymech_);
-    vmi->msym_ = memb_func[self->prop_->type].sym;
+    vmi->msym_ = memb_func[self->prop_->_type].sym;
     vmi->i_ = 0;
     return (PyObject*) vmi;
 }
@@ -1889,8 +1889,8 @@ static PyObject* segment_getattro(NPySegObj* self, PyObject* pyname) {
         PyDict_SetItemString(result, "cm", Py_None);
         assert(err == 0);
         for (Prop* p = nd->prop; p; p = p->next) {
-            if (p->type > CAP && !memb_func[p->type].is_point) {
-                char* pn = memb_func[p->type].sym->name;
+            if (p->_type > CAP && !memb_func[p->_type].is_point) {
+                char* pn = memb_func[p->_type].sym->name;
                 err = PyDict_SetItemString(result, pn, Py_None);
                 assert(err == 0);
             }
@@ -2035,11 +2035,11 @@ static PyObject* mech_getattro(NPyMechObj* self, PyObject* pyname) {
     PyObject* result = NULL;
     NrnProperty np(self->prop_);
     int isptr = (strncmp(n, "_ref_", 5) == 0);
-    char* mname = memb_func[self->prop_->type].sym->name;
+    char* mname = memb_func[self->prop_->_type].sym->name;
     int mnamelen = strlen(mname);
     int bufsz = strlen(n) + mnamelen + 2;
     char* buf = new char[bufsz];
-    if (nrn_is_ion(self->prop_->type)) {
+    if (nrn_is_ion(self->prop_->_type)) {
         strcpy(buf, isptr ? n + 5 : n);
     } else {
         sprintf(buf, "%s_%s", isptr ? n + 5 : n, mname);
@@ -2102,11 +2102,11 @@ static int mech_setattro(NPyMechObj* self, PyObject* pyname, PyObject* value) {
     // printf("mech_setattro %s\n", n);
     NrnProperty np(self->prop_);
     int isptr = (strncmp(n, "_ref_", 5) == 0);
-    char* mname = memb_func[self->prop_->type].sym->name;
+    char* mname = memb_func[self->prop_->_type].sym->name;
     int mnamelen = strlen(mname);
     int bufsz = strlen(n) + mnamelen + 2;
     char* buf = new char[bufsz];
-    if (nrn_is_ion(self->prop_->type)) {
+    if (nrn_is_ion(self->prop_->_type)) {
         strcpy(buf, isptr ? n + 5 : n);
     } else {
         sprintf(buf, "%s_%s", isptr ? n + 5 : n, mname);
@@ -2150,7 +2150,7 @@ double** nrnpy_setpointer_helper(PyObject* pyname, PyObject* mech) {
     if (!n) {
         return NULL;
     }
-    sprintf(buf, "%s_%s", n, memb_func[m->prop_->type].sym->name);
+    sprintf(buf, "%s_%s", n, memb_func[m->prop_->_type].sym->name);
     Symbol* sym = np.find(buf);
     if (!sym || sym->type != RANGEVAR || sym->subtype != NRNPOINTER) {
         return 0;

--- a/src/oc/debug.cpp
+++ b/src/oc/debug.cpp
@@ -7,9 +7,9 @@
 int zzdebug;
 
 #if DOS
-#define prcod(c1, c2) else if (p->pf == c1) Printf("%p %p %s", p, p->pf, c2);
+#define prcod(c1, c2) else if (p->pf == c1) Printf("%p %p %s", p, p->pf, c2)
 #else
-#define prcod(c1, c2) else if (p->pf == c1) Printf("%p %p %s", p, p->pf, c2);
+#define prcod(c1, c2) else if (p->pf == c1) Printf("%p %p %s", p, p->pf, c2)
 #endif
 
 void debug(void) /* print the machine */
@@ -20,143 +20,116 @@ void debug(void) /* print the machine */
         zzdebug = 0;
 }
 
-void debugzz(Inst* p) /* running copy of calls to execute */
-{
+/* running copy of calls to execute */
+void debugzz(Inst* p) {
 #if !OCSMALL
     {
         if (p->in == STOP)
             Printf("STOP\n");
-        prcod(nopop, "POP\n") prcod(eval, "EVAL\n") prcod(add, "ADD\n") prcod(hoc_sub, "SUB\n")
-            prcod(mul, "MUL\n") prcod(hoc_div, "DIV\n") prcod(negate, "NEGATE\n")
-                prcod(power, "POWER\n") prcod(assign, "ASSIGN\n") prcod(bltin, "BLTIN\n")
-                    prcod(varpush, "VARPUSH\n") prcod(constpush, "CONSTPUSH\n")
-                        prcod(pushzero, "PUSHZERO\n") prcod(print, "PRINT\n") prcod(varread,
-                                                                                    "VARREAD\n")
-                            prcod(prexpr, "PREXPR\n") prcod(prstr, "PRSTR\n") prcod(gt, "GT\n")
-                                prcod(lt, "LT\n") prcod(eq, "EQ\n") prcod(ge, "GE\n")
-                                    prcod(le, "LE\n") prcod(ne, "NE\n") prcod(hoc_and, "AND\n")
-                                        prcod(hoc_or, "OR\n") prcod(hoc_not, "NOT\n")
-                                            prcod(ifcode, "IFCODE\n") prcod(forcode, "FORCODE\n")
-                                                prcod(shortfor, "SHORTFOR\n") prcod(call, "CALL\n")
-                                                    prcod(arg, "ARG\n")
-                                                        prcod(argassign, "ARGASSIGN\n")
-                                                            prcod(funcret, "FUNCRET\n")
-                                                                prcod(procret, "PROCRET\n")
-                                                                    prcod(hocobjret, "HOCOBJRET\n")
+        prcod(nopop, "POP\n");
+        prcod(eval, "EVAL\n");
+        prcod(add, "ADD\n");
+        prcod(hoc_sub, "SUB\n");
+        prcod(mul, "MUL\n");
+        prcod(hoc_div, "DIV\n");
+        prcod(negate, "NEGATE\n");
+        prcod(power, "POWER\n");
+        prcod(assign, "ASSIGN\n");
+        prcod(bltin, "BLTIN\n");
+        prcod(varpush, "VARPUSH\n");
+        prcod(constpush, "CONSTPUSH\n");
+        prcod(pushzero, "PUSHZERO\n");
+        prcod(print, "PRINT\n");
+        prcod(varread, "VARREAD\n");
+        prcod(prexpr, "PREXPR\n");
+        prcod(prstr, "PRSTR\n");
+        prcod(gt, "GT\n");
+        prcod(lt, "LT\n");
+        prcod(eq, "EQ\n");
+        prcod(ge, "GE\n");
+        prcod(le, "LE\n");
+        prcod(ne, "NE\n");
+        prcod(hoc_and, "AND\n");
+        prcod(hoc_or, "OR\n");
+        prcod(hoc_not, "NOT\n");
+        prcod(ifcode, "IFCODE\n");
+        prcod(forcode, "FORCODE\n");
+        prcod(shortfor, "SHORTFOR\n");
+        prcod(call, "CALL\n");
+        prcod(arg, "ARG\n");
+        prcod(argassign, "ARGASSIGN\n");
+        prcod(funcret, "FUNCRET\n");
+        prcod(procret, "PROCRET\n");
+        prcod(hocobjret, "HOCOBJRET\n");
 #if DOS
 /* no room for all this stuff */
 #else
-                                                                        prcod(
-                                                                            hoc_iterator_stmt,
-                                                                            "hoc_iterator_stmt\n") prcod(hoc_iterator,
-                                                                                                         "hoc_iterator\n")
-                                                                            prcod(
-                                                                                hoc_argrefasgn,
-                                                                                "ARGREFASSIGN\n") prcod(hoc_argref,
-                                                                                                        "ARGREF\n") prcod(hoc_stringarg,
-                                                                                                                          "STRINGARG\n")
-                                                                                prcod(
-                                                                                    hoc_push_string,
-                                                                                    "push_"
-                                                                                    "string\n") prcod(Break,
-                                                                                                      "Break\n")
-                                                                                    prcod(
-                                                                                        Continue,
-                                                                                        "Continue"
-                                                                                        "\n") prcod(Stop,
-                                                                                                    "Stop()\n")
-                                                                                        prcod(
-                                                                                            assstr,
-                                                                                            "assstr"
-                                                                                            "\n") prcod(hoc_evalpointer,
-                                                                                                        "evalpo"
-                                                                                                        "inter"
-                                                                                                        "\n") prcod(hoc_newline,
-                                                                                                                    "newline\n")
-                                                                                            prcod(
-                                                                                                hoc_delete_symbol,
-                                                                                                "de"
-                                                                                                "le"
-                                                                                                "te"
-                                                                                                "_s"
-                                                                                                "ym"
-                                                                                                "bo"
-                                                                                                "l"
-                                                                                                "\n") prcod(hoc_cyclic,
-                                                                                                            "cyclic\n")
-                                                                                                prcod(
-                                                                                                    hoc_parallel_begin,
-                                                                                                    "pa"
-                                                                                                    "ra"
-                                                                                                    "ll"
-                                                                                                    "el"
-                                                                                                    "_b"
-                                                                                                    "eg"
-                                                                                                    "in"
-                                                                                                    "\n") prcod(hoc_parallel_end,
-                                                                                                                "parallel_end\n")
+        prcod(hoc_iterator_stmt, "hoc_iterator_stmt\n");
+        prcod(hoc_iterator, "hoc_iterator\n");
+        prcod(hoc_argrefasgn, "ARGREFASSIGN\n");
+        prcod(hoc_argref, "ARGREF\n");
+        prcod(hoc_stringarg, "STRINGARG\n");
+        prcod(hoc_push_string, "push_string\n");
+        prcod(Break, "Break\n");
+        prcod(Continue, "Continue\n");
+        prcod(Stop, "Stop()\n");
+        prcod(assstr, "assstr\n");
+        prcod(hoc_evalpointer, "evalpointer\n");
+        prcod(hoc_newline, "newline\n");
+        prcod(hoc_delete_symbol, "delete_symbol\n");
+        prcod(hoc_cyclic, "cyclic\n");
+        prcod(hoc_parallel_begin, "parallel_begin\n");
+        prcod(hoc_parallel_end, "parallel_end\n");
 
-                                                                                                    prcod(
-                                                                                                        dep_make,
-                                                                                                        "DEPENDENT\n")
-                                                                                                        prcod(
-                                                                                                            eqn_name,
-                                                                                                            "EQUATION\n")
-                                                                                                            prcod(
-                                                                                                                eqn_init,
-                                                                                                                "eqn_init()\n")
-                                                                                                                prcod(
-                                                                                                                    eqn_lhs,
-                                                                                                                    "eqn_lhs()\n")
-                                                                                                                    prcod(
-                                                                                                                        eqn_rhs,
-                                                                                                                        "eqn_rhs()\n")
-            /*OOP*/
-            prcod(hoc_push_current_object, "hoc_push_current_object\n")
-                prcod(hoc_objectvar, "objectvar\n") prcod(hoc_object_component,
-                                                          "objectcomponent()\n")
-                    prcod(hoc_object_eval, "objecteval\n") prcod(hoc_object_asgn, "objectasgn\n")
-                        prcod(hoc_objvardecl, "objvardecl\n") prcod(hoc_cmp_otype, "cmp_otype\n")
-                            prcod(hoc_newobj, "newobject\n")
-                                prcod(hoc_asgn_obj_to_str, "assignobj2str\n")
-                                    prcod(hoc_known_type, "known_type\n")
-                                        prcod(hoc_push_string, "push_string\n")
-                                            prcod(hoc_objectarg, "hoc_objectarg\n")
-                                                prcod(hoc_ob_pointer, "hoc_ob_pointer\n")
-                                                    prcod(hoc_constobject, "hoc_constobject\n")
+        prcod(dep_make, "DEPENDENT\n");
+        prcod(eqn_name, "EQUATION\n");
+        prcod(eqn_init, "eqn_init()\n");
+        prcod(eqn_lhs, "eqn_lhs()\n");
+        prcod(eqn_rhs, "eqn_rhs()\n");
+        /*OOP*/
+        prcod(hoc_push_current_object, "hoc_push_current_object\n");
+        prcod(hoc_objectvar, "objectvar\n");
+        prcod(hoc_object_component, "objectcomponent()\n");
+        prcod(hoc_object_eval, "objecteval\n");
+        prcod(hoc_object_asgn, "objectasgn\n");
+        prcod(hoc_objvardecl, "objvardecl\n");
+        prcod(hoc_cmp_otype, "cmp_otype\n");
+        prcod(hoc_newobj, "newobject\n");
+        prcod(hoc_asgn_obj_to_str, "assignobj2str\n");
+        prcod(hoc_known_type, "known_type\n");
+        prcod(hoc_push_string, "push_string\n");
+        prcod(hoc_objectarg, "hoc_objectarg\n");
+        prcod(hoc_ob_pointer, "hoc_ob_pointer\n");
+        prcod(hoc_constobject, "hoc_constobject\n");
 
-            /*NEWCABLE*/
-            prcod(connect_obsec_syntax, "connect_obsec_syntax()\n") prcod(connectsection,
-                                                                          "connectsection()\n")
-                prcod(simpleconnectsection, "simpleconnectsection()\n") prcod(connectpointer,
-                                                                              "connectpointer()\n")
-                    prcod(add_section, "add_section()\n") prcod(range_const, "range_const()\n")
-                        prcod(range_interpolate, "range_interpolate()\n") prcod(
-                            range_interpolate_single,
-                            "range_interpolate_single()\n") prcod(rangevareval, "rangevareval()\n")
-                            prcod(rangepoint, "rangepoint()\n") prcod(sec_access, "sec_access()\n")
-                                prcod(ob_sec_access, "ob_sec_access()\n")
-                                    prcod(mech_access, "mech_access()\n") prcod(for_segment,
-                                                                                "forsegment()\n")
-                                        prcod(sec_access_push, "sec_access_push()\n")
-                                            prcod(sec_access_pop, "sec_access_pop()\n")
-                                                prcod(forall_section, "forall_section()\n")
-                                                    prcod(hoc_ifsec,
-                                                          "hoc_ifsec()\n") prcod(hoc_ifseclist,
-                                                                                 "hocifseclist()\n")
-                                                        prcod(forall_sectionlist,
-                                                              "forall_sectionlist()\n")
-                                                            prcod(connect_point_process_pointer,
-                                                                  "connect_point_process_pointer\n")
-                                                                prcod(nrn_cppp, "nrn_cppp()\n")
-                                                                    prcod(rangevarevalpointer,
-                                                                          "rangevarevalpointer\n")
-                                                                        prcod(sec_access_object,
-                                                                              "sec_access_object\n")
-                                                                            prcod(mech_uninsert,
-                                                                                  "mech_uninsert\n")
+        /*NEWCABLE*/
+        prcod(connect_obsec_syntax, "connect_obsec_syntax()\n");
+        prcod(connectsection, "connectsection()\n");
+        prcod(simpleconnectsection, "simpleconnectsection()\n");
+        prcod(connectpointer, "connectpointer()\n");
+        prcod(add_section, "add_section()\n");
+        prcod(range_const, "range_const()\n");
+        prcod(range_interpolate, "range_interpolate()\n");
+        prcod(range_interpolate_single, "range_interpolate_single()\n");
+        prcod(rangevareval, "rangevareval()\n");
+        prcod(rangepoint, "rangepoint()\n");
+        prcod(sec_access, "sec_access()\n");
+        prcod(ob_sec_access, "ob_sec_access()\n");
+        prcod(mech_access, "mech_access()\n");
+        prcod(for_segment, "forsegment()\n");
+        prcod(sec_access_push, "sec_access_push()\n");
+        prcod(sec_access_pop, "sec_access_pop()\n");
+        prcod(forall_section, "forall_section()\n");
+        prcod(hoc_ifsec, "hoc_ifsec()\n");
+        prcod(hoc_ifseclist, "hocifseclist()\n");
+        prcod(forall_sectionlist, "forall_sectionlist()\n");
+        prcod(connect_point_process_pointer, "connect_point_process_pointer\n");
+        prcod(nrn_cppp, "nrn_cppp()\n");
+        prcod(rangevarevalpointer, "rangevarevalpointer\n");
+        prcod(sec_access_object, "sec_access_object\n");
+        prcod(mech_uninsert, "mech_uninsert\n");
 #endif
-                                                                        else {
+        else {
             size_t offset = (size_t) p->in;
             if (offset < 1000)
                 Printf("relative %d\n", p->i);

--- a/src/oc/hoclist.h
+++ b/src/oc/hoclist.h
@@ -25,7 +25,6 @@
 #define lappendobj  hoc_l_lappendobj
 #define lappendvoid hoc_l_lappendvoid
 #define delitems    hoc_l_delitems
-#define move        hoc_l_move
 #define movelist    hoc_l_movelist
 #define replacstr   hoc_l_replacstr
 #define Item        hoc_Item

--- a/src/oc/hoclist.h
+++ b/src/oc/hoclist.h
@@ -6,7 +6,6 @@
 #define newitem     hoc_l_newitem
 #define newlist     hoc_l_newlist
 #define freelist    hoc_l_freelist
-#define next        hoc_l_next
 #define prev        hoc_l_prev
 #define insertstr   hoc_l_insertstr
 #define insertitem  hoc_l_insertitem

--- a/src/oc/hoclist.h
+++ b/src/oc/hoclist.h
@@ -24,13 +24,12 @@
 #define lappendsec  hoc_l_lappendsec
 #define lappendobj  hoc_l_lappendobj
 #define lappendvoid hoc_l_lappendvoid
-#define delete hoc_l_delete
-#define delitems  hoc_l_delitems
-#define move      hoc_l_move
-#define movelist  hoc_l_movelist
-#define replacstr hoc_l_replacstr
-#define Item      hoc_Item
-#define List      hoc_List
+#define delitems    hoc_l_delitems
+#define move        hoc_l_move
+#define movelist    hoc_l_movelist
+#define replacstr   hoc_l_replacstr
+#define Item        hoc_Item
+#define List        hoc_List
 #endif
 
 struct Object;

--- a/src/oc/hoclist.h
+++ b/src/oc/hoclist.h
@@ -6,7 +6,6 @@
 #define newitem     hoc_l_newitem
 #define newlist     hoc_l_newlist
 #define freelist    hoc_l_freelist
-#define prev        hoc_l_prev
 #define insertstr   hoc_l_insertstr
 #define insertitem  hoc_l_insertitem
 #define insertlist  hoc_l_insertlist

--- a/src/oc/list.cpp
+++ b/src/oc/list.cpp
@@ -223,7 +223,7 @@ void delitems(Item* q1, Item* q2) { /* delete tokens from q1 to q2 */
     hoc_l_delete(q2);
 }
 
-void move(Item* q1, Item* q2, Item* q3) { /* move q1 to q2 and insert before q3*/
+void hoc_l_move(Item* q1, Item* q2, Item* q3) { /* move q1 to q2 and insert before q3*/
     /* it is a serious error if q2 precedes q1 */
     assert(q1 && q2);
     assert(q1->itemtype && q2->itemtype);
@@ -238,7 +238,7 @@ void move(Item* q1, Item* q2, Item* q3) { /* move q1 to q2 and insert before q3*
 
 void movelist(Item* q1, Item* q2, List* s) {
     /* move q1 to q2 from old list to end of list s*/
-    move(q1, q2, s);
+    hoc_l_move(q1, q2, s);
 }
 
 void replacstr(Item* q, const char* s) {

--- a/src/oc/list.cpp
+++ b/src/oc/list.cpp
@@ -77,7 +77,7 @@ static Item* linkitem(Item* item) {
     return i;
 }
 
-Item* next(Item* item) {
+Item* hoc_l_next(Item* item) {
     assert(item->next->element.lst); /* never return the list item */
     return item->next;
 }

--- a/src/oc/list.cpp
+++ b/src/oc/list.cpp
@@ -195,7 +195,7 @@ Item* lappendvoid(List* list, void* obj) {
     return insertvoid(list, obj);
 }
 
-void delete (Item* item) {
+void hoc_l_delete(Item* item) {
     assert(item->itemtype); /* can't delete list */
     item->next->prev = item->prev;
     item->prev->next = item->next;
@@ -218,9 +218,9 @@ void delitems(Item* q1, Item* q2) { /* delete tokens from q1 to q2 */
     Item* q;
     for (q = q1; q != q2;) {
         q = q->next;
-        delete (q->prev);
+        hoc_l_delete(q->prev);
     }
-    delete (q2);
+    hoc_l_delete(q2);
 }
 
 void move(Item* q1, Item* q2, Item* q3) { /* move q1 to q2 and insert before q3*/

--- a/src/oc/list.cpp
+++ b/src/oc/list.cpp
@@ -82,7 +82,7 @@ Item* hoc_l_next(Item* item) {
     return item->next;
 }
 
-Item* prev(Item* item) {
+Item* hoc_l_prev(Item* item) {
     assert(item->prev->element.lst); /* never return the list item */
     return item->prev;
 }

--- a/src/oc/redef.h
+++ b/src/oc/redef.h
@@ -29,7 +29,6 @@
 #define argassign          hoc_argassign
 #define assign             hoc_assign
 #define assstr             hoc_assstr
-#define begin              hoc_begin
 #define bltin              hoc_bltin
 #define call               hoc_call
 #define call_ob_proc       hoc_call_ob_proc


### PR DESCRIPTION
A few changes hoisted out of #1929 to help manage the size of that diff.

Having common names of C++ standard library functions/members (`begin`, `data`, ...) and language keywords (`delete`, ...) defined as macros causes problems when more C++ headers are included. Rather than playing games with orders of includes and so on, just drop the macros and apply their old results directly to the code.