### PR TITLE
Move virtualenv job into main build job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,10 +15,6 @@ variables:
 stages:
   - build
 
-upload_logs_to_github:
-  variables:
-    GIT_STRATEGY: clone
-
 # see https://gitlab.com/gitlab-org/gitlab/-/issues/263401 for why we specify the flags like this now
 # 130 characters seems to be the point at which jobs refuse to run
 .matrix:
@@ -48,8 +44,6 @@ cmake_build:
     - venv/bin/pip install --upgrade pip -r nrn_requirements.txt
     - venv/bin/python --version
     - 'venv/bin/python -c "import os,matplotlib; f = open(os.path.join(os.path.dirname(matplotlib.__file__), \"mpl-data/matplotlibrc\"),\"a\"); f.write(\"backend: TkAgg\");f.close();"'
-    - export CMAKE_BUILD_PARALLEL_LEVEL=${CMAKE_BUILD_PARALLEL_LEVEL}
-    - export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL}
     - 'export CXX=${CXX:-g++}'
     - 'export CC=${CC:-gcc}'
     - export PYTHON=$(pwd)/venv/bin/python3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,11 +9,10 @@ include:
     file: github-project-pipelines.gitlab-ci.yml
 
 variables:
-  GIT_STRATEGY: none
+  CMAKE_BUILD_PARALLEL_LEVEL: 3
+  CTEST_PARALLEL_LEVEL: 3
 
 stages:
-  - clean workspace
-  - prerequisites
   - build
 
 upload_logs_to_github:
@@ -31,37 +30,6 @@ upload_logs_to_github:
         cmake_rx3d: "OFF"
         sanitizer: address
 
-clean_workspace:
-  stage: clean workspace
-  variables:
-    GIT_STRATEGY: clone
-  script:
-    - echo "Workspace clean"
-
-set_homebrew_variables:
-  stage: prerequisites
-  script:
-    - echo CMAKE_BUILD_PARALLEL_LEVEL=3 >> build.env
-    - echo CTEST_PARALLEL_LEVEL=3 >> build.env
-  artifacts:
-    reports:
-      dotenv: build.env
-
-install_python_dependencies:
-  stage: prerequisites
-  script:
-    - pwd
-    - python3 -m virtualenv venv
-    - venv/bin/pip install --upgrade pip -r nrn_requirements.txt
-
-patches:
-  stage: prerequisites
-  needs: ['install_python_dependencies']
-  script:
-    - venv/bin/python --version
-    - 'venv/bin/python -c "import os,matplotlib; f = open(os.path.join(os.path.dirname(matplotlib.__file__), \"mpl-data/matplotlibrc\"),\"a\"); f.write(\"backend: TkAgg\");f.close();"'
-
-
 cmake_build:
   stage: build
   extends: .matrix
@@ -76,6 +44,12 @@ cmake_build:
     CCACHE_BASEDIR: ${CI_PROJECT_DIR}/nrn
     CCACHE_DIR: ${CI_PROJECT_DIR}/ccache
   script:
+    - python3 -m virtualenv venv
+    - venv/bin/pip install --upgrade pip -r nrn_requirements.txt
+    - venv/bin/python --version
+    - 'venv/bin/python -c "import os,matplotlib; f = open(os.path.join(os.path.dirname(matplotlib.__file__), \"mpl-data/matplotlibrc\"),\"a\"); f.write(\"backend: TkAgg\");f.close();"'
+    - export CMAKE_BUILD_PARALLEL_LEVEL=${CMAKE_BUILD_PARALLEL_LEVEL}
+    - export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL}
     - 'export CXX=${CXX:-g++}'
     - 'export CC=${CC:-gcc}'
     - export PYTHON=$(pwd)/venv/bin/python3


### PR DESCRIPTION
We'd rather not rely on jobs running on the same runner, but virtualenvs should not be moved.
While folding jobs, we might as well set the environment variables in the main build job as well, as it was setting several already. This also allows us to get rid of the GIT_STRATEGY variable.