### PR TITLE
CI: enable optimisations, use master of reporting libraries

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -185,8 +185,16 @@ build:nmodl:
     # avoids more rebuilding when +report is set (which it is by default)
     SPACK_PACKAGE_DEPENDENCIES: ^hpe-mpi%gcc ^hdf5%gcc
 
+.build_neuron_mod2c:
+  extends: [.build_neuron]
+  variables:
+    # libsonata-report and reportinglib parts avoid those libraries being
+    # compiled with intel, nvhpc and gcc in every pipeline; the
+    # hpe-mpi/python/py-setuptools parts try to avoid re-building py-mpi4py
+    SPACK_PACKAGE_DEPENDENCIES: ^libsonata-report%gcc ^reportinglib%gcc ^hpe-mpi%gcc ^python%gcc ^py-setuptools%gcc
+
 build:neuron:mod2c:intel:shared:debug:
-  extends: [.build_neuron, .spack_intel]
+  extends: [.build_neuron_mod2c, .spack_intel]
   variables:
     SPACK_PACKAGE_SPEC: +debug~rx3d~caliper~gpu+coreneuron~legacy-unit~nmodl~openmp+shared+tests~unified build_type=Debug model_tests=channel-benchmark,olfactory,tqperf-heavy
 
@@ -201,7 +209,7 @@ build:neuron:nmodl:intel:shared:debug:
     SPACK_PACKAGE_SPEC: +debug~rx3d~caliper~gpu+coreneuron~legacy-unit+nmodl~openmp+shared+sympy+tests~unified build_type=Debug model_tests=channel-benchmark,olfactory,tqperf-heavy
 
 build:neuron:mod2c:nvhpc:acc:shared:
-  extends: [.build_neuron, .spack_nvhpc]
+  extends: [.build_neuron_mod2c, .spack_nvhpc]
   variables:
     SPACK_PACKAGE_SPEC: +debug~rx3d~caliper+gpu+coreneuron~legacy-unit~nmodl~openmp+shared+tests~unified build_type=RelWithDebInfo model_tests=channel-benchmark,olfactory,tqperf-heavy
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,6 +99,9 @@ mac_m1_cmake_build:
     - fi;
 
 variables:
+  BLUECONFIGS_BRANCH:
+    description: Branch of blueconfigs to trigger the simulation stack pipeline from
+    value: main
   LIBSONATA_REPORT_BRANCH:
     description: Branch of libsonata-report to build BlueBrain models against in the simulation stack pipeline (LIBSONATA_REPORT_COMMIT and LIBSONATA_REPORT_TAG also possible)
     value: master
@@ -118,17 +121,25 @@ variables:
 # Set up Spack
 spack_setup:
   extends: .spack_setup_ccache
+  script:
+    - !reference [.spack_setup_ccache, script]
+    # try and make sure these are propagated to the simulation_stack bridge job and child pipeline
+    - echo "BLUECONFIGS_BRANCH=${BLUECONFIGS_BRANCH}" >> commit-mapping.env
+    - echo "BLUECONFIGS_BRANCH=${BLUECONFIGS_BRANCH}" >> spack_clone_variables.env
   variables:
     NEURON_COMMIT: ${CI_COMMIT_SHA}
     # Enable fetching GitHub PR descriptions and parsing them to find out what
     # branches to build of other projects.
     PARSE_GITHUB_PR_DESCRIPTIONS: "true"
+    # BLUECONFIGS_BRANCH does not correspond to a Spack package called blueconfigs
+    SPACK_SETUP_IGNORE_PACKAGE_VARIABLES: BLUECONFIGS
 
 simulation_stack:
   stage: .pre
   # Take advantage of GitHub PR description parsing in the spack_setup job.
   needs: [spack_setup]
   trigger:
+    branch: $BLUECONFIGS_BRANCH
     project: hpc/sim/blueconfigs
     # NEURON CI status depends on the BlueConfigs CI status.
     strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -156,7 +156,7 @@ simulation_stack:
   variables:
     bb5_duration: "2:00:00"
     SPACK_PACKAGE: neuron
