### PR TITLE
Fix docs building

### DIFF
--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx>6.0
 sphinx_rtd_theme
 jupyter
 nbconvert

--- a/docs/domains/hocdomain.py
+++ b/docs/domains/hocdomain.py
@@ -30,7 +30,6 @@ from sphinx import addnodes
 from sphinx.addnodes import desc_signature, pending_xref, pending_xref_condition
 from sphinx.application import Sphinx
 from sphinx.builders import Builder
-from sphinx.deprecation import RemovedInSphinx60Warning
 from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain, Index, IndexEntry, ObjType
 from sphinx.environment import BuildEnvironment
@@ -613,19 +612,7 @@ class HOCObject(ObjectDescription[Tuple[str, str]]):
 
         sig_prefix = self.get_signature_prefix(sig)
         if sig_prefix:
-            if type(sig_prefix) is str:
-                warnings.warn(
-                    "HOC directive method get_signature_prefix()"
-                    " returning a string is deprecated."
-                    " It must now return a list of nodes."
-                    " Return value was '{}'.".format(sig_prefix),
-                    RemovedInSphinx60Warning,
-                )
-                signode += addnodes.desc_annotation(
-                    sig_prefix, "", nodes.Text(sig_prefix)  # type: ignore
-                )  # type: ignore
-            else:
-                signode += addnodes.desc_annotation(str(sig_prefix), "", *sig_prefix)
+            signode += addnodes.desc_annotation(str(sig_prefix), "", *sig_prefix)
 
         if prefix:
             signode += addnodes.desc_addname(prefix, prefix)


### PR DESCRIPTION
`pip install docs/docs_requirements.txt` brings now `sphinx 6.1.3`  where the API has changed and we should remove the `RemovedInSphinx60Warning` since it's no longer available

@alexsavulescu this failed locally but I'm wondering whether this fails in RTD as well