### PR TITLE
doc system updates: links and testing

### DIFF
--- a/docs/hoc/modelspec/programmatic/mechanisms/mech.rst
+++ b/docs/hoc/modelspec/programmatic/mechanisms/mech.rst
@@ -826,7 +826,7 @@ Mechanisms
 
 **fastpas**
 
-        See `<nrn src dir>/src/nrnoc/passive0.c <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/passive0.c>`_
+        See `<nrn src dir>/src/nrnoc/passive0.cpp <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/passive0.cpp>`_
          
         Passive membrane channel. Same as the :ref:`pas <hoc_mech_pas>` mechanism but hand coded to
         be a bit faster (avoids the wasteful numerical derivative computation of 
@@ -943,7 +943,7 @@ Mechanisms
         It is best to start out believing that there are bugs in the method 
         and attempt to prove their existence. 
 
-        See `<nrn src dir>/src/nrnoc/extcell.c <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/extcell.c>`_
+        See `<nrn src dir>/src/nrnoc/extcell.cpp <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/extcell.cpp>`_
         and `<nrn src dir>/share/examples/nrniv/nrnoc/extcab*.hoc <https://github.com/neuronsimulator/nrn/tree/master/share/examples/nrniv/nrnoc>`_.
          
         NEURON can be compiled with any number of extracellular layers. 

--- a/docs/hoc/modelspec/programmatic/mechanisms/mech.rst
+++ b/docs/hoc/modelspec/programmatic/mechanisms/mech.rst
@@ -121,7 +121,7 @@ General
 
 
     Description:
-        See `<nrn src dir>/src/nrnoc/stim.mod <http://neuron.yale.edu/hg/neuron/nrn/file/tip/src/nrnoc/stim.mod>`_
+        See `<nrn src dir>/src/nrnoc/stim.mod <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/stim.mod>`_
          
         Single pulse current clamp point process. This is an electrode current 
         so positive amp depolarizes the cell. i is set to amp when t is within 
@@ -152,7 +152,7 @@ General
 
 
     Description:
-        See `<nrn src dir>/src/nrnoc/syn.mod <http://neuron.yale.edu/hg/neuron/nrn/file/tip/src/nrnoc/syn.mod>`_. The comment in this file reads: 
+        See `<nrn src dir>/src/nrnoc/syn.mod <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/syn.mod>`_. The comment in this file reads: 
 
         .. code-block::
             none
@@ -190,7 +190,7 @@ General
     Description:
         Two electrode voltage clamp. 
          
-        See `<nrn src dir>/src/nrnoc/vclmp.mod <http://neuron.yale.edu/hg/neuron/nrn/file/tip/src/nrnoc/vclmp.mod>`_. The comment in this file reads: 
+        See `<nrn src dir>/src/nrnoc/vclmp.mod <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/vclmp.mod>`_. The comment in this file reads: 
          
         Voltage clamp with three levels. Clamp is on at time 0, and off at time 
         dur[0]+dur[1]+dur[2]. When clamp is off the injected current is 0. 
@@ -272,7 +272,7 @@ General
     Description:
         Single electrode voltage clamp with three levels. 
          
-        See `<nrn src dir>/src/nrnoc/svclmp.mod <http://neuron.yale.edu/hg/neuron/nrn/file/tip/src/nrnoc/svclmp.mod>`_. The comment in this file reads: 
+        See `<nrn src dir>/src/nrnoc/svclmp.mod <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/svclmp.mod>`_. The comment in this file reads: 
          
         Single electrode Voltage clamp with three levels. 
         Clamp is on at time 0, and off at time 
@@ -368,7 +368,7 @@ General
         The apc is not notified if the vector is freed but this can be fixed if 
         it is convenient to add this feature. 
          
-        See `<nrn src dir>/src/nrnoc/apcount.mod <http://neuron.yale.edu/hg/neuron/nrn/file/tip/src/nrnoc/apcount.mod>`_
+        See `<nrn src dir>/src/nrnoc/apcount.mod <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/apcount.mod>`_
 
 
 ----
@@ -404,7 +404,7 @@ General
          
         This synapse summates. 
          
-        See `<nrn src dir>/src/nrnoc/expsyn.mod <http://neuron.yale.edu/hg/neuron/nrn/file/tip/src/nrnoc/expsyn.mod>`_
+        See `<nrn src dir>/src/nrnoc/expsyn.mod <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/expsyn.mod>`_
 
 
 ----
@@ -464,7 +464,7 @@ General
          
         This synapse summates. 
          
-        See `<nrn src dir>/src/nrnoc/exp2syn.mod <http://neuron.yale.edu/hg/neuron/nrn/file/tip/src/nrnoc/exp2syn.mod>`_
+        See `<nrn src dir>/src/nrnoc/exp2syn.mod <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/exp2syn.mod>`_
          
 
 
@@ -518,7 +518,7 @@ General
 
         That is, do not use ``&nc.y`` as the source for the netcon. 
          
-        See `<nrn src dir>/src/nrnoc/netstim.mod <http://neuron.yale.edu/hg/neuron/nrn/file/tip/src/nrnoc/netstim.mod>`_
+        See `<nrn src dir>/src/nrnoc/netstim.mod <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/netstim.mod>`_
 
     .. warning::
         Prior to version 5.2.1 an attempt was made to 
@@ -570,7 +570,7 @@ General
         for the first 0.5 ms and -1 for the rest of the period. Otherwise it 
         returns exp((t-t0)/tau) 
          
-        See `<nrn src dir>/src/nrnoc/intfire1.mod <http://neuron.yale.edu/hg/neuron/nrn/file/tip/src/nrnoc/intfire1.mod>`_
+        See `<nrn src dir>/src/nrnoc/intfire1.mod <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/intfire1.mod>`_
 
 
 ----
@@ -612,7 +612,7 @@ General
         changes abruptly by 
         the amount w. 
         
-        See `<nrn src dir>/src/nrnoc/intfire2.mod <http://neuron.yale.edu/hg/neuron/nrn/file/tip/src/nrnoc/intfire2.mod>`_         
+        See `<nrn src dir>/src/nrnoc/intfire2.mod <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/intfire2.mod>`_         
 
          
 
@@ -674,7 +674,7 @@ General
         an isolated inhibitory event of weight -1 will produce a minimum 
         membrane potential of -1. 
          
-        See `<nrn src dir>/src/nrnoc/intfire4.mod <http://neuron.yale.edu/hg/neuron/nrn/file/tip/src/nrnoc/intfire4.mod>`_         
+        See `<nrn src dir>/src/nrnoc/intfire4.mod <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/intfire4.mod>`_         
 
 ----
 
@@ -765,7 +765,7 @@ Mechanisms
 
 
     Description:
-        See `<nrn src dir>/src/nrnoc/hh.mod <http://neuron.yale.edu/hg/neuron/nrn/file/tip/src/nrnoc/hh.mod>`_
+        See `<nrn src dir>/src/nrnoc/hh.mod <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/hh.mod>`_
          
         Hodgkin-Huxley sodium, potassium, and leakage channels. Range variables 
         specific to this model are: 
@@ -810,7 +810,7 @@ Mechanisms
 
 
     Description:
-        See `<nrn src dir>/src/nrnoc/passive.mod <http://neuron.yale.edu/hg/neuron/nrn/file/tip/src/nrnoc/passive.mod>`_
+        See `<nrn src dir>/src/nrnoc/passive.mod <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/passive.mod>`_
          
         Passive membrane channel. 
 
@@ -826,7 +826,7 @@ Mechanisms
 
 **fastpas**
 
-        See `<nrn src dir>/src/nrnoc/passive0.c <http://neuron.yale.edu/hg/neuron/nrn/file/tip/src/nrnoc/passive0.c>`_
+        See `<nrn src dir>/src/nrnoc/passive0.c <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/passive0.c>`_
          
         Passive membrane channel. Same as the :ref:`pas <hoc_mech_pas>` mechanism but hand coded to
         be a bit faster (avoids the wasteful numerical derivative computation of 
@@ -943,8 +943,8 @@ Mechanisms
         It is best to start out believing that there are bugs in the method 
         and attempt to prove their existence. 
 
-        See `<nrn src dir>/src/nrnoc/extcell.c <http://neuron.yale.edu/hg/neuron/nrn/file/tip/src/nrnoc/extcell.c>`_
-        and `<nrn src dir>/examples/nrnoc/extcab*.hoc <http://neuron.yale.edu/hg/neuron/nrn/file/tip/share/examples/nrniv/nrnoc>`_.
+        See `<nrn src dir>/src/nrnoc/extcell.c <https://github.com/neuronsimulator/nrn/blob/master/src/nrnoc/extcell.c>`_
+        and `<nrn src dir>/share/examples/nrniv/nrnoc/extcab*.hoc <https://github.com/neuronsimulator/nrn/tree/master/share/examples/nrniv/nrnoc>`_.
          
         NEURON can be compiled with any number of extracellular layers. 
         See below. 

--- a/docs/hoc/simctrl/stdrun.rst
+++ b/docs/hoc/simctrl/stdrun.rst
@@ -27,7 +27,7 @@ Brief summaries of the menu options are provided below, for more information on 
     runctrl.rst
     family.rst
 
-Implementations of the standard tools are in `$NEURONHOME/lib/hoc/*.hoc <http://neuron.yale.edu/hg/neuron/nrn/file/tip/share/lib/hoc>`_ 
+Implementations of the standard tools are in `$NEURONHOME/lib/hoc/*.hoc <https://github.com/neuronsimulator/nrn/tree/master/share/lib/hoc>`_ 
      
 
 .. _hoc_NEURONMainMenu:
@@ -58,7 +58,7 @@ There is often reason to substitute a new step or advance
 procedure to do intermediate calculations on the fly. 
 Sometimes it is useful to replace the init() procedure. If so 
 make sure you don't take away functionality which is already 
-there. See `$NEURONHOME/lib/hoc/stdrun.hoc <http://neuron.yale.edu/hg/neuron/nrn/file/tip/share/lib/hoc/stdrun.hoc>`_ for the 
+there. See `$NEURONHOME/lib/hoc/stdrun.hoc <https://github.com/neuronsimulator/nrn/tree/master/share/lib/hoc/stdrun.hoc>`_ for the 
 implementations of these procedures. 
      
      
@@ -549,7 +549,7 @@ the label and count are always present in the file.
 For long files retrieval is much more efficient if the count is present. 
  
 The implementation of these operations is in 
-`$NEURONHOME/lib/hoc/stdlib.hoc <http://neuron.yale.edu/hg/neuron/nrn/file/tip/share/lib/hoc/stdlib.hoc>`_
+`$NEURONHOME/lib/hoc/stdlib.hoc <https://github.com/neuronsimulator/nrn/tree/master/share/lib/hoc/stdlib.hoc>`_
 vectors and performing simple manipulations on them. 
 
 .. seealso::

--- a/docs/python/programming/python.rst
+++ b/docs/python/programming/python.rst
@@ -46,7 +46,7 @@ Description:
 
     Most of the following is from the perspective of someone familiar
     with HOC; for a Python-based introduction to NEURON, see
-    http://neuron.yale.edu/neuron/static/docs/neuronpython/index.html
+    `Scripting NEURON Basics <../../tutorials/scripting-neuron-basics.html>`_
 
 
 .. class:: neuron.hoc.HocObject

--- a/share/lib/python/neuron/doc.py
+++ b/share/lib/python/neuron/doc.py
@@ -124,16 +124,14 @@ For a list of symbols defined in neuron.h try:
 
 NOTE: Several Hoc symbols are not useful in Python, and thus raise an exception when accessed, for example:
 
-In []: h.objref
----------------------------------------------------------------------------
-TypeError                                 Traceback (most recent call last)
-
-/home/emuller/hg/nrn_neurens_hg/<ipython console> in <module>()
-
-TypeError: Cannot access objref (NEURON type 323) directly.
-
-In []: h.objref ?
-Object `h.objref` not found.
+>>> h.objref
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+TypeError: Cannot access objref (NEURON type 325) directly.
+>>> help(h.objref)
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+TypeError: Cannot access objref (NEURON type 325) directly.
 
 
 """
@@ -143,7 +141,7 @@ default_class_doc_template = """
 No docstring available for class '%s'
 
 Try checking the online documentation at:
-https://www.neuron.yale.edu/neuron/static/py_doc/index.html
+https://nrn.readthedocs.org/
 """
 
 
@@ -151,7 +149,7 @@ default_object_doc_template = """
 No docstring available for object type '%s'
 
 Try checking the online documentation at:
-https://www.neuron.yale.edu/neuron/static/py_doc/index.html
+https://nrn.readthedocs.org/
 """
 
 
@@ -159,7 +157,7 @@ default_member_doc_template = """
 No docstring available for the class member '%s.%s'
 
 Try checking the online documentation at:
-https://www.neuron.yale.edu/neuron/static/py_doc/index.html
+https://nrn.readthedocs.org/
 
 ==================================================
 
@@ -178,8 +176,8 @@ def _get_class_from_help_dict(name):
         return ""
     methods = dir(h.__getattribute__(name))
     for m in methods:
-        if name + "." + m in _help_dict:
-            result += "\n\n\n%s.%s:\n\n%s" % (name, m, _help_dict[name + "." + m])
+        if f"{name}.{m}" in _help_dict:
+            result += "\n\n\n%s.%s:\n\n%s" % (name, m, _help_dict[f"{name}.{m}"])
     return result
 
 
@@ -225,7 +223,7 @@ def get_docstring(objtype, symbol):
             return default_object_doc_template % symbol
 
     # are we asking for help on a member of an object, e.g. h.Vector.size
-    full_name = "%s.%s" % (objtype, symbol)
+    full_name = f"{objtype}.{symbol}"
     if full_name in _help_dict:
         return _get_from_help_dict(full_name)
     else:

--- a/test/pynrn/test_basic.py
+++ b/test/pynrn/test_basic.py
@@ -442,6 +442,18 @@ def test_nworker():
             assert pc.nworker() == 2 * threads_enabled
 
 
+def test_help():
+    # a little fragile in the event we change the docs, but easily fixed
+    # checks the main paths for generating docstrings
+    assert h.Vector().to_python.__doc__.startswith(
+        "Syntax:\n    ``pythonlist = vec.to_python()"
+    )
+    assert h.Vector().__doc__.startswith("This class was imple")
+    assert h.Vector.__doc__.startswith("This class was imple")
+    assert h.finitialize.__doc__.startswith("Syntax:\n    ``h.finiti")
+    assert h.__doc__.startswith("\n\nneuron.h\n====")
+
+
 if __name__ == "__main__":
     set_quiet(False)
     test_soma()
@@ -452,3 +464,4 @@ if __name__ == "__main__":
     h.allobjects()
     test_nosection()
     test_nrn_mallinfo()
+    test_help()


### PR DESCRIPTION
Changed the error example snippet for h.objref because that's now type 325 not 323.