### PR TITLE
Add test showing bug with HOC variables that get redeclared with different numbers of indices

### DIFF
--- a/src/oc/code.cpp
+++ b/src/oc/code.cpp
@@ -378,6 +378,12 @@ void hoc_init_space(void) /* create space for stack and code */
     hoc_temp_obj_pool_ = (Object**) emalloc(sizeof(Object*) * TOBJ_POOL_SIZE);
 }
 
+[[nodiscard]] std::size_t hoc_stack_size() {
+    auto const dist = std::distance(stack, stackp);
+    assert(dist % 2 == 0);
+    return dist / 2;
+}
+
 #define MAXINITFCNS 10
 static int maxinitfcns;
 static Pfrv initfcns[MAXINITFCNS];
@@ -1401,7 +1407,7 @@ void call(void) /* call a function */
     /*SUPPRESS 26*/
     fp->argn = stackp - 2; /* last argument */
     auto const nargs_before_call = fp->nargs;
-    auto const stack_size_before_call = stack.size();
+    auto const stack_size_before_call = hoc_stack_size();
     BBSPOLL
 #if CABLE
     isec = nrn_isecstack();
@@ -1448,11 +1454,11 @@ void call(void) /* call a function */
     // (in hoc_ret) and a return value might have been pushed (hoc_returning == 1)
     auto const expected_stack_size = stack_size_before_call - nargs_before_call +
                                      (hoc_returning == 1);
-    if (stack.size() != expected_stack_size) {
+    if (hoc_stack_size() != expected_stack_size) {
         throw std::runtime_error("Stack mismatch: name=" + std::string{sp->name} +
                                  " before=" + std::to_string(stack_size_before_call) +
                                  " expected=" + std::to_string(expected_stack_size) +
-                                 " after=" + std::to_string(stack.size()) +
+                                 " after=" + std::to_string(hoc_stack_size()) +
                                  " nargs=" + std::to_string(nargs_before_call));
     }
     if (hoc_returning) {

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -1383,7 +1383,8 @@ int hoc_oc(const char* buf) {
         try {
             signal_handler_guard _{};
             kernel();
-        } catch (...) {
+        } catch (std::exception const& e) {
+            std::cerr << "hoc_oc caught exception: " << e.what() << std::endl;
             hoc_initcode();
             hoc_intset = 0;
             return 1;

--- a/test/unit_tests/oc/hoc_interpreter.cpp
+++ b/test/unit_tests/oc/hoc_interpreter.cpp
@@ -16,9 +16,7 @@ SCENARIO("Test small HOC functions", "[NEURON][hoc_interpreter]") {
     // This is targeting errors in ModelDB 136095 with #1995
     GIVEN("An objref that gets redeclared with fewer indices") {
         REQUIRE(hoc_oc("objref ncl[1][1][1]\n"
-                       "obfunc foo() { localobj x\n"
-                       "  return ncl\n"
-                       "}\n"
+                       "obfunc foo() { localobj x return ncl }\n"
                        "objref ncl\n"
                        "foo()\n") == 0);
     }

--- a/test/unit_tests/oc/hoc_interpreter.cpp
+++ b/test/unit_tests/oc/hoc_interpreter.cpp
@@ -11,3 +11,15 @@ TEST_CASE("Test hoc interpreter", "[Neuron][hoc_interpreter]") {
     hoc_add();
     REQUIRE(hoc_xpop() == 9.0);
 }
+
+SCENARIO("Test small HOC functions", "[NEURON][hoc_interpreter]") {
+    // This is targeting errors in ModelDB 136095 with #1995
+    GIVEN("An objref that gets redeclared with fewer indices") {
+        REQUIRE(hoc_oc("objref ncl[1][1][1]\n"
+                       "obfunc foo() { localobj x\n"
+                       "  return ncl\n"
+                       "}\n"
+                       "objref ncl\n"
+                       "foo()\n") == 0);
+    }
+}


### PR DESCRIPTION
- See discussion in https://github.com/neuronsimulator/nrn/pull/1995.
- If computing `expected_stack_size` proves difficult in some cases then the issue could probably be caught some other way.