### PR TITLE
Improve memory release

### DIFF
--- a/src/neuron/container/soa_container.hpp
+++ b/src/neuron/container/soa_container.hpp
@@ -765,6 +765,16 @@ struct soa {
         return result;
     }
 
+    void shrink_to_fit() {
+        if (m_frozen_count) {
+            throw_error("shrink() called on a frozen structure");
+        }
+        for_each_vector<detail::may_cause_reallocation::Yes>(
+            [](auto const& tag, auto& vec, int field_index, int array_dim) {
+                vec.shrink_to_fit();
+            });
+    }
+
   private:
     /**
      * @brief Remove the @f$i^{\text{th}}@f$ row from the container.

--- a/src/neuron/model_data.hpp
+++ b/src/neuron/model_data.hpp
@@ -117,6 +117,13 @@ struct Model {
     [[nodiscard]] std::unique_ptr<container::utils::storage_info> find_container_info(
         void const* cont) const;
 
+    void shrink_to_fit() {
+        m_node_data.shrink_to_fit();
+        apply_to_mechanisms([](auto& mech_data) { mech_data.shrink_to_fit(); });
+
+        m_identifier_ptrs_for_deferred_deletion.shrink_to_fit();
+    }
+
   private:
     container::Mechanism::storage& mechanism_data_impl(int type) const {
         if (0 <= type && type >= m_mech_data.size()) {

--- a/src/nrniv/cxprop.cpp
+++ b/src/nrniv/cxprop.cpp
@@ -2,6 +2,7 @@
 #include "hocdec.h"      // Datum
 #include "section.h"     // Section
 #include "structpool.h"  // Pool
+#include "../neuron/model_data.hpp"
 
 #include <memory>
 #include <vector>
@@ -111,6 +112,7 @@ void nrn_poolshrink(int shrink) {
                 pdatum.reset();
             }
         }
+        neuron::model().shrink_to_fit();
     } else {
         Printf("poolshrink --- type name (dbluse, size) (datumuse, size)\n");
         for (auto i = 0; i < datumpools().size(); ++i) {


### PR DESCRIPTION
The two improvements are:
  * call `shrink_to_fit` for all vectors in the model during `pool_shrink`.
  * ~allow users to delete identifiers whose deletion has been deferred, i.e.
    clear out the deferred deletion vectors.~ Caused segfaults.