### PR TITLE
Fix leak in `write_nrnthread`.

### DIFF
--- a/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
+++ b/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
@@ -352,8 +352,8 @@ int nrnthread_dat2_mech(int tid,
     int sz = nrn_prop_param_size_[type];
 
     // As the NEURON data is now transposed then for now always create a new
-    // copy in the format expected by CoreNEURON -- TODO make sure this is
-    // freed, then later TODO remove the need for this entirely
+    // copy in the format expected by CoreNEURON.
+    // TODO remove the need for this entirely
     if (!copy) {
         data = new double[n * sz];
     }
@@ -363,13 +363,10 @@ int nrnthread_dat2_mech(int tid,
         }
     }
 
-    // double* data1;
     if (isart) {  // data may not be contiguous
-        // data1 = contiguous_art_data(ml, n, sz);  // delete after use
         nodeindices = NULL;
     } else {
         nodeindices = ml->nodeindices;  // allocated below if copy
-        // data1 = ml->_data[0];           // do not delete after use
     }
     if (copy) {
         if (!isart) {
@@ -378,15 +375,6 @@ int nrnthread_dat2_mech(int tid,
                 nodeindices[i] = ml->nodeindices[i];
             }
         }
-        // int nn = n * sz;
-        // for (int i = 0; i < nn; ++i) {
-        //     data[i] = data1[i];
-        // }
-        // if (isart) {
-        //     delete[] data1;
-        // }
-        // } else {
-        //     data = data1;
     }
 
     sz = bbcore_dparam_size[type];  // nrn_prop_dparam_size off by 1 if cvode_ieq.

--- a/src/nrniv/nrncore_write/io/nrncore_io.cpp
+++ b/src/nrniv/nrncore_write/io/nrncore_io.cpp
@@ -304,28 +304,6 @@ void writedbl_(double* p, size_t size, FILE* f) {
 #define writeint(p, size) writeint_(p, size, f)
 #define writedbl(p, size) writedbl_(p, size, f)
 
-void write_contiguous_art_data(double** data, int nitem, int szitem, FILE* f) {
-    fprintf(f, "chkpnt %d\n", chkpnt++);
-    // the assumption is that an fwrite of nitem groups of szitem doubles can be
-    // fread as a single group of nitem*szitem doubles.
-    for (int i = 0; i < nitem; ++i) {
-        size_t n = fwrite(data[i], sizeof(double), szitem, f);
-        assert(n == szitem);
-    }
-}
-
-double* contiguous_art_data(Memb_list* ml, int nitem, int szitem) {
-    double* d1 = new double[nitem * szitem];
-    int k = 0;
-    for (int i = 0; i < nitem; ++i) {
-        for (int j = 0; j < szitem; ++j) {
-            d1[k++] = ml->data(i, j);
-        }
-    }
-    return d1;
-}
-
-
 void nrnbbcore_vecplay_write(FILE* f, NrnThread& nt) {
     // Get the indices in NetCvode.fixed_play_ for this thread
     // error if not a VecPlayContinuous with no discon vector

--- a/src/nrniv/nrncore_write/io/nrncore_io.cpp
+++ b/src/nrniv/nrncore_write/io/nrncore_io.cpp
@@ -215,7 +215,7 @@ void write_nrnthread(const char* path, NrnThread& nt, CellGroup& cg) {
             writeint(nodeindices, n);
         }
         writedbl(data, n * sz);
-        if (nrn_is_artificial_[type]) {
+        if (data) {
             delete[] data;
         }
         sz = bbcore_dparam_size[type];

--- a/src/nrniv/nrncore_write/io/nrncore_io.h
+++ b/src/nrniv/nrncore_write/io/nrncore_io.h
@@ -38,8 +38,6 @@ struct Memb_list;
 using bbcore_write_t =
     void (*)(double*, int*, int*, int*, Memb_list*, std::size_t, Datum*, Datum*, NrnThread*);
 
-void write_contiguous_art_data(double** data, int nitem, int szitem, FILE* f);
-double* contiguous_art_data(Memb_list* ml, int nitem, int szitem);
 void write_nrnthread_task(const char*, CellGroup* cgs, bool append);
 void nrnbbcore_vecplay_write(FILE* f, NrnThread& nt);
 


### PR DESCRIPTION
Running a memory profiler on simulations using neurodamus to create the input files for coreneuron in multiple cycles showed that memory allocated in:
https://github.com/neuronsimulator/nrn/blob/5ea534f3a4ee5f62ec9c30d1a95ac0982de76e54/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp#L358

accumulated across cycles. The function is called from `write_nrnthread`, with the following context:
```
        double* data = NULL;
        nrnthread_dat2_mech(..., data, ...);

        if (nrn_is_artificial_[type]) {
            delete[] data;
        }
```
looking into `nrnthread_dat2_mech` we find the following structure:
```
int nrnthread_dat2_mech(..., double*& data, ...) {
    bool copy = data ? true : false;

    // As the NEURON data is now transposed then for now always create a new
    // copy in the format expected by CoreNEURON -- TODO make sure this is
    // freed, then later TODO remove the need for this entirely
    if (!copy) {
        data = new double[n * sz];
    }
    // Don't give away/store `data` anywhere.
```
In summary when called from `write_nrnthread`:
1. The argument `data` passed to `nrnthread_dat2_mech` is unconditionally `NULL`.
2. Memory will be allocate to `data` unconditionally.
3. Memory is only released when `nrn_is_artificial_[type]` which seems to only sometimes hold.

The immediate fix is to simply release the memory since it doesn't seem to be used afterwards. Profiling the same run shows the expected reduced memory consumption.
