### PR TITLE
section connect obj.secarray[i](0), 1 is valid syntax

### DIFF
--- a/src/oc/hoc_oop.cpp
+++ b/src/oc/hoc_oop.cpp
@@ -1213,6 +1213,9 @@ void hoc_object_component() {
             if (!ISARRAY(sym) || OPARINFO(sym)->nsub != nindex) {
                 hoc_execerror(sym->name, ":not right number of subscripts");
             }
+            if (!hoc_stack_type_is_ndim()) {
+                hoc_push_ndim(nindex);
+            }
             nindex = araypt(sym, OBJECTVAR);
         }
         hoc_pop_defer();

--- a/test/hoctests/vardimtests/test4.hoc
+++ b/test/hoctests/vardimtests/test4.hoc
@@ -40,3 +40,7 @@ cell.dend { print secname() }
 expect_err("cell.dend[5] { print secname() }")
 expect_err("cell.dend[1][2] {print secname() }")
 expect_err("cell.soma[1] { print secname() }")
+
+forall disconnect()
+connect cell.dend[1](0), cell.dend[0](1)
+cell.dend[1] connect cell.dend[2](0), 1

--- a/test/hoctests/vardimtests/test4.hoc
+++ b/test/hoctests/vardimtests/test4.hoc
@@ -42,5 +42,6 @@ expect_err("cell.dend[1][2] {print secname() }")
 expect_err("cell.soma[1] { print secname() }")
 
 forall disconnect()
-connect cell.dend[1](0), cell.dend[0](1)
+expect_err("connect cell.dend[1](0), cell.dend[0](1)") // limitation of parser
 cell.dend[1] connect cell.dend[2](0), 1
+


### PR DESCRIPTION
Fixes error introduced by #2024 

I am going to review all use of ```hoc_araypt``` with respect to whether it is possible for an array to be missing an ndim stack item and that not be an error.

Anyway, please check to see if this fixes the issue seen with the old circuit.