### PR TITLE
PEP517 pyproject.toml with build_meta in legacy mode live-debug-docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools.build_meta"]
+build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
* traditional build process preserved -> setup.py
* build_meta will take care of other aspects

Ideally this also fixes recent failures seen in the Docs CI:
```
Installing collected packages: NEURON-nightly
Successfully installed NEURON-nightly-0.0.0
-------- now build docs--------
fatal: No names found, cannot describe anything.
/opt/hostedtoolcache/Python/3.11.1/x64/lib/python3.11/site-packages/setuptools/__init__.py:85: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated. Requirements should be satisfied by a PEP 517 installer. If you are using pip, you can try `pip install --use-pep517`.
  dist.fetch_build_eggs(dist.setup_requires)
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.11.1/x64/lib/python3.11/site-packages/setuptools/_normalization.py", line 62, in safe_version
    return str(packaging.version.Version(v))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
