### PR TITLE
Fix related to free_event_pools()

### DIFF
--- a/src/nrncvode/netcvode.cpp
+++ b/src/nrncvode/netcvode.cpp
@@ -2891,7 +2891,9 @@ void NetCvode::clear_events() {
     enqueueing_ = 0;
     for (i = 0; i < nrn_nthread; ++i) {
         NetCvodeThreadData& d = p[i];
-        delete d.tqe_;
+        if (d.tqe_) {
+            delete d.tqe_;
+        }
         d.tqe_ = new TQueue(p[i].tpool_);
         d.unreffed_event_cnt_ = 0;
         d.sepool_->free_all();


### PR DESCRIPTION
# Context
TQueue is getting cleared by `NetCvode::free_event_pools()` and `NetCvode::clear_events()` however in case `NetCvode::clear_events()` is called after `NetCvode::free_event_pools()` it's possible to try and delete a `nullptr` resulting in segfault

# Fix
Make sure that `d.tqe_` is not `nullptr` before deleting it in `NetCvode::clear_events()`