### PR TITLE
Assorted improvements from #1929

### DIFF
--- a/src/nrncvode/netcon.h
+++ b/src/nrncvode/netcon.h
@@ -29,7 +29,7 @@ struct NrnThread;
 class NetCvode;
 class HocEventPool;
 class HocCommand;
-class STETransition;
+struct STETransition;
 class IvocVect;
 class BGP_DMASend;
 class BGP_DMASend_Phase2;

--- a/src/nrncvode/netcvode.cpp
+++ b/src/nrncvode/netcvode.cpp
@@ -3416,13 +3416,8 @@ DiscreteEvent* SelfEvent::savestate_read(FILE* f) {
     nrn_assert(
         sscanf(buf, "%s %d %d %d %d %lf\n", ppname, &ppindex, &pptype, &ncindex, &moff, &flag) ==
         6);
-#if 0
-	// use of hoc_name2obj is way too inefficient
-	se->target_ = ob2pntproc(hoc_name2obj(ppname, ppindex));
-#else
     se->target_ = SelfEvent::index2pp(pptype, ppindex);
-#endif
-    se->weight_ = nil;
+    se->weight_ = nullptr;
     if (ncindex >= 0) {
         NetCon* nc = NetConSave::index2netcon(ncindex);
         se->weight_ = nc->weight_;
@@ -5526,18 +5521,14 @@ void StateTransitionEvent::transition(int src,
                                       int dest,
                                       double* var1,
                                       double* var2,
-                                      HocCommand* hc) {
-    STETransition* st = states_[src].add_transition();
-    st->dest_ = dest;
-    st->var1_ = var1;
-    st->var2_ = var2;
-    st->hc_ = hc;
-    st->ste_ = (StateTransitionEvent*) this;
-    st->stec_ = new STECondition(pnt_, NULL);
-    st->stec_->stet_ = st;
-    if (st->var1_ == &t) {
-        st->var1_is_time_ = true;
-    }
+                                      std::unique_ptr<HocCommand> hc) {
+    STETransition& st = states_[src].add_transition(pnt_);
+    st.dest_ = dest;
+    st.var1_ = var1;
+    st.var2_ = var2;
+    st.hc_ = std::move(hc);
+    st.ste_ = this;
+    st.var1_is_time_ = (st.var1_ == &t);
 }
 
 void STETransition::activate() {

--- a/src/nrnpython/grids.h
+++ b/src/nrnpython/grids.h
@@ -8,7 +8,8 @@ and Flux_pair structs and their respective functions
 #include <assert.h>
 #include <nrnmpi.h>
 
-#include <nrnwrap_Python.h>
+#include "nrn_pyhocobject.h"
+#include "nrnwrap_Python.h"
 
 #define SAFE_FREE(ptr)     \
     {                      \
@@ -34,29 +35,6 @@ and Flux_pair structs and their respective functions
 
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
-
-typedef struct {
-    PyObject_HEAD void* ho_;
-    union {
-        double x_;
-        char* s_;
-        void* ho_;
-        double* px_;
-    } u;
-    void* sym_;       // for functions and arrays
-    void* iteritem_;  // enough info to carry out Iterator protocol
-    int nindex_;      // number indices seen so far (or narg)
-    int* indices_;    // one fewer than nindex_
-    int type_;        // 0 HocTopLevelInterpreter, 1 HocObject
-                      // 2 function (or TEMPLATE)
-                      // 3 array
-                      // 4 reference to number
-                      // 5 reference to string
-                      // 6 reference to hoc object
-                      // 7 forall section iterator
-                      // 8 pointer to a hoc scalar
-                      // 9 incomplete pointer to a hoc array (similar to 3)
-} PyHocObject;
 
 typedef struct Hybrid_data {
     long num_1d_indices;

--- a/src/nrnpython/nrn_pyhocobject.h
+++ b/src/nrnpython/nrn_pyhocobject.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "nrnpython.h"
+
+struct Object;
+struct Symbol;
+struct PyHocObject {
+    PyObject_HEAD Object* ho_;
+    union {
+        double x_;
+        char* s_;
+        char** pstr_;
+        Object* ho_;
+        double* px_;
+        PyHoc::IteratorState its_;
+    } u;
+    Symbol* sym_;             // for functions and arrays
+    void* iteritem_;          // enough info to carry out Iterator protocol
+    int nindex_;              // number indices seen so far (or narg)
+    int* indices_;            // one fewer than nindex_
+    PyHoc::ObjectType type_;  // 0 HocTopLevelInterpreter, 1 HocObject
+                              // 2 function (or TEMPLATE)
+                              // 3 array
+                              // 4 reference to number
+                              // 5 reference to string
+                              // 6 reference to hoc object
+                              // 7 forall section iterator
+                              // 8 pointer to a hoc scalar
+                              // 9 incomplete pointer to a hoc array (similar to 3)
+};

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -1,17 +1,20 @@
-#include <nrnpython.h>
-#include <structmember.h>
-#include <InterViews/resource.h>
-#include <nrnoc2iv.h>
-#include <ocjump.h>
 #include "ivocvect.h"
-#include "oclist.h"
-#include "ocfile.h"
-#include <cstdint>
 #include "nrniv_mf.h"
+#include "nrn_pyhocobject.h"
+#include "nrnoc2iv.h"
 #include "nrnpy_utils.h"
-#include "../nrniv/shapeplt.h"
-#include <vector>
+#include "nrnpython.h"
 #include "nrnwrap_dlfcn.h"
+#include "ocfile.h"
+#include "ocjump.h"
+#include "oclist.h"
+#include "shapeplt.h"
+
+#include <InterViews/resource.h>
+#include <structmember.h>  // for PyMemberDef
+
+#include <cstdint>
+#include <vector>
 
 #if defined(NRNPYTHON_DYNAMICLOAD) && NRNPYTHON_DYNAMICLOAD > 0
 // when compiled with different Python.h, force correct value
@@ -132,23 +135,6 @@ extern Object* hoc_thisobject;
     assert(hoc_thisobject == 0);
 #define HocContextRestore /**/
 #endif
-
-typedef struct {
-    PyObject_HEAD Object* ho_;
-    union {
-        double x_;
-        char* s_;
-        char** pstr_;
-        Object* ho_;
-        double* px_;
-        PyHoc::IteratorState its_;
-    } u;
-    Symbol* sym_;     // for functions and arrays
-    void* iteritem_;  // enough info to carry out Iterator protocol
-    int nindex_;      // number indices seen so far (or narg)
-    int* indices_;    // one fewer than nindex_
-    PyHoc::ObjectType type_;
-} PyHocObject;
 
 static PyObject* rvp_plot = NULL;
 static PyObject* plotshape_plot = NULL;

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -1283,8 +1283,9 @@ static int hoc_run1() {
                 if (!loop_body()) {
                     break;
                 }
-            } catch (...) {
+            } catch (std::exception const& e) {
                 hoc_fin = sav_fin;
+                std::cerr << "hoc_run1: caught exception: " << e.what() << std::endl;
                 // Exit if we're not in interactive mode
                 if (!nrn_fw_eq(hoc_fin, stdin)) {
                     return EXIT_FAILURE;
@@ -1383,7 +1384,8 @@ int hoc_oc(const char* buf) {
         try {
             signal_handler_guard _{};
             kernel();
-        } catch (...) {
+        } catch (std::exception const& e) {
+            std::cerr << "hoc_oc caught exception: " << e.what() << std::endl;
             hoc_initcode();
             hoc_intset = 0;
             return 1;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,8 +12,8 @@ include(NeuronTestHelper)
 # =============================================================================
 # Test executables
 # =============================================================================
-set(TEST_SOURCES unit_tests/oc/hoc_interpreter.cpp unit_tests/threads/test_multicore.cpp)
-add_executable(testneuron unit_tests/unit_test.cpp ${TEST_SOURCES})
+add_executable(testneuron unit_tests/unit_test.cpp unit_tests/oc/hoc_interpreter.cpp
+                          unit_tests/threads/test_multicore.cpp)
 cpp_cc_configure_sanitizers(TARGET testneuron)
 target_compile_features(testneuron PUBLIC cxx_std_11)
 target_link_libraries(testneuron Catch2::Catch2 nrniv_lib)
@@ -206,15 +206,27 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
     ENVIRONMENT COVERAGE_FILE=.coverage.cover_tests
     COMMAND ${PYTHON_EXECUTABLE} ${pytest} ./test/cover
     SCRIPT_PATTERNS test/cover/*.py test/cover/*.json)
-  nrn_add_test_group(NAME example_nmodl MODFILE_PATTERNS share/examples/nrniv/nmodl/*.mod
-                                                         share/examples/nrniv/nmodl/*.inc)
-  nrn_add_test(
-    GROUP example_nmodl
+  nrn_add_test_group(
     NAME example_nmodl
-    COMMAND
-      bash -ceo pipefail
-      [=[ pushd share/examples/nrniv/nmodl && find . -type f -name "*.hoc" | xargs -I{} special {} ]=]
-    SCRIPT_PATTERNS share/examples/nrniv/nmodl/*.ses share/examples/nrniv/nmodl/*.hoc)
+    MODFILE_PATTERNS *.mod *.inc
+    SIM_DIRECTORY share/examples/nrniv/nmodl)
+  set(py_exe ${PYTHON_EXECUTABLE})
+  set(py_preload PRELOAD_SANITIZER)
+  set(hoc_exe special)
+  foreach(ext hoc py)
+    file(
+      GLOB example_nmodl_scripts
+      RELATIVE "${PROJECT_SOURCE_DIR}/share/examples/nrniv/nmodl"
+      "${PROJECT_SOURCE_DIR}/share/examples/nrniv/nmodl/*.${ext}")
+    foreach(example_script ${example_nmodl_scripts})
+      get_filename_component(name "${example_script}" NAME_WLE)
+      nrn_add_test(
+        GROUP example_nmodl
+        NAME ${name}_${ext} ${${ext}_preload} # PRELOAD_SANITIZER for Python
+        COMMAND ${${ext}_exe} "${example_script}"
+        SCRIPT_PATTERNS "${example_script}" "${name}.ses")
+    endforeach()
+  endforeach()
 
   if(NRN_ENABLE_RX3D)
     nrn_add_test_group(

--- a/test/unit_tests/unit_test.cpp
+++ b/test/unit_tests/unit_test.cpp
@@ -63,8 +63,7 @@ int main(int argc, char* argv[]) {
 
 SCENARIO("Test fast_imem calculation", "[Neuron][fast_imem]") {
     GIVEN("A section") {
-        hoc_oc("create s\n");
-
+        REQUIRE(hoc_oc("create s\n") == 0);
         WHEN("fast_imem and cachevec is allocated") {
             nrn_use_fast_imem = true;
             use_cachevec = 1;
@@ -78,10 +77,9 @@ SCENARIO("Test fast_imem calculation", "[Neuron][fast_imem]") {
         }
 
         WHEN("fast_imem is created") {
-            hoc_oc(
-                "objref cvode\n"
-                "cvode = new CVode()\n"
-                "cvode.use_fast_imem(1)\n");
+            REQUIRE(hoc_oc("objref cvode\n"
+                           "cvode = new CVode()\n"
+                           "cvode.use_fast_imem(1)\n") == 0);
             WHEN("iinitialize and run nrn_calc_fast_imem") {
                 hoc_oc("finitialize(-65)\n");
                 for (NrnThread* nt = nrn_threads; nt < nrn_threads + nrn_nthread; ++nt) {
@@ -97,7 +95,7 @@ SCENARIO("Test fast_imem calculation", "[Neuron][fast_imem]") {
             }
         }
 
-        hoc_oc("delete_section()");
+        REQUIRE(hoc_oc("delete_section()") == 0);
     }
 }
 


### PR DESCRIPTION
Various incidental improvements from https://github.com/neuronsimulator/nrn/pull/1929.

- `STETransition` et al. now use STL components
- Removal of `#if 0` block in `nrn_finitialize` fixes formatting there
- `table_check_` no longer uses `Datum`
- `PyHocObject` is consistently defined in only one place
- Exception messages are printed to stderr when they are caught
- `example_nmodl` tests are unpacked into different tests, Python versions are run (not just HOC)
- "Test fast_imem calculation" tests now check status codes