### PR TITLE
Separate benchmarks from unit tests 

### DIFF
--- a/src/oc/ocfunc.h
+++ b/src/oc/ocfunc.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "nrnfilewrap.h"
 
+#include <cstddef>
+
 extern double hoc_Log(double), hoc_Log10(double), hoc1_Exp(double), hoc_Sqrt(double),
     hoc_integer(double);
 extern double hoc_Pow(double, double);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,17 +12,22 @@ include(NeuronTestHelper)
 # =============================================================================
 # Test executables
 # =============================================================================
-add_executable(testneuron unit_tests/unit_test.cpp unit_tests/oc/hoc_interpreter.cpp
-                          unit_tests/threads/test_multicore.cpp)
-cpp_cc_configure_sanitizers(TARGET testneuron)
-target_compile_features(testneuron PUBLIC cxx_std_11)
-target_link_libraries(testneuron Catch2::Catch2 nrniv_lib)
-if(NRN_ENABLE_THREADS)
-  target_link_libraries(testneuron Threads::Threads)
+add_executable(testneuron common/catch2_main.cpp unit_tests/basic.cpp
+                          unit_tests/oc/hoc_interpreter.cpp)
+set(catch2_targets testneuron)
+# Benchmarks are known to be slow if you turn off optimisation...
+if(NRN_ENABLE_THREADS AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+  add_executable(nrn-benchmarks common/catch2_main.cpp benchmarks/threads/test_multicore.cpp)
+  target_link_libraries(nrn-benchmarks Threads::Threads)
+  list(APPEND catch2_targets nrn-benchmarks)
 endif()
-if(NOT MINGW)
-  target_link_libraries(testneuron ${CMAKE_DL_LIBS})
-endif()
+foreach(target ${catch2_targets})
+  cpp_cc_configure_sanitizers(TARGET ${target})
+  target_link_libraries(${target} Catch2::Catch2 nrniv_lib)
+  if(NOT MINGW)
+    target_link_libraries(${target} ${CMAKE_DL_LIBS})
+  endif()
+endforeach()
 
 # =============================================================================
 # Copy necessary hoc files to build directory if they have not been copied yet
@@ -42,9 +47,14 @@ nrn_add_test_group(NAME unit_tests MODFILE_PATTERNS NONE)
 nrn_add_test(
   GROUP unit_tests
   NAME testneuron
-  PROCESSORS 16
-  COMMAND $<TARGET_FILE:testneuron> --processors=16)
-
+  COMMAND $<TARGET_FILE:testneuron>)
+if(TARGET nrn-benchmarks)
+  nrn_add_test(
+    GROUP unit_tests
+    NAME benchmarks
+    PROCESSORS 16
+    COMMAND $<TARGET_FILE:nrn-benchmarks> --processors=16)
+endif()
 # =============================================================================
 # Add ringtest
 # =============================================================================

--- a/test/benchmarks/threads/test_multicore.cpp
+++ b/test/benchmarks/threads/test_multicore.cpp
@@ -1,16 +1,16 @@
+#include "test_multicore.h"
+
+#include "code.h"
+#include "hocdec.h"
+#include "multicore.h"
+#include "nrn_ansi.h"
+#include "ocfunc.h"
+
 #include <catch2/catch.hpp>
 
-#include <hocdec.h>
-#include <ocfunc.h>
-#include <code.h>
-#include <thread>
 #include <algorithm>
+#include <iostream>
 #include <vector>
-#include "../unit_test.h"
-
-#ifdef NRN_ENABLE_THREADS
-#include <multicore.h>
-#include <nrn_ansi.h>
 
 extern int use_cachevec;
 
@@ -241,4 +241,3 @@ TEST_CASE("Multicore unit and performance testing", "[NEURON][multicore]") {
         }
     }
 }
-#endif  // NRN_ENABLE_THREADS