-    SPACK_PACKAGE_SPEC: +coreneuron+debug+tests~legacy-unit~rx3d model_tests=channel-benchmark,olfactory,tqperf-heavy
+    SPACK_PACKAGE_SPEC: +coreneuron+tests~legacy-unit~rx3d build_type=FastDebug model_tests=channel-benchmark,olfactory,tqperf-heavy
 .gpu_node:
   variables:
     bb5_constraint: volta
@@ -193,66 +193,66 @@ build:nmodl:
     # hpe-mpi/python/py-setuptools parts try to avoid re-building py-mpi4py
     SPACK_PACKAGE_DEPENDENCIES: ^libsonata-report%gcc ^reportinglib%gcc ^hpe-mpi%gcc ^python%gcc ^py-setuptools%gcc
 
-build:neuron:mod2c:intel:shared:debug:
+build:neuron:mod2c:intel:shared:
   extends: [.build_neuron_mod2c, .spack_intel]
   variables:
-    SPACK_PACKAGE_SPEC: +debug~rx3d~caliper~gpu+coreneuron~legacy-unit~nmodl~openmp+shared+tests~unified build_type=Debug model_tests=channel-benchmark,olfactory,tqperf-heavy
+    SPACK_PACKAGE_SPEC: ~rx3d~caliper~gpu+coreneuron~legacy-unit~nmodl~openmp+shared+tests~unified build_type=FastDebug model_tests=channel-benchmark,olfactory,tqperf-heavy
 
-build:neuron:nmodl:intel:debug:legacy:
+build:neuron:nmodl:intel:legacy:
   extends: [.build_neuron_nmodl, .spack_intel]
   variables:
-    SPACK_PACKAGE_SPEC: +debug~rx3d~caliper~gpu+coreneuron~legacy-unit+nmodl~openmp~shared~sympy+tests~unified build_type=Debug model_tests=channel-benchmark,olfactory,tqperf-heavy
+    SPACK_PACKAGE_SPEC: ~rx3d~caliper~gpu+coreneuron~legacy-unit+nmodl~openmp~shared~sympy+tests~unified build_type=FastDebug model_tests=channel-benchmark,olfactory,tqperf-heavy
 
-build:neuron:nmodl:intel:shared:debug:
+build:neuron:nmodl:intel:shared:
   extends: [.build_neuron_nmodl, .spack_intel]
   variables:
-    SPACK_PACKAGE_SPEC: +debug~rx3d~caliper~gpu+coreneuron~legacy-unit+nmodl~openmp+shared+sympy+tests~unified build_type=Debug model_tests=channel-benchmark,olfactory,tqperf-heavy
+    SPACK_PACKAGE_SPEC: ~rx3d~caliper~gpu+coreneuron~legacy-unit+nmodl~openmp+shared+sympy+tests~unified build_type=FastDebug model_tests=channel-benchmark,olfactory,tqperf-heavy
 
 build:neuron:mod2c:nvhpc:acc:shared:
   extends: [.build_neuron_mod2c, .spack_nvhpc]
   variables:
-    SPACK_PACKAGE_SPEC: +debug~rx3d~caliper+gpu+coreneuron~legacy-unit~nmodl~openmp+shared+tests~unified build_type=RelWithDebInfo model_tests=channel-benchmark,olfactory,tqperf-heavy
+    SPACK_PACKAGE_SPEC: ~rx3d~caliper+gpu+coreneuron~legacy-unit~nmodl~openmp+shared+tests~unified build_type=FastDebug model_tests=channel-benchmark,olfactory,tqperf-heavy
 
-build:neuron:nmodl:nvhpc:acc:debug:legacy:
+build:neuron:nmodl:nvhpc:acc:legacy:
   extends: [.build_neuron_nmodl, .spack_nvhpc]
   variables:
-    SPACK_PACKAGE_SPEC: +debug~rx3d~caliper+gpu+coreneuron~legacy-unit+nmodl~openmp~shared~sympy+tests~unified build_type=Debug model_tests=channel-benchmark,olfactory,tqperf-heavy
+    SPACK_PACKAGE_SPEC: ~rx3d~caliper+gpu+coreneuron~legacy-unit+nmodl~openmp~shared~sympy+tests~unified build_type=FastDebug model_tests=channel-benchmark,olfactory,tqperf-heavy
 
 build:neuron:nmodl:nvhpc:acc:shared:
   extends: [.build_neuron_nmodl, .spack_nvhpc]
   variables:
