### PR TITLE
Improve error/exception handling

### DIFF
--- a/docs/dev/HOCInterpreter/HOCInterpreter.md
+++ b/docs/dev/HOCInterpreter/HOCInterpreter.md
@@ -223,7 +223,6 @@ With respect to the HOC grammar we have:
         }  // namespace nrn::oc
         using Frame = nrn::oc::frame;
         #define NFRAME 512 /* default size */
-        #define nframe hoc_nframe
         static Frame *frame, *fp, *framelast; /* first, frame pointer, last */
       ```
     

--- a/src/ivoc/ivoc.cpp
+++ b/src/ivoc/ivoc.cpp
@@ -8,6 +8,7 @@
 #include "oc2iv.h"
 #include "ocfunc.h"
 #include "ocnotify.h"
+#include "oc_ansi.h"
 
 extern Object** (*nrnpy_gui_helper_)(const char* name, Object* obj);
 extern double (*nrnpy_object_to_double_)(Object*);
@@ -161,7 +162,6 @@ void nrn_err_dialog(const char* mes) {
  */
 
 extern void hoc_main1_init(const char* pname, const char** env);
-extern int hoc_oc(const char*);
 extern int hoc_interviews;
 extern Symbol* hoc_parse_expr(const char*, Symlist**);
 extern double hoc_run_expr(Symbol*);

--- a/src/oc/code.cpp
+++ b/src/oc/code.cpp
@@ -90,8 +90,7 @@ struct frame {             /* proc/func call stack frame */
 };
 }  // namespace nrn::oc
 using Frame = nrn::oc::frame;
-#define NFRAME 512 /* default size */
-#define nframe hoc_nframe
+#define NFRAME 512                    /* default size */
 static Frame *frame, *fp, *framelast; /* first, frame pointer, last */
 
 /* temporary object references come from this pool. This allows the
@@ -419,8 +418,8 @@ static void stack_obtmp_recover_on_err(int tcnt) {
 
 // create space for stack and code
 void hoc_init_space() {
-    if (nframe == 0) {
-        nframe = NFRAME;
+    if (hoc_nframe == 0) {
+        hoc_nframe = NFRAME;
     }
     if (hoc_nstack == 0) {
         // Default stack size
@@ -428,8 +427,8 @@ void hoc_init_space() {
     }
     stack.reserve(hoc_nstack);
     progp = progbase = prog = (Inst*) emalloc(sizeof(Inst) * NPROG);
-    fp = frame = (Frame*) emalloc(sizeof(Frame) * nframe);
-    framelast = frame + nframe;
+    fp = frame = (Frame*) emalloc(sizeof(Frame) * hoc_nframe);
+    framelast = frame + hoc_nframe;
     hoc_temp_obj_pool_ = (Object**) emalloc(sizeof(Object*) * TOBJ_POOL_SIZE);
 }
 

--- a/src/oc/code2.cpp
+++ b/src/oc/code2.cpp
@@ -719,11 +719,13 @@ double* hoc_val_pointer(const char* s) {
         HocStr* buf;
         buf = hocstr_create(strlen(s) + 20);
         std::snprintf(buf->buf, buf->size + 1, "{hoc_pointer_(&%s)}\n", s);
-        hoc_oc(buf->buf);
+        auto const code = hoc_oc(buf->buf);
+        assert(code == 0);
         hocstr_delete(buf);
     } else {
         Sprintf(buf, "{hoc_pointer_(&%s)}\n", s);
-        hoc_oc(buf);
+        auto const code = hoc_oc(buf);
+        assert(code == 0);
     }
     return hoc_varpointer;
 }

--- a/src/oc/fileio.cpp
+++ b/src/oc/fileio.cpp
@@ -764,6 +764,9 @@ static int hoc_Load_file(int always, const char* name) {
                  base);
         b = hoc_oc(cmd);
         b = (int) hoc_ac_;
+        if (!b) {
+            hoc_execerror("hoc_Load_file", base);
+        }
     }
     /* change back */
     if (path[0] && goback) {

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -685,7 +685,7 @@ void hoc_execerror_mes(const char* s, const char* t, int prnt) { /* recover from
         message.append(1, ' ');
         message.append(t);
     }
-    throw std::runtime_error(std::move(message));
+    throw neuron::oc::runtime_error(std::move(message));
 }
 
 void hoc_execerror(const char* s, const char* t) /* recover from run-time error */

--- a/src/oc/ocmain.cpp
+++ b/src/oc/ocmain.cpp
@@ -5,7 +5,6 @@
 #include <stdlib.h>
 #include <hocdec.h>
 
-int hoc_nstack, hoc_nframe;
 extern const char* neuron_home;
 
 extern Object** (*nrnpy_gui_helper_)(const char* name, Object* obj) = NULL;

--- a/test/unit_tests/basic.cpp
+++ b/test/unit_tests/basic.cpp
@@ -25,7 +25,7 @@ SCENARIO("Test fast_imem calculation", "[Neuron][fast_imem]") {
                            "cvode = new CVode()\n"
                            "cvode.use_fast_imem(1)\n") == 0);
             WHEN("iinitialize and run nrn_calc_fast_imem") {
-                hoc_oc("finitialize(-65)\n");
+                REQUIRE(hoc_oc("finitialize(-65)\n") == 0);
                 for (NrnThread* nt = nrn_threads; nt < nrn_threads + nrn_nthread; ++nt) {
                     nrn_calc_fast_imem(nt);
                 }

--- a/test/unit_tests/oc/hoc_interpreter.cpp
+++ b/test/unit_tests/oc/hoc_interpreter.cpp
@@ -1,8 +1,12 @@
 #include <catch2/catch.hpp>
 
-#include <hocdec.h>
-#include <ocfunc.h>
-#include <code.h>
+#include "classreg.h"
+#include "code.h"
+#include "hocdec.h"
+#include "hoc_membf.h"
+#include "ocfunc.h"
+
+#include <sstream>
 
 TEST_CASE("Test hoc interpreter", "[NEURON][hoc_interpreter]") {
     hoc_init_space();
@@ -52,6 +56,138 @@ SCENARIO("Test for issue #1995", "[NEURON][hoc_interpreter][issue-1995]") {
         }
     }
 }
+
+namespace {
+struct UtilityThatLikesThrowing {
+    UtilityThatLikesThrowing(int data)
+        : m_data{data} {}
+    [[nodiscard]] bool hoc_destructor_should_throw() const {
+        return m_data == 1.0;
+    }
+    [[noreturn]] void throw_error() const {
+        throw std::runtime_error("throwing from throw_error");
+    }
+    [[noreturn]] void call_execerror() const {
+        hoc_execerror("throwing a tantrum", nullptr);
+    }
+
+  private:
+    int m_data{};
+};
+double throwing_util_member_call_execerror(void* ob_void) {
+    auto* const ob = static_cast<UtilityThatLikesThrowing*>(ob_void);
+    ob->call_execerror();
+}
+double throwing_util_member_throw_error(void* ob_void) {
+    auto* const ob = static_cast<UtilityThatLikesThrowing*>(ob_void);
+    ob->throw_error();
+}
+Object** throwing_util_member_call_execerror_obj_func(void* ob_void) {
+    auto* const ob = static_cast<UtilityThatLikesThrowing*>(ob_void);
+    ob->call_execerror();
+}
+Object** throwing_util_member_throw_error_obj_func(void* ob_void) {
+    auto* const ob = static_cast<UtilityThatLikesThrowing*>(ob_void);
+    ob->throw_error();
+}
+const char** throwing_util_member_call_execerror_str_func(void* ob_void) {
+    auto* const ob = static_cast<UtilityThatLikesThrowing*>(ob_void);
+    ob->call_execerror();
+}
+const char** throwing_util_member_throw_error_str_func(void* ob_void) {
+    auto* const ob = static_cast<UtilityThatLikesThrowing*>(ob_void);
+    ob->throw_error();
+}
+static Member_func throwing_util_members[] = {{"call_execerror",
+                                               throwing_util_member_call_execerror},
+                                              {"throw_error", throwing_util_member_throw_error},
+                                              {nullptr, nullptr}};
+static Member_ret_obj_func throwing_util_ret_obj_members[] = {
+    {"call_execerror_obj_func", throwing_util_member_call_execerror_obj_func},
+    {"throw_error_obj_func", throwing_util_member_throw_error_obj_func},
+    {nullptr, nullptr}};
+static Member_ret_str_func throwing_util_ret_str_members[] = {
+    {"call_execerror_str_func", throwing_util_member_call_execerror_str_func},
+    {"throw_error_str_func", throwing_util_member_throw_error_str_func},
+    {nullptr, nullptr}};
+void* throwing_util_constructor(Object*) {
+    if (!ifarg(1)) {
+        throw std::runtime_error("need at least one argument");
+    }
+    return new UtilityThatLikesThrowing{static_cast<int>(*hoc_getarg(1))};
+}
+void throwing_util_destructor(void* ob_void) {
+    auto* const ob = static_cast<UtilityThatLikesThrowing*>(ob_void);
+    bool const should_throw = ob->hoc_destructor_should_throw();
+    delete ob;
+    if (should_throw) {
+        throw std::runtime_error("throwing from HOC destructor");
+    }
+}
+}  // namespace
+
+std::string hoc_oc_require_error(const char* buf) {
+    std::ostringstream oss;
+    auto const code = hoc_oc(buf, oss);
+    REQUIRE(code != 0);
+    auto const output = std::move(oss).str();
+    REQUIRE(!output.empty());
+    return output;
+}
+
+using Catch::Matchers::Contains;  // ContainsSubstring in newer Catch2
+SCENARIO("Test calling code from HOC that throws exceptions", "[NEURON][hoc_interpreter]") {
+    static bool registered = false;
+    if (!registered) {
+        class2oc("UtilityThatLikesThrowing",
+                 throwing_util_constructor,
+                 throwing_util_destructor,
+                 throwing_util_members,
+                 nullptr /* checkpoint */,
+                 throwing_util_ret_obj_members,
+                 throwing_util_ret_str_members);
+        registered = true;
+        // declare these test variables exactly once
+        REQUIRE(hoc_oc("objref nil, util\n") == 0);
+    }
+    GIVEN("A HOC object constructor that throws") {
+        REQUIRE_THAT(hoc_oc_require_error("util = new UtilityThatLikesThrowing()\n"),
+                     Contains("hoc_execerror: UtilityThatLikesThrowing[0] constructor: need at "
+                              "least one argument"));
+    }
+    GIVEN("A HOC object destructor that throws") {
+        REQUIRE_THAT(hoc_oc_require_error("util = nil\n"
+                                          "util = new UtilityThatLikesThrowing(1)\n"
+                                          "util = nil\n"),
+                     Contains("hoc_execerror: UtilityThatLikesThrowing[0] destructor: throwing "
+                              "from HOC destructor"));
+    }
+    GIVEN("A HOC object whose constructor and destructor succeed") {
+        // Make sure there are not any instances alive from previous tests, otherwise we can't
+        // hardcode the zero in "UtilityThatLikesThrowing[0]"
+        REQUIRE(hoc_oc("util = nil\n") == 0);
+        // Make an instance and tell it not to throw from its destructor (with the 2)
+        REQUIRE(hoc_oc("util = new UtilityThatLikesThrowing(2)\n") == 0);
+        // Generate tests for the HOC member functions returning doubles, objects and strings
+        auto const method_suffix = GENERATE(as<std::string>{}, "", "_obj_func", "_str_func");
+        WHEN("A member function that throws is called") {
+            REQUIRE_THAT(
+                hoc_oc_require_error(("util.throw_error" + method_suffix + "()\n").c_str()),
+                Contains("hoc_execerror: UtilityThatLikesThrowing[0]::throw_error" + method_suffix +
+                         ": throwing "
+                         "from throw_error"));
+        }
+        WHEN("A member function that calls hoc_execerror is called") {
+            REQUIRE_THAT(hoc_oc_require_error(
+                             ("util.call_execerror" + method_suffix + "()\n").c_str()),
+                         Contains("hoc_execerror: UtilityThatLikesThrowing[0]::call_execerror" +
+                                  method_suffix +
+                                  ": "
+                                  "hoc_execerror: throwing a tantrum"));
+        }
+    }
+}
+
 #if USE_PYTHON
 TEST_CASE("Test hoc_array_access", "[NEURON][hoc_interpreter][nrnpython][array_access]") {
     REQUIRE(hoc_oc("nrnpython(\"avec = [0,1,2]\")\n"

--- a/test/unit_tests/oc/hoc_interpreter.cpp
+++ b/test/unit_tests/oc/hoc_interpreter.cpp
@@ -180,10 +180,7 @@ SCENARIO("Test calling code from HOC that throws exceptions", "[NEURON][hoc_inte
         WHEN("A member function that calls hoc_execerror is called") {
             REQUIRE_THAT(hoc_oc_require_error(
                              ("util.call_execerror" + method_suffix + "()\n").c_str()),
-                         Contains("hoc_execerror: UtilityThatLikesThrowing[0]::call_execerror" +
-                                  method_suffix +
-                                  ": "
-                                  "hoc_execerror: throwing a tantrum"));
+                         Contains("hoc_execerror: throwing a tantrum"));
         }
     }
 }


### PR DESCRIPTION
This PR extracts + extends some error handling improvements from #2027.
It builds on the work to remove `setjmp` and `longjmp` in https://github.com/neuronsimulator/nrn/pull/1989.
When lower-level code raises exceptions these are caught and annotated with HOC-level information closer to the error site, which makes error messages more verbose and informative.
Unit tests are also added that check that the error messages have the expected level of detail.

Related changes:
- `hoc_oc` now has the `[[nodiscard]]` attribute to encourage callers to check whether the commands they executed succeeded
- `hoc_oc` now has a variant taking an `std::ostream&` argument, which ~defaults to `std::cerr`
- `hoc_execerror` now throws an exception with a more informative `what()` string
- `nrniv` / `special` should now abort after the first HOC file that raises an error

Other minor fixes:
- Remove some conflicting definitions of `hoc_nstack` and `hoc_nframe` as `int`, remove an `nframe` macro.

Possible further improvements:
- Currently `stderr` still contains more information than the various machine-readable exception structures. For example:
```
NEURON: UtilityThatLikesThrowing[0] constructor: need at least one argument
 near line 1
 util = new UtilityThatLikesThrowing()
                                      ^
        UtilityThatLikesThrowing()
```
is printed to `stderr` but only the `UtilityThatLikesThrowing[0] constructor: need at least one argument` part is propagated to higher-level error handling code. We might like to propagate the extra information too.
- To avoid breaking existing code, we do not augment exceptions that come from more deeply nested calls to `hoc_execerror`. This may cause some error messages to be less helpful than they otherwise would be.