### PR TITLE
win_build_cmake.sh: call cmake install directly

### DIFF
--- a/ci/win_build_cmake.sh
+++ b/ci/win_build_cmake.sh
@@ -9,9 +9,6 @@ export MINGW_CHOST=x86_64-w64-mingw32
 export MSYSTEM_PREFIX=/mingw64
 export PATH=/mingw64/bin:$PATH
 
-# set core.autocrlf to true
-# in order to avoid GLOB mismatch on `install` target
-git config --global core.autocrlf true
 
 # if BUILD_SOURCESDIRECTORY not available, use te root of the repo
 if [ -z "$BUILD_SOURCESDIRECTORY" ]; then
@@ -39,7 +36,7 @@ cd $BUILD_SOURCESDIRECTORY/build
 	-DMPI_msmpi_LIBRARY:FILEPATH=c:/msmpi/lib/x64/msmpi.lib
 make -j 2
 ctest -VV
-make install
+VERBOSE=1 make install
 make setup_exe
 
 # copy installer with fixed name for nightly upload

--- a/ci/win_build_cmake.sh
+++ b/ci/win_build_cmake.sh
@@ -34,9 +34,8 @@ cd $BUILD_SOURCESDIRECTORY/build
 	-DMPI_CXX_LIB_NAMES:STRING=msmpi \
 	-DMPI_C_LIB_NAMES:STRING=msmpi \
 	-DMPI_msmpi_LIBRARY:FILEPATH=c:/msmpi/lib/x64/msmpi.lib
-make -j 2 install
+make -j 2 setup_exe
 ctest -VV
-make setup_exe
 
 # copy installer with fixed name for nightly upload
 cp src/mswin/nrn*AMD64.exe $BUILD_SOURCESDIRECTORY/nrn-nightly-AMD64.exe

--- a/ci/win_build_cmake.sh
+++ b/ci/win_build_cmake.sh
@@ -9,6 +9,10 @@ export MINGW_CHOST=x86_64-w64-mingw32
 export MSYSTEM_PREFIX=/mingw64
 export PATH=/mingw64/bin:$PATH
 
+# set core.autocrlf to true
+# in order to avoid GLOB mismatch on `install` target
+git config --global core.autocrlf true
+
 # if BUILD_SOURCESDIRECTORY not available, use te root of the repo
 if [ -z "$BUILD_SOURCESDIRECTORY" ]; then
 	export BUILD_SOURCESDIRECTORY=$(git rev-parse --show-toplevel)

--- a/ci/win_build_cmake.sh
+++ b/ci/win_build_cmake.sh
@@ -34,9 +34,8 @@ cd $BUILD_SOURCESDIRECTORY/build
 	-DMPI_CXX_LIB_NAMES:STRING=msmpi \
 	-DMPI_C_LIB_NAMES:STRING=msmpi \
 	-DMPI_msmpi_LIBRARY:FILEPATH=c:/msmpi/lib/x64/msmpi.lib
-make -j 2
+make -j 2 install
 ctest -VV
-VERBOSE=1 make install
 make setup_exe
 
 # copy installer with fixed name for nightly upload

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -58,9 +58,17 @@ As you can see in the script, a typical configuration would be:
 	-DMPI_C_LIB_NAMES:STRING=msmpi \
 	-DMPI_msmpi_LIBRARY:FILEPATH=c:/msmpi/lib/x64/msmpi.lib
 ```
+In order to build:
+```
+make -j 2
+```
+Install:
+```
+make install
+```
+
 To create the Windows installer, you need to run:
 ```bash
-make install
 make setup_exe
 ```
 


### PR DESCRIPTION
This mitigates the fact that doing `make` and then `make install` ends up in GLOB mismatch and re-triggers extension builds.