### PR TITLE
Fix ModelDB CI diffs introduced by #2317

### DIFF
--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -1209,9 +1209,15 @@ int hoc_moreinput() {
         }
         strcpy(hoc_xopen_file_, infile);
         // This is, unfortunately rather implicitly, how we trigger execution of HOC files on a
-        // commandline like `nrniv a.hoc b.hoc`
+        // commandline like `nrniv a.hoc b.hoc`. To make HOC treatment similar to Python treatment
+        // we would pass hoc_xopen_file_ here, which would imply that nrnpython("...") inside
+        // test.hoc sees sys.path[0] == "/dir/" when we run `nrniv /dir/test.hoc`, however it seems
+        // that legacy models (183300) assume that sys.path[0] == '' in this context, so we stick
+        // with that. There is no particular reason to follow Python conventions when launching HOC
+        // scripts, in contrast to Python scripts where we strive to make `nrniv foo.py` and
+        // `python foo.py` behave in the same way.
         if (neuron::python::methods.interpreter_set_path) {
-            neuron::python::methods.interpreter_set_path(hoc_xopen_file_);
+            neuron::python::methods.interpreter_set_path({});
         }
     }
     return 1;

--- a/test/pyinit/CMakeLists.txt
+++ b/test/pyinit/CMakeLists.txt
@@ -233,11 +233,13 @@ foreach(val RANGE ${NRN_PYTHON_COUNT})
       SCRIPT_PATTERNS check_sys_attr.py dump_sys_attr.py)
     # Replicate this with nrnpython(...) inside a .hoc script too. This checks that the Python
     # environment inside nrnpython(...) inside foo.hoc is the same as in foo.py -- which seems like
-    # a reasonable choice.
+    # a reasonable choice -- except for path, which has an explicit exception documented in (for
+    # now) hoc_moreinput -- there nrnpython(...) inside foo.hoc sees sys.path[0] == '' for backward
+    # compatibility reasons.
     nrn_add_test(
       GROUP pyinit
       NAME ${nrnivpy}_nrnpython_check_sys_${attr}
-      PRECOMMAND "${pyexe}" dump_sys_attr.py ref.json ${attr}
+      PRECOMMAND "${pyexe}" dump_sys_attr.py override_sys_path_0_to_be_empty ref.json ${attr}
       COMMAND nrniv ${nrniv_args} -c "strdef attr, fname" -c "attr=\"${attr}\"" -c
               "fname=\"ref.json\"" check_sys_attr.hoc
       SCRIPT_PATTERNS check_sys_attr.hoc dump_sys_attr.py)

--- a/test/pyinit/dump_sys_attr.py
+++ b/test/pyinit/dump_sys_attr.py
@@ -4,6 +4,8 @@ import sys
 
 fname, attr = sys.argv[-2:]
 data = reduce(getattr, [sys] + attr.split("."))
+if attr == "path" and sys.argv[-3] == "override_sys_path_0_to_be_empty":
+    data[0] = ""
 print("dumping sys.{} = {} to {}".format(attr, data, fname))
 with open(fname, "w") as ofile:
     json.dump(data, ofile)


### PR DESCRIPTION
This PR aims to introduce diffs in the ModelDB CI (https://github.com/neuronsimulator/nrn-modeldb-ci/) introduced by https://github.com/neuronsimulator/nrn/pull/2317.

There seem to be two sources of differences that were missed at the time:
- slight re-ordering of output, probably due to edge cases in when output is redirected via Python and `nrnpy_py`, this PR aligns more closely with the old behaviour
- slight change in semantics for `sys.path[0]`
  - in #2317 then `nrnpython` inside a HOC script was made consistent with launching a Python script directly, i.e. `nrnpython` inside `nrniv /path/to/foo.hoc` saw `sys.path[0] == '/path/to'` with #2317, which matches `python /path/to/foo.py`
  - the old behaviour was that `nrnpython` inside `nrniv foo.hoc` saw `sys.path[0] == ''`
  - this PR restores the old behaviour, fixing https://github.com/ModelDBRepository/183300/blob/1fe60b474f37f39b002f8d9ebb2e6bd21418848d/build_net_Shep.hoc#L308-L309

TODO:
- [x] check that the wheels from this PR have zero diff with 8.2.2 in nrn-modeldb-ci.