### PR TITLE
Fine tune clang-format rules

### DIFF
--- a/.clang-format.changes
+++ b/.clang-format.changes
@@ -1,3 +1,3 @@
 SortIncludes: false
 Standard: c++17
-StatementMacros: [MKDLL, MKDLLdec, MKDLLif, MKDLLvp, MKDLLvpf]
+StatementMacros: [MKDLL, MKDLLdec, MKDLLif, MKDLLvp, MKDLLvpf, declarePtrList, implementPtrList]

--- a/.clang-format.changes
+++ b/.clang-format.changes
@@ -1,3 +1,3 @@
 SortIncludes: false
 Standard: c++17
-StatementMacros: [MKDLL, MKDLLdec, MKDLLif, MKDLLvp, MKDLLvpf, declarePtrList, implementPtrList]
+StatementMacros: [MKDLL, MKDLLdec, MKDLLif, MKDLLvp, MKDLLvpf, declareList, declarePtrList, implementList, implementPtrList]

--- a/src/ivoc/checkpnt.cpp
+++ b/src/ivoc/checkpnt.cpp
@@ -249,9 +249,10 @@ void PortablePointer::set(void* address, int type, unsigned long s) {
 }
 PortablePointer::~PortablePointer() {}
 
-declareList(PPList, PortablePointer) implementList(PPList, PortablePointer)
+declareList(PPList, PortablePointer)
+implementList(PPList, PortablePointer)
 
-    class OcCheckpoint {
+class OcCheckpoint {
   public:
     OcCheckpoint();
     virtual ~OcCheckpoint();

--- a/src/ivoc/ochelp.cpp
+++ b/src/ivoc/ochelp.cpp
@@ -31,9 +31,10 @@ static FILE* help_pipe;
 
 extern const char* hoc_current_xopen();
 
-declareList(CopyStringList, CopyString) implementList(CopyStringList, CopyString)
+declareList(CopyStringList, CopyString)
+implementList(CopyStringList, CopyString)
 
-    static CopyStringList* filequeue;
+static CopyStringList* filequeue;
 
 void ivoc_help(const char* s) {
 #if 1

--- a/src/ivoc/scenepic.cpp
+++ b/src/ivoc/scenepic.cpp
@@ -86,9 +86,9 @@ GlyphIndex ButtonItemInfo::menu_index() {
 }
 
 declarePtrList(ButtonItemInfoList, ButtonItemInfo)
-    implementPtrList(ButtonItemInfoList, ButtonItemInfo)
+implementPtrList(ButtonItemInfoList, ButtonItemInfo)
 
-    /*static*/ class SceneMover: public OcHandler {
+/*static*/ class SceneMover: public OcHandler {
   public:
     SceneMover();
     virtual ~SceneMover();

--- a/src/ivoc/xmenu.cpp
+++ b/src/ivoc/xmenu.cpp
@@ -588,8 +588,9 @@ static void checkOpenPanel() {
     }
 }
 
-declarePtrList(HocMenuList, HocMenu) implementPtrList(HocMenuList, HocMenu)
-    /*static*/ class MenuStack {
+declarePtrList(HocMenuList, HocMenu)
+implementPtrList(HocMenuList, HocMenu)
+/*static*/ class MenuStack {
   public:
     bool isEmpty() {
         return l_.count() == 0;

--- a/src/ivoc/xmenu.h
+++ b/src/ivoc/xmenu.h
@@ -42,10 +42,11 @@ class ValEdLabel;
 class ScenePicker;
 struct HocSymExtension;
 
-declarePtrList(HocUpdateItemList, HocUpdateItem) declarePtrList(HocItemList, HocItem)
-    declarePtrList(HocPanelList, HocPanel)
+declarePtrList(HocUpdateItemList, HocUpdateItem)
+declarePtrList(HocItemList, HocItem)
+declarePtrList(HocPanelList, HocPanel)
 
-        class HocPanel: public OcGlyph {
+class HocPanel: public OcGlyph {
   public:
     HocPanel(const char* name, bool horizontal = false);
     virtual ~HocPanel();

--- a/src/nrncvode/netcvode.cpp
+++ b/src/nrncvode/netcvode.cpp
@@ -6212,8 +6212,8 @@ tryagain:
 
 implementPtrList(PlayRecList, PlayRecord)
 
-    void NetCvode::playrec_add(PlayRecord* pr) {  // called by PlayRecord constructor
-                                                  // printf("NetCvode::playrec_add %p\n", pr);
+void NetCvode::playrec_add(PlayRecord* pr) {  // called by PlayRecord constructor
+                                              // printf("NetCvode::playrec_add %p\n", pr);
     playrec_change_cnt_ = 0;
     prl_->append(pr);
 }

--- a/src/nrncvode/vrecitem.h
+++ b/src/nrncvode/vrecitem.h
@@ -96,7 +96,7 @@ class PlayRecord: public Observer {
 
 declarePtrList(PlayRecList, PlayRecord)
 
-    class PlayRecordSave {
+class PlayRecordSave {
   public:
     PlayRecordSave(PlayRecord*);
     virtual ~PlayRecordSave();

--- a/src/nrniv/glinerec.cpp
+++ b/src/nrniv/glinerec.cpp
@@ -29,7 +29,8 @@ extern NetCvode* net_cvode_instance;
 class GLineRecordList;
 
 declarePtrList(GLineRecordList, GLineRecord)
-    implementPtrList(GLineRecordList, GLineRecord) static GLineRecordList* grl;
+implementPtrList(GLineRecordList, GLineRecord)
+static GLineRecordList* grl;
 
 // Since GraphLine is not an observable, its destructor calls this.
 // So ivoc will work, a stub is placed in ivoc/datapath.cpp

--- a/src/uxnrnbbs/nrnbbs.cpp
+++ b/src/uxnrnbbs/nrnbbs.cpp
@@ -68,9 +68,9 @@ static void history(const char* s1, int i) {
 }
 
 declarePtrList(NrnBBSCallbackList, NrnBBSCallbackItem)
-    implementPtrList(NrnBBSCallbackList, NrnBBSCallbackItem)
+implementPtrList(NrnBBSCallbackList, NrnBBSCallbackItem)
 
-        static NrnBBSCallbackList* cblist_;
+static NrnBBSCallbackList* cblist_;
 static FILE* lockfile_;
 
 static void get_lock() {

--- a/test/pynrn/test_basic.py
+++ b/test/pynrn/test_basic.py
@@ -324,8 +324,6 @@ def test_deleted_sec():
     del ic, imp, dend
     locals()
 
-    return s, seg, mech, rvlist, vref, gnabarref
-
 
 def test_disconnect():
     print("test_disconnect")
@@ -417,7 +415,7 @@ if __name__ == "__main__":
     set_quiet(False)
     test_soma()
     test_simple_sim()
-    result = test_deleted_sec()
+    test_deleted_sec()
     test_disconnect()
     h.topology()
     h.allobjects()


### PR DESCRIPTION
- `declareList`, `declarePtrList`, `implementList`, `implementPtrList` macros need special treatment
- delete a return statement apparently causing an ASan error