### PR TITLE
Fixes linux wheel backspace by upgrading ncurses-6.2 to 6.4

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,7 +132,7 @@ stages:
         name: readlineSF
         displayName: 'Download readline secure file'
         inputs:
-          secureFile: 'readline7.0.tar.gz'
+          secureFile: 'readline7.0-ncurses6.4.tar.gz'
 
       # 10.14 is required for full C++17 support according to
       # https://cibuildwheel.readthedocs.io/en/stable/cpp_standards, but it

--- a/docs/install/python_wheels.md
+++ b/docs/install/python_wheels.md
@@ -66,18 +66,18 @@ docker push neuronsimulator/neuron_wheel:<tag>
 
 You can either build the neuron images locally or pull them from DockerHub:
 ```
-$ docker pull neuronsimulator/neuron_wheel
-Using default tag: latest
+$ docker pull neuronsimulator/neuron_wheel:latest-x86_64
+Using default tag: latest-x86_64
 latest: Pulling from neuronsimulator/neuron_wheel
 ....
 Status: Downloaded newer image for neuronsimulator/neuron_wheel:latest
-docker.io/neuronsimulator/neuron_wheel:latest
+docker.io/neuronsimulator/neuron_wheel:latest-x86_64
 ```
 
 We can conveniently mount the local NEURON repository inside docker, by using the `-v` option:
 
 ```
-docker run -v $PWD/nrn:/root/nrn -w /root/nrn -it neuronsimulator/neuron_wheel bash
+docker run -v $PWD/nrn:/root/nrn -w /root/nrn -it neuronsimulator/neuron_wheel:latest-x86_64 bash
 ```
 where `$PWD/nrn` is a NEURON repository on the host machine that ends up mounted at `/root/nrn`.
 This is how you can test your NEURON updates inside the NEURON Docker image.
@@ -89,7 +89,7 @@ The `neuronsimulator/neuron_wheel` provides out-of-the-box support for `mpich` a
 For `HPE-MPT MPI`, since it's not open source, you need to acquire the headers and mount them in the docker image:
 
 ```
-docker run -v $PWD/nrn:/root/nrn -w /root/nrn -v $PWD/mpt-headers/2.21/include:/nrnwheel/mpt/include -it neuronsimulator/neuron_wheel bash
+docker run -v $PWD/nrn:/root/nrn -w /root/nrn -v $PWD/mpt-headers/2.21/include:/nrnwheel/mpt/include -it neuronsimulator/neuron_wheel:latest-x86_64 bash
 ```
 where `$PWD/mpt-headers` is the path to the HPE-MPT MPI headers on the host machine that end up mounted at `/nrnwheel/mpt/include`.
 You can download the headers with:

--- a/docs/install/python_wheels.md
+++ b/docs/install/python_wheels.md
@@ -104,7 +104,7 @@ Note that for macOS there is no docker image needed, but all required dependenci
 In order to have the wheels working on multiple macOS target versions, special consideration must be made for `MACOSX_DEPLOYMENT_TARGET`.
 
 
-Taking Azure macOS `x86_64` wheels for example, `readline` was built with `MACOSX_DEPLOYMENT_TARGET=10.9` and stored as secure file on Azure.
+Taking Azure macOS `x86_64` wheels for example, `readline` was built with `MACOSX_DEPLOYMENT_TARGET=10.9` and stored as secure file on Azure (under `Pipelines > Library > Secure files`).
 For `arm64` we need to set `MACOSX_DEPLOYMENT_TARGET=11.0`. The wheels currently need to be built manually, using `universal2` Python installers.
 For upcoming `universal2` wheels (targeting both `x86_64` and `arm64`) we will consider leveling everything to `MACOSX_DEPLOYMENT_TARGET=11.0`.
 