-    SPACK_PACKAGE_SPEC: +debug~rx3d~caliper+gpu+coreneuron~legacy-unit+nmodl~openmp+shared+sympy+tests~unified build_type=RelWithDebInfo model_tests=channel-benchmark,olfactory,tqperf-heavy
+    SPACK_PACKAGE_SPEC: ~rx3d~caliper+gpu+coreneuron~legacy-unit+nmodl~openmp+shared+sympy+tests~unified build_type=FastDebug model_tests=channel-benchmark,olfactory,tqperf-heavy
 
-build:neuron:nmodl:nvhpc:omp:legacy:debug:
+build:neuron:nmodl:nvhpc:omp:legacy:
   extends: [.build_neuron_nmodl, .spack_nvhpc]
   variables:
-    SPACK_PACKAGE_SPEC: +debug~rx3d+caliper+gpu+coreneuron~legacy-unit+nmodl+openmp~shared~sympy+tests~unified build_type=Debug model_tests=channel-benchmark,olfactory,tqperf-heavy ^caliper+cuda%gcc cuda_arch=70
+    SPACK_PACKAGE_SPEC: ~rx3d+caliper+gpu+coreneuron~legacy-unit+nmodl+openmp~shared~sympy+tests~unified build_type=FastDebug model_tests=channel-benchmark,olfactory,tqperf-heavy ^caliper+cuda%gcc cuda_arch=70
 
-build:neuron:nmodl:nvhpc:omp:debug:
+build:neuron:nmodl:nvhpc:omp:
   extends: [.build_neuron_nmodl, .spack_nvhpc]
   variables:
-    SPACK_PACKAGE_SPEC: +debug~rx3d+caliper+gpu+coreneuron~legacy-unit+nmodl+openmp~shared+sympy+tests~unified build_type=Debug model_tests=channel-benchmark,olfactory,tqperf-heavy ^caliper+cuda%gcc cuda_arch=70
+    SPACK_PACKAGE_SPEC: ~rx3d+caliper+gpu+coreneuron~legacy-unit+nmodl+openmp~shared+sympy+tests~unified build_type=FastDebug model_tests=channel-benchmark,olfactory,tqperf-heavy ^caliper+cuda%gcc cuda_arch=70
 
 # Test NEURON
-test:neuron:mod2c:intel:shared:debug:
+test:neuron:mod2c:intel:shared:
   extends: [.test_neuron]
-  needs: ["build:neuron:mod2c:intel:shared:debug"]
+  needs: ["build:neuron:mod2c:intel:shared"]
 
-test:neuron:nmodl:intel:debug:legacy:
+test:neuron:nmodl:intel:legacy:
   extends: [.test_neuron]
-  needs: ["build:neuron:nmodl:intel:debug:legacy"]
+  needs: ["build:neuron:nmodl:intel:legacy"]
 
-test:neuron:nmodl:intel:shared:debug:
+test:neuron:nmodl:intel:shared:
   extends: [.test_neuron]
-  needs: ["build:neuron:nmodl:intel:shared:debug"]
+  needs: ["build:neuron:nmodl:intel:shared"]
 
 test:neuron:mod2c:nvhpc:acc:shared:
   extends: [.test_neuron, .gpu_node]
   needs: ["build:neuron:mod2c:nvhpc:acc:shared"]
 
-test:neuron:nmodl:nvhpc:acc:debug:legacy:
+test:neuron:nmodl:nvhpc:acc:legacy:
   extends: [.test_neuron, .gpu_node]
-  needs: ["build:neuron:nmodl:nvhpc:acc:debug:legacy"]
+  needs: ["build:neuron:nmodl:nvhpc:acc:legacy"]
 
 test:neuron:nmodl:nvhpc:acc:shared:
   extends: [.test_neuron, .gpu_node]
