### PR TITLE
CMake not used for user configuration of formatting.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -697,6 +697,7 @@ if(NRN_ENABLE_DOCS)
     sphinx
     COMMAND ${NRN_DOCS_COMMAND_PREFIX} ${SPHINX_EXECUTABLE} -j auto -b html
             "${PROJECT_SOURCE_DIR}/docs" "${PROJECT_SOURCE_DIR}/docs/_build"
+    COMMAND echo "Copy/Paste to Browser ${PROJECT_SOURCE_DIR}/docs/_build/index.html"
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/docs
     COMMENT "Generating documentation with Sphinx")
 
@@ -721,11 +722,29 @@ if(NRN_ENABLE_DOCS)
 endif()
 
 # =============================================================================
-# Add coding-conventions submodule if code formatting enabled
+# Black, Clang-format, Cmake-format (see $PROJECT_SOURCE_DIR/.bbp-project.yaml)
 # =============================================================================
-if(NRN_CMAKE_FORMAT OR NRN_CLANG_FORMAT)
-  add_subdirectory(external/coding-conventions/cpp)
-endif()
+add_custom_target(
+  format
+  COMMAND ${PROJECT_SOURCE_DIR}/external/coding-conventions/bin/format
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+
+# Prepare a shell script to format only files modified with respect to master branch
+file(
+  WRITE ${CMAKE_CURRENT_BINARY_DIR}/format-pr.sh
+  "\
+#!bash\n\
+set -e\n\
+cmd='cd ${PROJECT_SOURCE_DIR} && external/coding-conventions/bin/format `git diff --name-only master`'\n\
+echo $cmd\n\
+cd ${PROJECT_SOURCE_DIR} && external/coding-conventions/bin/format `git diff --name-only master`\n\
+")
+
+add_custom_target(
+  format-pr
+  COMMAND bash ${CMAKE_CURRENT_BINARY_DIR}/format-pr.sh
+  COMMENT "Format only files modified with respect to master branch."
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 # =============================================================================
 # ~~~

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,18 +106,18 @@ brew install clang-format # or your favorite package manager
 ```
 Now you should have the `clang-format` and `cmake-format` commands available.
 
-* Use `-DNRN_CMAKE_FORMAT=ON` option of CMake to enable CMake code formatting targets:
+* CMake automatically creates the formatting targets ``format`` and ``format-pr``
+
+The former, formats all cmake, c++, and python files. The latter
+(usually much faster) formats
+only those files that differ from the master (``git diff --name-only master``).
 
 ```
-cmake .. -DPYTHON_EXECUTABLE=`which python3.7` -DNRN_CMAKE_FORMAT=ON
-```
-
-With this, new target called **cmake-format** can be used to automatically format all CMake files:
-
-```
-$ make cmake-format
-Scanning dependencies of target cmake-format
-Built target cmake-format
+$ make format-pr
+Format only files modified with respect to master branch.
+/home/hines/neuron/nrn
+/home/hines/neuron/format/external/coding-conventions/bin/format CMakeLists.txt
+Built target format-pr
 ```
 
 You can now use `git diff` to see how cmake-format has formatted existing CMake files.
@@ -142,24 +142,7 @@ Or,
 
 See [cmake-format](https://github.com/cheshirekow/cmake_format) documentation for details.
 
-* For `clang-format` you should restrict formatting to only the code parts relevant to your change.
-  This can be eachieved by setting following build options:
-
-```
-cmake .. -DNRN_CLANG_FORMAT=ON \
-    -DNRN_CMAKE_FORMAT=ON \
-    -DNRN_FORMATTING_ON="since-ref:master" \
-    -DNRN_FORMATTING_CPP_CHANGES_ONLY=ON
-```
-
-Note: Sometimes it might be necessary to point your build-system to the clang-format-diff utility,
-this can be done by supplying an additional flag:
-`-DClangFormatDiff_EXECUTABLE=/path/to/share/clang/clang-format-diff.py`
-
-* You can then run the `clang-format` target after a full build:
-
-```
-make && make clang-format
+make && make format-pr
 ```
 
 ## Python Contributions

--- a/docs/cmake_doc/options.rst
+++ b/docs/cmake_doc/options.rst
@@ -19,6 +19,12 @@ This is often very much faster than a single process make. One can add a number
 after the ``-j`` (e.g. ``make -j 6``) to specify the maximum number of processes
 to use. This can be useful if there is the possibility of running out of memory.
 
+The make targets that are made available by cmake can be listed with
+
+.. code-block:: shell
+
+  make help
+
 You can list CMake options with
 ``cmake .. -LH``
 which runs ``cmake ..`` as above and lists the cache variables along with help
@@ -235,7 +241,7 @@ NRN_ENABLE_MUSIC:BOOL=OFF
     /path/lib/libmusic.so
 
   With the music installed above, cmake configuration example is
-  ``build % cmake .. -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=install -DPYTHON_EXECUTABLE=`which python3.11` -DNRN_ENABLE_RX3D=OFF -DCMAKE_BUILD_TYPE=Debug -DNRN_CLANG_FORMAT=ON -DNRN_ENABLE_TESTS=ON -DNRN_ENABLE_MUSIC=ON -DCMAKE_PREFIX_PATH=$HOME/neuron/MUSIC/musicinstall``
+  ``build % cmake .. -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=install -DPYTHON_EXECUTABLE=`which python3.11` -DNRN_ENABLE_RX3D=OFF -DCMAKE_BUILD_TYPE=Debug -DNRN_ENABLE_TESTS=ON -DNRN_ENABLE_MUSIC=ON -DCMAKE_PREFIX_PATH=$HOME/neuron/MUSIC/musicinstall``
 
 Python options:
 ===============
@@ -320,8 +326,8 @@ NRN_ENABLE_CORENEURON:BOOL=OFF
 ------------------------------
   Enable CoreNEURON support
 
-  If ON and no argument pointing to an external installation, CoreNEURON
-  will be cloned as a submodule along with all its NMODL submodule dependencies.
+  If ON CoreNEURON will be built and any needed NMODL submodule dependencies
+  cloned as external submodules.
 
 NRN_ENABLE_MOD_COMPATIBILITY:BOOL=OFF
 -------------------------------------
@@ -338,21 +344,6 @@ Other CoreNEURON options:
   build that are listed in https://github.com/BlueBrain/CoreNeuron/blob/master/CMakeLists.txt.
   The ones of particular interest that can be used on the NEURON
   CMake configure line are `CORENRN_ENABLE_NMODL` and `CORENRN_ENABLE_GPU`.
-  For developers preparing a pull request that involves associated changes
-  to CoreNEURON sources, a CoreNEURON pull request will fail if the
-  changes are not formatted properly. In this case, note that
-  `CORENRN_CLANG_FORMAT` can only be used in a CoreNEURON specific CMake
-  configure line in external/coreneuron/build.
-
-  .. code-block::
-
-    cd external/coreneuron
-    mkdir build
-    cd build
-    cmake .. -DCMAKE_INSTALL_PREFIX=install -DPYTHON_EXECUTABLE=`which python` -DCORENRN_CLANG_FORMAT=ON
-    make clang-format
-
-
 
 Occasionally useful advanced options:
 =====================================
@@ -520,30 +511,6 @@ NRN_COVERAGE_FILES:STRING=
   relative to ``PROJECT_SOURCE_DIR``.
 
   ``-DNRN_COVERAGE_FILES="src/nrniv/partrans.cpp;src/nmodl/parsact.cpp;src/nrnpython/nrnpy_hoc.cpp"``
-
-NRN_CMAKE_FORMAT:BOOL=OFF
-----------------------------
-  Enable CMake code formatting
-
-  Clones the submodule coding-conventions from https://github.com/BlueBrain/hpc-coding-conventions.git.
-  Also need to ``pip install cmake-format=0.6.0 --user``.
-  After a build using ``make`` can reformat cmake files with ``make cmake-format``
-  See nrn/CONTRIBUTING.md for further details.
-  How does one reformat a specific cmake file?
-
-NRN_CLANG_FORMAT:BOOL=OFF
--------------------------
-  Enable code formatting
-
-  Clones the submodule coding-conventions from https://github.com/BlueBrain/hpc-coding-conventions.git.
-  For mac, need: ``brew install clang-format``
-  After a build using ``make``, can reformat all sources with ``make clang_format``
-  Incremental code formatting (of the current patch) can be done by setting additional build flags
-  ``NRN_FORMATTING_ON="since-ref:master"`` and ``NRN_FORMATTING_CPP_CHANGES_ONLY=ON``.
-  ```
-
-  To manually format a single file, run in the top folder, e.g.:
-  ``clang-format --style=file -i src/nrniv/bbsavestate.cpp``
 
 NRN_SANITIZERS:STRING=
 ----------------------

--- a/docs/install/developer.rst
+++ b/docs/install/developer.rst
@@ -11,5 +11,6 @@ Each aspect generally has extra dependencies and special instructions.
    mac_pkg.md
    python_wheels.md
    windows.md
+   formatting.md
    code_coverage.md
    debug.md

--- a/docs/install/formatting.md
+++ b/docs/install/formatting.md
@@ -1,0 +1,49 @@
+# Code Formatting
+
+Pull requests fail if python, c++, and cmake files are not formatted according
+``CONTRIBUTING.md`` policies.  ``make format-pr`` can be used to ensure all
+the files that are a part of the pull request are formatted according to
+those policies.
+
+## Dependencies
+```
+pip install black # format python files
+pip install cmake-format=0.6.13 # format cmake files
+```
+### Linux
+```
+sudo apt install clang-format
+```
+### Mac
+```
+brew install clang-format
+```
+
+## Instructions
+
+Clone the nrn repository and configure with cmake. Cmake will
+automatically clone a subrepository into nrn/external/coding-conventions
+No special cmake formatting options are needed.
+
+```
+make format # formats all cmake, c++, and *.py files.
+
+make format-pr # formats all files that are different from the nrn master branch.
+```
+
+## Behind the scenes
+
+``nrn/.bbp-project.yaml`` specifies the tools used for format python
+files (black), cpp,c,h files (ClangFormat version 12.0.1),
+and cmake files (CMakeFormat version 0.6.13)
+
+``nrn/.clang-format`` specfies our choices for clang format options.
+
+``nrn/.cmake-format.yaml`` specifies our choices for cmake file format options.
+
+``make format-pr`` executes the command
+```
+cd /home/hines/neuron/format && external/coding-conventions/bin/format `git diff --name-only master`
+```
+
+``black`` can be executed from anywhere with folder args or python file args.

--- a/src/coreneuron/README.md
+++ b/src/coreneuron/README.md
@@ -346,18 +346,10 @@ To see all CLI options for CoreNEURON, see `./bin/nrniv-core -h`.
 
 #### Formatting CMake and C++ Code
 
-In order to format code with `cmake-format` and `clang-format` tools, before creating a PR, enable below CMake options:
-
+Format code with `black`, `cmake-format`, and `clang-format` tools, before creating a PR.
+It should suffice within the build folder to ...
 ```
-cmake .. -DCORENRN_CLANG_FORMAT=ON -DCORENRN_CMAKE_FORMAT=ON
-cmake --build . --parallel 8 --target install
-```
-
-and now you can use `cmake-format` or `clang-format` targets:
-
-```
-cmake --build . --target cmake-format
-cmake --build . --target clang-format
+make format-pr
 ```
 
 ## Run CI


### PR DESCRIPTION
  However supply `make format` and `make format-pr`

Closes #2141
