### PR TITLE
CNRN: Bug fix with the checkpointing of VecPlay instances

### DIFF
--- a/src/coreneuron/io/nrn_checkpoint.cpp
+++ b/src/coreneuron/io/nrn_checkpoint.cpp
@@ -505,7 +505,7 @@ void CheckPoints::write_phase2(NrnThread& nt) const {
         Memb_list* ml = nullptr;
         for (NrnThreadMembList* tml = nt.tml; tml; tml = tml->next) {
             ml = tml->ml;
-            int nn = corenrn.get_prop_param_size()[tml->index] * ml->nodecount;
+            int nn = corenrn.get_prop_param_size()[tml->index] * ml->_nodecount_padded;
             if (nn && pr->pd_ >= ml->data && pr->pd_ < (ml->data + nn)) {
                 mtype = tml->index;
                 ix = (pr->pd_ - ml->data);


### PR DESCRIPTION
 - In thalamus simulations with coreneuron (@BBP) we saw following errors with checkpoining: 
 ```
   io/nrn_checkpoint.cpp:515: void coreneuron::CheckPoints::write_phase2(coreneuron::NrnThread &) const: Assertion `mtype >= 0' failed.
 ```
- Looking into model loading and checkpointing code we see that due to padding of mechanism data, the VecPlay can have point to the memory address beyond 
   > ml->data + size_of_mech_instance * num_mech_instance
    i.e. new limits for mechanism data are
   > ml->data + size_of_mech_instance * num_mech_instance_with_padding
- In this PR we fix the checkpointing code with the above calculation