### PR TITLE
Support Intel oneAPI compilers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -165,7 +165,7 @@ simulation_stack:
 
 .spack_intel:
   variables:
-    SPACK_PACKAGE_COMPILER: intel
+    SPACK_PACKAGE_COMPILER: oneapi
 .spack_nvhpc:
   variables:
     SPACK_PACKAGE_COMPILER: nvhpc

--- a/docs/coreneuron/installation.rst
+++ b/docs/coreneuron/installation.rst
@@ -6,20 +6,29 @@ CoreNEURON is integrated into the NEURON repository, and it is straightforward t
 
 Starting with version 8.1, NEURON also provides Python wheels that include CoreNEURON and, optionally, GPU support. These binary distributions are described in :ref:`Installing Binary Distribution`.
 
-.. warning::
-   These wheels are not yet released, and must currently be installed using ``pip install neuron-nightly`` and/or ``pip install neuron-gpu-nightly``.
-
 Installing with ``pip``
 ***********************
-This should be as simple as ``pip install neuron-nightly``.
+This should be as simple as ``pip install neuron``, for the latest
+release, or ``pip install neuron-nightly`` to install a snapshot of the
+development branch.
 You may want to use ``virtualenv`` to manage your Python package installations.
 
-If you want to use the GPU-enabled wheel then you should run ``pip install neuron-gpu-nightly``.
-This binary wheel does not include all the NVIDIA dependencies that are required to build and execute GPU code, so you should install the `NVIDIA HPC SDK <https://developer.nvidia.com/hpc-sdk>`_ on your machine.
+If you want to use the GPU-enabled wheel then you should run
+``pip install neuron-gpu``, for the latest release, or
+``pip install neuron-gpu-nightly`` to install a snapshot of the
+development branch.
+This binary wheel does not include all the NVIDIA dependencies that are
+required to build and execute GPU code, so you should install the
+`NVIDIA HPC SDK <https://developer.nvidia.com/hpc-sdk>`_ on your
+machine.
 
 .. warning::
-   It is safest to use the same version of the HPC SDK as was used to build the binary wheels.
-   This is currently defined `in this file <https://github.com/neuronsimulator/nrn/blob/master/packaging/python/Dockerfile_gpu>`_ in the NEURON repository.
+   It is currently necessary to use the same version of the HPC SDK as
+   was used to build the binary wheels.
+   This is currently defined
+   `in this file <https://github.com/neuronsimulator/nrn/blob/master/packaging/python/Dockerfile_gpu>`_
+   in the NEURON repository, at the time of writing this is version
+   22.1
 
 
 Installing from source
@@ -36,7 +45,14 @@ Compiler Selection
 ==================
 CoreNEURON relies on compiler `auto-vectorisation <https://en.wikipedia.org/wiki/Automatic_vectorization>`_ to achieve better performance on modern CPUs.
 With this release we recommend compilers from **Intel**, **Cray** and, for GPU support, **NVIDIA** (formerly **PGI**).
-These compilers are able to vectorise the code better than **GCC** or **Clang**, achieving the best possible performance gains.
+These compilers are often able to vectorise the code better than
+**GCC** or **Clang**, achieving the best possible performance gains.
+
+.. note::
+   To benefit from auto-vectorisation it is important to ensure that
+   your compiler flags allow the compiler to assume that vector CPU
+   instructions are available. See the discussion of compiler flags
+   below.
 
 Computer clusters will typically provide the Intel and/or Cray compilers as modules.
 You can also install the Intel compiler by downloading the `oneAPI HPC Toolkit <https://software.intel.com/content/www/us/en/develop/tools/oneapi/hpc-toolkit.html>`_.
@@ -128,18 +144,23 @@ For example,
      -DCMAKE_CXX_COMPILER=nvc++
 
 .. note::
-  ``nvcc`` is provided both by the NVIDIA HPC SDK and by CUDA toolkit
+   ``nvcc`` is provided both by the NVIDIA HPC SDK and by CUDA toolkit
    installations, which can lead to fragile and surprising behaviour.
    See, for example, `this issue <https://forums.developer.nvidia.com/t/nvcc-only-partially-respects-cuda-home-input-file-newer-than-toolkit/182599>`_.
    On some systems it is necessary to load the ``nvhpc`` module before
    the ``cuda`` module, thereby ensuring that ``nvcc`` comes from a
    CUDA toolkit installation, but your mileage may vary.
 
