### PR TITLE
Matplotlib 3.6 PlotShape Compatibility

### DIFF
--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -1128,7 +1128,9 @@ class _PlotShapePlot(_WrapperPlot):
                                     line.set_color(col)
                     return lines
 
-            return Axis3DWithNEURON(fig)
+            ax = Axis3DWithNEURON(fig)
+            fig.add_axes(ax)
+            return ax
 
         def _get_variable_seg(seg, variable):
             if isinstance(variable, str):


### PR DESCRIPTION
Updated the Matplotlib section in PlotShape to accommodate changes from Matplotplib 3.5 to 3.6, so that it does not generate an empty plot.  
Contributed to #2386