### PR TITLE
xstatebutton, xcheckbox, xslider use data_handle.

### DIFF
--- a/src/ivoc/graph.cpp
+++ b/src/ivoc/graph.cpp
@@ -1369,7 +1369,7 @@ Graph::Graph(bool b)
     : Scene(0, 0, XSCENE, YSCENE) {
     loc_ = 0;
     x_expr_ = NULL;
-    x_pval_ = NULL;
+    x_pval_ = {};
     var_name_ = NULL;
     rvp_ = NULL;
     cross_action_ = NULL;
@@ -1940,12 +1940,12 @@ void Graph::x_expr(const char* expr, bool usepointer) {
         hoc_execerror(expr, "not an expression");
     }
     if (usepointer) {
-        x_pval_ = hoc_val_pointer(expr);
+        x_pval_ = hoc_val_handle(expr);
         if (!x_pval_) {
             hoc_execerror(expr, "is invalid left hand side of assignment statement");
         }
     } else {
-        x_pval_ = 0;
+        x_pval_ = {};
     }
 }
 

--- a/src/ivoc/graph.h
+++ b/src/ivoc/graph.h
@@ -190,7 +190,7 @@ class Graph: public Scene {  // Scene of GraphLines labels and polylines
     bool vector_copy_;
 
     Symbol* x_expr_;
-    double* x_pval_;
+    neuron::container::data_handle<double> x_pval_;
 
     GraphVector* rvp_;
     static std::ostream* ascii_;

--- a/src/ivoc/oc2iv.h
+++ b/src/ivoc/oc2iv.h
@@ -51,13 +51,13 @@ void hoc_ivpvaluerun(CChar* name,
 
 extern void hoc_ivlabel(CChar*);
 extern void hoc_ivvarlabel(char**, Object* pyvar = 0);
-extern void hoc_ivstatebutton(double*,
+extern void hoc_ivstatebutton(neuron::container::data_handle<double>,
                               CChar* name,
                               CChar* action,
                               int style,
                               Object* pyvar = 0,
                               Object* pyact = 0);
-extern void hoc_ivslider(double*,
+extern void hoc_ivslider(neuron::container::data_handle<double>,
                          float low = 0,
                          float high = 100,
                          float resolution = 1,

--- a/src/ivoc/xmenu.h
+++ b/src/ivoc/xmenu.h
@@ -53,7 +53,7 @@ class HocPanel: public OcGlyph {
     virtual void map_window(int scroll = -1);  // -1 leave up to panel_scroll attribute
 
     void pushButton(const char* name, const char* action, bool activate = false, Object* pyact = 0);
-    void stateButton(double* pd,
+    void stateButton(neuron::container::data_handle<double> pd,
                      const char* name,
                      const char* action,
                      int style,
@@ -64,7 +64,7 @@ class HocPanel: public OcGlyph {
                        const char* action,
                        bool activate = false,
                        Object* pyact = 0);
-    MenuItem* menuStateItem(double* pd,
+    MenuItem* menuStateItem(neuron::container::data_handle<double> pd,
                             const char* name,
                             const char* action,
                             Object* pyvar = NULL,
@@ -87,7 +87,7 @@ class HocPanel: public OcGlyph {
                  bool keep_updated = false);
 
     // ZFM added vert
-    void slider(double*,
+    void slider(neuron::container::data_handle<double>,
                 float low = 0,
                 float high = 100,
                 float resolution = 1,
@@ -417,7 +417,7 @@ class HocValAction: public HocAction {
 // ZFM added vert_
 class OcSlider: public HocUpdateItem, public Observer {
   public:
-    OcSlider(double*,
+    OcSlider(neuron::container::data_handle<double>,
              float low,
              float high,
              float resolution,
@@ -446,7 +446,7 @@ class OcSlider: public HocUpdateItem, public Observer {
     float resolution_;
     BoundedValue* bv_;
     HocCommand* send_;
-    double* pval_;
+    neuron::container::data_handle<double> pval_;
     Object* pyvar_;
     CopyString* variable_;
     bool scrolling_;
@@ -457,7 +457,7 @@ class OcSlider: public HocUpdateItem, public Observer {
 
 class HocStateButton: public HocUpdateItem, public Observer {
   public:
-    HocStateButton(double*,
+    HocStateButton(neuron::container::data_handle<double>,
                    const char*,
                    Button*,
                    HocAction*,
@@ -480,7 +480,7 @@ class HocStateButton: public HocUpdateItem, public Observer {
     int style_;
     CopyString* variable_;
     CopyString* name_;
-    double* pval_;
+    neuron::container::data_handle<double> pval_;
     Object* pyvar_;
     Button* b_;
     HocAction* action_;
@@ -489,7 +489,7 @@ class HocStateButton: public HocUpdateItem, public Observer {
 
 class HocStateMenuItem: public HocUpdateItem, public Observer {
   public:
-    HocStateMenuItem(double*,
+    HocStateMenuItem(neuron::container::data_handle<double>,
                      const char*,
                      MenuItem*,
                      HocAction*,
@@ -509,7 +509,7 @@ class HocStateMenuItem: public HocUpdateItem, public Observer {
   private:
     CopyString* variable_;
     CopyString* name_;
-    double* pval_;
+    neuron::container::data_handle<double> pval_;
     Object* pyvar_;
     MenuItem* b_;
     HocAction* action_;

--- a/src/nrniv/shapeplt.cpp
+++ b/src/nrniv/shapeplt.cpp
@@ -1,6 +1,7 @@
 #include <../../nrnconf.h>
 #include "classreg.h"
 #include "gui-redirect.h"
+#include "ocnotify.h"
 
 #if HAVE_IV
 
@@ -248,7 +249,7 @@ static double sh_hinton(void* v) {
 #if HAVE_IV
     IFGUI
     ShapeScene* ss = (ShapeScene*) v;
-    double* pd = hoc_pgetarg(1);
+    neuron::container::data_handle<double> pd = hoc_hgetarg<double>(1);
     double xsize = chkarg(4, 1e-9, 1e9);
     double ysize = xsize;
     if (ifarg(5)) {
@@ -1141,21 +1142,23 @@ FastGraphItem::FastGraphItem(FastShape* g, bool s, bool p)
 FastShape::FastShape() {}
 FastShape::~FastShape() {}
 
-Hinton::Hinton(double* pd, Coord xsize, Coord ysize, ShapeScene* ss) {
+Hinton::Hinton(neuron::container::data_handle<double> pd,
+               Coord xsize,
+               Coord ysize,
+               ShapeScene* ss) {
     pd_ = pd;
     old_ = NULL;  // not referenced
     xsize_ = xsize / 2;
     ysize_ = ysize / 2;
     ss_ = ss;
-    Oc oc;
-    oc.notify_when_freed(pd_, this);
+    neuron::container::notify_when_handle_dies(pd_, this);
 }
 Hinton::~Hinton() {
     Oc oc;
     oc.notify_pointer_disconnect(this);
 }
 void Hinton::update(Observable*) {
-    pd_ = NULL;
+    pd_ = {};
     ss_->remove(ss_->glyph_index(this));
 }
 void Hinton::request(Requisition& req) const {

--- a/src/nrniv/shapeplt.h
+++ b/src/nrniv/shapeplt.h
@@ -106,7 +106,7 @@ class ColorValue: public Resource, public Observable {
 
 class Hinton: public Observer, public FastShape {
   public:
-    Hinton(double*, Coord xsize, Coord ysize, ShapeScene*);
+    Hinton(neuron::container::data_handle<double>, Coord xsize, Coord ysize, ShapeScene*);
     virtual ~Hinton();
     virtual void request(Requisition&) const;
     virtual void allocate(Canvas*, const Allocation&, Extension&);
@@ -115,7 +115,7 @@ class Hinton: public Observer, public FastShape {
     virtual void update(Observable*);
 
   private:
-    double* pd_;
+    neuron::container::data_handle<double> pd_{};
     const Color* old_;
     Coord xsize_, ysize_;
     ShapeScene* ss_;

--- a/test/hoctests/tests/test_hocGUI2.py
+++ b/test/hoctests/tests/test_hocGUI2.py
@@ -1,0 +1,89 @@
+# tests of GUI with hoc variables that go out of scope or move
+
+from neuron import h, gui
+
+h(
+    """
+var1 = 0.0
+proc act1() { print "hoc var1 = ", var1 }
+proc actvec() { print "hoc vec.x[0] = ", $o1.x[0] }
+proc actcell() {forall {print secname(), "  ", g_pas(.5)}}
+"""
+)
+
+
+class Cell:
+    def __init__(self, id):
+        self.id = id
+        s = self.soma = h.Section(name="soma", cell=self)
+        s.diam = 10.0
+        s.L = 100.0 / h.PI / s(0.5).diam
+        s.insert("pas")
+        s.g_pas = 0.001
+        s.e_pas = -65.0
+
+    def __str__(self):
+        return "Cell_%d" % self.id
+
+
+class GUI:
+    def __init__(self, cell):
+        self.cell = cell
+        self.vec = h.Vector(1)  # for hoc ref variable self.vec._ref_x[0]
+        self.build()
+        self.map()
+
+    def build(self):
+        self.box = h.HBox()
+        self.box.intercept(1)
+        self.box.ref(self)
+
+        h.xpanel("")
+        h.xstatebutton("hoc var1", h._ref_var1, "act1()")
+        h.xcheckbox("hoc var1", h._ref_var1, "act1()")
+        h.xmenu("hoc var1")
+        h.xcheckbox("hoc var1", h._ref_var1, "act1()")
+        h.xmenu()
+        h.xslider(h._ref_var1, 0, 1, 0, 1)
+        h.xvalue("hoc var1", h._ref_var1, 1, "act1()")
+
+        h.xstatebutton("vec.x[0]", self.vec._ref_x[0], "actvec(%s)" % self.vec)
+        h.xcheckbox("vec.x[0]", self.vec._ref_x[0], "actvec(%s)" % self.vec)
+        h.xmenu("vec.x[0]")
+        h.xcheckbox("vec.x[0]", self.vec._ref_x[0], "actvec(%s)" % self.vec)
+        h.xmenu()
+        h.xslider(self.vec._ref_x[0], 0, 1, 0, 1)
+        h.xvalue("vec.x[0]", self.vec._ref_x[0], 1, "actvec(%s)" % self.vec)
+
+        h.xstatebutton(
+            "cell.soma(.5).pas.g", self.cell.soma(0.5).pas._ref_g, "actcell()"
+        )
+        h.xcheckbox("cell.soma(.5).pas.g", self.cell.soma(0.5).pas._ref_g, "actcell()")
+        h.xmenu("cell.soma(.5).pas.g")
+        h.xcheckbox("cell.soma(.5).pas.g", self.cell.soma(0.5).pas._ref_g, "actcell()")
+        h.xmenu()
+        h.xslider(self.cell.soma(0.5).pas._ref_g, 0, 1, 0, 1)
+        h.xvalue("cell.soma(.5).pas.g", self.cell.soma(0.5).pas._ref_g, 1, "actcell()")
+        h.xpanel()
+
+        self.box.intercept(0)
+
+    def map(self):
+        self.box.map("GUI test with %s" % str(self.cell))
+
+    def act1(self, vec):
+        print("hoc vec.x[0] = ", vec.x[0])
+
+
+def test1():
+    cells = [Cell(i) for i in range(5)]
+    gui = GUI(cells[3])
+    h("delete var1")  # does NOT gray out the items
+    gui.vec = None
+    gui.cell = None
+    # sliders do not get grayed out
+    return gui
+
+
+if __name__ == "__main__":
+    gui = test1()

--- a/test/hoctests/tests/test_hocGUI2.py
+++ b/test/hoctests/tests/test_hocGUI2.py
@@ -1,7 +1,8 @@
 # tests of GUI with hoc variables that go out of scope or move
 
-from neuron import h, gui
+from neuron import config, h, gui
 from neuron.expect_hocerr import expect_err, set_quiet
+import os
 
 set_quiet(False)
 
@@ -98,7 +99,8 @@ def test2():  # Graph.xexpr
         ic.dur = 0.1
         ic.amp = 0.3
     h.newPlotV()
-    expect_err('h.graphItem.xexpr("_pysec.Cell_3.soma(0.5).ina", 1)')
+    if config.arguments["NRN_ENABLE_INTERVIEWS"] and "DISPLAY" in os.environ:
+        expect_err('h.graphItem.xexpr("_pysec.Cell_3.soma(0.5).ina", 1)')
     h.graphItem.xexpr("_pysec.Cell_3.soma.ina(0.5)", 1)
     h.run()
     h.graphItem.exec_menu("View = plot")

--- a/test/hoctests/tests/test_hocGUI2.py
+++ b/test/hoctests/tests/test_hocGUI2.py
@@ -107,6 +107,34 @@ def test2():  # Graph.xexpr
     return cells
 
 
+def test_Hinton():  # PlotShape.hinton
+    class Net:
+        def __init__(self, netid):
+            self.netid = netid
+            self.cells = [
+                [Cell(i + 10 * j + 100 * netid) for i in range(10)] for j in range(10)
+            ]
+
+    net = [Net(i) for i in range(3)]
+
+    def pnet(net):
+        sl = h.SectionList()  # leave empty so only hinton plot
+        s = h.PlotShape(sl)
+        for i, cellrow in enumerate(net.cells):
+            for j, cell in enumerate(cellrow):
+                s.hinton(cell.soma(0.5)._ref_v, i, j, 1, 1)
+                cell.soma(0.5).v = i / 10.0 + j / 10.0
+
+        s.size(-1, 11, -1, 11)
+        s.scale(0, 2)
+        return s, sl, net
+
+    rval = pnet(net[1])
+
+    return rval  # net[1] is only remaining Net (in rval)
+
+
 if __name__ == "__main__":
     gui = test1()
     cells = test2()
+    net = test_Hinton()


### PR DESCRIPTION
The test works for references to Vector.x[I] and range variables. (in the sense of xstatebutton and xcheckbox being grayed out and becoming inactive when their variable is destroyed) Notification for inactivation does not take place for user defined
hoc variables.

Also data_handle for Graph.xexpr and PlotShape.hinton with tests.

CI_BRANCHES:NMODL_BRANCH=olupton/fixes-for-soa-neuron,PY_NEURODAMUS_BRANCH=olupton/neuron-9,LIBSONATA_REPORT_BRANCH=olupton/generic-handles