### PR TITLE
Bug fix for detecting ION channel type in LoadBalance

### DIFF
--- a/share/lib/hoc/loadbal.hoc
+++ b/share/lib/hoc/loadbal.hoc
@@ -44,7 +44,7 @@ proc init() {local i, j  localobj ms
 			ms = new MechanismStandard(mname, 3)
 			m_complex_[j].x[i] = 1 + ms.count
 //			printf("complexity %d for %s\n", m_complex_[j].x[i], mname)
-			if (j == 0 && hoc_sf_.substr(mname, "_ion") != -1) {
+			if (j == 0 && mt[j].is_ion(i)) {
 				m_complex_[j].x[i] = 0
 				ion_complex_.x[i] = 1
 			}
@@ -388,7 +388,7 @@ proc ExperimentalMechComplex() {local i, j, k, b, ts, ns, baseindex, irun, par \
 	for i=0, mt[0].count-1 {
 		mt[0].select(i)
 		mt[0].selected(s.s)
-		if (hoc_sf_.substr(s.s, "_ion") != -1) {
+		if(mt[0].is_ion(i)) {
 			ionindices.x[i] = j
 			j += 1
 		}

--- a/src/nrniv/nrnmenu.cpp
+++ b/src/nrniv/nrnmenu.cpp
@@ -1051,6 +1051,12 @@ static double mt_is_artificial(void* v) {
     hoc_return_type_code = 2;
     return double(mt->is_artificial(int(chkarg(1, 0, mt->count()))));
 }
+static double mt_is_ion(void* v) {
+    auto* mt = static_cast<MechanismType*>(v);
+    hoc_return_type_code = 2;
+    return double(mt->is_ion(int(chkarg(1, 0, mt->count()))));
+}
+
 static Object** mt_pp_begin(void* v) {
     MechanismType* mt = (MechanismType*) v;
     Point_process* pp = mt->pp_begin();
@@ -1115,6 +1121,7 @@ static Member_func mt_members[] = {{"select", mt_select},
                                    {"is_netcon_target", mt_is_target},
                                    {"has_net_event", mt_has_net_event},
                                    {"is_artificial", mt_is_artificial},
+                                   {"is_ion", mt_is_ion},
                                    {"internal_type", mt_internal_type},
                                    {0, 0}};
 static Member_ret_obj_func mt_retobj_members[] = {{"pp_begin", mt_pp_begin},
@@ -1241,6 +1248,11 @@ bool MechanismType::has_net_event(int i) {
 bool MechanismType::is_artificial(int i) {
     int j = mti_->type_[i];
     return (nrn_is_artificial_[j] ? true : false);
+}
+
+bool MechanismType::is_ion(int i) {
+    int j = mti_->type_[i];
+    return nrn_is_ion(j);
 }
 
 void MechanismType::select(const char* name) {

--- a/src/nrniv/nrnmenu.cpp
+++ b/src/nrniv/nrnmenu.cpp
@@ -1054,7 +1054,7 @@ static double mt_is_artificial(void* v) {
 static double mt_is_ion(void* v) {
     auto* mt = static_cast<MechanismType*>(v);
     hoc_return_type_code = 2;
-    return double(mt->is_ion(int(chkarg(1, 0, mt->count()))));
+    return double(mt->is_ion());
 }
 
 static Object** mt_pp_begin(void* v) {
@@ -1250,9 +1250,8 @@ bool MechanismType::is_artificial(int i) {
     return (nrn_is_artificial_[j] ? true : false);
 }
 
-bool MechanismType::is_ion(int i) {
-    int j = mti_->type_[i];
-    return nrn_is_ion(j);
+bool MechanismType::is_ion() {
+    return nrn_is_ion(internal_type());
 }
 
 void MechanismType::select(const char* name) {

--- a/src/nrniv/nrnmenu.h
+++ b/src/nrniv/nrnmenu.h
@@ -53,7 +53,7 @@ class MechanismType: public Resource {
     bool is_netcon_target(int);
     bool has_net_event(int);
     bool is_artificial(int);
-    bool is_ion(int);
+    bool is_ion();
     void select(const char*);
     const char* selected();
     void insert(Section*);

--- a/src/nrniv/nrnmenu.h
+++ b/src/nrniv/nrnmenu.h
@@ -53,6 +53,7 @@ class MechanismType: public Resource {
     bool is_netcon_target(int);
     bool has_net_event(int);
     bool is_artificial(int);
+    bool is_ion(int);
     void select(const char*);
     const char* selected();
     void insert(Section*);

--- a/test/hoctests/tests/test_loadbal.hoc
+++ b/test/hoctests/tests/test_loadbal.hoc
@@ -1,0 +1,18 @@
+proc exit_with_error() {
+    nrnpython("import sys; sys.exit(1)")
+}
+
+objref mt
+mt = new MechanismType(0)
+
+// check for non ion type
+mt.select("hh")
+if (mt.is_ion() != 1) {
+    exit_with_error()
+}
+
+// check for ion type
+mt.select("k_ion")
+if (mt.is_ion() != 1) {
+    exit_with_error()
+}

--- a/test/pynrn/test_loadbal.py
+++ b/test/pynrn/test_loadbal.py
@@ -1,0 +1,16 @@
+from neuron import h
+import sys
+
+def test_is_ion():
+    mt = h.MechanismType(0)
+
+    # check for non-ion type
+    mt.select("hh")
+    assert mt.is_ion() == False
+
+    # check for ion type
+    mt.select("k_ion")
+    assert mt.is_ion() == True
+
+if __name__ == "__main__":
+    test_is_ion()


### PR DESCRIPTION
* loadbal.hoc was checking the existance of `_ion` to determine if a given mechanism is ion type.
* This was causing a runtime error if `SUFFIX` has names like `SUFFIX internal_ions`  like:
``` console
... internal_ions  is not an ion 0 LoadBalance[0].ion_style("internal_ions", 3, 2, 1, 1, 0)
```
* with this PR, introduce an `is_ion()` method in `MechanismType` class to robustly check if a particular channel is of type ION.
* add python & hoc test

> NOTE: Ref: internal [slack discussion](https://neurondev.slack.com/archives/CS8R6MU2Y/p1680003836824419)