### PR TITLE
Windows 11 fix for hoc icon.

### DIFF
--- a/src/mswin/extra/neuron.cpp
+++ b/src/mswin/extra/neuron.cpp
@@ -101,10 +101,41 @@ int main(int argc, char** argv) {
 #endif
     auto const msg_size = strlen(buf) + 100;
     char* const msg = new char[msg_size];
-    err = WinExec(buf, SW_SHOW);
-    if (err < 32) {
-        std::snprintf(msg, msg_size, "Cannot WinExec %s\n", buf);
+
+    // Windows 11 exits immediately
+    // err = WinExec(buf, SW_SHOW);
+    // https://stackoverflow.com/questions/2255608/force-application-to-wait-until-winexec-has-completed
+    // WinExec is no longer recommended. You can use CreateProcess and WaitForSingleObject as
+    // shown in this example on Creating Processes.
+    STARTUPINFO si;
+    PROCESS_INFORMATION pi;
+    ZeroMemory(&si, sizeof(si));
+    si.cb = sizeof(si);
+    ZeroMemory(&pi, sizeof(pi));
+    // Start the child process.
+    err = CreateProcess(NULL,   // No module name (use command line)
+                        buf,    // Command line
+                        NULL,   // Process handle not inheritable
+                        NULL,   // Thread handle not inheritable
+                        FALSE,  // Set handle inheritance to FALSE
+                        0,      // No creation flags
+                        NULL,   // Use parent's environment block
+                        NULL,   // Use parent's starting directory
+                        &si,    // Pointer to STARTUPINFO structure
+                        &pi);   // Pointer to PROCESS_INFORMATION structure
+
+    if (!err) {
+        std::snprintf(msg, msg_size, "CreateProcess failed (%d).  %s\n", GetLastError(), buf);
         MessageBox(0, msg, "NEURON", MB_OK);
+        return 1;
     }
+
+    // Wait until child process exits.
+    WaitForSingleObject(pi.hProcess, INFINITE);
+
+    // Close process and thread handles.
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+
     return 0;
 }

--- a/src/mswin/extra/neuron.cpp
+++ b/src/mswin/extra/neuron.cpp
@@ -103,7 +103,6 @@ int main(int argc, char** argv) {
     char* const msg = new char[msg_size];
 
     // Windows 11 exits immediately
-    // err = WinExec(buf, SW_SHOW);
     // https://stackoverflow.com/questions/2255608/force-application-to-wait-until-winexec-has-completed
     // WinExec is no longer recommended. You can use CreateProcess and WaitForSingleObject as
     // shown in this example on Creating Processes.


### PR DESCRIPTION
Replacement of WinExec by CreateProcess (and then wait with WaitForSingleObject)
The bug it overcomes is failure to run by double clicking on hoc file.

This is the part of #2255 that works. It is separated out to allow merging. The other part, fixing "nrniv -python" is still a work in progress.