### PR TITLE
Add missing include; GCC13 is more pedantic

### DIFF
--- a/src/coreneuron/apps/corenrn_parameters.hpp
+++ b/src/coreneuron/apps/corenrn_parameters.hpp
@@ -6,6 +6,7 @@
 # =============================================================================.
 */
 #pragma once
+#include <cstdint>  // std::uint32_t
 #include <memory>
 #include <ostream>
 #include <string>


### PR DESCRIPTION
See https://github.com/neuronsimulator/nrn-build-ci/actions/runs/4847844623/jobs/8638451587, for example.
There are still runtime errors with the MPI implementation shipping with Fedora 38.