### PR TITLE
RTD: bump to Python 3.11 & enable notebooks debug

### DIFF
--- a/docs/conda_environment.yml
+++ b/docs/conda_environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.10
+  - python=3.11
   - bison
   - cmake
   - xorg-libxcomposite

--- a/docs/notebooks.sh
+++ b/docs/notebooks.sh
@@ -11,7 +11,7 @@ convert_notebooks() {
   set -e
   working_dir=$1
   echo "Running convert_notebooks in $1"
-  (cd "$working_dir" && jupyter nbconvert --to notebook --inplace --execute *.ipynb)
+  (cd "$working_dir" && jupyter nbconvert --debug --to notebook --inplace --execute *.ipynb)
 }
 
 clean_notebooks() {


### PR DESCRIPTION
Initially just wanted to see if bumping to Python3.11 could fix #2387, but if we already built with this we can go ahead and merge. 
Also by adding `--debug` to nbconvert, we will get more detailed errors in the logss when jupyter notebooks crash.