### PR TITLE
Remove setjmp and longjmp.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -379,6 +379,7 @@ def setup_package():
                 "src/nrnpython",
                 "src/nrnmpi",
             ],
+            extra_compile_args=["-std=c++17"],
             extra_link_args=[
                 # use relative rpath to .data/lib
                 "-Wl,-rpath,{}".format(REL_RPATH + "/.data/lib/")

--- a/share/lib/python/neuron/rxd/geometry3d/setup.py.in
+++ b/share/lib/python/neuron/rxd/geometry3d/setup.py.in
@@ -56,7 +56,8 @@ else:
 
     define_macros=[]
 
-    extra_compile_args = [@NRN_COMPILE_FLAGS_COMMA_SEPARATED_STRINGS@]
+    extra_compile_args = ["@CMAKE_CXX17_STANDARD_COMPILE_OPTION@"]
+    extra_compile_args += [@NRN_COMPILE_FLAGS_COMMA_SEPARATED_STRINGS@]
     extra_link_args = [@NRN_LINK_FLAGS_COMMA_SEPARATED_STRINGS@]
     if olevel != "":
         extra_compile_args.append('-O' + olevel)

--- a/src/ivoc/graph.cpp
+++ b/src/ivoc/graph.cpp
@@ -2578,7 +2578,6 @@ GraphLine::GraphLine(const char* expr,
             oc.notify_when_freed((void*) obj_, this);
             ObjectContext objc(obj_);
             expr_ = oc.parseExpr(expr, symlist);
-            objc.restore();
         } else {
             expr_ = oc.parseExpr(expr, symlist);
         }
@@ -2972,7 +2971,6 @@ void GraphLine::plot() {
         if (obj_) {
             ObjectContext obc(obj_);
             y_->add(oc.runExpr(expr_));
-            obc.restore();
         } else if (valid()) {
             y_->add(oc.runExpr(expr_));
         }

--- a/src/ivoc/ocjump.cpp
+++ b/src/ivoc/ocjump.cpp
@@ -1,7 +1,5 @@
 #include <../../nrnconf.h>
 #include <InterViews/resource.h>
-#include <setjmp.h>
-#include <string.h>
 #if CABLE
 #include "nrnoc2iv.h"
 #else
@@ -13,6 +11,8 @@
 #if HAVE_IV
 #include "ivoc.h"
 #endif
+
+#include <utility>
 
 extern Objectdata* hoc_top_level_data;
 extern Symlist* hoc_top_level_symlist;

--- a/src/ivoc/ocjump.cpp
+++ b/src/ivoc/ocjump.cpp
@@ -161,7 +161,7 @@ void* OcJumpImpl::fpycall(void* (*f)(void*, void*), void* a, void* b) {
     return c;
 }
 
-extern int OcJumpImpl_nest_depth;
+extern int nrn_try_catch_nest_depth;
 void OcJumpImpl::begin() {
     // not complete but it is good for expressions and it can be improved
     oc_save_hoc_oop(&o1, &o2, &o4, &o5);
@@ -170,7 +170,7 @@ void OcJumpImpl::begin() {
 #if CABLE
     oc_save_cabcode(&cc1, &cc2);
 #endif
-    ++OcJumpImpl_nest_depth;
+    ++nrn_try_catch_nest_depth;
 }
 void OcJumpImpl::restore() {
     oc_restore_hoc_oop(&o1, &o2, &o4, &o5);
@@ -181,7 +181,7 @@ void OcJumpImpl::restore() {
 #endif
 }
 void OcJumpImpl::finish() {
-    --OcJumpImpl_nest_depth;
+    --nrn_try_catch_nest_depth;
 }
 
 ObjectContext::ObjectContext(Object* obj) {

--- a/src/ivoc/ocjump.cpp
+++ b/src/ivoc/ocjump.cpp
@@ -65,8 +65,7 @@ void hoc_execute1() {
 
 class OcJumpImpl {
   public:
-    OcJumpImpl();
-    virtual ~OcJumpImpl();
+    virtual ~OcJumpImpl() {}
     bool execute(Inst* p);
     bool execute(const char*, Object* ob = NULL);
     void* fpycall(void* (*f)(void*, void*), void* a, void* b);
@@ -123,12 +122,9 @@ bool Oc::valid_stmt(const char* stmt, Object* ob) {
 #endif
 //------------------------------------------------------------------
 
-OcJump::OcJump() {
-    impl_ = new OcJumpImpl();
-}
-OcJump::~OcJump() {
-    delete impl_;
-}
+OcJump::OcJump()
+    : impl_{std::make_unique<OcJumpImpl>()} {}
+OcJump::~OcJump() {}
 bool OcJump::execute(Inst* p) {
     return impl_->execute(p);
 }
@@ -140,11 +136,6 @@ bool OcJump::execute(const char* stmt, Object* ob) {
 void* OcJump::fpycall(void* (*f)(void*, void*), void* a, void* b) {
     return impl_->fpycall(f, a, b);
 }
-
-//-------------------------------------------------------------------
-
-OcJumpImpl::OcJumpImpl() {}
-OcJumpImpl::~OcJumpImpl() {}
 
 void hoc_execute(Inst*);
 

--- a/src/ivoc/ocjump.cpp
+++ b/src/ivoc/ocjump.cpp
@@ -224,16 +224,8 @@ ObjectContext::ObjectContext(Object* obj) {
         hoc_objectdata = hoc_top_level_data;
         hoc_symlist = hoc_top_level_symlist;
     }
-    restored_ = false;
 }
 
 ObjectContext::~ObjectContext() {
-    if (!restored_) {
-        restore();
-    }
-}
-
-void ObjectContext::restore() {
     oc_restore_hoc_oop(&a1, &a2, &a4, &a5);
-    restored_ = true;
 }

--- a/src/ivoc/ocjump.cpp
+++ b/src/ivoc/ocjump.cpp
@@ -1,5 +1,6 @@
 #include <../../nrnconf.h>
 
+#include "nrnfilewrap.h"
 #include "nrnoc2iv.h"
 #include "ocfunc.h"
 #include "ocjump.h"
@@ -20,7 +21,7 @@ extern int hoc_execerror_messages;
 bool hoc_valid_stmt(const char* stmt, Object* ob) {
     std::string s{stmt};
     s.append(1, '\n');
-    return OcJump{}.execute(s.c_str(), ob);
+    return OcJump::execute(s.c_str(), ob);
 }
 
 void hoc_execute1() {
@@ -47,7 +48,7 @@ void hoc_execute1() {
 
 #if HAVE_IV
 bool Oc::valid_expr(Symbol* s) {
-    return OcJump{}.execute(s->u.u_proc->defn.in);
+    return OcJump::execute(s->u.u_proc->defn.in);
 }
 
 bool Oc::valid_stmt(const char* stmt, Object* ob) {
@@ -57,63 +58,88 @@ bool Oc::valid_stmt(const char* stmt, Object* ob) {
 //------------------------------------------------------------------
 void hoc_execute(Inst*);
 
+namespace {
+struct saved_state {
+    saved_state() {
+        // not complete but it is good for expressions and it can be improved
+        oc_save_hoc_oop(&o1, &o2, &o4, &o5);
+        oc_save_code(&c1, &c2, &c3, &c4, &c5, &c6, &c7, &c8, &c9, &c10, &c11, &c12);
+        oc_save_input_info(&i1, &i2, &i3, &i4);
+        oc_save_cabcode(&cc1, &cc2);
+    }
+    void restore() {
+        oc_restore_hoc_oop(&o1, &o2, &o4, &o5);
+        oc_restore_code(&c1, &c2, &c3, &c4, &c5, &c6, &c7, &c8, &c9, &c10, &c11, &c12);
+        oc_restore_input_info(i1, i2, i3, i4);
+        oc_restore_cabcode(&cc1, &cc2);
+    }
+
+  private:
+    // hoc_oop
+    Object* o1{};
+    Objectdata* o2{};
+    int o4{};
+    Symlist* o5{};
+
+    // code
+    Inst* c1{};
+    Inst* c2{};
+    Datum* c3{};
+    nrn::oc::frame* c4{};
+    int c5{};
+    int c6{};
+    Inst* c7{};
+    nrn::oc::frame* c8{};
+    Datum* c9{};
+    Symlist* c10{};
+    Inst* c11{};
+    int c12{};
+
+    // input_info
+    const char* i1{};
+    int i2{};
+    int i3{};
+    NrnFILEWrap* i4{};
+
+    // cabcode
+    int cc1{};
+    int cc2{};
+};
+}  // namespace
+
 bool OcJump::execute(Inst* p) {
-    bool ret{false};
-    begin();
+    saved_state before{};
+    try_catch_depth_increment tell_children_we_will_catch{};
     try {
         hoc_execute(p);
-        ret = true;
+        return true;
     } catch (...) {
-        restore();
+        before.restore();
+        return false;
     }
-    finish();
-    return ret;
 }
 
 bool OcJump::execute(const char* stmt, Object* ob) {
-    bool ret{false};
-    begin();
+    saved_state before{};
+    try_catch_depth_increment tell_children_we_will_catch{};
     try {
         hoc_obj_run(stmt, ob);
-        ret = true;
+        return true;
     } catch (...) {
-        restore();
+        before.restore();
+        return false;
     }
-    finish();
-    return ret;
 }
 
 void* OcJump::fpycall(void* (*f)(void*, void*), void* a, void* b) {
-    void* c = 0;
-    begin();
+    saved_state before{};
+    try_catch_depth_increment tell_children_we_will_catch{};
     try {
-        c = (*f)(a, b);
+        return (*f)(a, b);
     } catch (...) {
-        restore();
+        before.restore();
+        return nullptr;
     }
-    finish();
-    return c;
-}
-
-extern int nrn_try_catch_nest_depth;
-void OcJump::begin() {
-    // not complete but it is good for expressions and it can be improved
-    oc_save_hoc_oop(&o1, &o2, &o4, &o5);
-    oc_save_code(&c1, &c2, &c3, &c4, &c5, &c6, &c7, &c8, &c9, &c10, &c11, &c12);
-    oc_save_input_info(&i1, &i2, &i3, &i4);
-    oc_save_cabcode(&cc1, &cc2);
-    ++nrn_try_catch_nest_depth;
-}
-
-void OcJump::restore() {
-    oc_restore_hoc_oop(&o1, &o2, &o4, &o5);
-    oc_restore_code(&c1, &c2, &c3, &c4, &c5, &c6, &c7, &c8, &c9, &c10, &c11, &c12);
-    oc_restore_input_info(i1, i2, i3, i4);
-    oc_restore_cabcode(&cc1, &cc2);
-}
-
-void OcJump::finish() {
-    --nrn_try_catch_nest_depth;
 }
 
 ObjectContext::ObjectContext(Object* obj) {

--- a/src/ivoc/ocjump.cpp
+++ b/src/ivoc/ocjump.cpp
@@ -71,13 +71,6 @@ class OcJumpImpl {
     bool execute(const char*, Object* ob = NULL);
     void* fpycall(void* (*f)(void*, void*), void* a, void* b);
 
-    /* jmpbuf is not portable and I can't figure out how get a pointer to one.
-    therefore hoc_execerror looks at a function pointer and if it's non-NULL
-    (ljmptarget) calls it instead of doing a longjump. That means we are back
-    here and can do an explicit longjump using the begin_ */
-    static void ljmptarget();
-    void ljmp();
-
   private:
     void begin();
     void restore();
@@ -152,15 +145,6 @@ void* OcJump::fpycall(void* (*f)(void*, void*), void* a, void* b) {
 
 OcJumpImpl::OcJumpImpl() {}
 OcJumpImpl::~OcJumpImpl() {}
-
-void OcJumpImpl::ljmptarget() {
-    // This is never called
-    std::abort();
-}
-
-void OcJumpImpl::ljmp() {
-    throw std::runtime_error("OcJumpImpl::ljmp");
-}
 
 void hoc_execute(Inst*);
 

--- a/src/ivoc/ocjump.cpp
+++ b/src/ivoc/ocjump.cpp
@@ -87,8 +87,6 @@ class OcJumpImpl {
 
   private:
     OcJumpImpl* prev_;
-    jmp_buf begin_;
-
     // hoc_oop
     Object* o1;
     Objectdata* o2;
@@ -173,7 +171,7 @@ void OcJumpImpl::ljmptarget() {
 }
 
 void OcJumpImpl::ljmp() {
-    longjmp(begin_, 1);
+    throw std::runtime_error("OcJumpImpl::ljmp");
 }
 
 OcJumpImpl* OcJumpImpl::oji_;
@@ -181,49 +179,41 @@ OcJumpImpl* OcJumpImpl::oji_;
 void hoc_execute(Inst*);
 
 bool OcJumpImpl::execute(Inst* p) {
+    bool ret{false};
     begin();
-#if 1
-    if (setjmp(begin_)) {
-        restore();
-        finish();
-        return false;
-    } else
-#endif
-    {
+    try {
         hoc_execute(p);
+        ret = true;
+    } catch(...) {
+        std::cerr << "OcJumpImpl::execute(stmt, ob) caught an exception" << std::endl;
+        restore();
     }
     finish();
-    return true;
+    return ret;
 }
 
 bool OcJumpImpl::execute(const char* stmt, Object* ob) {
+    bool ret{false};
     begin();
-#if 1
-    if (setjmp(begin_)) {
-        restore();
-        finish();
-        return false;
-    } else
-#endif
-    {
+    try {
         hoc_obj_run(stmt, ob);
+        ret = true;
+    } catch(...) {
+        std::cerr << "OcJumpImpl::execute(stmt, ob) caught an exception" << std::endl;
+        restore();
     }
     finish();
-    return true;
+    return ret;
 }
 
 void* OcJumpImpl::fpycall(void* (*f)(void*, void*), void* a, void* b) {
     void* c = 0;
     begin();
-#if 1
-    if (setjmp(begin_)) {
-        restore();
-        finish();
-        return c;
-    } else
-#endif
-    {
+    try {
         c = (*f)(a, b);
+    } catch(...) {
+        std::cerr << "OcJump::fpycall caught an exception" << std::endl;
+        restore();
     }
     finish();
     return c;

--- a/src/ivoc/ocjump.cpp
+++ b/src/ivoc/ocjump.cpp
@@ -184,8 +184,7 @@ bool OcJumpImpl::execute(Inst* p) {
     try {
         hoc_execute(p);
         ret = true;
-    } catch(...) {
-        std::cerr << "OcJumpImpl::execute(stmt, ob) caught an exception" << std::endl;
+    } catch (...) {
         restore();
     }
     finish();
@@ -198,8 +197,7 @@ bool OcJumpImpl::execute(const char* stmt, Object* ob) {
     try {
         hoc_obj_run(stmt, ob);
         ret = true;
-    } catch(...) {
-        std::cerr << "OcJumpImpl::execute(stmt, ob) caught an exception" << std::endl;
+    } catch (...) {
         restore();
     }
     finish();
@@ -211,8 +209,7 @@ void* OcJumpImpl::fpycall(void* (*f)(void*, void*), void* a, void* b) {
     begin();
     try {
         c = (*f)(a, b);
-    } catch(...) {
-        std::cerr << "OcJump::fpycall caught an exception" << std::endl;
+    } catch (...) {
         restore();
     }
     finish();

--- a/src/ivoc/ocjump.h
+++ b/src/ivoc/ocjump.h
@@ -1,10 +1,14 @@
 #pragma once
-#include <memory>
+#include "nrnfilewrap.h"
+union Datum;
 union Inst;
 struct OcJumpImpl;
-struct Symlist;
 struct Object;
 union Objectdata;
+struct Symlist;
+namespace nrn::oc {
+struct frame;
+}
 
 struct ObjectContext {
     ObjectContext(Object*);
@@ -18,13 +22,42 @@ struct ObjectContext {
 };
 
 struct OcJump {
-    OcJump();
-    ~OcJump();
     bool execute(Inst* p);
     bool execute(const char*, Object* ob = NULL);
     void* fpycall(void* (*) (void*, void*), void*, void*);
 
   private:
-    // https://en.cppreference.com/w/cpp/language/pimpl
-    std::unique_ptr<OcJumpImpl> impl_;
+    void begin();
+    void restore();
+    void finish();
+
+    // hoc_oop
+    Object* o1{};
+    Objectdata* o2{};
+    int o4{};
+    Symlist* o5{};
+
+    // code
+    Inst* c1{};
+    Inst* c2{};
+    Datum* c3{};
+    nrn::oc::frame* c4{};
+    int c5{};
+    int c6{};
+    Inst* c7{};
+    nrn::oc::frame* c8{};
+    Datum* c9{};
+    Symlist* c10{};
+    Inst* c11{};
+    int c12{};
+
+    // input_info
+    const char* i1{};
+    int i2{};
+    int i3{};
+    NrnFILEWrap* i4{};
+
+    // cabcode
+    int cc1{};
+    int cc2{};
 };

--- a/src/ivoc/ocjump.h
+++ b/src/ivoc/ocjump.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <memory>
 union Inst;
 class OcJumpImpl;
 struct Symlist;
@@ -30,5 +31,5 @@ class OcJump {
     static void restore_context(ObjectContext*);
 
   private:
-    OcJumpImpl* impl_;
+    std::unique_ptr<OcJumpImpl> impl_;
 };

--- a/src/ivoc/ocjump.h
+++ b/src/ivoc/ocjump.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <memory>
 union Inst;
-class OcJumpImpl;
+struct OcJumpImpl;
 struct Symlist;
 struct Object;
 union Objectdata;
@@ -19,7 +19,7 @@ struct ObjectContext {
 
 struct OcJump {
     OcJump();
-    virtual ~OcJump();
+    ~OcJump();
     bool execute(Inst* p);
     bool execute(const char*, Object* ob = NULL);
     void* fpycall(void* (*) (void*, void*), void*, void*);

--- a/src/ivoc/ocjump.h
+++ b/src/ivoc/ocjump.h
@@ -20,16 +20,12 @@ class ObjectContext {
     bool restored_;
 };
 
-class OcJump {
-  public:
+struct OcJump {
     OcJump();
     virtual ~OcJump();
     bool execute(Inst* p);
     bool execute(const char*, Object* ob = NULL);
     void* fpycall(void* (*) (void*, void*), void*, void*);
-    static void save_context(ObjectContext*);
-    static void restore_context(ObjectContext*);
-
   private:
     std::unique_ptr<OcJumpImpl> impl_;
 };

--- a/src/ivoc/ocjump.h
+++ b/src/ivoc/ocjump.h
@@ -6,18 +6,15 @@ struct Symlist;
 struct Object;
 union Objectdata;
 
-class ObjectContext {
-  public:
+struct ObjectContext {
     ObjectContext(Object*);
-    virtual ~ObjectContext();
-    void restore();
+    ~ObjectContext();
 
   private:
     Object* a1;
     Objectdata* a2;
     int a4;
     Symlist* a5;
-    bool restored_;
 };
 
 struct OcJump {
@@ -26,6 +23,8 @@ struct OcJump {
     bool execute(Inst* p);
     bool execute(const char*, Object* ob = NULL);
     void* fpycall(void* (*) (void*, void*), void*, void*);
+
   private:
+    // https://en.cppreference.com/w/cpp/language/pimpl
     std::unique_ptr<OcJumpImpl> impl_;
 };

--- a/src/nrncvode/netcvode.cpp
+++ b/src/nrncvode/netcvode.cpp
@@ -6062,7 +6062,6 @@ void nrnthread_trajectory_values(int tid, int n_pr, void** vpr, double tt) {  //
             Oc oc;
             oc.run("screen_update()\n");
         }
-        obc.restore();
 #else
         }
 #endif  // HAVE_IV

--- a/src/nrniv/glinerec.cpp
+++ b/src/nrniv/glinerec.cpp
@@ -139,13 +139,6 @@ void GLineRecord::fill_pd() {
     assert(gl_->expr_);
     ObjectContext objc(gl_->obj_);
     fill_pd1();
-    objc.restore();
-#if 0
-  printf("\n%s\n", gl_->name());
-  for (GLineRecordEData::iterator it = pd_and_vec_.begin(); it != pd_and_vec_.end(); ++it) {
-    printf("  pd=%p\n", (*it).first);
-  }
-#endif
 }
 
 GLineRecord::GLineRecord(GraphLine* gl)
@@ -249,7 +242,6 @@ void GLineRecord::plot(int vecsz, double tstop) {
             }
             gl_->plot();
         }
-        obc.restore();
     } else {
         assert(0);
     }

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -753,16 +753,9 @@ static PyObject* hocobj_call(PyHocObject* self, PyObject* args, PyObject* kwrds)
     if (self->type_ == PyHoc::HocTopLevelInterpreter) {
         result = nrnexec((PyObject*) self, args);
     } else if (self->type_ == PyHoc::HocFunction) {
-        OcJump* oj;
-        oj = new OcJump();
-        if (oj) {
-            result = (PyObject*) oj->fpycall(fcall, (void*) self, (void*) args);
-            delete oj;
-            if (result == NULL) {
-                PyErr_SetString(PyExc_RuntimeError, "hocobj_call error");
-            }
-        } else {
-            result = (PyObject*) fcall((void*) self, (void*) args);
+        result = static_cast<PyObject*>(OcJump{}.fpycall(fcall, self, args));
+        if (!result) {
+            PyErr_SetString(PyExc_RuntimeError, "hocobj_call error");
         }
         hoc_unref_defer();
     } else {

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -753,7 +753,7 @@ static PyObject* hocobj_call(PyHocObject* self, PyObject* args, PyObject* kwrds)
     if (self->type_ == PyHoc::HocTopLevelInterpreter) {
         result = nrnexec((PyObject*) self, args);
     } else if (self->type_ == PyHoc::HocFunction) {
-        result = static_cast<PyObject*>(OcJump{}.fpycall(fcall, self, args));
+        result = static_cast<PyObject*>(OcJump::fpycall(fcall, self, args));
         if (!result) {
             PyErr_SetString(PyExc_RuntimeError, "hocobj_call error");
         }

--- a/src/nrnpython/nrnpy_p2h.cpp
+++ b/src/nrnpython/nrnpy_p2h.cpp
@@ -118,7 +118,6 @@ static void call_python_with_section(Object* pyact, Section* sec) {
         if (mes) {
             Fprintf(stderr, "%s\n", mes);
             free(mes);
-            lock.release();
             hoc_execerror("Call of Python Callable failed", NULL);
         }
         if (PyErr_Occurred()) {
@@ -284,7 +283,6 @@ void py2n_component(Object* ob, Symbol* sym, int nindex, int isfunc) {
     }
     if (!tail) {
         PyErr_Print();
-        lock.release();
         hoc_execerror("No attribute:", sym->name);
     }
     PyObject* args = 0;
@@ -312,7 +310,6 @@ void py2n_component(Object* ob, Symbol* sym, int nindex, int isfunc) {
             if (mes) {
                 Fprintf(stderr, "%s\n", mes);
                 free(mes);
-                lock.release();
                 hoc_execerror("PyObject method call failed:", sym->name);
             }
             if (PyErr_Occurred()) {
@@ -330,7 +327,6 @@ void py2n_component(Object* ob, Symbol* sym, int nindex, int isfunc) {
         result = PyObject_GetItem(tail, arg);
         if (!result) {
             PyErr_Print();
-            lock.release();
             hoc_execerror("Python get item failed:", hoc_object_name(ob));
         }
     } else {
@@ -473,7 +469,6 @@ static double praxis_efun(Object* ho, Object* v) {
         if (mes) {
             Fprintf(stderr, "%s\n", mes);
             free(mes);
-            lock.release();
             hoc_execerror("Call of Python Callable failed in praxis_efun", NULL);
         }
         if (PyErr_Occurred()) {
@@ -497,7 +492,6 @@ static int hoccommand_exec(Object* ho) {
         if (mes) {
             Fprintf(stderr, "%s\n", mes);
             free(mes);
-            lock.release();
             hoc_execerror("Python Callback failed", 0);
         }
         if (PyErr_Occurred()) {
@@ -524,7 +518,6 @@ static int hoccommand_exec_strret(Object* ho, char* buf, int size) {
         if (mes) {
             Fprintf(stderr, "%s\n", mes);
             free(mes);
-            lock.release();
             hoc_execerror("Python Callback failed", 0);
         }
         if (PyErr_Occurred()) {
@@ -549,7 +542,6 @@ static void grphcmdtool(Object* ho, int type, double x, double y, int key) {
         if (mes) {
             Fprintf(stderr, "%s\n", mes);
             free(mes);
-            lock.release();
             hoc_execerror("Python Callback failed", 0);
         }
         if (PyErr_Occurred()) {
@@ -564,19 +556,16 @@ static Object* callable_with_args(Object* ho, int narg) {
 
     PyObject* args = PyTuple_New((Py_ssize_t) narg);
     if (args == NULL) {
-        lock.release();
         hoc_execerror("PyTuple_New failed", 0);
     }
     for (int i = 0; i < narg; ++i) {
         PyObject* item = nrnpy_hoc_pop();
         if (item == NULL) {
             Py_XDECREF(args);
-            lock.release();
             hoc_execerror("nrnpy_hoc_pop failed", 0);
         }
         if (PyTuple_SetItem(args, (Py_ssize_t) (narg - i - 1), item) != 0) {
             Py_XDECREF(args);
-            lock.release();
             hoc_execerror("PyTuple_SetItem failed", 0);
         }
     }
@@ -599,19 +588,16 @@ static double func_call(Object* ho, int narg, int* err) {
 
     PyObject* args = PyTuple_New((Py_ssize_t) narg);
     if (args == NULL) {
-        lock.release();
         hoc_execerror("PyTuple_New failed", 0);
     }
     for (int i = 0; i < narg; ++i) {
         PyObject* item = nrnpy_hoc_pop();
         if (item == NULL) {
             Py_XDECREF(args);
-            lock.release();
             hoc_execerror("nrnpy_hoc_pop failed", 0);
         }
         if (PyTuple_SetItem(args, (Py_ssize_t) (narg - i - 1), item) != 0) {
             Py_XDECREF(args);
-            lock.release();
             hoc_execerror("PyTuple_SetItem failed", 0);
         }
     }
@@ -633,7 +619,6 @@ static double func_call(Object* ho, int narg, int* err) {
             PyErr_Clear();
         }
         if (!err || *err) {
-            lock.release();
             hoc_execerror("func_call failed", NULL);
         }
         if (err) {

--- a/src/nrnpython/nrnpy_utils.h
+++ b/src/nrnpython/nrnpy_utils.h
@@ -104,12 +104,16 @@ class Py2NRNString {
 
 
 struct PyLockGIL {
-    PyLockGIL() : state_{PyGILState_Ensure()} {}
+    PyLockGIL()
+        : state_{PyGILState_Ensure()} {}
     PyLockGIL(PyLockGIL&&) = delete;
     PyLockGIL(PyLockGIL const&) = delete;
     PyLockGIL& operator=(PyLockGIL&&) = delete;
     PyLockGIL& operator=(PyLockGIL const&) = delete;
-    ~PyLockGIL() { PyGILState_Release(state_); }
+    ~PyLockGIL() {
+        PyGILState_Release(state_);
+    }
+
   private:
     PyGILState_STATE state_;
 };

--- a/src/nrnpython/nrnpy_utils.h
+++ b/src/nrnpython/nrnpy_utils.h
@@ -103,31 +103,15 @@ class Py2NRNString {
 };
 
 
-class PyLockGIL {
-  public:
-    PyLockGIL()
-        : state_(PyGILState_Ensure())
-        , locked_(true) {}
-
-    /* This is mainly used to unlock manually prior to a hoc_execerror() call
-     * since this uses longjmp()
-     */
-    void release() {
-        assert(locked_);
-        locked_ = false;
-        PyGILState_Release(state_);
-    }
-
-    ~PyLockGIL() {
-        release();
-    }
-
+struct PyLockGIL {
+    PyLockGIL() : state_{PyGILState_Ensure()} {}
+    PyLockGIL(PyLockGIL&&) = delete;
+    PyLockGIL(PyLockGIL const&) = delete;
+    PyLockGIL& operator=(PyLockGIL&&) = delete;
+    PyLockGIL& operator=(PyLockGIL const&) = delete;
+    ~PyLockGIL() { PyGILState_Release(state_); }
   private:
-    PyLockGIL(const PyLockGIL&);
-    PyLockGIL& operator=(const PyLockGIL&);
-
     PyGILState_STATE state_;
-    bool locked_; /* check if double unlocking */
 };
 
 extern void nrnpy_sec_referr();

--- a/src/nrnpython/setup.py.in
+++ b/src/nrnpython/setup.py.in
@@ -143,7 +143,8 @@ libs = [@BUILD_NRNPYTHON_DYNAMIC_TRUE@nrnpython_pyver10,
 if "@IVHINES@" != "":
     libs.append("@IVHINES@")
 
-extra_compile_args = [@NRN_COMPILE_FLAGS_COMMA_SEPARATED_STRINGS@]
+extra_compile_args = ["@CMAKE_CXX17_STANDARD_COMPILE_OPTION@"]
+extra_compile_args += [@NRN_COMPILE_FLAGS_COMMA_SEPARATED_STRINGS@]
 
 if using_pgi:
   extra_link_args.append(pgi_compiler_flags)

--- a/src/oc/code.cpp
+++ b/src/oc/code.cpp
@@ -2592,7 +2592,7 @@ void varread(void) /* read into variable */
 Again:
     switch (nrn_fw_fscanf(fin, "%lf", OPVAL(var))) {
     case EOF:
-        if (moreinput())
+        if (hoc_moreinput())
             goto Again;
         d = *(OPVAL(var)) = 0.0;
         break;

--- a/src/oc/fileio.cpp
+++ b/src/oc/fileio.cpp
@@ -11,12 +11,10 @@
 #include "hoclist.h"
 #include "parse.hpp"
 #include "hocparse.h"
-#include <setjmp.h>
 #include <errno.h>
 #include "nrnfilewrap.h"
 
 
-extern jmp_buf begin;
 extern char* neuron_home;
 
 NrnFILEWrap* frin;

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -977,8 +977,9 @@ int hoc_main1(int argc, const char** argv, const char** envp) {
             ++gargv;
             --gargc;
         }
-        while (moreinput())
+        while (hoc_moreinput()) {
             exit_status = hoc_run1();
+        }
         return exit_status;
     } catch (...) {
         nrn_exit(1);
@@ -1089,7 +1090,7 @@ static const char* double_at2space(const char* infile) {
 }
 #endif /*MINGW*/
 
-int moreinput(void) {
+int hoc_moreinput() {
     if (pipeflag) {
         pipeflag = 0;
         return 1;
@@ -1157,7 +1158,7 @@ int moreinput(void) {
         with the hoc interpreter.
         */
         if (strlen(infile) < 4 || strcmp(infile + strlen(infile) - 4, ".hoc") != 0) {
-            return moreinput();
+            return hoc_moreinput();
         }
     }
 #endif
@@ -1169,7 +1170,7 @@ int moreinput(void) {
         /* ignore "val" as next argument */
         infile = *gargv++;
         gargc--;
-        return moreinput();
+        return hoc_moreinput();
     } else if (strcmp(infile, "-c") == 0) {
         int hpfi, err;
         HocStr* hs;
@@ -1190,13 +1191,13 @@ int moreinput(void) {
         if (err) {
             hoc_execerror("arg not valid statement:", infile);
         }
-        return moreinput();
+        return hoc_moreinput();
     } else if (strlen(infile) > 3 && strcmp(infile + strlen(infile) - 3, ".py") == 0) {
         if (!p_nrnpy_pyrun) {
             hoc_execerror("Python not available to interpret", infile);
         }
         (*p_nrnpy_pyrun)(infile);
-        return moreinput();
+        return hoc_moreinput();
     } else if ((fin = nrn_fw_fopen(infile, "r")) == (NrnFILEWrap*) 0) {
 #if OCSMALL
         hoc_menu_cleanup();
@@ -1207,7 +1208,7 @@ int moreinput(void) {
             nrnmpi_abort(-1);
         }
 #endif
-        return moreinput();
+        return hoc_moreinput();
     }
     if (infile) {
         if (strlen(infile) >= hoc_xopen_file_size_) {

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -906,7 +906,7 @@ void hoc_main1_init(const char* pname, const char** envp) {
     hoc_init();
     initplot();
     hoc_main1_inited_ = 1;
-} 
+}
 
 HocStr* hocstr_create(size_t size) {
     HocStr* hs;
@@ -965,49 +965,48 @@ int hoc_main1(int argc, const char** argv, const char** envp) {
     hoc_main1_init(argv[0], envp);
     try {
 #if HAS_SIGPIPE
-    signal(SIGPIPE, sigpipe_handler);
+        signal(SIGPIPE, sigpipe_handler);
 #endif
-    gargv = argv;
-    gargc = argc;
-    if (argc > 2 && strcmp(argv[1], "-bbs_nhost") == 0) {
-        /* if IV not running this may still be here */
-        gargv += 2;
-        gargc -= 2;
-    }
-    if (argc > 1 && argv[1][0] != '-') {
-        /* first file may be a checkpoint file */
-        extern int hoc_readcheckpoint(char*);
-        switch (hoc_readcheckpoint(const_cast<char*>(argv[1]))) {
-        case 1:
-            ++gargv;
-            --gargc;
-            break;
-        case 2:
-            nrn_exit(1);
-            break;
-        default:
-            break;
+        gargv = argv;
+        gargc = argc;
+        if (argc > 2 && strcmp(argv[1], "-bbs_nhost") == 0) {
+            /* if IV not running this may still be here */
+            gargv += 2;
+            gargc -= 2;
         }
-    }
+        if (argc > 1 && argv[1][0] != '-') {
+            /* first file may be a checkpoint file */
+            extern int hoc_readcheckpoint(char*);
+            switch (hoc_readcheckpoint(const_cast<char*>(argv[1]))) {
+            case 1:
+                ++gargv;
+                --gargc;
+                break;
+            case 2:
+                nrn_exit(1);
+                break;
+            default:
+                break;
+            }
+        }
 
-    if (gargc == 1) /* fake an argument list */
-    {
-        static const char* stdinonly[] = {"-"};
+        if (gargc == 1) /* fake an argument list */
+        {
+            static const char* stdinonly[] = {"-"};
 
 #ifdef MINGW
-        cygonce = 1;
+            cygonce = 1;
 #endif
-        gargv = stdinonly;
-        gargc = 1;
-    } else {
-        ++gargv;
-        --gargc;
-    }
-    while (moreinput())
-        exit_status = hoc_run1();
-    return exit_status;
-    } catch(...) {
-        std::cerr << "hoc_main1 caught an exception" << std::endl;
+            gargv = stdinonly;
+            gargc = 1;
+        } else {
+            ++gargv;
+            --gargc;
+        }
+        while (moreinput())
+            exit_status = hoc_run1();
+        return exit_status;
+    } catch (...) {
         nrn_exit(1);
     }
 }
@@ -1300,7 +1299,7 @@ static int hoc_run1() {
         if (intset) {
             hoc_execerror("interrupted", (char*) 0);
         }
-    } catch(...) {
+    } catch (...) {
         if (!controlled) {
             // execute this if we catch an exception and !controlled
             fin = sav_fin;
@@ -1382,15 +1381,15 @@ void oc_restore_input_info(const char* i1, int i2, int i3, NrnFILEWrap* i4) {
 
 int hoc_oc(const char* buf) {
     char* cp;
-
     int sav_pipeflag = pipeflag;
     int sav_lineno = lineno;
     const char* sav_inputbufptr = nrn_inputbufptr;
     nrn_inputbufptr = buf;
     pipeflag = 3;
     lineno = 1;
+    // is this controlled logic needed with exceptions?
     int controlled = hoc_oc_jmpbuf || oc_jump_target_;
-    if (!controlled) { // i.e. this is the highest level catch block?
+    if (!controlled) {  // i.e. this is the highest level catch block?
         hoc_oc_jmpbuf = 1;
     }
     try {
@@ -1401,11 +1400,10 @@ int hoc_oc(const char* buf) {
         while (*ctp || *nrn_inputbufptr) {
             hoc_ParseExec(yystart);
             if (intset) {
-                execerror("interrupted", (char*) 0);
+                hoc_execerror("interrupted", nullptr);
             }
         }
-    } catch(...) {
-        std::cerr << "hoc_oc caught an exception" << std::endl;
+    } catch (...) {
         if (controlled) {
             // there's a higher catch block
             throw;

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -663,17 +663,6 @@ void (*oc_jump_target_)(); /* see ivoc/SRC/ocjump.cpp */
 
 int yystart;
 
-/* what to do about partially constructed objects at hoc_execerror */
-extern void hoc_newobj1_err();
-
-/** If one of the two jmp_buf is controlling the longjmp
- *  hoc_newobj1_err needs handle to know how much to unwrap the newobj1 stack.
- **/
-void* nrn_get_hoc_jmp() {
-    void* jmp = hoc_oc_jmpbuf ? (void*) hoc_oc_begin : (void*) begin;
-    return jmp;
-}
-
 void hoc_execerror_mes(const char* s, const char* t, int prnt) { /* recover from run-time error */
     hoc_in_yyparse = 0;
     yystart = 1;
@@ -706,7 +695,6 @@ void hoc_execerror_mes(const char* s, const char* t, int prnt) { /* recover from
     *ctp = '\0';
 
     if (oc_jump_target_ && (nrnmpi_numprocs_world == 1 || !nrn_mpiabort_on_error_)) {
-        hoc_newobj1_err();
         (*oc_jump_target_)();
     }
 #if NRNMPI
@@ -719,10 +707,8 @@ void hoc_execerror_mes(const char* s, const char* t, int prnt) { /* recover from
         IGNORE(nrn_fw_fseek(fin, 0L, 2)); /* flush rest of file */
     hoc_oop_initaftererror();
     if (hoc_oc_jmpbuf) {
-        hoc_newobj1_err();
         throw std::runtime_error("hoc_oc_begin, 1");
     }
-    hoc_newobj1_err();
     throw std::runtime_error("begin, 1");
 }
 

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -25,6 +25,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <thread>
+#include <utility>
 
 /* for eliminating "ignoreing return value" warnings. */
 int nrnignore;

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -658,32 +658,14 @@ void hoc_execerror_mes(const char* s, const char* t, int prnt) { /* recover from
     yystart = 1;
     hoc_menu_cleanup();
     hoc_errno_check();
-#if 0
-	hoc_xmenu_cleanup();
-#endif
     if (debug_message_ || prnt) {
-        warning(s, t);
+        hoc_warning(s, t);
         frame_debug();
         nrn_err_dialog(s);
-#if defined(__GO32__)
-        {
-            extern int egagrph;
-            if (egagrph) {
-                hoc_outtext("Error:");
-                hoc_outtext(s);
-                if (t) {
-                    hoc_outtext(" ");
-                    hoc_outtext(t);
-                }
-                hoc_outtext("\n");
-            }
-        }
-#endif
     }
-    /* in case warning not called */
-    ctp = cbuf;
-    *ctp = '\0';
-
+    // In case hoc_warning not called
+    hoc_ctp = hoc_cbuf;
+    *hoc_ctp = '\0';
     // There used to be some logic here to abort here if we are inside an OcJump call.
 #if NRNMPI
     if (nrnmpi_numprocs_world > 1 && nrn_mpiabort_on_error_) {
@@ -691,8 +673,9 @@ void hoc_execerror_mes(const char* s, const char* t, int prnt) { /* recover from
     }
 #endif
     hoc_execerror_messages = 1;
-    if (fin && pipeflag == 0 && (!nrn_fw_eq(fin, stdin) || !nrn_istty_))
-        IGNORE(nrn_fw_fseek(fin, 0L, 2)); /* flush rest of file */
+    if (hoc_fin && hoc_pipeflag == 0 && (!nrn_fw_eq(hoc_fin, stdin) || !nrn_istty_)) {
+        IGNORE(nrn_fw_fseek(hoc_fin, 0L, 2)); /* flush rest of file */
+    }
     hoc_oop_initaftererror();
     throw std::runtime_error("hoc_execerror");
 }

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -191,11 +191,8 @@ int lineno;
 #include <execinfo.h>
 #endif
 #include <signal.h>
-#include <setjmp.h>
 static int control_jmpbuf = 0; /* don't change jmp_buf if being controlled */
-jmp_buf begin;
 static int hoc_oc_jmpbuf;
-static jmp_buf hoc_oc_begin;
 int intset; /* safer interrupt handling */
 int indef;
 const char* infile; /* input file name */
@@ -1321,8 +1318,9 @@ static int hoc_run1() {
    of hoc. But just maybe that is here. However hoc_oc may be called
    recursively. Or it may be called from the original hoc_run. Or it may be
    There is therefore a notion of the controlling routine for the jmp_buf begin.
-   We only do a setjmp and set the signals
-   when there is no other controlling routine.
+   We only do a setjmp and set the signals when there is no other controlling
+   routine. Note that setjmp is no longer used, but for now the same notion of a
+   controlling routine is maintained.
 */
 
 /* allow hoc_oc(buf) to handle any number of multiline statements */

--- a/src/oc/hoc_oop.cpp
+++ b/src/oc/hoc_oop.cpp
@@ -493,10 +493,6 @@ Object** hoc_temp_objvar(Symbol* symtemp, void* v) {
     return hoc_temp_objptr(hoc_new_object(symtemp, v));
 }
 
-
-extern void* nrn_get_oji();
-extern void (*oc_jump_target_)();
-
 struct guard_t {
     ~guard_t() {
         if (ob) {

--- a/src/oc/hoc_oop.cpp
+++ b/src/oc/hoc_oop.cpp
@@ -511,57 +511,16 @@ typedef struct {
 } newobj1_err_t;
 
 extern void* nrn_get_oji();
-extern void* nrn_get_hoc_jmp();
 extern void (*oc_jump_target_)();
-static int newobj1_err_index_; /* stack index */
-static int newobj1_err_size_;
-static newobj1_err_t* newobj1_err_; /* stack of newobj1_err_t */
 
-/** save partially constructed object and controlling longjump handle **/
-static void push_newobj1_err(Object* ob) {
-    if (newobj1_err_index_ >= newobj1_err_size_) {
-        if (newobj1_err_size_ == 0) {
-            newobj1_err_size_ = NEWOBJ1_ERR_SIZE;
-            newobj1_err_ = (newobj1_err_t*) calloc(newobj1_err_size_, sizeof(newobj1_err_t));
-            assert(newobj1_err_);
-        } else {
-            newobj1_err_size_ *= 2;
-            newobj1_err_ = (newobj1_err_t*) realloc(newobj1_err_,
-                                                    newobj1_err_size_ * sizeof(newobj1_err_t));
-            assert(newobj1_err_);
+struct guard_t {
+    ~guard_t() {
+        if (ob) {
+            hoc_obj_unref(ob);
         }
     }
-
-    newobj1_err_t* ne = newobj1_err_ + newobj1_err_index_++;
-    ne->ob = ob;
-    ne->oji = oc_jump_target_ ? nrn_get_oji() : nrn_get_hoc_jmp();
-}
-
-/** pop the now fully constructed object **/
-void pop_newobj1_err() {
-    --newobj1_err_index_;
-    assert(newobj1_err_index_ >= 0);
-}
-
-/** unref partially constructed objects controlled by current longjump handle **/
-void hoc_newobj1_err() { /* called from hoc_execerror */
-    if (newobj1_err_index_ > 0) {
-        int i;
-        /* Note: for the case of pure hoc, there may not be an oc_jump_target_
-           in which case jmp will get set to the hoc.c controlling jmp_buf
-        */
-        void* oji = oc_jump_target_ ? nrn_get_oji() : nrn_get_hoc_jmp();
-        while (newobj1_err_index_ > 0) {
-            newobj1_err_t* ne = newobj1_err_ + (newobj1_err_index_ - 1);
-            if (ne->oji == oji) {
-                hoc_obj_unref(ne->ob);
-                pop_newobj1_err();
-            } else {
-                break;
-            }
-        }
-    }
-}
+    Object* ob{};
+};
 
 Object* hoc_newobj1(Symbol* sym, int narg) {
     Object* ob;
@@ -569,9 +528,10 @@ Object* hoc_newobj1(Symbol* sym, int narg) {
     Symbol* s;
     int i, total;
 
-    ob = hoc_new_object(sym, nullptr);
+    guard_t guard{};  // unref the object we're creating if there is an exception before the end of
+                      // this method
+    guard.ob = ob = hoc_new_object(sym, nullptr);
     ob->refcount = 1;
-    push_newobj1_err(ob); /* allow unref if execerror before return */
     if (sym->subtype & (CPLUSOBJECT | JAVAOBJECT)) {
         call_constructor(ob, sym, narg);
     } else {
@@ -634,7 +594,7 @@ Object* hoc_newobj1(Symbol* sym, int narg) {
         }
     }
     hoc_template_notify(ob, 1);
-    pop_newobj1_err();
+    guard.ob = nullptr;  // do not unref, disable the guard
     return ob;
 }
 

--- a/src/oc/hoc_oop.cpp
+++ b/src/oc/hoc_oop.cpp
@@ -493,22 +493,6 @@ Object** hoc_temp_objvar(Symbol* symtemp, void* v) {
     return hoc_temp_objptr(hoc_new_object(symtemp, v));
 }
 
-/** If hoc_newob1 fails after creating a new object, that object needs to be
-  unreffed. To handle the case of constructors themselves creating new objects
-  before the error or intervening recovery of error by a callee recovering from
-  execerror, the incomplete new object is put on a stack along with the
-  current longjump target, and removed from the stack when the object
-  is complete. There could be a problem if the destructor doesn't work
-  with a partially constructed object. In case of a execerror before newobj1
-  completion, all partially constructed objects with a longjump handle equal
-  to the current longjump handle are unreffed.
-**/
-
-#define NEWOBJ1_ERR_SIZE 32 /* starts with this size, and doubles on overflow */
-typedef struct {
-    Object* ob;
-    void* oji;
-} newobj1_err_t;
 
 extern void* nrn_get_oji();
 extern void (*oc_jump_target_)();

--- a/src/oc/hocparse.h
+++ b/src/oc/hocparse.h
@@ -14,7 +14,7 @@ extern int hoc_yyparse(void);
 extern void hoc_define(Symbol*);
 extern void hoc_iterator_object(Symbol*, int, Inst*, Inst*, Object*);
 extern int hoc_zzdebug;
-extern int hoc_moreinput(void);
+int hoc_moreinput();
 extern Symlist* hoc_p_symlist;
 extern void hoc_defnonly(const char*);
 extern Symbol* hoc_decl(Symbol*);

--- a/src/oc/oc_ansi.h
+++ b/src/oc/oc_ansi.h
@@ -179,7 +179,7 @@ void* hoc_Erealloc(void* ptr, std::size_t size);
 
 void* nrn_cacheline_alloc(void** memptr, std::size_t size);
 void* nrn_cacheline_calloc(void** memptr, std::size_t nmemb, std::size_t size);
-void nrn_exit(int);
+[[noreturn]] void nrn_exit(int);
 void hoc_free_list(Symlist**);
 int hoc_errno_check();
 Symbol* hoc_parse_stmt(const char*, Symlist**);

--- a/src/oc/redef.h
+++ b/src/oc/redef.h
@@ -120,7 +120,6 @@
 #define pop_frame          hoc_pop_frame
 #define ret                hoc_ret
 #define ropen              hoc_ropen
-#define run                hoc_run
 #define solve              hoc_solve
 #define spinit             hoc_spinit
 #define symbols            hoc_symbols

--- a/src/oc/redef.h
+++ b/src/oc/redef.h
@@ -88,7 +88,6 @@
 #define lineno             hoc_lineno
 #define lookup             hoc_lookup
 #define lt                 hoc_lt
-#define moreinput          hoc_moreinput
 #define mul                hoc_mul
 #define ne                 hoc_ne
 #define negate             hoc_negate


### PR DESCRIPTION
Prefer using exceptions, so that the stack is unwound properly and destructors are called.

Inspired by #1929, where I tried to use a RAII-style guard and was thwarted by longjmp.