-By default the GPU code will be compiled for NVIDIA devices with compute capability 7.0 or 8.0.
-This can be steered by passing, for example, ``-DCMAKE_CUDA_ARCHITECTURES:STRING=60;70;80`` to CMake.
+By default the GPU code will be compiled for NVIDIA devices with
+compute capability 7.0 (Volta) or 8.0 (Ampere).
+This can be steered by passing, for example,
+``-DCMAKE_CUDA_ARCHITECTURES:STRING=60;70;80`` to CMake.
 
-You can change C/C++ optimisation flags using the  ``-DCMAKE_C_FLAGS``, ``-DCMAKE_CUDA_FLAGS`` and ``-DCMAKE_CXX_FLAGS`` options.
-To make sure your custom flags are not modified, you should also set ``-DCMAKE_BUILD_TYPE=Custom``, for example:
+You can change C/C++ optimisation flags using the  ``-DCMAKE_C_FLAGS``,
+``-DCMAKE_CUDA_FLAGS`` and ``-DCMAKE_CXX_FLAGS`` options.
+These will be appended to the default flags for the CMake build type.
+If you need to override the default flags, you can also set
+``-DCMAKE_BUILD_TYPE=Custom``, for example:
 
 .. code-block::
 
@@ -150,6 +171,44 @@ To make sure your custom flags are not modified, you should also set ``-DCMAKE_B
 
 .. warning::
    If the CMake command fails, make sure to delete temporary CMake cache files (``CMakeCache.txt`` and ``CMakeFiles``, or the entire build directory) before re-running CMake.
+
+To enable support for the vector instructions available on modern CPUs
+and auto-vectorisation optimisations, you may need to pass additional
+flags to your compiler.
+
+For compilers that accept GCC-like options, this often involves setting
+the ``-march`` and ``-mtune`` options.
+Other compilers may vary.
+If you are building on the same machine that you will be running NEURON
+on, you may be able to use ``-march=native`` and ``-mtune=native``, in
+which case many compilers will detect the CPU features that are
+available on the machine that is compiling NEURON.
+Alternatively, you may need to set this explictly, for example:
+``-march=skylake-avx512 -mtune=skylake-avx512``.
+Note that compute clusters may contain a mix of CPU types.
+
+Please also note the following observations about different compilers,
+but ultimately refer to the documentation of the compiler version that
+you are using:
+
+* The handling of ``-march=native`` in GCC `can be surprising <https://lemire.me/blog/2018/07/25/it-is-more-complicated-than-i-thought-mtune-march-in-gcc/>`_.
+
+* The NVIDIA HPC compiler ``nvc++`` uses the equivalent of
+  ``-march=native`` by default
+  (`nvc++ documentation <https://docs.nvidia.com/hpc-sdk/compilers/hpc-compilers-ref-guide/index.html#tp>`_).
+
+* The Intel C++ compilers ``icpc`` and ``icpx`` support an ``-x``
+  option that enables even more specialised optimisations for Intel
+  CPUs
+  (`icpc documentation <https://www.intel.com/content/www/us/en/docs/cpp-compiler/developer-guide-reference/2021-8/x-qx.html>`_,
+  `icpx documentation <https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/developer-guide-reference/2023-0/x-qx.html>`_),
+  this has been seen to give modest performance improvements when using
+  the ``mod2c``, but not ``NMODL``, transpiler.
+
+.. warning::
+   If you tell the compiler to target a more modern CPU than you have
+   available, your NEURON installation may crash with illegal
+   instruction errors and/or ``SIGILL`` signals.
 
 Once the configure step is done, you can build and install the project by running
 

