### PR TITLE
bump documentation timeout to 25 minutes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
 
     name: Documentation
 
-    timeout-minutes: 20
+    timeout-minutes: 25
 
     steps:
 


### PR DESCRIPTION
doing this because #2440 keeps timing out.