### PR TITLE
retrofit: macOS arm64 wheels: delocate workaround (#1897)

### DIFF
--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -163,6 +163,9 @@ build_wheel_osx() {
         echo " - Python installation is universal2 and we are on arm64, setting _PYTHON_HOST_PLATFORM to: ${_PYTHON_HOST_PLATFORM}"
         export ARCHFLAGS="-arch arm64"
         echo " - Setting ARCHFLAGS to: ${ARCHFLAGS}"
+        # This is a shortcut to have a successful delocate-wheel. See:
+        # https://github.com/matthew-brett/delocate/issues/153
+        python -c "import os,delocate; print(os.path.join(os.path.dirname(delocate.__file__), 'tools.py'));quit()"  | xargs -I{} sed -i."" "s/first, /input.pop('i386',None); first, /g" {}
       else
         export _PYTHON_HOST_PLATFORM="${py_platform/universal2/x86_64}"
         echo " - Python installation is universal2 and we are on x84_64, setting _PYTHON_HOST_PLATFORM to: ${_PYTHON_HOST_PLATFORM}"

--- a/packaging/python/test_wheels.sh
+++ b/packaging/python/test_wheels.sh
@@ -173,6 +173,7 @@ run_parallel_test() {
 
       brew unlink mpich
       brew link openmpi
+      export DYLD_LIBRARY_PATH=${BREW_PREFIX}/opt/open-mpi/lib:$DYLD_LIBRARY_PATH
       run_mpi_test "${BREW_PREFIX}/opt/open-mpi/bin/mpirun" "OpenMPI" ""
 
     # CI Linux or Azure Linux

--- a/packaging/python/test_wheels.sh
+++ b/packaging/python/test_wheels.sh
@@ -165,10 +165,11 @@ run_parallel_test() {
     # this is for MacOS system
     if [[ "$OSTYPE" == "darwin"* ]]; then
       # assume both MPIs are installed via brew.
+      BREW_PREFIX=$(brew --prefix)
 
       brew unlink openmpi
       brew link mpich
-      BREW_PREFIX=$(brew --prefix)
+      export DYLD_LIBRARY_PATH=${BREW_PREFIX}/opt/mpich/lib:$DYLD_LIBRARY_PATH
       run_mpi_test "${BREW_PREFIX}/opt/mpich/bin/mpirun" "MPICH" ""
 
       brew unlink mpich


### PR DESCRIPTION
* fix MPI testing via `DYLD_LIBRARY_PATH`