### PR TITLE
Update link to cmake build options in install_instructions.md

### DIFF
--- a/docs/install/install_instructions.md
+++ b/docs/install/install_instructions.md
@@ -360,7 +360,7 @@ Particularly useful CMake options are (use **ON** to enable and **OFF** to disab
 * **-DCMAKE_INSTALL_PREFIX=/install/dir/path** : Location for installing
 * **-DCORENRN\_ENABLE\_NMODL=ON** : Use [NMODL](https://github.com/BlueBrain/nmodl/) instead of [MOD2C](https://github.com/BlueBrain/mod2c/) for code generation with CoreNEURON
 
-Please refer to [docs/cmake_doc/options.rst](docs/cmake_doc/options.rst) for more information on
+Please refer to [docs/cmake_doc/options.rst](https://github.com/neuronsimulator/nrn/blob/master/docs/cmake_doc/options.rst) for more information on
 the CMake options.
 
 #### Optimized CPU and GPU Support using CoreNEURON


### PR DESCRIPTION
The link to cmake build options currently points to (master/docs/install/docs/cmake_doc/options.rst). It should point to (master/docs/cmake_doc/options.rst), i.e. the cmake_doc folder is not in the master/docs/install/docs folder, but rather the master/docs one. 

EDIT: To clarify further.

The link as currently written, (docs/cmake_doc/options.rst), points to within the containing folder, i.e. /install/docs. To point to two directories back, i.e. to /master/docs, the full link needs to be written.