### PR TITLE
Make sure tests are run with actual python exe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,11 +253,6 @@ if(NOT PYTHON_EXECUTABLE)
 endif()
 
 # =============================================================================
-# Enable sanitizer support if the NRN_SANITIZERS variable is set
-# =============================================================================
-include(cmake/SanitizerHelper.cmake)
-
-# =============================================================================
 # Find required packages
 # =============================================================================
 find_package(BISON REQUIRED)
@@ -408,6 +403,11 @@ if(NRN_ENABLE_PYTHON)
 else()
   set(USE_PYTHON 0)
 endif()
+
+# =============================================================================
+# Enable sanitizer support if the NRN_SANITIZERS variable is set
+# =============================================================================
+include(cmake/SanitizerHelper.cmake)
 
 # =============================================================================
 # Enable Threads support

--- a/cmake/NeuronTestHelper.cmake
+++ b/cmake/NeuronTestHelper.cmake
@@ -428,6 +428,7 @@ function(nrn_add_test)
     # https://tobywf.com/2021/02/python-ext-asan/
     list(APPEND test_env NRN_SANITIZER_PRELOAD_VAR=${NRN_SANITIZER_PRELOAD_VAR})
     list(APPEND test_env NRN_SANITIZER_PRELOAD_VAL=${NRN_SANITIZER_LIBRARY_PATH})
+    list(APPEND test_env NRN_PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE})
   endif()
   list(APPEND test_env ${NRN_SANITIZER_ENABLE_ENVIRONMENT})
   # Add the actual test job, including the `special` and `special-core` binaries in the path. TODOs:

--- a/cmake/SanitizerHelper.cmake
+++ b/cmake/SanitizerHelper.cmake
@@ -54,7 +54,9 @@ if(NRN_SANITIZERS)
   endif()
   # Needed for using sanitizers on macOS
   cpp_cc_strip_python_shims(EXECUTABLE "${PYTHON_EXECUTABLE}" OUTPUT PYTHON_EXECUTABLE)
-  set(NRN_DEFAULT_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}" PARENT_SCOPE)
+  set(NRN_DEFAULT_PYTHON_EXECUTABLE
+      "${PYTHON_EXECUTABLE}"
+      PARENT_SCOPE)
   configure_file(bin/nrn-enable-sanitizer.in bin/nrn-enable-sanitizer @ONLY)
   install(PROGRAMS ${PROJECT_BINARY_DIR}/bin/nrn-enable-sanitizer
           DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/cmake/SanitizerHelper.cmake
+++ b/cmake/SanitizerHelper.cmake
@@ -54,6 +54,7 @@ if(NRN_SANITIZERS)
   endif()
   # Needed for using sanitizers on macOS
   cpp_cc_strip_python_shims(EXECUTABLE "${PYTHON_EXECUTABLE}" OUTPUT PYTHON_EXECUTABLE)
+  set(NRN_DEFAULT_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}" PARENT_SCOPE)
   configure_file(bin/nrn-enable-sanitizer.in bin/nrn-enable-sanitizer @ONLY)
   install(PROGRAMS ${PROJECT_BINARY_DIR}/bin/nrn-enable-sanitizer
           DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/test/pynrn/test_basic.py
+++ b/test/pynrn/test_basic.py
@@ -392,6 +392,7 @@ def test_errorcode():
     process = subprocess.run('nrniv -c "1/0"', shell=True)
     assert process.returncode > 0
 
+    exe = os.environ.get("NRN_PYTHON_EXECUTABLE", sys.executable)
     env = os.environ.copy()
     try:
         env[os.environ["NRN_SANITIZER_PRELOAD_VAR"]] = os.environ[
@@ -400,7 +401,7 @@ def test_errorcode():
     except:
         pass
     process = subprocess.run(
-        [sys.executable, "-c", "from neuron import h; h.sqrt(-1)"], env=env, shell=False
+        [exe, "-c", "from neuron import h; h.sqrt(-1)"], env=env, shell=False
     )
     assert process.returncode > 0
 

--- a/test/pynrn/test_units.py
+++ b/test/pynrn/test_units.py
@@ -73,6 +73,7 @@ def test_env_legacy():
     import os, subprocess, sys
 
     for i in [0, 1]:
+        exe = os.environ.get("NRN_PYTHON_EXECUTABLE", sys.executable)
         env = os.environ.copy()
         env["NRNUNIT_USE_LEGACY"] = str(i)
         try:
@@ -83,7 +84,7 @@ def test_env_legacy():
             pass
         a = subprocess.check_output(
             [
-                sys.executable,
+                exe,
                 "-c",
                 "from neuron import h; print(h.nrnunit_use_legacy())",
             ],


### PR DESCRIPTION
On mac in some setups we end up still in the situation where some python tests are executed with the python shim. This causes sanitizer libraries to be lost in the chain of executions once again.
This change forwards the Python executable that was determined using the SanitizerHelper.cmake utility all the way down to the subprocess invokations inside some of the python tests.
Also, update coding conventions to fix an issue where the non-Apple clang was not properly recognized (for sanitizer libraries).