### PR TITLE
Windows: update pacman cache before install

### DIFF
--- a/ci/win_install_deps.cmd
+++ b/ci/win_install_deps.cmd
@@ -50,6 +50,9 @@ if not exist "%MSYS2_ROOT%\usr\bin\bash.exe" (
 )
 set PATH=%MSYS2_ROOT%\usr\bin;%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem;%PATH%
 
+:: update cache (should be temporary)
+%MSYS2_ROOT%\usr\bin\pacman -Syy
+
 %MSYS2_ROOT%\usr\bin\pacman --noconfirm --needed -S --disable-download-timeout ^
 cmake ^
 git ^


### PR DESCRIPTION
* not a robust mitigation plan, but better to unblock CIs until new runner images are out