### PR TITLE
Use SETUPTOOLS_USE_DISTUTILS=stdlib for newer setuptools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
                 -e NRN_RELEASE_UPLOAD \
                 -e NEURON_WHEEL_VERSION \
                 -e NRN_BUILD_FOR_UPLOAD=1 \
+                -e SETUPTOOLS_USE_DISTUTILS=stdlib \
                 'neuronsimulator/neuron_wheel:latest-gcc9-aarch64' \
                 packaging/python/build_wheels.bash linux << parameters.NRN_PYTHON_VERSION >> coreneuron
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,6 +69,7 @@ stages:
             -e NRN_RELEASE_UPLOAD \
             -e NEURON_WHEEL_VERSION \
             -e NRN_BUILD_FOR_UPLOAD=1 \
+            -e SETUPTOOLS_USE_DISTUTILS=stdlib \
             'neuronsimulator/neuron_wheel:latest-gcc9-x86_64' \
             packaging/python/build_wheels.bash linux $(python.version) coreneuron
         displayName: 'Building ManyLinux Wheel'


### PR DESCRIPTION
 * removal of distutils.log.Log from setuptools breaks building packages like numpy. See https://github.com/pypa/setuptools/issues/3693
 * we have used SETUPTOOLS_USE_DISTUTILS alternative already in #1924
 * update circle-ci and azure pipelines similarly


- [x] [Check CircleCI build](https://app.circleci.com/pipelines/github/neuronsimulator/nrn/2684/workflows/3ef122bb-bf78-4dd8-a07e-078a26093fc2) before merging