### PR TITLE
Introduce setuptools_scm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
                 -e NEURON_NIGHTLY_TAG \
                 -e NRN_NIGHTLY_UPLOAD \
                 -e NRN_RELEASE_UPLOAD \
-                -e NEURON_WHEEL_VERSION \
+                -e SETUPTOOLS_SCM_PRETEND_VERSION \
                 -e NRN_BUILD_FOR_UPLOAD=1 \
                 'neuronsimulator/neuron_wheel:latest-gcc9-aarch64' \
                 packaging/python/build_wheels.bash linux << parameters.NRN_PYTHON_VERSION >> coreneuron

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,7 @@ stages:
             -e NEURON_NIGHTLY_TAG \
             -e NRN_NIGHTLY_UPLOAD \
             -e NRN_RELEASE_UPLOAD \
-            -e NEURON_WHEEL_VERSION \
+            -e SETUPTOOLS_SCM_PRETEND_VERSION \
             -e NRN_BUILD_FOR_UPLOAD=1 \
             'neuronsimulator/neuron_wheel:latest-gcc9-x86_64' \
             packaging/python/build_wheels.bash linux $(python.version) coreneuron
@@ -118,7 +118,7 @@ stages:
             -e NEURON_NIGHTLY_TAG \
             -e NRN_NIGHTLY_UPLOAD \
             -e NRN_RELEASE_UPLOAD \
-            -e NEURON_WHEEL_VERSION \
+            -e SETUPTOOLS_SCM_PRETEND_VERSION \
             -e NRN_BUILD_FOR_UPLOAD=1 \
             'neuronsimulator/neuron_wheel_gpu:nvhpc-22.1-cuda-11.5-gcc9' \
             packaging/python/build_wheels.bash linux $(python.version) coreneuron-gpu

--- a/docs/install/python_wheels.md
+++ b/docs/install/python_wheels.md
@@ -261,7 +261,7 @@ $ git diff
      machine:
        image: ubuntu-2004:202101-01
 +    environment:
-+      NEURON_WHEEL_VERSION: 8.1a
++      SETUPTOOLS_SCM_PRETEND_VERSION: 8.1a
 +      NEURON_NIGHTLY_TAG: ""
 +      NRN_NIGHTLY_UPLOAD: false
 +      NRN_RELEASE_UPLOAD: false
