### PR TITLE
Fix Windows and Mac crash on multiline HOC statements input from terminal.

### DIFF
--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -1550,6 +1550,7 @@ extern void hoc_notify_value(void);
 #if READLINE
 #ifdef MINGW
 extern int (*rl_getc_function)(void);
+extern int rl_getc;
 static int getc_hook(void) {
     if (!inputReady_) {
         stdin_event_ready(); /* store main thread id */
@@ -1753,7 +1754,7 @@ int hoc_get_line(void) { /* supports re-entry. fill cbuf with next line */
                 rl_getc_function = getc_hook;
                 hoc_notify_value();
             } else {
-                rl_getc_function = NULL;
+                rl_getc_function = rl_getc;
             }
             ENDGUI
 #else /* not MINGW */

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -142,11 +142,6 @@ extern char* readline(const char* prompt);
 extern void rl_deprep_terminal(void);
 extern void add_history(const char*);
 }
-#if defined(MINGW) || defined(use_rl_getc_function)
-extern "C" int (*rl_getc_function)(void);
-static int (*rl_getc_default)(void);
-#endif
-
 #endif
 
 int nrn_nobanner_;
@@ -829,12 +824,6 @@ int hoc_main1_inited_;
 void hoc_main1_init(const char* pname, const char** envp) {
     extern NrnFILEWrap* frin;
     extern FILE* fout;
-
-#if READLINE && (defined(MINGW) || defined(use_rl_getc_function))
-    if (!rl_getc_default) {
-        rl_getc_default = rl_getc_function;
-    }
-#endif
 
     if (!hoc_xopen_file_) {
         hoc_xopen_file_size_ = 200;
@@ -1561,7 +1550,7 @@ extern void hoc_notify_value(void);
 #if READLINE
 #ifdef MINGW
 extern "C" int (*rl_getc_function)(void);
-extern "C" int rl_getc(void);
+extern "C" int rl_getc();
 static int getc_hook(void) {
     if (!inputReady_) {
         stdin_event_ready(); /* store main thread id */
@@ -1586,7 +1575,7 @@ static int getc_hook(void) {
 /* e.g. mac libedit.3.dylib missing rl_event_hook */
 
 extern int iv_dialog_is_running;
-
+extern int (*rl_getc_function)(void);
 static int getc_hook(void) {
     while (1) {
         int r;
@@ -1765,7 +1754,7 @@ int hoc_get_line(void) { /* supports re-entry. fill cbuf with next line */
                 rl_getc_function = getc_hook;
                 hoc_notify_value();
             } else {
-                rl_getc_function = rl_getc_default;
+                rl_getc_function = rl_getc;
             }
             ENDGUI
 #else /* not MINGW */
@@ -1774,7 +1763,7 @@ int hoc_get_line(void) { /* supports re-entry. fill cbuf with next line */
                 rl_getc_function = getc_hook;
                 hoc_notify_value();
             } else {
-                rl_getc_function = rl_getc_default;
+                rl_getc_function = NULL;
             }
 #else  /* not use_rl_getc_function */
             if (hoc_interviews && !hoc_in_yyparse) {

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -1549,8 +1549,8 @@ extern void hoc_notify_value(void);
 
 #if READLINE
 #ifdef MINGW
-extern int (*rl_getc_function)(void);
-extern int rl_getc;
+extern "C" int (*rl_getc_function)(void);
+extern "C" int rl_getc();
 static int getc_hook(void) {
     if (!inputReady_) {
         stdin_event_ready(); /* store main thread id */

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -1550,7 +1550,7 @@ extern void hoc_notify_value(void);
 #if READLINE
 #ifdef MINGW
 extern "C" int (*rl_getc_function)(void);
-extern "C" int rl_getc();
+extern "C" int rl_getc(void);
 static int getc_hook(void) {
     if (!inputReady_) {
         stdin_event_ready(); /* store main thread id */
@@ -1575,12 +1575,12 @@ static int getc_hook(void) {
 /* e.g. mac libedit.3.dylib missing rl_event_hook */
 
 extern int iv_dialog_is_running;
-extern int (*rl_getc_function)(void);
+extern "C" int (*rl_getc_function)(void);
 static int getc_hook(void) {
     while (1) {
         int r;
         unsigned char c;
-        if (run_til_stdin() == 0) {
+        if (hoc_interviews && !hoc_in_yyparse && run_til_stdin() == 0) {
             // nothing in stdin  (happens when windows are dismissed)
             continue;
         }
@@ -1763,7 +1763,7 @@ int hoc_get_line(void) { /* supports re-entry. fill cbuf with next line */
                 rl_getc_function = getc_hook;
                 hoc_notify_value();
             } else {
-                rl_getc_function = NULL;
+                rl_getc_function = getc_hook;
             }
 #else  /* not use_rl_getc_function */
             if (hoc_interviews && !hoc_in_yyparse) {

--- a/test/hoctests/tests/test_nrniv-launch.py
+++ b/test/hoctests/tests/test_nrniv-launch.py
@@ -1,0 +1,27 @@
+import subprocess
+
+
+def srun(cmd, inp):
+    print(cmd, inp)
+    cp = subprocess.run(
+        cmd, shell=True, input=inp, capture_output=True, text=True, timeout=5
+    )
+    return cp.returncode, cp.stderr, cp.stdout
+
+
+r = srun(
+    "nrniv -isatty -c 'a=5' -",
+    r"""
+func square() {
+  return $1*$1
+}
+print "a = ", a
+print "square(a)=", square(a)
+quit()
+""",
+)
+
+assert r[0] == 0
+print(r[2])
+assert "square(a)=25" in r[2]
+assert "oc>quit()" in r[2]

--- a/test/hoctests/tests/test_nrniv-launch.py
+++ b/test/hoctests/tests/test_nrniv-launch.py
@@ -1,3 +1,9 @@
+from sys import platform
+
+if platform == "win32":  # skip the test.
+    # Cannot get subprocess.run to feed stdin to nrniv
+    quit()
+
 import subprocess
 
 
@@ -10,7 +16,7 @@ def srun(cmd, inp):
 
 
 r = srun(
-    "nrniv -isatty -c 'a=5' -",
+    'nrniv -isatty -c "a=5" -',
     r"""
 func square() {
   return $1*$1
@@ -24,4 +30,5 @@ quit()
 assert r[0] == 0
 print(r[2])
 assert "square(a)=25" in r[2]
-assert "oc>quit()" in r[2]
+if platform != "darwin":  # Mac does not print the "oc>" prompt
+    assert "oc>quit()" in r[2]


### PR DESCRIPTION
Closes #2257 

Windows and Mac now act like linux for multiline HOC statements
```
$ nrniv
NEURON -- VERSION 9.0.dev-1312-g53ce9c5e2 hines/readline-bug (53ce9c5e2) 2023-03-08
Duke, Yale, and the BlueBrain Project -- Copyright 1984-2022
See http://neuron.yale.edu/neuron/credits

oc>proc foo() {
>	oc>print 5
>	oc>}
oc>foo()
5 
oc>
```
Note that on linux, the GUI is locked out during multiline statement input. On the mac an error is generated
```
    hoc_run1: caught exception: hoc_execerror: Cannot reenter parser. Maybe
    you were in the middle of a direct command.
```