### PR TITLE
NEURON CI: discriminate sanitizer CI names

### DIFF
--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -23,7 +23,7 @@ jobs:
   ci:
     runs-on: ${{ matrix.os }}
 
-    name: ${{ matrix.os }} - ${{ matrix.config.build_mode }} (${{ matrix.config.cmake_option }}${{ matrix.config.config_options }}${{ matrix.config.matrix_eval }})
+    name: ${{ matrix.os }} - ${{ matrix.config.build_mode }} (${{ matrix.config.cmake_option }}${{ matrix.config.config_options }}${{ matrix.config.matrix_eval }}${{ matrix.config.sanitizer }})
 
     timeout-minutes: 45
 


### PR DESCRIPTION
The two Ubuntu sanitizer jobs end up having the same name, therefore required checks may be circumvented.