### PR TITLE
CI: run on master to keep ccache hot

### DIFF
--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -7,6 +7,8 @@ concurrency:
 on:
   push:
     branches: 
+      # If nothing else, this is important for the ccache logic below...
+      - master
       - release/**
   pull_request:
     branches:
@@ -74,7 +76,6 @@ jobs:
               cmake_option: -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_INTERVIEWS=OFF
                 -DNRN_ENABLE_RX3D=OFF
               sanitizer: address
-              ccache_fudge: 1 # manually invalidate the cache for this build
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Undo a change from https://github.com/neuronsimulator/nrn/pull/2079 so we build on pushes to `master`.
This should mean that new PRs are able to access a warm ccache cache (from `master`), instead of having to start from scratch in each feature branch.