### PR TITLE
CircleCI: upgrade pip before twine upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,8 +95,8 @@ workflows:
                 - /circleci\/.*/
           matrix:
             parameters:
-              NRN_PYTHON_VERSION: ["39"]
-              NRN_NIGHTLY_UPLOAD: ["true"]
+              NRN_PYTHON_VERSION: ["311"]
+              NRN_NIGHTLY_UPLOAD: ["false"]
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
           name: Upload nightly wheel to pypi.org
           command: |
             if [ "<< parameters.NRN_NIGHTLY_UPLOAD >>" == "true" ]; then
+              python -m pip install --upgrade pip
               python -m pip install twine
               python -m twine upload --verbose --skip-existing -u $TWINE_USERNAME -p $TWINE_PASSWORD  wheelhouse/*.whl
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ workflows:
                 - /circleci\/.*/
           matrix:
             parameters:
-              NRN_PYTHON_VERSION: ["311"]
+              NRN_PYTHON_VERSION: ["39"]
               NRN_NIGHTLY_UPLOAD: ["false"]
 
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ workflows:
           matrix:
             parameters:
               NRN_PYTHON_VERSION: ["39"]
-              NRN_NIGHTLY_UPLOAD: ["false"]
+              NRN_NIGHTLY_UPLOAD: ["true"]
 
   nightly:
     triggers:


### PR DESCRIPTION
Nightly is failing:
```
Installing collected packages: urllib3, pkginfo, zipp, importlib-metadata, charset-normalizer, idna, certifi, requests, requests-toolbelt, docutils, webencodings, bleach, Pygments, readme-renderer, jeepney, pycparser, cffi, cryptography, SecretStorage, more-itertools, jaraco.classes, keyring, mdurl, markdown-it-py, rich, rfc3986, twine
ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.

We recommend you use --use-feature=2020-resolver to test your packages with the new resolver before it becomes the default.

requests 2.29.0 requires urllib3<1.27,>=1.21.1, but you'll have urllib3 2.0.1 which is incompatible.
Successfully installed Pygments-2.15.1 SecretStorage-3.3.3 bleach-6.0.0 certifi-2022.12.7 cffi-1.15.1 charset-normalizer-3.1.0 cryptography-40.0.2 docutils-0.19 idna-3.4 importlib-metadata-6.6.0 jaraco.classes-3.2.3 jeepney-0.8.0 keyring-23.13.1 markdown-it-py-2.2.0 mdurl-0.1.2 more-itertools-9.1.0 pkginfo-1.9.6 pycparser-2.21 readme-renderer-37.3 requests-2.29.0 requests-toolbelt-1.0.0 rfc3986-2.0.0 rich-13.3.5 twine-4.0.2 urllib3-2.0.1 webencodings-0.5.1 zipp-3.15.0
WARNING: You are using pip version 20.2.3; however, version 23.1.2 is available.
You should consider upgrading via the '/opt/circleci/.pyenv/versions/3.9.1/bin/python -m pip install --upgrade pip' command.
```