### PR TITLE
Exclude additional libnrniv shipped with neurondemo as part of wheels

### DIFF
--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -115,10 +115,15 @@ build_wheel_linux() {
         echo " - Auditwheel show"
         auditwheel show dist/*.whl
         echo " - Repairing..."
-	# TODO: still need work to make sure this robust and usable
-	# currently this will break when coreneuron is used and when
-	# dev environment is not installed.
-        auditwheel repair dist/*.whl --exclude "libgomp.so.1"
+        # NOTE:
+        #   libgomp:  still need work to make sure this robust and usable
+        #             currently this will break when coreneuron is used and when
+        #             dev environment is not installed. Note that on aarch64 we have
+        #             seen issue with libgomp.so and hence we started excluding it.
+        #   libnrniv: we ship precompiled version of neurondemo containing libnrnmech.so
+        #             which is linked to libnrniv.so. auditwheel manipulate rpaths and
+        #             ships an extra copy of libnrniv.so and hence exclude it here.
+        auditwheel -v repair dist/*.whl --exclude "libgomp.so.1" --exclude "libnrniv.so"
     fi
 
     deactivate


### PR DESCRIPTION
 - since v7.8.2 we ship precompiled neurondemo containing libnrnmech.so which links to libnrniv.so. The change was done in 10a58a80e63220b4e6f and c02aaf37bf44799425
 - hence, auditwheel wraps libnrniv.so along with wheel and we end up in two copied of libnrniv.so
 - to avoid this, use --exclude option of auditwheel. As libnrniv.so is always shipped with neuron and available under lib directory, neurondemo works fine.