### PR TITLE
Avoid segfault if user fails to call setdata before a mech FUNCTION.

### DIFF
--- a/src/nmodl/modl.cpp
+++ b/src/nmodl/modl.cpp
@@ -136,6 +136,7 @@ int main(int argc, char** argv) {
 
     openfiles(finname, output_dir); /* .mrg else .mod,  .var, .c */
     IGNORE(yyparse());
+    func_needs_setdata();  // Do FUNCTION/PROCEDURE need prior call to setdata.
     /*
      * At this point all blocks are fully processed except the kinetic
      * block and the solve statements. Even in these cases the

--- a/src/nmodl/nmodlfunc.h
+++ b/src/nmodl/nmodlfunc.h
@@ -139,3 +139,9 @@ void netrec_discon();
 char* items_as_string(Item* begin, Item* last); /* does not include last */
 int slist_search(int listnum, Symbol* s);
 void nrnunit_dynamic_str(char (&buf)[NRN_BUFSIZE], const char* name, char* unit1, char* unit2);
+
+// help know if setdata required to call FUNCTION or PROCEDURE
+void check_range_in_func(Symbol*);
+void set_inside_func(Symbol*);
+void func_needs_setdata();
+void hocfunc_setdata_item(Symbol*, Item*);

--- a/src/nmodl/parsact.cpp
+++ b/src/nmodl/parsact.cpp
@@ -758,6 +758,7 @@ void hocfunchack(Symbol* n, Item* qpar1, Item* qpar2, int hack) {
                              "  _thread = _extcall_thread.data();\n"
                              "  _nt = static_cast<NrnThread*>(_pnt->_vnt);\n");
     } else {
+        hocfunc_setdata_item(n, lappendstr(procfunc, ""));
         vectorize_substitute(
             lappendstr(procfunc, ""),
             "_nrn_mechanism_cache_instance _ml_real{_extcall_prop};\n"

--- a/src/nmodl/parse1.ypp
+++ b/src/nmodl/parse1.ypp
@@ -228,7 +228,9 @@ limits: /*nothing*/
 		}
 	;
 name:	Name
+		{check_range_in_func(SYM($1));}
 	| PRIME
+		{check_range_in_func(SYM($1));}
 	;
 number: NUMBER	{lastok = $1;}
 	| '-' NUMBER
@@ -397,6 +399,7 @@ ostmt:	fromstmt
 	| conducthint
 	| VERBATIM 
 		{inblock(SYM($1)->name);
+                check_range_in_func(nullptr);
 		replacstr($1, "\n/*VERBATIM*/\n");
 		if (!assert_threadsafe && !saw_verbatim_) {
  		 fprintf(stderr, "Notice: VERBATIM blocks are not thread safe\n");
@@ -609,6 +612,7 @@ funccall: NAME '('
 		{ if (SYM($1)->subtype & EXTDEF2) { extdef2 = 1;}}
 	   exprlist ')'
 		{lastok = $5; SYM($1)->usage |= FUNCT;
+		 check_range_in_func(SYM($1));
 		 if (SYM($1)->subtype & EXTDEF2) { extdef2 = 0;}
 		 if (SYM($1)->subtype & EXTDEF3) { add_reset_args($2);}
 		 if (SYM($1)->subtype & EXTDEF4) { add_nrnthread_arg($2);}
@@ -707,7 +711,7 @@ functableblk: FUNCTION_TABLE NAME '(' arglist ')' units
 		}
 	;
 funcblk: FUNCTION1 NAME '(' arglist ')' units
-		{IGNORE(copylocal(SYM($2)));}
+		{IGNORE(copylocal(SYM($2))); set_inside_func(SYM($2));}
 	stmtlist '}'
 		/* boilerplate added to form double function(){...}
 		   Note all arguments have prefix _l */
@@ -727,6 +731,7 @@ funcblk: FUNCTION1 NAME '(' arglist ')' units
 		SYM($2)->subtype |= FUNCT;
 		SYM($2)->usage |= FUNCT;
 		hocfunc(s, $3, $5);
+		set_inside_func(nullptr);
 		poplocal(); freelist(&$4);}
 	;
 arglist: /*nothing*/ {pushlocal(); $$ = LIST0; argcnt_ = 0;}
@@ -741,20 +746,21 @@ arglist1: name units
 		 ++argcnt_;
 		}
 	;
-procedblk: PROCEDURE NAME '(' arglist ')' units stmtlist '}'
+procedblk: PROCEDURE NAME '(' arglist ')' units {set_inside_func(SYM($2));} stmtlist '}'
 		{Symbol *s = SYM($2);
 		s->u.i = 0; 	/* avoid objectcenter warning if solved */
 		s->varnum = argcnt_; /* allow proper number of "double" in prototype */
 		table_massage(table_list, $1, $2, $4); freelist(&table_list);
 		replacstr($1, "\nstatic int "); defarg($3, $5);
-		Insertstr($8, " return 0;");
-		movelist($1, $8, procfunc);
+		Insertstr($9, " return 0;");
+		movelist($1, $9, procfunc);
 		if (SYM($2)->subtype & PROCED) {
 			diag(SYM($2)->name, " declared as PROCEDURE twice");
 		}
 		SYM($2)->subtype |= PROCED;
 		SYM($2)->usage |= FUNCT;
 		hocfunc(s, $3, $5);
+                set_inside_func(nullptr);
 		poplocal(); freelist(&$4);}
 	;
 netrecblk: NETRECEIVE '(' arglist ')'

--- a/test/hoctests/sdata.mod
+++ b/test/hoctests/sdata.mod
@@ -1,0 +1,79 @@
+: Tests for exploring setdata
+NEURON {
+    THREADSAFE
+    SUFFIX sdata
+    RANGE a, b, c
+    POINTER p
+}
+
+PARAMETER {
+  a = 0
+  b = 1
+  c[3]
+}
+
+ASSIGNED { p }
+
+INITIAL {
+  a = 1
+  b = 2
+  c[1] = 3
+}
+
+PROCEDURE A(x,y,z) {
+  a = x
+  b = y
+  c[1] = z
+}
+
+PROCEDURE Aexp() {
+  printf("exp(a) is %g\n", exp(a))
+}
+
+PROCEDURE Aexp2(x) {
+  LOCAL a
+  a = x
+  printf("exp(%g) is %g\n", a, exp(a))
+}
+
+FUNCTION C() {
+  C = c[1]
+}
+
+PROCEDURE d(x) {
+  e(x)
+}
+
+PROCEDURE e(x) {
+  a = x
+}
+
+FUNCTION f(x) {
+  if (x > 0) {
+    f = g(x)
+  }else{
+    f = 0
+  }
+}
+
+PROCEDURE g(x) {
+  b = b + f(x-1)
+}
+
+FUNCTION h(x) {
+VERBATIM
+  _lh =  _lx*_lx;
+ENDVERBATIM
+}
+
+FUNCTION k(x) {
+  if (x > 0) {
+    k = k(x-1) + x
+  } else {
+    k = 0
+  }
+}
+
+PROCEDURE P() {
+  a = p
+}

--- a/test/hoctests/tests/test_setdata.py
+++ b/test/hoctests/tests/test_setdata.py
@@ -1,0 +1,4 @@
+from neuron import h
+from neuron.expect_hocerr import expect_err
+
+expect_err("h.A_sdata(5,6,7)")


### PR DESCRIPTION
Closes #686

At the moment, implemented only for vectorized density mechanisms.
Need to explore vectorized vs non-vectorized, POINT_PROCESS vs ARTIFICIAL_CELL vs SUFFIX(density).

This is most important for HOC users. A subsequent PR should extend to allow something like
```
soma(0.5).hd.alpl(-65)
```
which could automatically set the data appropriately. 
I believe POINT_PROCESS already allows such syntax.