--- a/test/benchmarks/threads/test_multicore.h
+++ b/test/benchmarks/threads/test_multicore.h
@@ -1,6 +1,8 @@
 #pragma once
-#include <iostream>
-
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <vector>
 
 namespace nrn::test {
 extern int MAX_PROCESSORS;

--- a/test/common/catch2_main.cpp
+++ b/test/common/catch2_main.cpp
@@ -1,0 +1,68 @@
+#define CATCH_CONFIG_RUNNER
+
+#include <catch2/catch.hpp>
+
+#include <ocfunc.h>
+#include <code.h>
+#include <section.h>
+#include <neuron.h>
+
+#include <nrnmpi.h>
+
+extern int ivocmain_session(int, const char**, const char**, int);
+
+extern int nrn_main_launch;
+extern int nrn_nobanner_;
+
+/// Needed for compilation
+extern "C" void modl_reg() {}
+extern int nrn_nthread;
+extern NrnThread* nrn_threads;
+#if NRNMPI_DYNAMICLOAD
+extern void nrnmpi_stubs();
+#endif
+
+extern int nrn_how_many_processors();
+namespace nrn::test {
+int PROCESSORS{0};
+int MAX_PROCESSORS{nrn_how_many_processors()};
+}  // namespace nrn::test
+
+int main(int argc, char* argv[]) {
+    // global setup...
+    nrn_main_launch = 2;
+    int argc_nompi = 2;
+    const char* argv_nompi[] = {"NEURON", "-nogui", nullptr};
+    nrn_nobanner_ = 1;
+
+#if NRNMPI
+    if (!nrnmpi_use) {
+#if NRNMPI_DYNAMICLOAD
+        nrnmpi_stubs();
+#endif
+    }
+#endif
+
+    Catch::Session session{};
+
+    using namespace Catch::clara;
+    auto cli = session.cli() |
+               Opt(nrn::test::PROCESSORS, "number of PROCESSORS to consider")["--processors"](
+                   "How many processors are available for perf tests");
+
+    session.cli(cli);
+
+    int returnCode = session.applyCommandLine(argc, argv);
+    if (returnCode != 0)  // Indicates a command line error
+        return returnCode;
+
+    if (nrn::test::PROCESSORS > 0) {
+        std::cout << "[cli][input] --processors=" << nrn::test::PROCESSORS << std::endl;
+        nrn::test::MAX_PROCESSORS = std::min(nrn::test::PROCESSORS, nrn_how_many_processors());
+    }
+    std::cout << "MAX_PROCESSORS=" << nrn::test::MAX_PROCESSORS << std::endl;
+
+    ivocmain_session(argc_nompi, argv_nompi, nullptr, 0);
+#undef run
+    return session.run();
+}

--- a/test/common/catch2_main.cpp
+++ b/test/common/catch2_main.cpp
@@ -1,25 +1,21 @@
+// Has to be included early to stop NEURON's macros wreaking havoc
 #define CATCH_CONFIG_RUNNER
-
 #include <catch2/catch.hpp>
 
-#include <ocfunc.h>
-#include <code.h>
-#include <section.h>
-#include <neuron.h>
+#include "code.h"
+#include "neuron.h"
+#include "nrnmpi.h"
+#include "ocfunc.h"
+#include "section.h"
 
-#include <nrnmpi.h>
-
-extern int ivocmain_session(int, const char**, const char**, int);
-
+int ivocmain_session(int, const char**, const char**, int);
 extern int nrn_main_launch;
 extern int nrn_nobanner_;
 
 /// Needed for compilation
 extern "C" void modl_reg() {}
-extern int nrn_nthread;
-extern NrnThread* nrn_threads;
 #if NRNMPI_DYNAMICLOAD
-extern void nrnmpi_stubs();
+void nrnmpi_stubs();
 #endif
 
 extern int nrn_how_many_processors();
@@ -35,11 +31,9 @@ int main(int argc, char* argv[]) {
     const char* argv_nompi[] = {"NEURON", "-nogui", nullptr};
     nrn_nobanner_ = 1;
 
-#if NRNMPI
+#if NRNMPI && NRNMPI_DYNAMICLOAD
     if (!nrnmpi_use) {
-#if NRNMPI_DYNAMICLOAD
         nrnmpi_stubs();
-#endif
     }
 #endif
 

--- a/test/unit_tests/basic.cpp
+++ b/test/unit_tests/basic.cpp
@@ -1,78 +1,9 @@
-#define CATCH_CONFIG_RUNNER
+#include "code.h"
+#include "neuron.h"
+#include "ocfunc.h"
+#include "section.h"
 
 #include <catch2/catch.hpp>
-
-#include <ocfunc.h>
-#include <code.h>
-#include <section.h>
-#include <neuron.h>
-
-#include <nrnmpi.h>
-
-extern int ivocmain_session(int, const char**, const char**, int);
-
-extern int nrn_main_launch;
-extern int nrn_nobanner_;
-
-/// Needed for compilation
-extern "C" void modl_reg() {}
-extern int nrn_nthread;
-extern NrnThread* nrn_threads;
-#if NRNMPI_DYNAMICLOAD
-extern void nrnmpi_stubs();
-#endif
-
-extern int nrn_use_fast_imem;
-extern int use_cachevec;
-extern int nrn_how_many_processors();
-namespace nrn::test {
-int PROCESSORS{0};
-int MAX_PROCESSORS{nrn_how_many_processors()};
-}  // namespace nrn::test
-
-int main(int argc, char* argv[]) {
-    // global setup...
-    nrn_main_launch = 2;
-    int argc_nompi = 2;
-    const char* argv_nompi[] = {"NEURON", "-nogui", nullptr};
-    nrn_nobanner_ = 1;
-
-#if NRNMPI
-    if (!nrnmpi_use) {
-#if NRNMPI_DYNAMICLOAD
-        nrnmpi_stubs();
-#endif
-    }
-#endif
-
-    Catch::Session session;
-
-    using namespace Catch::clara;
-    auto cli = session.cli() |
-               Opt(nrn::test::PROCESSORS, "number of PROCESSORS to consider")["--processors"](
-                   "How many processors are available for perf tests");
-
-    session.cli(cli);
-
-    int returnCode = session.applyCommandLine(argc, argv);
-    if (returnCode != 0)  // Indicates a command line error
-        return returnCode;
-
-    if (nrn::test::PROCESSORS > 0) {
-        std::cout << "[cli][input] --processors=" << nrn::test::PROCESSORS << std::endl;
-        nrn::test::MAX_PROCESSORS = std::min(nrn::test::PROCESSORS, nrn_how_many_processors());
-    }
-    std::cout << "MAX_PROCESSORS=" << nrn::test::MAX_PROCESSORS << std::endl;
-
-    ivocmain_session(argc_nompi, argv_nompi, NULL, 0);
-#undef run
-    int result = session.run();
-#define run hoc_run
-    // global clean-up...
-
-    return result;
-}
-
 
 SCENARIO("Test fast_imem calculation", "[Neuron][fast_imem]") {
     GIVEN("A section") {


### PR DESCRIPTION
- https://github.com/neuronsimulator/nrn/pull/1993 added some tests checking that settings like the number of threads and the cache efficiency mode have the expected effect
- These tests were added to the same `testneuron` binary that held the unit tests
- One had to manually use Catch2's command line arguments if you wanted to have unit tests without benchmarks, or vice versa
- The tests are prone to failing in the CI due to contention and the use of -O0 builds

This PR reorganises the Catch2 boilerplate so it can be reused and uses it to build `testneuron` (with unit tests) and, if threading is enabled and the build type is not Debug, `nrn-benchmarks` with the benchmarks.

For now, `ctest` executes `nrn-benchmarks` if it exists (i.e. not in debug builds, not if threading is disabled)