### PR TITLE
Add a test showing an ASan issue in regex.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,8 +13,17 @@ include(NeuronTestHelper)
 # Test executables
 # =============================================================================
 set(TEST_SOURCES unit_tests/oc/hoc_interpreter.cpp unit_tests/threads/test_multicore.cpp)
-add_executable(testneuron unit_tests/unit_test.cpp ${TEST_SOURCES})
+add_executable(testneuron unit_tests/regex.cpp unit_tests/unit_test.cpp ${TEST_SOURCES})
 cpp_cc_configure_sanitizers(TARGET testneuron)
+if(NRN_ENABLE_INTERVIEWS)
+  set(header_dir_for_regex "${IV_INCLUDE_DIR}")
+else()
+  set(header_dir_for_regex "${NRN_IVOS_SRC_DIR}")
+endif()
+set_property(
+  SOURCE unit_tests/regex.cpp
+  APPEND
+  PROPERTY INCLUDE_DIRECTORIES "${header_dir_for_regex}")
 target_compile_features(testneuron PUBLIC cxx_std_11)
 target_link_libraries(testneuron Catch2::Catch2 nrniv_lib)
 if(NRN_ENABLE_THREADS)

--- a/test/unit_tests/regex.cpp
+++ b/test/unit_tests/regex.cpp
@@ -1,0 +1,32 @@
+#include <catch2/catch.hpp>
+
+#include <string_view>
+
+// This does lots of macro hackery, not safe to include it before other headers...
+#include <InterViews/regexp.h>
+
+// Make sure that there is no short string optimisation and we allocate exactly
+// the right size of heap buffer
+std::unique_ptr<char[]> string_as_char_array(std::string_view string) {
+    auto ret = std::make_unique<char[]>(string.size() + 1);
+    std::copy(string.begin(), string.end(), ret.get());
+    ret[string.size()] = '\0';
+    return ret;
+}
+
+SCENARIO("Test regular expression utilities", "[NEURON][InterViews][Regex]") {
+    // This is targetting AddressSantizer errors that were seen when executing
+    // https://github.com/ModelDBRepository/136095
+    GIVEN("A string and pattern from ModelDB ID 136095") {
+        constexpr auto pattern = "^[do]\\[";
+        constexpr std::string_view text{"d[1][1]"};
+        Regexp regex{pattern};
+        auto const text_as_char_array = string_as_char_array(text);
+        WHEN("We search for the pattern in the string") {
+            regex.Search(text_as_char_array.get(), text.size(), 0, text.size());
+            THEN("The returned value should be correct") {
+                // dsfsd
+            }
+        }
+    }
+}

--- a/test/unit_tests/regex.cpp
+++ b/test/unit_tests/regex.cpp
@@ -1,16 +1,20 @@
 #include <catch2/catch.hpp>
 
+#include <iostream>
+#include <memory>
 #include <string_view>
 
 // This does lots of macro hackery, not safe to include it before other headers...
 #include <InterViews/regexp.h>
 
 // Make sure that there is no short string optimisation and we allocate exactly
