### PR TITLE
Bugfix: Allow result of python call from rxd include flux to be free'd.

### DIFF
--- a/src/nrnpython/rxd.cpp
+++ b/src/nrnpython/rxd.cpp
@@ -334,6 +334,7 @@ void apply_node_flux(int n,
                     PyErr_SetString(PyExc_Exception,
                                     "node._include_flux callback did not return a number.\n");
                 }
+                Py_DECREF(result);
             }
         } else {
             PyErr_SetString(PyExc_Exception, "node._include_flux unrecognised source term.\n");


### PR DESCRIPTION
This should fix an issue from the forum, where scaling a simple model to include more fluxes over a longer simulation fails; https://www.neuron.yale.edu/phpBB/viewtopic.php?t=4631