### PR TITLE
Do not #define assign

### DIFF
--- a/src/ivoc/checkpnt.cpp
+++ b/src/ivoc/checkpnt.cpp
@@ -119,7 +119,7 @@ static struct HocInst {
                  {hoc_div, 0},
                  {negate, 0},
                  {power, 0},
-                 {assign, 0},
+                 {hoc_assign, nullptr},
                  {bltin, "s"},    // requires change
                  {varpush, "s"},  // 10
                  {constpush, "s"},

--- a/src/oc/code.h
+++ b/src/oc/code.h
@@ -9,7 +9,8 @@ extern void edit(void);
 extern void eval(void);
 extern void add(void), hoc_sub(void), mul(void), hoc_div(void), hoc_cyclic(void), negate(void),
     power(void);
-extern void assign(void), bltin(void), varpush(void), constpush(void), print(void), varread(void);
+void hoc_assign();
+extern void bltin(void), varpush(void), constpush(void), print(void), varread(void);
 extern void prexpr(void), prstr(void), assstr(void), pushzero(void);
 extern void hoc_chk_sym_has_ndim(), hoc_chk_sym_has_ndim1(), hoc_chk_sym_has_ndim2();
 extern void gt(void), lt(void), eq(void), ge(void), le(void), ne(void), hoc_and(void), hoc_or(void),

--- a/src/oc/debug.cpp
+++ b/src/oc/debug.cpp
@@ -34,7 +34,7 @@ void debugzz(Inst* p) {
         prcod(hoc_div, "DIV\n");
         prcod(negate, "NEGATE\n");
         prcod(power, "POWER\n");
-        prcod(assign, "ASSIGN\n");
+        prcod(hoc_assign, "ASSIGN\n");
         prcod(bltin, "BLTIN\n");
         prcod(varpush, "VARPUSH\n");
         prcod(constpush, "CONSTPUSH\n");

--- a/src/oc/parse.ypp
+++ b/src/oc/parse.ypp
@@ -176,7 +176,7 @@ goto yynewstate;
 asgn:	varname ROP expr
 		{Symbol *s; TPD; s = spop();
 		hoc_obvar_declare(s, VAR, 1);
-		code3(varpush, s, assign); codei($2); PN;}
+		code3(varpush, s, hoc_assign); codei($2); PN;}
 	| ARG ROP expr
 		{  TPD; defnonly("$"); argcode(argassign, $1); codei($2); $$=$3; PN;}
 	| ARGREF argrefdim ROP expr

--- a/src/oc/redef.h
+++ b/src/oc/redef.h
@@ -27,7 +27,6 @@
 #define araypt             hoc_araypt
 #define arg                hoc_arg
 #define argassign          hoc_argassign
-#define assign             hoc_assign
 #define assstr             hoc_assstr
 #define bltin              hoc_bltin
 #define call               hoc_call


### PR DESCRIPTION
This clashes with member functions of standard library types (https://en.cppreference.com/w/cpp/container/vector/assign for a random example) and requires that includes are ordered carefully.