### PR TITLE
Always use %a to print unit computation

### DIFF
--- a/cmake/ConfigFileSetting.cmake
+++ b/cmake/ConfigFileSetting.cmake
@@ -273,7 +273,7 @@ nrn_configure_file(nrnneosm.h src/nrncvode)
 nrn_configure_file(sundials_config.h src/sundials)
 nrn_configure_dest_src(nrnunits.lib share/nrn/lib nrnunits.lib share/lib)
 nrn_configure_dest_src(nrn.defaults share/nrn/lib nrn.defaults share/lib)
-# Requirement: nrnunits.lib.in be in same places as nrnunits.lib
+# NRN_DYNAMIC_UNITS requires nrnunits.lib.in be in same places as nrnunits.lib
 file(COPY ${PROJECT_SOURCE_DIR}/share/lib/nrnunits.lib.in
      DESTINATION ${PROJECT_BINARY_DIR}/share/nrn/lib)
 

--- a/cmake/ConfigFileSetting.cmake
+++ b/cmake/ConfigFileSetting.cmake
@@ -273,7 +273,7 @@ nrn_configure_file(nrnneosm.h src/nrncvode)
 nrn_configure_file(sundials_config.h src/sundials)
 nrn_configure_dest_src(nrnunits.lib share/nrn/lib nrnunits.lib share/lib)
 nrn_configure_dest_src(nrn.defaults share/nrn/lib nrn.defaults share/lib)
-# NRN_DYNAMIC_UNITS requires nrnunits.lib.in be in same places as nrnunits.lib
+# Requirement: nrnunits.lib.in be in same places as nrnunits.lib
 file(COPY ${PROJECT_SOURCE_DIR}/share/lib/nrnunits.lib.in
      DESTINATION ${PROJECT_BINARY_DIR}/share/nrn/lib)
 

--- a/src/modlunit/units.cpp
+++ b/src/modlunit/units.cpp
@@ -1149,4 +1149,5 @@ void nrnunit_dynamic_str(char (&buf)[NRN_BUFSIZE], const char* name, char* u1, c
             name,
             modern,
             legacy);
+
 }

--- a/src/modlunit/units.cpp
+++ b/src/modlunit/units.cpp
@@ -1149,5 +1149,4 @@ void nrnunit_dynamic_str(char (&buf)[NRN_BUFSIZE], const char* name, char* u1, c
             name,
             modern,
             legacy);
-
 }

--- a/src/modlunit/units.cpp
+++ b/src/modlunit/units.cpp
@@ -33,6 +33,11 @@
   static double _nrnunit_FARADAY_[2] = {96485.3321233100184, 96485.3};
 **/
 
+/* modlunit can do its thing in the old way */
+#if !defined(NRN_DYNAMIC_UNITS)
+#define NRN_DYNAMIC_UNITS 0
+#endif
+
 #ifdef MINGW
 #include "../mswin/extra/d2upath.cpp"
 #endif
@@ -55,7 +60,11 @@ extern void diag(const char*, const char*);
 
 #define NTAB 601
 
+#if NRN_DYNAMIC_UNITS
 #define SUFFIX ".in"
+#else
+#define SUFFIX ""
+#endif
 
 /* if MODLUNIT environment variable not set then look in the following places*/
 #if MAC
