### PR TITLE
scopmath: do not assume indices are integers

### DIFF
--- a/src/scopmath/dimplic.hpp
+++ b/src/scopmath/dimplic.hpp
@@ -3,11 +3,11 @@
  */
 #pragma once
 namespace neuron::scopmath {
-template <typename Array>
+template <typename Array, typename IndexArray>
 int derivimplicit(int /* _ninits */,
                   int /* n */,
-                  int* /* slist */,
-                  int* /* dlist */,
+                  IndexArray /* slist */,
+                  IndexArray /* dlist */,
                   Array /* p */,
                   double* /* pt */,
                   double /* dt */,
@@ -16,10 +16,10 @@ int derivimplicit(int /* _ninits */,
     fun();
     return 0;
 }
-template <typename Array, typename Callable, typename... Args>
+template <typename Array, typename Callable, typename IndexArray, typename... Args>
 int derivimplicit_thread(int /* n */,
-                         int* /* slist */,
-                         int* /* dlist */,
+                         IndexArray /* slist */,
+                         IndexArray /* dlist */,
                          Array /* p */,
                          Callable fun,
                          Args&&... args) {

--- a/src/scopmath/euler.hpp
+++ b/src/scopmath/euler.hpp
@@ -22,11 +22,11 @@
  * @return Error code (always SUCCESS for euler)
  */
 namespace neuron::scopmath {
-template <typename Array>
+template <typename Array, typename IndexArray>
 int euler(int ninits,
           int neqn,
-          int* var,
-          int* der,
+          IndexArray var,
+          IndexArray der,
           Array p,
           double* t,
           double dt,

--- a/src/scopmath/euler_thread.hpp
+++ b/src/scopmath/euler_thread.hpp
@@ -5,8 +5,8 @@
 struct NrnThread;
 double _modl_get_dt_thread(NrnThread*);
 namespace neuron::scopmath {
-template <typename Array, typename Callable, typename... Args>
-int euler_thread(int neqn, int* var, int* der, Array p, Callable func, Args&&... args) {
+template <typename Array, typename Callable, typename IndexArray, typename... Args>
+int euler_thread(int neqn, IndexArray var, IndexArray der, Array p, Callable func, Args&&... args) {
     auto* const nt = get_first<NrnThread*>(std::forward<Args>(args)...);
     auto const dt = _modl_get_dt_thread(nt);
 

--- a/src/scopmath/newton.hpp
+++ b/src/scopmath/newton.hpp
@@ -25,8 +25,8 @@ namespace neuron::scopmath {
  *
  * Output: jacobian, computed jacobian matrix.
  */
-template <std::size_t n, typename Array, typename Matrix>
-int buildjacobian(int* index, Array& x, int (*pfunc)(), double* value, Matrix& jacobian) {
+template <std::size_t n, typename Array, typename IndexArray, typename Matrix>
+int buildjacobian(IndexArray index, Array& x, int (*pfunc)(), double* value, Matrix& jacobian) {
     std::array<double, n> high_value{}, low_value{};
     // Compute partial derivatives by central finite differences
     if (index) {
@@ -90,8 +90,8 @@ int buildjacobian(int* index, Array& x, int (*pfunc)(), double* value, Matrix& j
  * Output: x contains the solution value or the most recent iteration's result
  * in the event of an error.
  */
-template <std::size_t n, typename Array>
-int newton(int* index, Array&& x, int (*pfunc)(), double* value) {
+template <std::size_t n, typename Array, typename IndexArray>
+int newton(IndexArray index, Array&& x, int (*pfunc)(), double* value) {
     // Create arrays for Jacobian, variable increments, function values, and
     // permutation vector
     std::array<int, n> perm{};

--- a/src/scopmath/newton_thread.hpp
+++ b/src/scopmath/newton_thread.hpp
@@ -25,10 +25,10 @@ namespace detail::newton_thread {
  * @param value pointer to array of addresses of function values
  * @param[out] jacobian computed jacobian matrix
  */
-template <typename Array, typename Callable, typename... Args>
+template <typename Array, typename Callable, typename IndexArray, typename... Args>
 void buildjacobian(NewtonSpace* ns,
                    int n,
-                   int* index,
+                   IndexArray index,
                    Array x,
                    Callable pfunc,
                    double* value,
@@ -106,10 +106,10 @@ void buildjacobian(NewtonSpace* ns,
  * @returns 0 if no error; 2 if matrix is singular or ill-conditioned; 1 if
  * maximum iterations exceeded
  */
-template <typename Array, typename Function, typename... Args>
+template <typename Array, typename Function, typename IndexArray, typename... Args>
 int nrn_newton_thread(NewtonSpace* ns,
                       int n,
-                      int* index,
+                      IndexArray index,
                       Array x,
                       Function pfunc,
                       double* value,

--- a/src/scopmath/runge.hpp
+++ b/src/scopmath/runge.hpp
@@ -30,20 +30,20 @@ namespace neuron::scopmath {
  * variables and their derivatives at time + h. Time is also updated.
  * @return Error code (always SUCCESS for runge)
  */
-template <typename Array>
+template <typename Array, typename IndexArray>
 int runge(int ninits,
           int n,
-          int* y,
-          int* d,
+          IndexArray y,
+          IndexArray d,
           Array p,
           double* t,
           double h,
           int (*dy)(),
           double** work) {
-    auto const d_ = [d, &p](auto arg) -> auto& {
+    auto const d_ = [&d, &p](auto arg) -> auto& {
         return p[d[arg]];
     };
-    auto const y_ = [y, &p](auto arg) -> auto& {
+    auto const y_ = [&y, &p](auto arg) -> auto& {
         return p[y[arg]];
     };
     int i;

--- a/src/scopmath/simeq.hpp
+++ b/src/scopmath/simeq.hpp
@@ -23,8 +23,8 @@ namespace neuron::scopmath {
  *
  * @return 0 if no error; 2 if matrix is singular or ill-conditioned
  */
-template <typename Array>
-int simeq(int n, double** coef, Array soln, int* index) {
+template <typename Array, typename IndexArray>
+int simeq(int n, double** coef, Array soln, IndexArray index) {
     static int np = 0;
     static int* perm = nullptr;
 

--- a/src/scopmath/sparse.hpp
+++ b/src/scopmath/sparse.hpp
@@ -645,21 +645,21 @@ ensures all elements needed are present */
  *   varord[el->row] < varord[el->c_right->row]
  *   varord[el->col] < varord[el->r_down->col]
  */
-template <typename Array>
+template <typename Array, typename IndexArray>
 int sparse(void** v,
            int n,
-           int* s,
-           int* d,
+           IndexArray s,
+           IndexArray d,
            Array p,
            double* t,
            double dt,
            int (*fun)(),
            double** prhs,
            int linflag) {
-    auto const s_ = [&p, s](auto arg) -> auto& {
+    auto const s_ = [&p, &s](auto arg) -> auto& {
         return p[s[arg]];
     };
-    auto const d_ = [&p, d](auto arg) -> auto& {
+    auto const d_ = [&p, &d](auto arg) -> auto& {
         return p[d[arg]];
     };
     int i, j, ierr;
@@ -714,9 +714,9 @@ int sparse(void** v,
 }
 
 /* for solving ax=b */
-template <typename Array>
-int _cvode_sparse(void** v, int n, int* x, Array p, int (*fun)(), double** prhs) {
-    auto const x_ = [&p, x](auto arg) -> auto& {
+template <typename Array, typename IndexArray>
+int _cvode_sparse(void** v, int n, IndexArray x, Array p, int (*fun)(), double** prhs) {
+    auto const x_ = [&p, &x](auto arg) -> auto& {
         return p[x[arg]];
     };
     int i, j, ierr;

--- a/src/scopmath/sparse_thread.hpp
+++ b/src/scopmath/sparse_thread.hpp
@@ -639,21 +639,21 @@ inline SparseObj* create_sparseobj() {
  * @param linflag solve as linear equations when nonlinear, all states are
  * forced >= 0
  */
-template <typename Array, typename Callable, typename... Args>
+template <typename Array, typename Callable, typename IndexArray, typename... Args>
 int sparse_thread(void** v,
                   int n,
-                  int* s,
-                  int* d,
+                  IndexArray s,
+                  IndexArray d,
                   Array p,
                   double* t,
                   double dt,
                   Callable fun,
                   int linflag,
                   Args&&... args) {
-    auto const s_ = [&p, s](auto arg) -> auto& {
+    auto const s_ = [&p, &s](auto arg) -> auto& {
         return p[s[arg]];
     };
-    auto const d_ = [&p, d](auto arg) -> auto& {
+    auto const d_ = [&p, &d](auto arg) -> auto& {
         return p[d[arg]];
     };
     int i, j, ierr;
@@ -701,9 +701,9 @@ int sparse_thread(void** v,
 }
 
 /* for solving ax=b */
-template <typename Array, typename Callable, typename... Args>
-int _cvode_sparse_thread(void** v, int n, int* x, Array p, Callable fun, Args&&... args) {
-    auto const x_ = [&p, x](auto arg) -> auto& {
+template <typename Array, typename Callable, typename IndexArray, typename... Args>
+int _cvode_sparse_thread(void** v, int n, IndexArray x, Array p, Callable fun, Args&&... args) {
+    auto const x_ = [&p, &x](auto arg) -> auto& {
         return p[x[arg]];
     };
     int i, j, ierr;

--- a/src/scopmath/ssimplic.hpp
+++ b/src/scopmath/ssimplic.hpp
@@ -3,18 +3,18 @@
 #include "sparse.hpp"
 void _modl_set_dt(double);
 namespace neuron::scopmath {
-template <typename Array>
+template <typename Array, typename IndexArray>
 int _ss_sparse(void** v,
                int n,
-               int* s,
-               int* d,
+               IndexArray s,
+               IndexArray d,
                Array p,
                double* t,
                double dt,
                int (*fun)(),
                double** pcoef,
                int linflag) {
-    auto const check_state = [&p](int n, int* s) {
+    auto const check_state = [n, &p, &s]() {
         auto const s_ = [&p, s](auto arg) -> auto& {
             return p[s[arg]];
         };
@@ -42,7 +42,7 @@ int _ss_sparse(void** v,
             if (err) {
                 break; /* perhaps we should re-start */
             }
-            if (check_state(n, s)) {
+            if (check_state()) {
                 err = sparse(v, n, s, d, p, t, ss_dt, fun, pcoef, 0);
                 break;
             }

--- a/src/scopmath/ssimplic_thread.hpp
+++ b/src/scopmath/ssimplic_thread.hpp
@@ -7,19 +7,19 @@ struct NrnThread;
 double _modl_get_dt_thread(NrnThread*);
 void _modl_set_dt_thread(double, NrnThread*);
 namespace neuron::scopmath {
-template <typename Array, typename Callable, typename... Args>
+template <typename Array, typename Callable, typename IndexArray, typename... Args>
 int _ss_sparse_thread(void** v,
                       int n,
-                      int* s,
-                      int* d,
+                      IndexArray s,
+                      IndexArray d,
                       Array p,
                       double* t,
                       double dt,
                       Callable fun,
                       int linflag,
                       Args&&... args) {
-    auto const check_state = [&p](int n, int* s) {
-        auto const s_ = [&p, s](auto arg) -> auto& {
+    auto const check_state = [n, &p, &s]() {
+        auto const s_ = [&p, &s](auto arg) -> auto& {
             return p[s[arg]];
         };
         int flag = 1;
@@ -47,7 +47,7 @@ int _ss_sparse_thread(void** v,
             if (err) {
                 break; /* perhaps we should re-start */
             }
-            if (check_state(n, s)) {
+            if (check_state()) {
                 err = sparse_thread(v, n, s, d, p, t, ss_dt, fun, 0, args...);
                 break;
             }
@@ -60,8 +60,13 @@ int _ss_sparse_thread(void** v,
     _modl_set_dt_thread(dt, nt);
     return err;
 }
-template <typename Array, typename Callable, typename... Args>
-int _ss_derivimplicit_thread(int n, int* slist, int* dlist, Array p, Callable fun, Args&&... args) {
+template <typename Array, typename Callable, typename IndexArray, typename... Args>
+int _ss_derivimplicit_thread(int n,
+                             IndexArray slist,
+                             IndexArray dlist,
+                             Array p,
+                             Callable fun,
+                             Args&&... args) {
     auto* const nt = get_first<NrnThread*>(std::forward<Args>(args)...);
     auto const dtsav = _modl_get_dt_thread(nt);
     _modl_set_dt_thread(1e-9, nt);


### PR DESCRIPTION
More in the vein of https://github.com/neuronsimulator/nrn/pull/2175, https://github.com/neuronsimulator/nrn/pull/2131 and https://github.com/neuronsimulator/nrn/pull/2083.

This is useful in #2027 where the transformation to SoAoS data layout implies that a pair of indices is needed to efficiently navigate to the correct field.