@@ -274,7 +274,7 @@ $ git diff
 +              NRN_PYTHON_VERSION: ["38", "39", "310", "311"]
 ```
 
-The reason we are setting `NEURON_WHEEL_VERSION` to a desired version `8.1a` because `setup.py` uses `git describe` and it will give different version name as we are now on a new branch!
+The reason we are setting `SETUPTOOLS_SCM_PRETEND_VERSION` to a desired version `8.1a` because `setup.py` uses `git describe` and it will give different version name as we are now on a new branch!
 
 
 ## Nightly wheels

--- a/nrn_requirements.txt
+++ b/nrn_requirements.txt
@@ -1,5 +1,6 @@
 wheel
 setuptools
+setuptools_scm
 scikit-build
 matplotlib
 # bokeh 3 seems to break docs notebooks

--- a/setup.py
+++ b/setup.py
@@ -452,7 +452,10 @@ def setup_package():
         cmdclass=dict(build_ext=CMakeAugmentedBuilder, docs=Docs),
         install_requires=["numpy>=1.9.3"] + maybe_patchelf,
         tests_require=["flake8", "pytest"],
-        setup_requires=["wheel", "setuptools_scm"] + maybe_docs + maybe_test_runner + maybe_rxd_reqs,
+        setup_requires=["wheel", "setuptools_scm"]
+        + maybe_docs
+        + maybe_test_runner
+        + maybe_rxd_reqs,
         dependency_links=[],
     )
 

--- a/setup.py
+++ b/setup.py
@@ -25,42 +25,6 @@ if os.name != "posix":
         "for Mac and Linux systems (POSIX)"
     )
 
-# Main source of the version. Dont rename, used by Cmake
-try:
-    # github actions somehow fails with check_output and python3
-
-    # Official Versioning shall rely on annotated tags (don't use `--tags` or `--all`)
-    # (please refer to NEURON SCM documentation)
-    v = (
-        subprocess.run(["git", "describe"], stdout=subprocess.PIPE)
-        .stdout.strip()
-        .decode()
-    )
-
-    # make git describe output PEP440 compliant
-    __version__ = v.replace("-", ".", 1).replace("-", "+", 1)
-
-    # if version is not a valid PEP440 version, then create a bogus version
-    # that will be used only for development purposes which appends the commit hash
-    try:
-        version_obj = parse_version(__version__)
-    except ValueError:
-        __version__ = "0.0.dev0+g" + (
-            subprocess.run(
-                ["git", "rev-parse", "--short", "HEAD"], stdout=subprocess.PIPE
-            )
-            .stdout.strip()
-            .decode()
-        )
-
-    # allow to override version during development/testing
-    if "NEURON_WHEEL_VERSION" in os.environ:
-        __version__ = os.environ["NEURON_WHEEL_VERSION"]
-
-except Exception as e:
-    raise RuntimeError("Could not get version from Git repo : " + str(e))
-
-
 # setup options must be checked for very early as it impacts imports
 if "--disable-rx3d" in sys.argv:
     Components.RX3D = False
@@ -471,7 +435,6 @@ def setup_package():
 
     setup(
         name=package_name,
-        version=__version__,
         package_dir={"": NRN_PY_ROOT},
         packages=py_packages,
         package_data={"neuron": ["*.dat"]},
@@ -481,10 +444,15 @@ def setup_package():
             for f in os.listdir(NRN_PY_SCRIPTS)
             if f[0] != "_"
         ],
+        use_scm_version={
+            "local_scheme": "no-local-version"
+            if os.getenv("NRN_NIGHTLY_UPLOAD", False) == "true"
+            else "node-and-date"
+        },
         cmdclass=dict(build_ext=CMakeAugmentedBuilder, docs=Docs),
         install_requires=["numpy>=1.9.3"] + maybe_patchelf,
         tests_require=["flake8", "pytest"],
-        setup_requires=["wheel"] + maybe_docs + maybe_test_runner + maybe_rxd_reqs,
+        setup_requires=["wheel", "setuptools_scm"] + maybe_docs + maybe_test_runner + maybe_rxd_reqs,
         dependency_links=[],
     )
 


### PR DESCRIPTION
* drop "manual" logic for version handling
* rely on setuptools_scm to leverage git (including shallow clones)
* local PEP440 versions not accepted on PyPi: use local_scheme
  * leverage NRN_NIGHTLY_UPLOAD to drop the hash from the version (`local_scheme:no-local-version`)
  * default: `local_scheme:node-and-date`
* exchange NEURON_WHEEL_VERSION with SETUPTOOLS_SCM_PRETEND_VERSION

closes #2240 
implements part of #2238 

some checks
-----------------
```bash
(venv) savulesc@bbd-cjngk03:~/Workspace/nrn$ python setup.py --version
9.0.dev1301+g63adaaf3e
(venv) savulesc@bbd-cjngk03:~/Workspace/nrn$ export NRN_NIGHTLY_UPLOAD=true
(venv) savulesc@bbd-cjngk03:~/Workspace/nrn$ python setup.py --version
9.0.dev1301
```
shallow:
```bash
(venv) savulesc@bbd-cjngk03:~/Workspace$ git clone git@github.com:neuronsimulator/nrn.git --depth=1 -b setuptools_scm nnn
....
(venv) savulesc@bbd-cjngk03:~/Workspace/nnn$ python setup.py --version
/home/savulesc/Workspace/nrn/venv/lib/python3.10/site-packages/setuptools_scm/git.py:135: UserWarning: "/home/savulesc/Workspace/nnn" is shallow and may cause errors
  warnings.warn(f'"{wd.path}" is shallow and may cause errors')
0.1.dev1
(venv) savulesc@bbd-cjngk03:~/Workspace/nnn$ unset NRN_NIGHTLY_UPLOAD
(venv) savulesc@bbd-cjngk03:~/Workspace/nnn$ python setup.py --version
/home/savulesc/Workspace/nrn/venv/lib/python3.10/site-packages/setuptools_scm/git.py:135: UserWarning: "/home/savulesc/Workspace/nnn" is shallow and may cause errors
  warnings.warn(f'"{wd.path}" is shallow and may cause errors')
0.1.dev1+g63adaaf
```
SETUPTOOLS_SCM_PRETEND_VERSION
```
SETUPTOOLS_SCM_PRETEND_VERSION=9.9.9 packaging/python/build_wheels.bash CI
...
9464502 Feb 21 09:59 NEURON_nightly-9.9.9-cp310-cp310-linux_x86_64.whl
```