--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -335,12 +335,32 @@ if(NRN_HAVE_NVHPC_COMPILER)
   endif()
   set_source_files_properties(
     ${PROJECT_SOURCE_DIR}/src/oc/math.cpp
-    PROPERTIES COMPILE_DEFINITIONS NVHPC_CHECK_FE_EXCEPTIONS=1 COMPILE_OPTIONS
-                                                               "${NVHPC_MATH_COMPILE_OPTIONS}")
+    PROPERTIES COMPILE_DEFINITIONS NRN_CHECK_FE_EXCEPTIONS=1 COMPILE_OPTIONS
+                                                             "${NVHPC_MATH_COMPILE_OPTIONS}")
   # Versions of nvc++ around ~22.5 up to at least 23.1 have problems with this file see
   # https://github.com/BlueBrain/CoreNeuron/issues/888
   set_source_files_properties(${PROJECT_SOURCE_DIR}/src/ivoc/ivocvect.cpp PROPERTIES COMPILE_OPTIONS
                                                                                      "-O1")
+elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM")
+  # Tested with icpx 2022.2.1:
+  #
+  # * With -fp-model=fast (the default...), icpx does not set the C++11 macro math_errhandling.
+  # * With -fp-model=fast and anything but -O0, icpx does not set floating point exception bits.
+  # * With -fp-model={precise,strict}, floating point exceptions are set at all optimisation levels.
+  # * With -fp-model=precise and anything but -O0, -fno-math-errno also disables exceptions.
+  # * When defined, math_errhandling always contains both MATH_ERRNO and MATH_ERREXCEPT.
+  #
+  # Based on all of this, forcing strict mode and forcing floating point exceptions to be used (with
+  # NRN_CHECK_FE_EXCEPTIONS) seems that it should work at all optimisation levels. We might as well
+  # also pass -fno-math-errno because we will not be checking errno.
+  set_property(
+    SOURCE ${PROJECT_SOURCE_DIR}/src/oc/math.cpp
+    APPEND
+    PROPERTY COMPILE_DEFINITIONS NRN_CHECK_FE_EXCEPTIONS)
+  set_property(
+    SOURCE ${PROJECT_SOURCE_DIR}/src/oc/math.cpp
+    APPEND
+    PROPERTY COMPILE_OPTIONS "-fp-model=strict" "-fno-math-errno")
 elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
   # When optimisation is enabled then icpc apparently does not set errno
   set_property(

--- a/src/oc/math.cpp
+++ b/src/oc/math.cpp
@@ -19,10 +19,13 @@ int hoc_errno_count;
 #ifdef MINGW
 static const auto errno_enabled = true;
 static const auto check_fe_except = false;
-#elif defined(NVHPC_CHECK_FE_EXCEPTIONS)
+#elif defined(NRN_CHECK_FE_EXCEPTIONS)
 static constexpr auto errno_enabled = false;
 static constexpr auto check_fe_except = true;
+#ifdef math_errhandling
+// LLVM-based Intel compiles don't define math_errhandling when -fp-model=fast
 static_assert(math_errhandling & MATH_ERREXCEPT);
+#endif
 #else
 static const auto errno_enabled = math_errhandling & MATH_ERRNO;
 static const auto check_fe_except = !errno_enabled && math_errhandling & MATH_ERREXCEPT;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -269,6 +269,8 @@ if(NRN_ENABLE_PYTHON)
     # GCC. Other compilers produce larger differences.
     if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
       set(change_test_tolerance NRN_RXD_TEST_TOLERANCE=1e-8)
+    elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM")
+      set(change_test_tolerance NRN_RXD_TEST_TOLERANCE=3e-8)
     elseif(NRN_HAVE_NVHPC_COMPILER)
       set(change_test_tolerance NRN_RXD_TEST_TOLERANCE=1e-4)
     endif()

--- a/test/cover/test_netcvode.py
+++ b/test/cover/test_netcvode.py
@@ -83,7 +83,7 @@ def node():
     def ev(*arg):
         print("ev t=%g v=%g x=%g nc.x=%g" % (h.t, s(0.5).v, src.x, nc.x))
         ref_t, ref_x = results[arg[0]][arg[1]]
-        assert h.t == ref_t
+        assert math.isclose(h.t, ref_t, rel_tol=1e-15)
         assert math.isclose(src.x, ref_x, rel_tol=1e-13)
 
     def run():


### PR DESCRIPTION
Closes https://github.com/neuronsimulator/nrn/issues/2232. https://github.com/BlueBrain/mod2c/pull/91 was needed to mitigate a performance regression with `icpx` and CoreNEURON. This needed https://github.com/BlueBrain/spack/pull/1992.