### PR TITLE
Python version of nrntest t13.hoc

### DIFF
--- a/share/lib/python/neuron/tests/utils/__init__.py
+++ b/share/lib/python/neuron/tests/utils/__init__.py
@@ -36,6 +36,8 @@ def cvode_use_long_double(enabled):
     cv = h.CVode()
     old_setting = cv.use_long_double()
     cv.use_long_double(enabled)
+    if enabled != old_setting:
+        cv.re_init()
     try:
         yield None
     finally:

--- a/share/lib/python/neuron/tests/utils/__init__.py
+++ b/share/lib/python/neuron/tests/utils/__init__.py
@@ -1,0 +1,65 @@
+"""
+Utilities for writing tests
+"""
+from contextlib import contextmanager
+
+
+@contextmanager
+def cvode_enabled(enabled):
+    """
+    Helper for tests to enable/disable CVode, leaving the setting as they found it.
+
+    For example:
+    from neuron.tests.utils import cvode_enabled
+    with cvode_enabled(True):
+        # cvode is enabled here
+        some_test_using_cvode()
+    # cvode is disabled again
+    """
+    from neuron import h
+
+    old_status = h.cvode_active()
+    h.cvode_active(enabled)
+    try:
+        yield None
+    finally:
+        h.cvode_active(old_status)
+
+
+@contextmanager
+def cvode_use_long_double(enabled):
+    """
+    Helper for tests to enable/disable long double support in CVode, leaving the setting as they found it.
+    """
+    from neuron import h
+
+    cv = h.CVode()
+    old_setting = cv.use_long_double()
+    cv.use_long_double(enabled)
+    try:
+        yield None
+    finally:
+        cv.use_long_double(old_setting)
+
+
+@contextmanager
+def num_threads(threads=1, parallel=True):
+    """
+    Helper for tests to change the number of threads, leaving the setting as they found it.
+
+    Keyword arguments:
+    threads -- the number of NrnThreads to partition the model into
+    parallel -- whether to process NrnThreads in parallel, if threading support was enabled
+    """
+    from neuron import h
+
+    pc = h.ParallelContext()
+    old_threads = pc.nthread()
+    old_workers = pc.nworker()
+    old_parallel = False if old_threads > 1 and old_workers == 0 else True
+    assert old_workers == 0 or old_workers == old_threads
+    pc.nthread(threads, parallel)
+    try:
+        yield None
+    finally:
+        pc.nthread(old_threads, old_parallel)

