### PR TITLE
Fix bug on Intel with R("")

### DIFF
--- a/test/unit_tests/oc/hoc_interpreter.cpp
+++ b/test/unit_tests/oc/hoc_interpreter.cpp
@@ -54,12 +54,10 @@ SCENARIO("Test for issue #1995", "[NEURON][hoc_interpreter][issue-1995]") {
 }
 #if USE_PYTHON
 TEST_CASE("Test hoc_array_access", "[NEURON][hoc_interpreter][nrnpython][array_access]") {
-    const auto hoc_command =
-        "nrnpython(\"avec = [0,1,2]\")\n"
-        "objref po\n"
-        "po = new PythonObject()\n"
-        "po = po.avec)";
-    REQUIRE(hoc_oc(hoc_command) == 0);
+    REQUIRE(hoc_oc("nrnpython(\"avec = [0,1,2]\")\n"
+                   "objref po\n"
+                   "po = new PythonObject()\n"
+                   "po = po.avec\n") == 0);
     THEN("The avec can value should be correct") {
         auto const i = GENERATE_COPY(range(0, 3));
         REQUIRE(hoc_oc(("hoc_ac_ = po._[" + std::to_string(i) + "]\n").c_str()) == 0);

--- a/test/unit_tests/oc/hoc_interpreter.cpp
+++ b/test/unit_tests/oc/hoc_interpreter.cpp
@@ -54,10 +54,12 @@ SCENARIO("Test for issue #1995", "[NEURON][hoc_interpreter][issue-1995]") {
 }
 #if USE_PYTHON
 TEST_CASE("Test hoc_array_access", "[NEURON][hoc_interpreter][nrnpython][array_access]") {
-    REQUIRE(hoc_oc(R"(nrnpython("avec = [0,1,2]") 
-                    objref po
-                    po = new PythonObject()
-                    po = po.avec)") == 0);
+    const auto hoc_command =
+        "nrnpython(\"avec = [0,1,2]\")\n"
+        "objref po\n"
+        "po = new PythonObject()\n"
+        "po = po.avec)";
+    REQUIRE(hoc_oc(hoc_command) == 0);
     THEN("The avec can value should be correct") {
         auto const i = GENERATE_COPY(range(0, 3));
         REQUIRE(hoc_oc(("hoc_ac_ = po._[" + std::to_string(i) + "]\n").c_str()) == 0);


### PR DESCRIPTION
The Intel classic compiler does not appear to parse `foo = R"(...)";` correctly.