--- a/packaging/python/Dockerfile
+++ b/packaging/python/Dockerfile
@@ -33,12 +33,12 @@ RUN rpmbuild --rebuild https://vault.centos.org/8-stream/AppStream/Source/SPacka
     && yum -y install rpmbuild/RPMS/*/flex-2.6.1-9.el7.*.rpm \
     && rm -rf rpmbuild
 
-RUN wget http://ftpmirror.gnu.org/ncurses/ncurses-6.2.tar.gz \
-    && tar -xvzf ncurses-6.2.tar.gz \
-    && cd ncurses-6.2  \
-    && ./configure --prefix=/nrnwheel/ncurses --without-shared --without-debug CFLAGS="-fPIC" \
+RUN wget http://ftpmirror.gnu.org/ncurses/ncurses-5.9.tar.gz \
+    && tar -xvzf ncurses-5.9.tar.gz \
+    && cd ncurses-5.9  \
+    && ./configure --prefix=/nrnwheel/ncurses --without-shared --without-debug CFLAGS="-fPIC" CPPFLAGS="-P" --without-cxx\
     && make -j install \
-    && cd .. && rm -rf ncurses-6.2 ncurses-6.2.tar.gz
+    && cd .. && rm -rf ncurses-5.9 ncurses-5.9.tar.gz
 
 RUN curl -L -o mpich-3.3.2.tar.gz http://www.mpich.org/static/downloads/3.3.2/mpich-3.3.2.tar.gz \
     && tar -xvzf mpich-3.3.2.tar.gz \

--- a/packaging/python/Dockerfile
+++ b/packaging/python/Dockerfile
@@ -33,12 +33,12 @@ RUN rpmbuild --rebuild https://vault.centos.org/8-stream/AppStream/Source/SPacka
     && yum -y install rpmbuild/RPMS/*/flex-2.6.1-9.el7.*.rpm \
     && rm -rf rpmbuild
 
-RUN wget http://ftpmirror.gnu.org/ncurses/ncurses-5.9.tar.gz \
-    && tar -xvzf ncurses-5.9.tar.gz \
-    && cd ncurses-5.9  \
-    && ./configure --prefix=/nrnwheel/ncurses --without-shared --without-debug CFLAGS="-fPIC" CPPFLAGS="-P" --without-cxx\
+RUN wget http://ftpmirror.gnu.org/ncurses/ncurses-6.4.tar.gz \
+    && tar -xvzf ncurses-6.4.tar.gz \
+    && cd ncurses-6.4  \
+    && ./configure --prefix=/nrnwheel/ncurses --without-shared --without-debug CFLAGS="-fPIC" \
     && make -j install \
-    && cd .. && rm -rf ncurses-5.9 ncurses-5.9.tar.gz
+    && cd .. && rm -rf ncurses-6.4 ncurses-6.4.tar.gz
 
 RUN curl -L -o mpich-3.3.2.tar.gz http://www.mpich.org/static/downloads/3.3.2/mpich-3.3.2.tar.gz \
     && tar -xvzf mpich-3.3.2.tar.gz \

--- a/packaging/python/build_static_readline_osx.bash
+++ b/packaging/python/build_static_readline_osx.bash
@@ -29,9 +29,9 @@ else
 	export MACOSX_DEPLOYMENT_TARGET=10.9  # for x86_64
 fi
 
-(wget http://ftpmirror.gnu.org/ncurses/ncurses-6.2.tar.gz \
-    && tar -xvzf ncurses-6.2.tar.gz \
-    && cd ncurses-6.2  \
+(wget http://ftpmirror.gnu.org/ncurses/ncurses-6.4.tar.gz \
+    && tar -xvzf ncurses-6.4.tar.gz \
+    && cd ncurses-6.4  \
     && ./configure --prefix=/opt/nrnwheel/ncurses --without-shared CFLAGS="-fPIC" \
     && make -j install)
 


### PR DESCRIPTION
Closes #2399 

When new docker image is published,  8.2.2 linux wheel needs to be recreated and become what users get with ```pip install neuron```