### PR TITLE
pytest-cov: do not use with ASan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,6 +430,8 @@ endif()
 # Enable sanitizer support if the NRN_SANITIZERS variable is set
 # =============================================================================
 include(cmake/SanitizerHelper.cmake)
+# Make a CMake list NRN_SANITIZERS_LIST
+string(REPLACE "," ";" NRN_SANITIZERS_LIST "${NRN_SANITIZERS}")
 
 # =============================================================================
 # Enable Threads support

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -183,7 +183,8 @@ if(NRN_ENABLE_PYTHON AND PYTEST_FOUND)
   # use `--capture=tee-sys`: combines 'sys' and '-s', capturing sys.stdout/stderr and passing it
   # along to the actual sys.stdout/stderr
   set(pytest -m pytest --capture=tee-sys)
-  if(PYTEST_COV_FOUND)
+  # pytest-cov runs extremely slowly under AddressSanitizer
+  if(PYTEST_COV_FOUND AND NOT "address" IN_LIST NRN_SANITIZERS_LIST)
     list(APPEND pytest --cov-report=xml --cov=neuron)
   endif()
   # TODO: consider allowing the group-related parts to be dropped here


### PR DESCRIPTION
O(30x) speedup for these tests with ASan + AppleClang on my Mac.
We also see very slow speeds in the ASan builds in the CI; hopefully this will improve that too.


Reference run from **before** this PR using macOS-12 and AppleClang (https://github.com/neuronsimulator/nrn/actions/runs/4164826339/jobs/7206993580) contains e.g.
```
120/172 Test  #75: coreneuron_modtests::version_macros ................................   Passed   88.23 sec
122/172 Test  #76: coreneuron_modtests::fornetcon_py_cpu ..............................   Passed   84.17 sec
123/172 Test  #77: coreneuron_modtests::direct_py_cpu .................................   Passed   86.06 sec
````
while with Ubuntu it was a little faster (https://github.com/neuronsimulator/nrn/actions/runs/4164826339/jobs/7206993263)
```
 95/176 Test  #77: coreneuron_modtests::version_macros ................................   Passed   55.29 sec
 96/176 Test  #78: coreneuron_modtests::fornetcon_py_cpu ..............................   Passed   55.30 sec
 97/176 Test  #79: coreneuron_modtests::direct_py_cpu .................................   Passed   55.24 sec
```

In the CI of this PR Ubuntu now has (https://github.com/neuronsimulator/nrn/actions/runs/4165461226/jobs/7208493850)
```
 95/176 Test  #77: coreneuron_modtests::version_macros ................................   Passed    1.07 sec
 96/176 Test  #78: coreneuron_modtests::fornetcon_py_cpu ..............................   Passed    1.15 sec
 97/176 Test  #79: coreneuron_modtests::direct_py_cpu .................................   Passed    1.16 sec
```
and macOS-12 and AppleClang (https://github.com/neuronsimulator/nrn/actions/runs/4165461226/jobs/7208494003) show
```
103/172 Test  #75: coreneuron_modtests::version_macros ................................   Passed    1.88 sec
105/172 Test  #77: coreneuron_modtests::direct_py_cpu .................................   Passed    1.77 sec
106/172 Test  #76: coreneuron_modtests::fornetcon_py_cpu ..............................   Passed    1.94 sec
```