@@ -99,10 +108,12 @@ static struct table {
 
 static char* names;
 
+#if NRN_DYNAMIC_UNITS
 static struct dynam {
     struct table* table; /* size NTAB */
     char* names;         /* size NTAB*10 */
 } dynam[2];
+#endif
 
 static struct prefix {
     double factor;
@@ -336,16 +347,22 @@ static void install_units_help(char* s1, char* s2) /* define s1 as s2 */
 }
 
 static void switch_units(int legacy) {
+#if NRN_DYNAMIC_UNITS
     table = dynam[legacy].table;
     names = dynam[legacy].names;
+#endif
 }
 
 void install_units(char* s1, char* s2) {
+#if NRN_DYNAMIC_UNITS
     int i;
     for (i = 0; i < 2; ++i) {
         switch_units(i);
         install_units_help(s1, s2);
     }
+#else
+    install_units_help(s1, s2);
+#endif
 }
 
 void check_num() {
@@ -566,6 +583,7 @@ static void units_alloc() {
     static int units_alloc_called = 0;
     if (!units_alloc_called) {
         units_alloc_called = 1;
+#if NRN_DYNAMIC_UNITS
         for (i = 0; i < 2; ++i) {
             dynam[i].table = (struct table*) calloc(NTAB, sizeof(struct table));
             assert(dynam[i].table);
@@ -573,6 +591,12 @@ static void units_alloc() {
             assert(dynam[i].names);
             switch_units(i);
         }
+#else
+        table = (struct table*) calloc(NTAB, sizeof(struct table));
+        assert(table);
+        names = (char*) calloc(NTAB * 10, sizeof(char));
+        assert(names);
+#endif
     }
 }
 
@@ -584,10 +608,14 @@ void modl_units() {
     unitonflag = 1;
     if (first) {
         units_alloc();
+#if NRN_DYNAMIC_UNITS
         for (i = 0; i < 2; ++i) {
             switch_units(i);
             unit_init();
         }
+#else
+        unit_init();
+#endif
         first = 0;
     }
 }
@@ -891,6 +919,7 @@ l0:
         goto l0;
     }
 
+#if NRN_DYNAMIC_UNITS
     if (c == '@') {
         /**
            Dynamic unit line beginning with @LegacyY@ or @LegacyN@.
@@ -918,6 +947,7 @@ l0:
         }
         c = get();
     }
+#endif
 
     if (c == '\n')
         goto l0;
@@ -970,6 +1000,7 @@ redef:
     goto l0;
 }
 
+#if NRN_DYNAMIC_UNITS
 /* Translate string to double using a2f for modern units
    to allow consistency with BlueBrain/nmodl
 */
@@ -1015,15 +1046,18 @@ l1:
     peekc = c;
     return (d_modern);
 }
+#endif /* NRN_DYNAMIC_UNITS */
 
 double getflt() {
     int c, i, dp;
     double d, e;
     int f;
 
+#if NRN_DYNAMIC_UNITS
     if (table == dynam[0].table) {
         return modern_getflt();
     }
+#endif /* NRN_DYNAMIC_UNITS */
     d = 0.;
     dp = 0;
     do
@@ -1138,6 +1172,8 @@ static double dynam_unit_mag(int legacy, char* u1, char* u2) {
 }
 
 void nrnunit_dynamic_str(char (&buf)[NRN_BUFSIZE], const char* name, char* u1, char* u2) {
+#if NRN_DYNAMIC_UNITS
+
     double legacy = dynam_unit_mag(1, u1, u2);
     double modern = dynam_unit_mag(0, u1, u2);
     Sprintf(buf,
@@ -1150,4 +1186,17 @@ void nrnunit_dynamic_str(char (&buf)[NRN_BUFSIZE], const char* name, char* u1, c
             modern,
             legacy);
 
+#else
+
+    Unit_push(u1);
+    Unit_push(u2);
+    unit_div();
+#if (defined(LegacyFR) && LegacyFR == 1)
+    Sprintf(buf, "static double %s = %g;\n", name, unit_mag());
+#else
+    Sprintf(buf, "static double %s = %a;\n", name, unit_mag());
+#endif
+    unit_pop();
+
+#endif
 }

--- a/src/modlunit/units.cpp
+++ b/src/modlunit/units.cpp
@@ -33,11 +33,6 @@
   static double _nrnunit_FARADAY_[2] = {96485.3321233100184, 96485.3};
 **/
 
-/* modlunit can do its thing in the old way */
-#if !defined(NRN_DYNAMIC_UNITS)
-#define NRN_DYNAMIC_UNITS 0
-#endif
-
 #ifdef MINGW
 #include "../mswin/extra/d2upath.cpp"
 #endif
@@ -60,11 +55,7 @@ extern void diag(const char*, const char*);
 
 #define NTAB 601
 
-#if NRN_DYNAMIC_UNITS
 #define SUFFIX ".in"
-#else
-#define SUFFIX ""
-#endif
 
 /* if MODLUNIT environment variable not set then look in the following places*/
 #if MAC
@@ -108,12 +99,10 @@ static struct table {
 
 static char* names;
 
-#if NRN_DYNAMIC_UNITS
 static struct dynam {
     struct table* table; /* size NTAB */
     char* names;         /* size NTAB*10 */
 } dynam[2];
-#endif
 
 static struct prefix {
     double factor;
@@ -347,22 +336,16 @@ static void install_units_help(char* s1, char* s2) /* define s1 as s2 */
 }
 
 static void switch_units(int legacy) {
-#if NRN_DYNAMIC_UNITS
     table = dynam[legacy].table;
     names = dynam[legacy].names;
-#endif
 }
 
 void install_units(char* s1, char* s2) {
-#if NRN_DYNAMIC_UNITS
     int i;
     for (i = 0; i < 2; ++i) {
         switch_units(i);
         install_units_help(s1, s2);
     }
-#else
-    install_units_help(s1, s2);
-#endif
 }
 
 void check_num() {
@@ -583,7 +566,6 @@ static void units_alloc() {
     static int units_alloc_called = 0;
     if (!units_alloc_called) {
         units_alloc_called = 1;
-#if NRN_DYNAMIC_UNITS
         for (i = 0; i < 2; ++i) {
             dynam[i].table = (struct table*) calloc(NTAB, sizeof(struct table));
             assert(dynam[i].table);
@@ -591,12 +573,6 @@ static void units_alloc() {
             assert(dynam[i].names);
             switch_units(i);
         }
-#else
-        table = (struct table*) calloc(NTAB, sizeof(struct table));
-        assert(table);
-        names = (char*) calloc(NTAB * 10, sizeof(char));
-        assert(names);
-#endif
     }
 }
 
@@ -608,14 +584,10 @@ void modl_units() {
     unitonflag = 1;
     if (first) {
         units_alloc();
-#if NRN_DYNAMIC_UNITS
         for (i = 0; i < 2; ++i) {
             switch_units(i);
             unit_init();
         }
-#else
-        unit_init();
-#endif
         first = 0;
     }
 }
@@ -919,7 +891,6 @@ l0:
         goto l0;
     }
 
-#if NRN_DYNAMIC_UNITS
     if (c == '@') {
         /**
            Dynamic unit line beginning with @LegacyY@ or @LegacyN@.
@@ -947,7 +918,6 @@ l0:
         }
         c = get();
     }
-#endif
 
     if (c == '\n')
         goto l0;
@@ -1000,7 +970,6 @@ redef:
     goto l0;
 }
 
-#if NRN_DYNAMIC_UNITS
 /* Translate string to double using a2f for modern units
    to allow consistency with BlueBrain/nmodl
 */
@@ -1046,18 +1015,15 @@ l1:
     peekc = c;
     return (d_modern);
 }
-#endif /* NRN_DYNAMIC_UNITS */
 
 double getflt() {
     int c, i, dp;
     double d, e;
     int f;
 
-#if NRN_DYNAMIC_UNITS
     if (table == dynam[0].table) {
         return modern_getflt();
     }
-#endif /* NRN_DYNAMIC_UNITS */
     d = 0.;
     dp = 0;
     do
@@ -1172,8 +1138,6 @@ static double dynam_unit_mag(int legacy, char* u1, char* u2) {
 }
 
 void nrnunit_dynamic_str(char (&buf)[NRN_BUFSIZE], const char* name, char* u1, char* u2) {
-#if NRN_DYNAMIC_UNITS
-
     double legacy = dynam_unit_mag(1, u1, u2);
     double modern = dynam_unit_mag(0, u1, u2);
     Sprintf(buf,
@@ -1186,17 +1150,4 @@ void nrnunit_dynamic_str(char (&buf)[NRN_BUFSIZE], const char* name, char* u1, c
             modern,
             legacy);
 
-#else
-
-    Unit_push(u1);
-    Unit_push(u2);
-    unit_div();
-#if (defined(LegacyFR) && LegacyFR == 1)
-    Sprintf(buf, "static double %s = %g;\n", name, unit_mag());
-#else
-    Sprintf(buf, "static double %s = %a;\n", name, unit_mag());
-#endif
-    unit_pop();
-
-#endif
 }

--- a/src/modlunit/units.cpp
+++ b/src/modlunit/units.cpp
@@ -1194,7 +1194,7 @@ void nrnunit_dynamic_str(char (&buf)[NRN_BUFSIZE], const char* name, char* u1, c
 #if (defined(LegacyFR) && LegacyFR == 1)
     Sprintf(buf, "static double %s = %g;\n", name, unit_mag());
 #else
-    Sprintf(buf, "static double %s = %.12g;\n", name, unit_mag());
+    Sprintf(buf, "static double %s = %a;\n", name, unit_mag());
 #endif
     unit_pop();
 

--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -90,7 +90,7 @@ add_dependencies(generated_source_files nocmodl_generated_files)
 add_executable(nocmodl ${NRN_NMODL_SRC_FILES} "${NRN_NMODL_GEN}/lex.cpp"
                        "${NRN_NMODL_GEN}/parse1.cpp" "${NRN_NMODL_GEN}/diffeq.cpp")
 cpp_cc_configure_sanitizers(TARGET nocmodl)
-target_compile_definitions(nocmodl PRIVATE COMPILE_DEFINITIONS NMODL=1 CVODE=1 NRN_DYNAMIC_UNITS=1)
+target_compile_definitions(nocmodl PRIVATE COMPILE_DEFINITIONS NMODL=1 CVODE=1)
 # Otherwise the generated code in the binary directory does not find headers in the modlunit source
 # directory and the source files in the source directory do not find generated headers in the binary
 # directory.

--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -90,7 +90,7 @@ add_dependencies(generated_source_files nocmodl_generated_files)
 add_executable(nocmodl ${NRN_NMODL_SRC_FILES} "${NRN_NMODL_GEN}/lex.cpp"
                        "${NRN_NMODL_GEN}/parse1.cpp" "${NRN_NMODL_GEN}/diffeq.cpp")
 cpp_cc_configure_sanitizers(TARGET nocmodl)
-target_compile_definitions(nocmodl PRIVATE COMPILE_DEFINITIONS NMODL=1 CVODE=1)
+target_compile_definitions(nocmodl PRIVATE COMPILE_DEFINITIONS NMODL=1 CVODE=1 NRN_DYNAMIC_UNITS=1)
 # Otherwise the generated code in the binary directory does not find headers in the modlunit source
 # directory and the source files in the source directory do not find generated headers in the binary
 # directory.

--- a/test/pynrn/test_units.py
+++ b/test/pynrn/test_units.py
@@ -41,6 +41,7 @@ def test_mod_legacy():
     assert ut.e * ut.avogadro == ut.faraday
     assert abs(ut.faraday - h.FARADAY) < 1e-10
     assert ut.gasconst == h.R
+    assert ut.gasconst_exact == 8.313424
     assert ut.k * ut.avogadro == ut.gasconst
     assert abs(ut.planck - ut.hbar * 2.0 * h.PI) < 1e-49
     assert ut.avogadro == h.Avogadro_constant

--- a/test/pynrn/unitstest.mod
+++ b/test/pynrn/unitstest.mod
@@ -29,6 +29,7 @@ ASSIGNED {
   planck (joule-sec)
   hbar (joule-sec)
   gasconst (joule/degC)
+  gasconst_exact (joule/degC)
   avogadro (1)
   k (joule/degC)
   erev (mV)

--- a/test/pynrn/unitstest.mod
+++ b/test/pynrn/unitstest.mod
@@ -1,6 +1,6 @@
 NEURON {
   POINT_PROCESS UnitsTest
-  RANGE mole, e, faraday, planck, hbar, gasconst, avogadro, k
+  RANGE mole, e, faraday, planck, hbar, gasconst, gasconst_exact, avogadro, k
   RANGE erev, ghk
   USEION na READ ena WRITE ina
 }
@@ -15,6 +15,7 @@ UNITS {
   h = (planck) (joule-sec)
   hb = (hbar) (joule-sec)
   R = (k-mole) (joule/degC)
+  Rexact = 8.313424 (joule/degC)
   boltzmann = (k) (joule/degC)
 
   (avogadro) = (mole)
@@ -43,6 +44,7 @@ INITIAL {
   planck = h
   hbar = hb
   gasconst = R
+  gasconst_exact = Rexact
   avogadro = avo
   k = boltzmann
   erev = ena


### PR DESCRIPTION
In the commit c63f8df0, a partial move have been done from .18g to a formatter. The one in case of non dynamic units have been forgotten.