### PR TITLE
CoreNEURON unit tests logic: if we require them, require them

### DIFF
--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Install homebrew packages
         if: startsWith(matrix.os, 'macOS')
         run: |
-          brew install ccache coreutils doxygen flex bison mpich ninja xz autoconf autoconf automake libtool
+          brew install ccache coreutils doxygen flex bison mpich ninja xz autoconf autoconf automake libtool boost
           brew unlink mpich
           brew install openmpi
           brew install --cask xquartz
@@ -104,7 +104,7 @@ jobs:
         run: |
           sudo apt-get install build-essential ccache libopenmpi-dev \
             libmpich-dev libx11-dev libxcomposite-dev mpich ninja-build \
-            openmpi-bin flex libfl-dev bison
+            openmpi-bin flex libfl-dev bison libboost-all-dev
           # The sanitizer builds use ubuntu 22.04
           if [[ "${{matrix.os}}" == "ubuntu-20.04" ]]; then
             sudo apt-get install g++-7 g++-8

--- a/test/coreneuron/unit/CMakeLists.txt
+++ b/test/coreneuron/unit/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_BUILD_RPATH ${CMAKE_BINARY_DIR}/bin/${CMAKE_HOST_SYSTEM_PROCESSOR})
 if(CORENRN_ENABLE_UNIT_TESTS)
   set(Boost_NO_BOOST_CMAKE TRUE)
   # Minimum set by needing the multi-argument version of BOOST_AUTO_TEST_CASE.
-  find_package(Boost 1.59 REQUIRED COMPONENTS filesystem system atomic unit_test_framework)
+  find_package(Boost REQUIRED COMPONENTS filesystem system atomic unit_test_framework)
   include_directories(${PROJECT_SOURCE_DIR}/src ${Boost_INCLUDE_DIRS})
   add_library(coreneuron-unit-test INTERFACE)
   target_compile_options(coreneuron-unit-test INTERFACE ${CORENEURON_BOOST_UNIT_TEST_COMPILE_FLAGS})

--- a/test/coreneuron/unit/CMakeLists.txt
+++ b/test/coreneuron/unit/CMakeLists.txt
@@ -18,31 +18,24 @@ endif()
 
 set(CMAKE_BUILD_RPATH ${CMAKE_BINARY_DIR}/bin/${CMAKE_HOST_SYSTEM_PROCESSOR})
 
-set(Boost_NO_BOOST_CMAKE TRUE)
-# Minimum set by needing the multi-argument version of BOOST_AUTO_TEST_CASE.
-find_package(Boost 1.59 QUIET COMPONENTS filesystem system atomic unit_test_framework)
-
-if(Boost_FOUND)
-  if(CORENRN_ENABLE_UNIT_TESTS)
-    include_directories(${PROJECT_SOURCE_DIR}/src ${Boost_INCLUDE_DIRS})
-    add_library(coreneuron-unit-test INTERFACE)
-    target_compile_options(coreneuron-unit-test
-                           INTERFACE ${CORENEURON_BOOST_UNIT_TEST_COMPILE_FLAGS})
-    target_include_directories(coreneuron-unit-test SYSTEM INTERFACE ${Boost_INCLUDE_DIRS}
-                                                                     ${CMAKE_BINARY_DIR}/include)
-    target_link_libraries(coreneuron-unit-test INTERFACE coreneuron-all)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/cmdline_interface)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/interleave_info)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/alignment)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/queueing)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/solver)
-    # lfp test uses nrnmpi_* wrappers but does not load the dynamic MPI library TODO: re-enable
-    # after NEURON and CoreNEURON dynamic MPI are merged
-    if(NOT NRN_ENABLE_MPI_DYNAMIC)
-      add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lfp)
-    endif()
+if(CORENRN_ENABLE_UNIT_TESTS)
+  set(Boost_NO_BOOST_CMAKE TRUE)
+  # Minimum set by needing the multi-argument version of BOOST_AUTO_TEST_CASE.
+  find_package(Boost 1.59 REQUIRED COMPONENTS filesystem system atomic unit_test_framework)
+  include_directories(${PROJECT_SOURCE_DIR}/src ${Boost_INCLUDE_DIRS})
+  add_library(coreneuron-unit-test INTERFACE)
+  target_compile_options(coreneuron-unit-test INTERFACE ${CORENEURON_BOOST_UNIT_TEST_COMPILE_FLAGS})
+  target_include_directories(coreneuron-unit-test SYSTEM INTERFACE ${Boost_INCLUDE_DIRS}
+                                                                   ${CMAKE_BINARY_DIR}/include)
+  target_link_libraries(coreneuron-unit-test INTERFACE coreneuron-all)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/cmdline_interface)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/interleave_info)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/alignment)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/queueing)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/solver)
+  # lfp test uses nrnmpi_* wrappers but does not load the dynamic MPI library TODO: re-enable after
+  # NEURON and CoreNEURON dynamic MPI are merged
+  if(NOT NRN_ENABLE_MPI_DYNAMIC)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lfp)
   endif()
-  message(STATUS "Boost found, unit tests enabled")
-else()
-  message(STATUS "Boost not found, unit tests disabled")
 endif()

--- a/test/coreneuron/unit/CMakeLists.txt
+++ b/test/coreneuron/unit/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_BUILD_RPATH ${CMAKE_BINARY_DIR}/bin/${CMAKE_HOST_SYSTEM_PROCESSOR})
 if(CORENRN_ENABLE_UNIT_TESTS)
   set(Boost_NO_BOOST_CMAKE TRUE)
   # Minimum set by needing the multi-argument version of BOOST_AUTO_TEST_CASE.
-  find_package(Boost REQUIRED COMPONENTS filesystem system atomic unit_test_framework)
+  find_package(Boost REQUIRED COMPONENTS filesystem atomic unit_test_framework)
   include_directories(${PROJECT_SOURCE_DIR}/src ${Boost_INCLUDE_DIRS})
   add_library(coreneuron-unit-test INTERFACE)
   target_compile_options(coreneuron-unit-test INTERFACE ${CORENEURON_BOOST_UNIT_TEST_COMPILE_FLAGS})

--- a/test/coreneuron/unit/lfp/lfp.cpp
+++ b/test/coreneuron/unit/lfp/lfp.cpp
@@ -123,8 +123,8 @@ BOOST_AUTO_TEST_CASE(LFP_ReportEvent) {
     for (const auto& gid: gids) {
         mapinfo->mappingvec.push_back(new CellMapping(gid));
         for (const auto& segment: segment_ids) {
-            mapinfo->mappingvec.back()->add_segment_lfp_factor(segment,
-                                                               {segment + 1.0, segment + 2.0});
+            std::vector<double> lfp_factors{segment + 1.0, segment + 2.0};
+            mapinfo->mappingvec.back()->add_segment_lfp_factor(segment, lfp_factors);
         }
     }
     mapinfo->prepare_lfp();


### PR DESCRIPTION
Unit tests for `%intel~shared` don't actually work