### PR TITLE
Do not #define eq, lt, arg and negate.

### DIFF
--- a/src/ivoc/checkpnt.cpp
+++ b/src/ivoc/checkpnt.cpp
@@ -117,7 +117,7 @@ static struct HocInst {
                  {hoc_sub, 0},
                  {mul, 0},
                  {hoc_div, 0},
-                 {negate, 0},
+                 {hoc_negate, nullptr},
                  {power, 0},
                  {hoc_assign, nullptr},
                  {bltin, "s"},    // requires change

--- a/src/ivoc/checkpnt.cpp
+++ b/src/ivoc/checkpnt.cpp
@@ -130,7 +130,7 @@ static struct HocInst {
                  {prstr, 0},
                  {gt, 0},
                  {lt, 0},
-                 {eq, 0},  // 20
+                 {hoc_eq, nullptr},  // 20
                  {ge, 0},
                  {le, 0},
                  {ne, 0},

--- a/src/ivoc/checkpnt.cpp
+++ b/src/ivoc/checkpnt.cpp
@@ -141,7 +141,7 @@ static struct HocInst {
                  {forcode, "iii"},
                  {shortfor, "ii"},
                  {call, "si"},  // 30
-                 {arg, "i"},
+                 {hoc_arg, "i"},
                  {argassign, "i"},
                  {funcret, 0},
                  {procret, 0},

--- a/src/ivoc/checkpnt.cpp
+++ b/src/ivoc/checkpnt.cpp
@@ -129,7 +129,7 @@ static struct HocInst {
                  {prexpr, 0},
                  {prstr, 0},
                  {gt, 0},
-                 {lt, 0},
+                 {hoc_lt, nullptr},
                  {hoc_eq, nullptr},  // 20
                  {ge, 0},
                  {le, 0},

--- a/src/oc/code.cpp
+++ b/src/oc/code.cpp
@@ -2070,7 +2070,7 @@ void gt(void) {
     hoc_pushx(d1);
 }
 
-void lt(void) {
+void hoc_lt() {
     double d1, d2;
     d2 = hoc_xpop();
     d1 = hoc_xpop();

--- a/src/oc/code.cpp
+++ b/src/oc/code.cpp
@@ -2054,10 +2054,9 @@ void hoc_cyclic(void) /* the modulus function */
     hoc_pushx(r);
 }
 
-void negate(void) /* negate top element on stack */
-{
-    double d;
-    d = hoc_xpop();
+// negate top element on stack
+void hoc_negate() {
+    double const d = hoc_xpop();
     hoc_pushx(-d);
 }
 

--- a/src/oc/code.cpp
+++ b/src/oc/code.cpp
@@ -1655,14 +1655,13 @@ int hoc_argindex(void) {
     return j;
 }
 
-void arg(void) /* push argument onto stack */
-{
-    int i;
-    i = (pc++)->i;
+// push argument onto stack
+void hoc_arg() {
+    int i = (pc++)->i;
     if (i == 0) {
         i = hoc_argindex();
     }
-    hoc_pushx(*getarg(i));
+    hoc_pushx(*hoc_getarg(i));
 }
 
 void hoc_stringarg(void) /* push string arg onto stack */

--- a/src/oc/code.h
+++ b/src/oc/code.h
@@ -16,7 +16,8 @@ extern void hoc_chk_sym_has_ndim(), hoc_chk_sym_has_ndim1(), hoc_chk_sym_has_ndi
 void hoc_eq();
 void hoc_lt();
 extern void gt(void), ge(void), le(void), ne(void), hoc_and(void), hoc_or(void), hoc_not(void);
-extern void ifcode(void), forcode(void), shortfor(void), call(void), arg(void), argassign(void);
+void hoc_arg();
+extern void ifcode(void), forcode(void), shortfor(void), call(void), argassign(void);
 extern void hoc_argrefasgn(void), hoc_argref(void), hoc_iterator(void), hoc_iterator_stmt(void);
 extern void funcret(void), procret(void), Break(void), Continue(void), Stop(void);
 extern void debug(void), hoc_evalpointer(void);

--- a/src/oc/code.h
+++ b/src/oc/code.h
@@ -13,7 +13,8 @@ void hoc_assign();
 extern void bltin(void), varpush(void), constpush(void), print(void), varread(void);
 extern void prexpr(void), prstr(void), assstr(void), pushzero(void);
 extern void hoc_chk_sym_has_ndim(), hoc_chk_sym_has_ndim1(), hoc_chk_sym_has_ndim2();
-extern void gt(void), lt(void), eq(void), ge(void), le(void), ne(void), hoc_and(void), hoc_or(void),
+void hoc_eq();
+extern void gt(void), lt(void), ge(void), le(void), ne(void), hoc_and(void), hoc_or(void),
     hoc_not(void);
 extern void ifcode(void), forcode(void), shortfor(void), call(void), arg(void), argassign(void);
 extern void hoc_argrefasgn(void), hoc_argref(void), hoc_iterator(void), hoc_iterator_stmt(void);

--- a/src/oc/code.h
+++ b/src/oc/code.h
@@ -7,8 +7,8 @@ extern void nopop(void);
 extern void edit(void);
 
 extern void eval(void);
-extern void add(void), hoc_sub(void), mul(void), hoc_div(void), hoc_cyclic(void), negate(void),
-    power(void);
+void hoc_negate();
+extern void add(void), hoc_sub(void), mul(void), hoc_div(void), hoc_cyclic(void), power(void);
 void hoc_assign();
 extern void bltin(void), varpush(void), constpush(void), print(void), varread(void);
 extern void prexpr(void), prstr(void), assstr(void), pushzero(void);

--- a/src/oc/code.h
+++ b/src/oc/code.h
@@ -14,8 +14,8 @@ extern void bltin(void), varpush(void), constpush(void), print(void), varread(vo
 extern void prexpr(void), prstr(void), assstr(void), pushzero(void);
 extern void hoc_chk_sym_has_ndim(), hoc_chk_sym_has_ndim1(), hoc_chk_sym_has_ndim2();
 void hoc_eq();
-extern void gt(void), lt(void), ge(void), le(void), ne(void), hoc_and(void), hoc_or(void),
-    hoc_not(void);
+void hoc_lt();
+extern void gt(void), ge(void), le(void), ne(void), hoc_and(void), hoc_or(void), hoc_not(void);
 extern void ifcode(void), forcode(void), shortfor(void), call(void), arg(void), argassign(void);
 extern void hoc_argrefasgn(void), hoc_argref(void), hoc_iterator(void), hoc_iterator_stmt(void);
 extern void funcret(void), procret(void), Break(void), Continue(void), Stop(void);

--- a/src/oc/debug.cpp
+++ b/src/oc/debug.cpp
@@ -32,7 +32,7 @@ void debugzz(Inst* p) {
         prcod(hoc_sub, "SUB\n");
         prcod(mul, "MUL\n");
         prcod(hoc_div, "DIV\n");
-        prcod(negate, "NEGATE\n");
+        prcod(hoc_negate, "NEGATE\n");
         prcod(power, "POWER\n");
         prcod(hoc_assign, "ASSIGN\n");
         prcod(bltin, "BLTIN\n");

--- a/src/oc/debug.cpp
+++ b/src/oc/debug.cpp
@@ -45,7 +45,7 @@ void debugzz(Inst* p) {
         prcod(prstr, "PRSTR\n");
         prcod(gt, "GT\n");
         prcod(lt, "LT\n");
-        prcod(eq, "EQ\n");
+        prcod(hoc_eq, "EQ\n");
         prcod(ge, "GE\n");
         prcod(le, "LE\n");
         prcod(ne, "NE\n");

--- a/src/oc/debug.cpp
+++ b/src/oc/debug.cpp
@@ -56,7 +56,7 @@ void debugzz(Inst* p) {
         prcod(forcode, "FORCODE\n");
         prcod(shortfor, "SHORTFOR\n");
         prcod(call, "CALL\n");
-        prcod(arg, "ARG\n");
+        prcod(hoc_arg, "ARG\n");
         prcod(argassign, "ARGASSIGN\n");
         prcod(funcret, "FUNCRET\n");
         prcod(procret, "PROCRET\n");

--- a/src/oc/debug.cpp
+++ b/src/oc/debug.cpp
@@ -44,7 +44,7 @@ void debugzz(Inst* p) {
         prcod(prexpr, "PREXPR\n");
         prcod(prstr, "PRSTR\n");
         prcod(gt, "GT\n");
-        prcod(lt, "LT\n");
+        prcod(hoc_lt, "LT\n");
         prcod(hoc_eq, "EQ\n");
         prcod(ge, "GE\n");
         prcod(le, "LE\n");

--- a/src/oc/parse.ypp
+++ b/src/oc/parse.ypp
@@ -698,7 +698,7 @@ expr:	NUMBER
 	| expr '^' expr
 		{ TPD; TPD; code(power); PN;}
 	| '-' expr %prec UNARYMINUS
-		{ TPD; $$ = $2; code(negate); PN;}
+		{ TPD; $$ = $2; code(hoc_negate); PN;}
 	| expr GT expr
 		{ TPD; TPD; code(gt); PN;}
 	| expr GE expr

--- a/src/oc/parse.ypp
+++ b/src/oc/parse.ypp
@@ -708,7 +708,7 @@ expr:	NUMBER
 	| expr LE expr
 		{ TPD; TPD; code(le); PN;}
 	| expr EQ expr
-		{ hoc_ob_check(-1); hoc_ob_check(-1); code(eq); PN;}
+		{ hoc_ob_check(-1); hoc_ob_check(-1); code(hoc_eq); PN;}
 	| expr NE expr
 		{ hoc_ob_check(-1); hoc_ob_check(-1); code(ne); PN;}
 	| expr AND expr

--- a/src/oc/parse.ypp
+++ b/src/oc/parse.ypp
@@ -659,7 +659,7 @@ expr:	NUMBER
 	| varname
 		{ code3(varpush, spop(), eval); PN;}
 	| ARG
-		{ defnonly("$"); $$ = argcode(arg, $1); PN;}
+		{ defnonly("$"); $$ = argcode(hoc_arg, $1); PN;}
 	| ARGREF argrefdim
 		{ defnonly("$&"); $$ = argrefcode(hoc_argref, $1, $2); PN;}
 /* NEWCABLE */

--- a/src/oc/parse.ypp
+++ b/src/oc/parse.ypp
@@ -704,7 +704,7 @@ expr:	NUMBER
 	| expr GE expr
 		{ TPD; TPD; code(ge); PN;}
 	| expr LT expr
-		{ TPD; TPD; code(lt); PN;}
+		{ TPD; TPD; code(hoc_lt); PN;}
 	| expr LE expr
 		{ TPD; TPD; code(le); PN;}
 	| expr EQ expr

--- a/src/oc/redef.h
+++ b/src/oc/redef.h
@@ -85,7 +85,6 @@
 #define le                 hoc_le
 #define lineno             hoc_lineno
 #define lookup             hoc_lookup
-#define lt                 hoc_lt
 #define mul                hoc_mul
 #define ne                 hoc_ne
 #define negate             hoc_negate

--- a/src/oc/redef.h
+++ b/src/oc/redef.h
@@ -86,7 +86,6 @@
 #define lookup             hoc_lookup
 #define mul                hoc_mul
 #define ne                 hoc_ne
-#define negate             hoc_negate
 #define onintr             hoc_onintr
 #define p_symlist          hoc_p_symlist
 #define parserror          hoc_parserror

--- a/src/oc/redef.h
+++ b/src/oc/redef.h
@@ -44,7 +44,6 @@
 #define defnonly           hoc_defnonly
 #define dep_make           hoc_dep_make
 #define do_equation        hoc_do_equation
-#define eq                 hoc_eq
 #define eqinit             hoc_eqinit
 #define eqn_init           hoc_eqn_init
 #define eqn_lhs            hoc_eqn_lhs

--- a/src/oc/redef.h
+++ b/src/oc/redef.h
@@ -25,7 +25,6 @@
 #define arayinstal         hoc_arayinstal
 #define free_arrayinfo     hoc_free_arrayinfo
 #define araypt             hoc_araypt
-#define arg                hoc_arg
 #define argassign          hoc_argassign
 #define assstr             hoc_assstr
 #define bltin              hoc_bltin


### PR DESCRIPTION
Aim to make NEURON more robust against the order in which its headers are included.