### PR TITLE
drop windows nightly installer

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -93,14 +93,6 @@ jobs:
       shell: cmd
       working-directory: ${{runner.workspace}}\nrn
 
-    - name: Publish Nightly Installer
-      if: github.ref == 'refs/heads/master'
-      working-directory: ${{runner.workspace}}\nrn
-      run: |
-        gh release upload nightly nrn-nightly-AMD64.exe -R neuronsimulator/installers
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
     - name: Publish Release Installer
       working-directory: ${{runner.workspace}}\nrn
       if: inputs.tag != ''


### PR DESCRIPTION
* more setup required than GITHUB_TOKEN
* no user requirement as of today. to be revisited if needed