### PR TITLE
Fix compilation on Debian stable

### DIFF
--- a/test/unit_tests/container/container.cpp
+++ b/test/unit_tests/container/container.cpp
@@ -36,11 +36,6 @@ using owning_handle = handle_interface<owning_identifier<storage>>;
 }  // namespace
 
 TEST_CASE("Tag type with array_dimension and without num_variables", "[Neuron][data_structures]") {
-    storage data{};
+    storage data;  // Debian's GCC 10.2 doesn't like a {} before the ;
     owning_handle instance{data};
-    // GIVEN("A null handle") {
-    //     THEN("Check it is really null") {
-    //         REQUIRE_FALSE(handle);
-    //     }
-    // }
 }


### PR DESCRIPTION
A file added in #2027 did not compile with Debian stable: https://github.com/neuronsimulator/nrn-build-ci/actions/runs/5184018307/jobs/9344080598
With this change, it does: https://github.com/neuronsimulator/nrn-build-ci/actions/runs/5186212735/jobs/9347034540

It's not entirely clear why, the minimal reproducer:
```c++
template <typename Storage, typename... Tags>
struct soa {
    soa(): soa(Tags{}...) {}
    soa(Tags... tag_instances) {}
    soa(soa&&) = delete;
    soa(soa const&) = delete;
    soa& operator=(soa&&) = delete;
    soa& operator=(soa const&) = delete;
};
struct A {
    using type = float;
};
struct storage: soa<storage, A> {};
void foo() {
    storage data{};
}
```
fails inside a `debian:stable` Docker image but does not fail with GCC 10.2 on compiler explorer.
I believe that the error returned on Debian is not valid/correct.