-// the right size of heap buffer
-std::unique_ptr<char[]> string_as_char_array(std::string_view string) {
-    auto ret = std::make_unique<char[]>(string.size() + 1);
-    std::copy(string.begin(), string.end(), ret.get());
-    ret[string.size()] = '\0';
+// the right size of heap buffer plus `pad_before` bytes at the beginning
+std::unique_ptr<char[]> string_as_char_array(std::string_view string, std::size_t pad_before = 0) {
+    auto const size = pad_before + string.size() + 1;
+    auto ret = std::make_unique<char[]>(size);
+    std::fill(ret.get(), std::next(ret.get(), pad_before), '\0');
+    std::copy(string.begin(), string.end(), std::next(ret.get(), pad_before));
+    ret[size - 1] = '\0';
     return ret;
 }
 
@@ -19,13 +23,17 @@ SCENARIO("Test regular expression utilities", "[NEURON][InterViews][Regex]") {
     // https://github.com/ModelDBRepository/136095
     GIVEN("A string and pattern from ModelDB ID 136095") {
         constexpr auto pattern = "^[do]\\[";
-        constexpr std::string_view text{"d[1][1]"};
+        constexpr auto* const text_cstr = "d[1][1]";
+        constexpr std::string_view text{text_cstr};
         Regexp regex{pattern};
-        auto const text_as_char_array = string_as_char_array(text);
-        WHEN("We search for the pattern in the string") {
-            regex.Search(text_as_char_array.get(), text.size(), 0, text.size());
+        auto const padding = GENERATE(1, 0);
+        WHEN("We use a heap-allocated buffer with " + std::to_string(padding) +
+             " valid characters before the start of the string") {
+            auto const array = string_as_char_array(text, padding);
             THEN("The returned value should be correct") {
-                // dsfsd
+                REQUIRE(
+                    regex.Search(std::next(array.get(), padding), text.size(), 0, text.size()) ==
+                    0);
             }
         }
     }


### PR DESCRIPTION
```
==33388==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200000bf78 at pc 0x00010273e54b bp 0x7ff7bfefcec0 sp 0x7ff7bfefceb8
READ of size 1 at 0x60200000bf78 thread T0
    #0 0x10273e54a in ivRegexp::Search(char const*, int, int, int) regexp.cpp:149
    #1 0x100005257 in ____C_A_T_C_H____T_E_S_T____0() regex.cpp:33
    #2 0x1000686a2 in Catch::TestInvokerAsFunction::invoke() const catch.hpp:14321
    #3 0x100051002 in Catch::TestCase::invoke() const catch.hpp:14160
    #4 0x100050dfe in Catch::RunContext::invokeActiveTestCase() catch.hpp:13020
    #5 0x10004a363 in Catch::RunContext::runCurrentTest(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) catch.hpp:12993
    #6 0x1000480a0 in Catch::RunContext::runTest(Catch::TestCase const&) catch.hpp:12754
    #7 0x100058d47 in Catch::(anonymous namespace)::TestGroup::execute() catch.hpp:13347
    #8 0x1000577f6 in Catch::Session::runInternal() catch.hpp:13553
    #9 0x100057202 in Catch::Session::run() catch.hpp:13509
    #10 0x1000a40d7 in main unit_test.cpp:56
    #11 0x1006d552d in start+0x1cd (dyld:x86_64+0x552d)

0x60200000bf78 is located 0 bytes to the right of 8-byte region [0x60200000bf70,0x60200000bf78)
allocated by thread T0 here:
    #0 0x10317931d in wrap__Znam+0x7d (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x5c31d)
    #1 0x100003fb7 in std::__1::__unique_if<char []>::__unique_array_unknown_bound std::__1::make_unique<char []>(unsigned long) unique_ptr.h:737
    #2 0x100003c76 in string_as_char_array(std::__1::basic_string_view<char, std::__1::char_traits<char> >, unsigned long) regex.cpp:14
    #3 0x100004e81 in ____C_A_T_C_H____T_E_S_T____0() regex.cpp:31
    #4 0x1000686a2 in Catch::TestInvokerAsFunction::invoke() const catch.hpp:14321
    #5 0x100051002 in Catch::TestCase::invoke() const catch.hpp:14160
    #6 0x100050dfe in Catch::RunContext::invokeActiveTestCase() catch.hpp:13020
    #7 0x10004a363 in Catch::RunContext::runCurrentTest(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) catch.hpp:12993
    #8 0x1000480a0 in Catch::RunContext::runTest(Catch::TestCase const&) catch.hpp:12754
    #9 0x100058d47 in Catch::(anonymous namespace)::TestGroup::execute() catch.hpp:13347
    #10 0x1000577f6 in Catch::Session::runInternal() catch.hpp:13553
    #11 0x100057202 in Catch::Session::run() catch.hpp:13509
    #12 0x1000a40d7 in main unit_test.cpp:56
    #13 0x1006d552d in start+0x1cd (dyld:x86_64+0x552d)
```