### PR TITLE
Prevent user from declaring variables and functions with same name

### DIFF
--- a/src/nmodl/consist.cpp
+++ b/src/nmodl/consist.cpp
@@ -31,16 +31,13 @@ int is_var_declared_as_function(Symbol* s) {
     int usage = s->usage;
 
     // if not function or procedure name then return already
-    if (! (usage & FUNCT) ) {
+    if (!(usage & FUNCT)) {
         return 0;
     }
 
     // conflicting name if presence of NEURON block variable type
-    return ( type & NRNRANGE
-            || type & NRNGLOBAL
-            || type & NRNPOINTER
-            || type & NRNBBCOREPOINTER
-            || type & NRNEXTRN);
+    return (type & NRNRANGE || type & NRNGLOBAL || type & NRNPOINTER || type & NRNBBCOREPOINTER ||
+            type & NRNEXTRN);
 }
 
 void consistency() {
@@ -81,7 +78,10 @@ void consistency() {
         // check for conflicting variable declaration with function
         // do not use diag() because line number might be misleading
         if (is_var_declared_as_function(s)) {
-            Fprintf(stderr, "Error: %s used as both variable and function in file %s\n", s->name, finname);
+            Fprintf(stderr,
+                    "Error: %s used as both variable and function in file %s\n",
+                    s->name,
+                    finname);
             exit(1);
         }
         if ((t == 0) && tu) {

--- a/src/nmodl/consist.cpp
+++ b/src/nmodl/consist.cpp
@@ -19,6 +19,30 @@ extern Symbol* indepsym;
             err = 1;                                        \
         }
 
+/**
+ * Check if variable declared in NEURON block is conflicting with a PROCEDURE or FUNCTION
+ *
+ * In order to avoid "declaring" variable in NEURON block and then defining
+ * PROCEDURE or FUNCTION with the same name, we check if the variable is
+ * function and has one of the NRN* type.
+ */
+int is_var_declared_as_function(Symbol* s) {
+    int type = s->nrntype;
+    int usage = s->usage;
+
+    // if not function or procedure name then return already
+    if (! (usage & FUNCT) ) {
+        return 0;
+    }
+
+    // conflicting name if presence of NEURON block variable type
+    return ( type & NRNRANGE
+            || type & NRNGLOBAL
+            || type & NRNPOINTER
+            || type & NRNBBCOREPOINTER
+            || type & NRNEXTRN);
+}
+
 void consistency() {
     Symbol* s;
     Item* qs;
@@ -51,10 +75,18 @@ void consistency() {
         con("STEPPED", STEP1, 0);
         con("CONSTANT UNITS FACTOR", UNITDEF, 0);
         tu = s->usage;
-        if ((tu & DEP) && (tu & FUNCT))
+        if ((tu & DEP) && (tu & FUNCT)) {
             diag(s->name, " used as both variable and function");
-        if ((t == 0) && tu)
+        }
+        // check for conflicting variable declaration with function
+        // do not use diag() because line number might be misleading
+        if (is_var_declared_as_function(s)) {
+            Fprintf(stderr, "Error: %s used as both variable and function in file %s\n", s->name, finname);
+            exit(1);
+        }
+        if ((t == 0) && tu) {
             Fprintf(stderr, "Warning: %s undefined. (declared within VERBATIM?)\n", s->name);
+        }
     }
     if (err) {
         diag("multiple uses for same variable", (char*) 0);

--- a/src/nmodl/io.cpp
+++ b/src/nmodl/io.cpp
@@ -233,7 +233,7 @@ char* current_line() { /* assumes we actually want the previous line */
 /* two arguments so we can pass a name to construct an error message. */
 void diag(char* s1, char* s2) {
     char* cp;
-    Fprintf(stderr, "%s", s1);
+    Fprintf(stderr, "Error: %s", s1);
     if (s2) {
         Fprintf(stderr, "%s", s2);
     }

--- a/src/nmodl/modl.h
+++ b/src/nmodl/modl.h
@@ -216,17 +216,18 @@ typedef struct Symbol {
 #define EXPLICIT_DECL 01         /* usage field, variable occurs in input file */
 
 
-#define NRNEXTRN     01          /* t, dt, celsius, etc. */
-#define NRNCURIN     02          /* input value used */
-#define NRNCUROUT    04          /* added to output value */
+#define NRNEXTRN     01 /* t, dt, celsius, etc. */
+#define NRNCURIN     02 /* input value used */
+#define NRNCUROUT    04 /* added to output value */
 #define NRNRANGE     010
 #define NRNPRANGEIN  020
 #define NRNPRANGEOUT 040
-#define NRNGLOBAL    0100        /* same for all sections, defined here */
-#define NRNSTATIC    0200        /* v */
-#define NRNNOTP      0400        /* doesn't belong in p array */
-#define NRNIONFLAG   01000       /* temporary flag to allow READ and WRITE \
-			                        without declaring twice */
+#define NRNGLOBAL    0100 /* same for all sections, defined here */
+#define NRNSTATIC    0200 /* v */
+#define NRNNOTP      0400 /* doesn't belong in p array */
+#define NRNIONFLAG                                  \
+    01000 /* temporary flag to allow READ and WRITE \
+             without declaring twice */
 #define NRNSECTION       02000
 #define NRNPOINTER       04000
 #define IONCONC          010000

--- a/src/nmodl/modl.h
+++ b/src/nmodl/modl.h
@@ -215,6 +215,24 @@ typedef struct Symbol {
 #define EXTDEF5       040000000L /* not threadsafe from the extdef list */
 #define EXPLICIT_DECL 01         /* usage field, variable occurs in input file */
 
+
+#define NRNEXTRN     01          /* t, dt, celsius, etc. */
+#define NRNCURIN     02          /* input value used */
+#define NRNCUROUT    04          /* added to output value */
+#define NRNRANGE     010
+#define NRNPRANGEIN  020
+#define NRNPRANGEOUT 040
+#define NRNGLOBAL    0100        /* same for all sections, defined here */
+#define NRNSTATIC    0200        /* v */
+#define NRNNOTP      0400        /* doesn't belong in p array */
+#define NRNIONFLAG   01000       /* temporary flag to allow READ and WRITE \
+			                        without declaring twice */
+#define NRNSECTION       02000
+#define NRNPOINTER       04000
+#define IONCONC          010000
+#define NRNBBCOREPOINTER 020000
+
+
 extern char *emalloc(unsigned), /* malloc with out of space checking */
     *stralloc(char*, char*),    /* copies string to new space */
     *inputline(),               /* used only by parser to get title line */

--- a/src/nmodl/nocpout.cpp
+++ b/src/nmodl/nocpout.cpp
@@ -85,22 +85,6 @@ not thread safe and _p and _ppvar are static.
 */
 
 #endif
-#define NRNEXTRN     01 /* t, dt, celsius, etc. */
-#define NRNCURIN     02 /* input value used */
-#define NRNCUROUT    04 /* added to output value */
-#define NRNRANGE     010
-#define NRNPRANGEIN  020
-#define NRNPRANGEOUT 040
-#define NRNGLOBAL    0100 /* same for all sections, defined here */
-#define NRNSTATIC    0200 /* v */
-#define NRNNOTP      0400 /* doesn't belong in p array */
-#define NRNIONFLAG                                  \
-    01000 /* temporary flag to allow READ and WRITE \
- without declaring twice */
-#define NRNSECTION       02000
-#define NRNPOINTER       04000
-#define IONCONC          010000
-#define NRNBBCOREPOINTER 020000
 
 #define IONEREV 0 /* Parameter */
 #define IONIN   1

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -13,7 +13,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   testcorenrn
   GIT_REPOSITORY https://github.com/neuronsimulator/testcorenrn
-  GIT_TAG 41a6d7ea47551559cc89a71544a746a5d3c2a6b8
+  GIT_TAG 014aab9bee60a2bdd44b28a784c88092d2f6b92b
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/testcorenrn)
 
 FetchContent_Declare(
@@ -25,7 +25,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   reduced_dentate
   GIT_REPOSITORY https://github.com/neuronsimulator/reduced_dentate
-  GIT_TAG 6aecc53021dbe1a1c23b20673163051143c168d9
+  GIT_TAG 58ad3890536ba09e05fd3ee7a178a18270ea8faa
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/reduced_dentate)
 
 FetchContent_Declare(


### PR DESCRIPTION
* Today user can "declare" a variable in the NEURON block and then PROCEDURE or FUNCTION with the same name. For example, the below doesn't raise any error today:

   ```python
   NEURON {
       SUFFIX glia
       RANGE alfa
   }

   FUNCTION alfa(v(mV)) {
       alfa = exp(v)
   }
   ```

* The reason this works is that the `RANGE alfa` declaration in the NEURON block is not complete (i.e. variable needs to be "defined" in blocks like ASSIGNED, PARAMETER, etc) and hence doesn't appear anywhere in the generated code. If we try to use `alfa` as a variable then that is a warning and resulted in a compilation error.

* This behavior kind of works but is [error-prone](https://github.com/BlueBrain/nmodl/issues/927). Apart from corner cases and confusing behavior, it's difficult to do certain analyses that we would like to do (e.g. in new NMODL code generation).

* So for robustness and simplicity, we now throw an error if a user tries to declare a variable and function with the same name.

  ```console 
      $ ./bin/nocmodl mod_x/test.mod Translating mod_x/test.mod into mod_x/test.cpp
          Error: alfa used as both variable and function in file mod/test.mod 
   ```

- [x] Once there is a wheel, I will launch ModelDB CI to check if any MOD files need to be fixed
- [x] A PR to [dbbs-lab/dbbs-mod-collection](https://github.com/dbbs-lab/dbbs-mod-collection/blob/master/dbbs_mod_collection/mod/glia__dbbs_mod_collection__Na__granule_cell.mod) would be nice! dbbs-lab/dbbs-mod-collection/pull/7
- [x] Update dentate model soltesz-lab/dentate/pull/4
- [x] Update tests like testcorenrn and reduced_dentate

#### ModelDB PRs

- ModelDBRepository/138205/pull/1
- https://github.com/ModelDBRepository/155601/pull/2
- https://github.com/ModelDBRepository/190559/pull/1
- https://github.com/ModelDBRepository/139657/pull/1
- https://github.com/ModelDBRepository/124513/pull/1
- https://github.com/ModelDBRepository/262115/pull/1
- https://github.com/ModelDBRepository/139656/pull/1
- https://github.com/ModelDBRepository/116835/pull/1
- https://github.com/ModelDBRepository/232876/pull/1
- https://github.com/ModelDBRepository/240116/pull/1
- https://github.com/ModelDBRepository/217882/pull/1
- https://github.com/ModelDBRepository/151825/pull/1
- https://github.com/ModelDBRepository/97917/pull/3
- https://github.com/ModelDBRepository/183949/pull/1
- https://github.com/ModelDBRepository/155602/pull/2
- https://github.com/ModelDBRepository/127021/pull/1
- https://github.com/ModelDBRepository/143671/pull/1
- https://github.com/ModelDBRepository/144482/pull/1
- https://github.com/ModelDBRepository/53893/pull/1
- https://github.com/ModelDBRepository/265584/pull/2
- https://github.com/ModelDBRepository/232023/pull/1
- https://github.com/ModelDBRepository/150024/pull/1
- https://github.com/ModelDBRepository/122329/pull/1
- https://github.com/ModelDBRepository/141273/pull/1
- https://github.com/ModelDBRepository/83590/pull/1