### PR TITLE
nmodl: remove excessive warning about voltage v variable

### DIFF
--- a/src/nmodl/consist.cpp
+++ b/src/nmodl/consist.cpp
@@ -11,6 +11,7 @@
 
 extern Symbol* scop_indep;
 extern Symbol* indepsym;
+extern int vectorize;
 
 #define con(arg1, arg2, arg3)                               \
     if (t & (arg2))                                         \
@@ -84,7 +85,10 @@ void consistency() {
             exit(1);
         }
         if ((t == 0) && tu) {
-            Fprintf(stderr, "Warning: %s undefined. (declared within VERBATIM?)\n", s->name);
+            // variable `v` is always defined in data array for vectorized mod files
+            if (!(vectorize && strcmp(s->name, "v") == 0)) {
+                Fprintf(stderr, "Warning: %s undefined. (declared within VERBATIM?)\n", s->name);
+            }
         }
     }
     if (err) {


### PR DESCRIPTION
* `v` variable is always declared in data array if mod file is thread-safe. So don't need to show this warning.
* Fixes #1999