### PR TITLE
Bring back `hoc_is_tempobj_arg`

### DIFF
--- a/src/oc/code.cpp
+++ b/src/oc/code.cpp
@@ -876,6 +876,10 @@ int hoc_is_object_arg(int narg) {
     return (type == OBJECTVAR || type == OBJECTTMP);
 }
 
+int hoc_is_tempobj_arg(int narg) {
+    return (hoc_argtype(narg) == OBJECTTMP);
+}
+
 Object* hoc_obj_look_inside_stack(int i) { /* stack pointer at depth i; i=0 is top */
     auto const& entry = get_stack_entry_variant(i);
     return std::visit(

--- a/src/oc/oc_ansi.h
+++ b/src/oc/oc_ansi.h
@@ -63,6 +63,7 @@ void install_vector_method(const char*, double (*)(void*));
 int vector_arg_px(int i, double** p);
 
 double hoc_Exp(double);
+int hoc_is_tempobj_arg(int narg);
 std::FILE* hoc_obj_file_arg(int i);
 void hoc_reg_nmodl_text(int type, const char* txt);
 void hoc_reg_nmodl_filename(int type, const char* filename);

--- a/test/unit_tests/oc/hoc_interpreter.cpp
+++ b/test/unit_tests/oc/hoc_interpreter.cpp
@@ -4,7 +4,7 @@
 #include <ocfunc.h>
 #include <code.h>
 
-TEST_CASE("Test hoc interpreter", "[Neuron][hoc_interpreter]") {
+TEST_CASE("Test hoc interpreter", "[NEURON][hoc_interpreter]") {
     hoc_init_space();
     hoc_pushx(4.0);
     hoc_pushx(5.0);
@@ -12,7 +12,24 @@ TEST_CASE("Test hoc interpreter", "[Neuron][hoc_interpreter]") {
     REQUIRE(hoc_xpop() == 9.0);
 }
 
-SCENARIO("Test small HOC functions", "[NEURON][hoc_interpreter]") {
+constexpr static auto check_tempobj_canary = 0xDEADBEEF;
+
+static void istmpobj() {
+    auto _listmpobj = hoc_is_tempobj_arg(1) ? check_tempobj_canary : 0;
+    hoc_retpushx(_listmpobj);
+}
+
+static VoidFunc hoc_intfunc[] = {{"istmpobj", istmpobj}, {0, 0}};
+
+
+TEST_CASE("Test hoc_register_var", "[NEURON][hoc_interpreter][istmpobj]") {
+    hoc_register_var(nullptr, nullptr, hoc_intfunc);
+    REQUIRE(hoc_lookup("istmpobj") != nullptr);
+    hoc_pushobj(hoc_temp_objptr(nullptr));
+    REQUIRE(hoc_call_func(hoc_lookup("istmpobj"), 1) == check_tempobj_canary);
+}
+
+SCENARIO("Test for issue #1995", "[NEURON][hoc_interpreter][issue-1995]") {
     // This is targeting AddressSanitizer errors that were seen in #1995
     GIVEN("Test calling a function that returns an Object that lived on the stack") {
         constexpr auto vector_size = 5;


### PR DESCRIPTION
This code was removed via #2072 cleanup. It is used in several ModeldDB NEURON models. Added a unit test since it's not used in the codebase.