### PR TITLE
Reduce testing setup complexity.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -192,18 +192,9 @@ build:nmodl:
 .build_neuron_nmodl:
   extends: [.build_neuron]
   needs: ["build:nmodl"]
-  variables:
-    # hpe-mpi part avoids re-building py-mpi4py (when +mpi is set), hdf part
-    # avoids more rebuilding when +report is set (which it is by default)
-    SPACK_PACKAGE_DEPENDENCIES: ^hpe-mpi%gcc ^hdf5%gcc
 
 .build_neuron_mod2c:
   extends: [.build_neuron]
-  variables:
-    # libsonata-report and reportinglib parts avoid those libraries being
-    # compiled with intel, nvhpc and gcc in every pipeline; the
-    # hpe-mpi/python/py-setuptools parts try to avoid re-building py-mpi4py
-    SPACK_PACKAGE_DEPENDENCIES: ^libsonata-report%gcc ^reportinglib%gcc ^hpe-mpi%gcc ^python%gcc ^py-setuptools%gcc
 
 build:neuron:mod2c:intel:shared:
   extends: [.build_neuron_mod2c, .spack_intel]
@@ -238,12 +229,12 @@ build:neuron:nmodl:nvhpc:acc:shared:
 build:neuron:nmodl:nvhpc:omp:legacy:
   extends: [.build_neuron_nmodl, .spack_nvhpc]
   variables:
-    SPACK_PACKAGE_SPEC: ~rx3d+caliper+gpu+coreneuron~legacy-unit+nmodl+openmp~shared~sympy+tests~unified build_type=FastDebug model_tests=channel-benchmark,olfactory,tqperf-heavy ^caliper+cuda%gcc cuda_arch=70
+    SPACK_PACKAGE_SPEC: ~rx3d+caliper+gpu+coreneuron~legacy-unit+nmodl+openmp~shared~sympy+tests~unified build_type=FastDebug model_tests=channel-benchmark,olfactory,tqperf-heavy ^caliper+cuda cuda_arch=70
 
 build:neuron:nmodl:nvhpc:omp:
   extends: [.build_neuron_nmodl, .spack_nvhpc]
   variables:
-    SPACK_PACKAGE_SPEC: ~rx3d+caliper+gpu+coreneuron~legacy-unit+nmodl+openmp~shared+sympy+tests~unified build_type=FastDebug model_tests=channel-benchmark,olfactory,tqperf-heavy ^caliper+cuda%gcc cuda_arch=70
+    SPACK_PACKAGE_SPEC: ~rx3d+caliper+gpu+coreneuron~legacy-unit+nmodl+openmp~shared+sympy+tests~unified build_type=FastDebug model_tests=channel-benchmark,olfactory,tqperf-heavy ^caliper+cuda cuda_arch=70
 
 # Test NEURON
 test:neuron:mod2c:intel:shared:


### PR DESCRIPTION
With the new software deployment at BlueBrain, `%gcc` specifications are
not need any longer.  Packages will have to have a different compiler
specified explicitly, dependencies will by default be built with `%gcc`.