@@ -260,8 +260,8 @@ test:neuron:nmodl:nvhpc:acc:shared:
 
 test:neuron:nmodl:nvhpc:omp:legacy:
   extends: [.test_neuron, .gpu_node]
-  needs: ["build:neuron:nmodl:nvhpc:omp:legacy:debug"]
+  needs: ["build:neuron:nmodl:nvhpc:omp:legacy"]
 
-test:neuron:nmodl:nvhpc:omp:debug:
+test:neuron:nmodl:nvhpc:omp:
   extends: [.test_neuron, .gpu_node]
-  needs: ["build:neuron:nmodl:nvhpc:omp:debug"]
+  needs: ["build:neuron:nmodl:nvhpc:omp"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,8 +99,14 @@ mac_m1_cmake_build:
     - fi;
 
 variables:
+  LIBSONATA_REPORT_BRANCH:
+    description: Branch of libsonata-report to build BlueBrain models against in the simulation stack pipeline (LIBSONATA_REPORT_COMMIT and LIBSONATA_REPORT_TAG also possible)
+    value: master
   NMODL_BRANCH:
     description: Branch of NMODL to build CoreNEURON against (NMODL_COMMIT and NMODL_TAG also possible)
+    value: master
+  REPORTINGLIB_BRANCH:
+    description: Branch of reportinglib to build BlueBrain models against in the simulation stack pipeline (REPORTINGLIB_COMMIT and REPORTINGLIB_TAG also possible)
     value: master
   SPACK_BRANCH:
     description: Branch of BlueBrain Spack to use for the CI pipeline

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -31,7 +31,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   tqperf
   GIT_REPOSITORY https://github.com/neuronsimulator/tqperf.git
-  GIT_TAG 41453597fcc3866b721696d4aba0265ac763e0c2
+  GIT_TAG 4ef7427bb4243b5c84ced73eb7f5de3eba5bf601
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/tqperf)
 
 FetchContent_MakeAvailable(nrntest reduced_dentate ringtest testcorenrn tqperf)

--- a/test/external/CMakeLists.txt
+++ b/test/external/CMakeLists.txt
@@ -31,7 +31,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   tqperf
   GIT_REPOSITORY https://github.com/neuronsimulator/tqperf.git
-  GIT_TAG b3882fe3cbc0e5bd02ca5727e9dafa4768c8e26e
+  GIT_TAG 41453597fcc3866b721696d4aba0265ac763e0c2
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/tests/tqperf)
 
 FetchContent_MakeAvailable(nrntest reduced_dentate ringtest testcorenrn tqperf)


### PR DESCRIPTION
This PR aims to make two changes:
- The simulation stack CI now uses development versions of libsonata-report and reportinglib.  Previously, development versions of NEURON were tested against the latest releases of libsonata-report and reportinglib.
- The GitLab-based CI now builds with more compiler optimisations enabled than before.

In pursuit of these two goals, a few other changes crept in:
- The CI_BRANCHES syntax in PR descriptions on GitHub now supports setting BLUECONFIGS_BRANCH.
- `solve_interleaved2` gains two workarounds for issues in `nvc++` 22.3:
  - an `if (nt->compute_gpu)` condition is made explicit, as this was being ignored. some other re-organisation (`solve_interleaved2_loop_body`) avoids code duplication.
  - an explicit `map` clause is added to `nrn_pragma_omp(target teams loop ...)` to avoid a crash where `nvc++` 
appeared to mis-deduce the length of an array
- https://github.com/neuronsimulator/tqperf/pull/14 modifies the `tqperf` tests not to use cryptographic hashes but instead compute basic statistics of network events. this allows the test to have a fuzzy comparisons, which allows it to pass with compiler optimisations enabled

TODO:
- [x] Merge https://github.com/neuronsimulator/tqperf/pull/14 and update the "submodule" commit.
- [x] Merge https://github.com/BlueBrain/spack/pull/1814 and https://bbpgitlab.epfl.ch/hpc/sim/blueconfigs/-/merge_requests/72 "at the same time" as this (in practice: merge Spack, then blueconfigs, then this)

CI_BRANCHES:SPACK_BRANCH=olupton/neuron-fast-debug,BLUECONFIGS_BRANCH=olupton/neuron-fast-debug