--- a/src/nrncvode/cvodeobj.cpp
+++ b/src/nrncvode/cvodeobj.cpp
@@ -362,11 +362,12 @@ static double use_long_double(void* v) {
     NetCvode* d = (NetCvode*) v;
     hoc_return_type_code = 2;  // boolean
     if (ifarg(1)) {
-        int i = (int) chkarg(1, 0, 1);
-        d->use_long_double_ = i;
+        bool const new_value = chkarg(1, 0, 1);
+        d->use_long_double_changed_ = (new_value != d->use_long_double_);
+        d->use_long_double_ = new_value;
         recalc_diam();
     }
-    return (double) d->use_long_double_;
+    return d->use_long_double_;
 }
 
 static double condition_order(void* v) {
@@ -890,7 +891,8 @@ void Cvode::stat_init() {
 }
 
 void Cvode::init_prepare() {
-    if (init_global()) {
+    auto const do_init = init_global();
+    if (do_init) {
         if (y_) {
             N_VDestroy(y_);
             y_ = nil;

--- a/src/nrncvode/netcvode.cpp
+++ b/src/nrncvode/netcvode.cpp
@@ -1178,7 +1178,6 @@ void NetCvodeThreadData::enqueue(NetCvode* nc, NrnThread* nt) {
 }
 
 NetCvode::NetCvode(bool single) {
-    use_long_double_ = 0;
     empty_ = true;  // no equations (only artificial cells).
     MUTCONSTRUCT(0);
     maxorder_ = 5;

--- a/src/nrncvode/netcvode.h
+++ b/src/nrncvode/netcvode.h
@@ -255,7 +255,7 @@ class NetCvode {
     int pcnt_;
     NetCvodeThreadData* p;
     int enqueueing_;
-    int use_long_double_;
+    bool use_long_double_{false}, use_long_double_changed_{false};
 
   public:
     MUTDEC  // only for enqueueing_ so far.

--- a/src/nrncvode/occvode.cpp
+++ b/src/nrncvode/occvode.cpp
@@ -80,6 +80,7 @@ The variable step method for these cases is handled by daspk.
 // determine neq_ and vector of pointers to scatter/gather y
 // as well as algebraic nodes (no_cap)
 
+extern NetCvode* net_cvode_instance;
 bool Cvode::init_global() {
 #if PARANEURON
     if (!use_partrans_ && nrnmpi_numprocs > 1 && (nrnmpi_v_transfer_ || nrn_multisplit_solve_)) {
@@ -87,9 +88,17 @@ bool Cvode::init_global() {
         // threads and mpi together
         // could be a lot better.
         use_partrans_ = true;
+        if (net_cvode_instance->use_long_double_changed_) {
+            net_cvode_instance->use_long_double_changed_ = false;
+            return true;
+        }
     } else
 #endif
-        if (!structure_change_) {
+        if (net_cvode_instance->use_long_double_changed_) {
+        net_cvode_instance->use_long_double_changed_ = false;
+        return true;
+    }
+    if (!structure_change_) {
         return false;
     }
     if (ctd_[0].cv_memb_list_ == nil) {

--- a/src/parallel/ocbbs.cpp
+++ b/src/parallel/ocbbs.cpp
@@ -913,6 +913,11 @@ static double nthrd(void*) {
     return double(nrn_nthread);
 }
 
+static double number_of_worker_threads(void*) {
+    hoc_return_type_code = 1;  // integer
+    return nof_worker_threads();
+}
+
 static double partition(void*) {
     Object* ob = 0;
     int it;
@@ -1085,6 +1090,7 @@ static Member_func members[] = {{"submit", submit},
                                 {"broadcast", broadcast},
 
                                 {"nthread", nthrd},
+                                {"nworker", number_of_worker_threads},
                                 {"partition", partition},
                                 {"thread_stat", thread_stat},
                                 {"thread_busywait", thread_busywait},

--- a/test/pynrn/test_nrntest_fast.py
+++ b/test/pynrn/test_nrntest_fast.py
@@ -43,13 +43,13 @@ def test_t13():
     in N_VWrmsNorm)
     """
     h.nrnunit_use_legacy(True)
-    cells = [Cell(i) for i in range(2)]
-    with num_threads(threads=1, parallel=True), open("temp13_py", "w") as ofile:
+    cells = [Cell(i) for i in range(3)]
+    with num_threads(threads=3, parallel=True), open("temp13_py", "w") as ofile:
         print("fixed step", file=ofile)
         h.run()
         for cell in cells:
             cell.pr(ofile)
-        with cvode_enabled(True), cvode_use_long_double(False):
+        with cvode_enabled(True), cvode_use_long_double(True):
             print("cvode", file=ofile)
             h.run()
             for cell in cells:

--- a/test/pynrn/test_nrntest_fast.py
+++ b/test/pynrn/test_nrntest_fast.py
@@ -1,0 +1,60 @@
+"""
+Tests that used to live in the fast/ subdirectory of the
+https://github.com/neuronsimulator/nrntest repository
+"""
+import math
+from neuron import h
+from neuron.tests.utils import cvode_enabled, cvode_use_long_double, num_threads
+
+h.load_file("stdrun.hoc")
+
+
+class Cell:
+    def __init__(self, id):
+        self.id = id
+        self.soma = h.Section(name="soma", cell=self)
+        self.soma.L = 10
+        self.soma.diam = 100 / (math.pi * self.soma.L)
+        self.soma.insert("hh")
+        self.s = h.IClamp(self.soma(0.5))
+        self.s.dur = 0.1 + 0.1 * id
+        self.s.amp = 0.2 + 0.1 * id
+        self.vv = h.Vector()
+        self.vv.record(self.soma(0.5)._ref_v)
+        self.tv = h.Vector()
+        self.tv.record(h._ref_t)
+
+    def pr(self, file=None):
+        print("\n{}".format(self), file=file)
+        assert self.tv.size() == self.vv.size()
+        for t, v in zip(self.tv, self.vv):
+            print("{:.20g} {:.20g}".format(t, v), file=file)
+
+    def __str__(self):
+        return "Cell[{:d}]".format(self.id)
+
+
+def test_t13():
+    """
+    hh model, fixed step, and cvode with threads
+    Note: full double precision identity between single and multiple
+    threads is obtainable when cvode.use_long_double(1) is invoked
+    (avoids different roundoff error due to different summation order
+    in N_VWrmsNorm)
+    """
+    h.nrnunit_use_legacy(True)
+    cells = [Cell(i) for i in range(2)]
+    with num_threads(threads=1, parallel=True), open("temp13_py", "w") as ofile:
+        print("fixed step", file=ofile)
+        h.run()
+        for cell in cells:
+            cell.pr(ofile)
+        with cvode_enabled(True), cvode_use_long_double(False):
+            print("cvode", file=ofile)
+            h.run()
+            for cell in cells:
+                cell.pr(ofile)
+
+
+if __name__ == "__main__":
+    test_t13()


### PR DESCRIPTION
- `use_long_double_changed_` is a temporary solution; presumably a more elegant one can be found
- without it, the Python script seems to initialise CVODE without long double accumulation, and subsequent attempts to enable it are ignored
- the Python test doesn't do any validation yet, but it prints a file in the same format as the HOC test, which can be compared (from the build directory) with:
```
olupton@ewaewa build % vim -d ../external/tests/nrntest/fast/temp13 test/pynrn/basic_tests/temp13_py
```
after changing t13.hoc to have `printf("%.20g %.20g\n", tv.x[i], vv.x[i])`