### PR TITLE
Reference counted stable identifiers.

### DIFF
--- a/src/neuron/container/memory_usage.hpp
+++ b/src/neuron/container/memory_usage.hpp
@@ -121,13 +121,11 @@ struct MemoryUsage {
     ModelMemoryUsage model{};
     cache::ModelMemoryUsage cache_model{};
     VectorMemoryUsage stable_pointers{};
-    VectorMemoryUsage stable_identifiers{};
 
     const MemoryUsage& operator+=(const MemoryUsage& other) {
         model += other.model;
         cache_model += other.cache_model;
         stable_pointers += other.stable_pointers;
-        stable_identifiers += other.stable_identifiers;
 
         return *this;
     }
@@ -136,7 +134,6 @@ struct MemoryUsage {
         auto total = model.compute_total();
         total += cache_model.compute_total();
         total += stable_pointers;
-        total += stable_identifiers;
 
         return total;
     }
@@ -174,7 +171,6 @@ struct MemoryUsageSummary {
         add(memory_usage.model);
         add(memory_usage.cache_model);
         add(leaked, memory_usage.stable_pointers);
-        add(leaked, memory_usage.stable_identifiers);
     }
 
   private:

--- a/src/neuron/container/non_owning_soa_identifier.hpp
+++ b/src/neuron/container/non_owning_soa_identifier.hpp
@@ -119,14 +119,14 @@ struct non_owning_identifier_without_container {
     template <typename, typename...>
     friend struct soa;
     friend struct std::hash<non_owning_identifier_without_container>;
-    non_owning_identifier_without_container(std::shared_ptr<std::size_t> ptr)
+    explicit non_owning_identifier_without_container(std::shared_ptr<std::size_t> ptr)
         : m_ptr{std::move(ptr)} {}
     void set_current_row(std::size_t row) {
         assert(m_ptr);
         *m_ptr = row;
     }
 
-    non_owning_identifier_without_container(size_t row)
+    explicit non_owning_identifier_without_container(size_t row)
         : m_ptr(std::make_shared<size_t>(row)) {}
 
   private:

--- a/src/neuron/container/non_owning_soa_identifier.hpp
+++ b/src/neuron/container/non_owning_soa_identifier.hpp
@@ -118,21 +118,24 @@ struct non_owning_identifier_without_container {
     template <typename, typename...>
     friend struct soa;
     friend struct std::hash<non_owning_identifier_without_container>;
-    non_owning_identifier_without_container(std::size_t* ptr)
-        : m_ptr{ptr} {}
+    non_owning_identifier_without_container(std::shared_ptr<std::size_t> ptr)
+        : m_ptr{std::move(ptr)} {}
     void set_current_row(std::size_t row) {
         assert(m_ptr);
         *m_ptr = row;
     }
 
+    non_owning_identifier_without_container(size_t row)
+        : m_ptr(std::make_shared<size_t>(row)) {}
+
   private:
-    std::size_t* m_ptr{};
+    std::shared_ptr<std::size_t> m_ptr{};
 };
 }  // namespace neuron::container
 template <>
 struct std::hash<neuron::container::non_owning_identifier_without_container> {
     std::size_t operator()(
         neuron::container::non_owning_identifier_without_container const& h) noexcept {
-        return reinterpret_cast<std::size_t>(h.m_ptr);
+        return reinterpret_cast<std::size_t>(h.m_ptr.get());
     }
 };

--- a/src/neuron/container/non_owning_soa_identifier.hpp
+++ b/src/neuron/container/non_owning_soa_identifier.hpp
@@ -13,6 +13,7 @@ namespace neuron::container {
 struct field_index {
     int field{}, array_index{};
 };
+
 inline constexpr std::size_t invalid_row = std::numeric_limits<std::size_t>::max();
 
 /**

--- a/src/neuron/container/non_owning_soa_identifier.hpp
+++ b/src/neuron/container/non_owning_soa_identifier.hpp
@@ -27,6 +27,19 @@ struct non_owning_identifier_without_container {
      */
     non_owning_identifier_without_container() = default;
 
+    non_owning_identifier_without_container(const non_owning_identifier_without_container& other) =
+        default;
+    non_owning_identifier_without_container(non_owning_identifier_without_container&& other) =
+        default;
+
+    non_owning_identifier_without_container& operator=(
+        const non_owning_identifier_without_container&) = default;
+    non_owning_identifier_without_container& operator=(non_owning_identifier_without_container&&) =
+        default;
+
+    ~non_owning_identifier_without_container() = default;
+
+
     /**
      * @brief Does the identifier refer to a valid entry?
      *

--- a/src/neuron/container/soa_identifier.hpp
+++ b/src/neuron/container/soa_identifier.hpp
@@ -73,10 +73,9 @@ struct owning_identifier {
         : owning_identifier(storage.acquire_owning_identifier()) {}
 
     owning_identifier(const owning_identifier&) = delete;
-    owning_identifier(owning_identifier&& other) {
-        m_ptr = std::move(other.m_ptr);
-
-        m_data_ptr = other.m_data_ptr;
+    owning_identifier(owning_identifier&& other) noexcept
+        : m_ptr(std::move(other.m_ptr))
+        , m_data_ptr(other.m_data_ptr) {
         other.m_data_ptr = nullptr;
     }
 

--- a/src/neuron/container/soa_identifier.hpp
+++ b/src/neuron/container/soa_identifier.hpp
@@ -87,6 +87,14 @@ struct owning_identifier {
         swap(*this, tmp);
     }
 
+    owning_identifier(const owning_identifier&) = delete;
+    owning_identifier(owning_identifier&& other) = default;
+
+    owning_identifier& operator=(const owning_identifier&) = delete;
+    owning_identifier& operator=(owning_identifier&&) = default;
+
+    ~owning_identifier() = default;
+
     /**
      * @brief Return a reference to the container in which this entry lives.
      */

--- a/src/neuron/container/soa_identifier.hpp
+++ b/src/neuron/container/soa_identifier.hpp
@@ -12,17 +12,6 @@
 #include <vector>
 
 namespace neuron::container {
-namespace detail {
-/**
- * @brief The vector in which dying owning_identifier std::size_t's live.
- *
- * This is defined in container.cpp to avoid multiple-definition issues.
- */
-extern std::vector<std::unique_ptr<std::size_t>>* identifier_defer_delete_storage;
-VectorMemoryUsage compute_identifier_defer_delete_storage_size();
-
-}  // namespace detail
-
 /**
  * @brief A non-owning permutation-stable identifier for a entry in a container.
  * @tparam Storage The type of the referred-to container. This might be a type

--- a/src/neuron/container/soa_identifier.hpp
+++ b/src/neuron/container/soa_identifier.hpp
@@ -81,11 +81,7 @@ struct owning_identifier {
      * @brief Create a non-null owning identifier by creating a new entry.
      */
     owning_identifier(Storage& storage)
-        : owning_identifier{} {
-        // The default constructor has finished, so *this is a valid object.
-        auto tmp = storage.acquire_owning_identifier();
-        swap(*this, tmp);
-    }
+        : owning_identifier(storage.acquire_owning_identifier()) {}
 
     owning_identifier(const owning_identifier&) = delete;
     owning_identifier(owning_identifier&& other) = default;
@@ -126,10 +122,6 @@ struct owning_identifier {
     [[nodiscard]] std::size_t current_row() const {
         assert(m_ptr);
         return *m_ptr;
-    }
-
-    friend void swap(owning_identifier& first, owning_identifier& second) {
-        std::swap(first.m_ptr, second.m_ptr);
     }
 
     friend std::ostream& operator<<(std::ostream& os, owning_identifier const& oi) {

--- a/src/neuron/container/soa_identifier.hpp
+++ b/src/neuron/container/soa_identifier.hpp
@@ -86,7 +86,6 @@ struct owning_identifier {
     owning_identifier(const owning_identifier&) = delete;
     owning_identifier(owning_identifier&& other) {
         m_ptr = std::move(other.m_ptr);
-        other.m_ptr = nullptr;
 
         m_data_ptr = other.m_data_ptr;
         other.m_data_ptr = nullptr;
@@ -97,7 +96,6 @@ struct owning_identifier {
         destroy();
 
         m_ptr = std::move(other.m_ptr);
-        other.m_ptr = nullptr;
 
         m_data_ptr = other.m_data_ptr;
         other.m_data_ptr = nullptr;
@@ -139,7 +137,7 @@ struct owning_identifier {
      */
     [[nodiscard]] std::size_t current_row() const {
         assert(m_ptr);
-        return *m_ptr;
+        return m_ptr.current_row();
     }
 
     friend std::ostream& operator<<(std::ostream& os, owning_identifier const& oi) {
@@ -162,15 +160,15 @@ struct owning_identifier {
 
         // We should still be a valid reference at this point.
         assert(m_ptr);
-        assert(*m_ptr < data_container.size());
+        assert(m_ptr.current_row() < data_container.size());
 
         // Prove that the bookkeeping works.
-        assert(data_container.at(*m_ptr) == m_ptr);
+        assert(data_container.at(m_ptr.current_row()) == m_ptr);
 
         bool terminate = false;
         // Delete the corresponding row from `data_container`
         try {
-            data_container.erase(*m_ptr);
+            data_container.erase(m_ptr.current_row());
         } catch (std::exception const& e) {
             // Cannot throw from unique_ptr release/reset/destructor, this
             // is the best we can do. Most likely what has happened is
@@ -190,32 +188,22 @@ struct owning_identifier {
         }
         // We don't know how many people know the pointer `p`, so write a sentinel
         // value to it and transfer ownership "elsewhere".
-        set_current_row(invalid_row);
+        m_ptr.set_current_row(invalid_row);
 
         // This is to provide compatibility with NEURON's old nrn_notify_when_double_freed and
         // nrn_notify_when_void_freed methods.
         detail::notify_handle_dying(m_ptr);
-
-        // This is sort-of formalising a memory leak. In principle we could cleanup
-        // identifier_defer_delete_storage by scanning all our data structures and finding
-        // references to the pointers that it contains. In practice it seems unlikely that
-        // either this, or using std::shared_ptr just to avoid it, would be worth it.
-        if (detail::identifier_defer_delete_storage) {
-            detail::identifier_defer_delete_storage->emplace_back(m_ptr);
-        } else {
-            delete m_ptr;
-        }
     }
 
 
-    size_t* m_ptr = nullptr;
+    non_owning_identifier_without_container m_ptr{};
     Storage* m_data_ptr{};
 
     template <typename, typename...>
     friend struct soa;
     void set_current_row(std::size_t new_row) {
         assert(m_ptr);
-        *m_ptr = new_row;
+        m_ptr.set_current_row(new_row);
     }
     /**
      * @brief Create a non-null owning identifier that owns the given row.
@@ -225,9 +213,7 @@ struct owning_identifier {
      * be used without great care.
      */
     owning_identifier(Storage& storage, std::size_t row)
-        : m_ptr(new size_t)
-        , m_data_ptr(&storage) {
-          *m_ptr = row;
-        }
+        : m_ptr(row)
+        , m_data_ptr(&storage) {}
 };
 }  // namespace neuron::container

--- a/src/neuron/model_data.hpp
+++ b/src/neuron/model_data.hpp
@@ -120,8 +120,6 @@ struct Model {
     void shrink_to_fit() {
         m_node_data.shrink_to_fit();
         apply_to_mechanisms([](auto& mech_data) { mech_data.shrink_to_fit(); });
-
-        m_identifier_ptrs_for_deferred_deletion.shrink_to_fit();
     }
 
   private:
@@ -157,11 +155,6 @@ struct Model {
      * @brief Backing storage for defer_delete helper.
      */
     std::vector<void*> m_ptrs_for_deferred_deletion{};
-
-    /**
-     * @brief Backing storage for global identifier_defer_delete_storage.
-     */
-    std::vector<std::unique_ptr<std::size_t>> m_identifier_ptrs_for_deferred_deletion{};
 };
 
 struct model_sorted_token {

--- a/src/nrniv/memory_usage.cpp
+++ b/src/nrniv/memory_usage.cpp
@@ -43,8 +43,7 @@ cache::ModelMemoryUsage memory_usage(const neuron::cache::Model& model) {
 MemoryUsage local_memory_usage() {
     return MemoryUsage{memory_usage(model()),
                        memory_usage(neuron::cache::model),
-                       detail::compute_defer_delete_storage_size(),
-                       detail::compute_identifier_defer_delete_storage_size()};
+                       detail::compute_defer_delete_storage_size()};
 }
 
 namespace detail {
@@ -61,10 +60,6 @@ VectorMemoryUsage compute_defer_delete_storage_size(std::vector<T> const* const 
     return {0ul, 0ul};
 }
 
-
-VectorMemoryUsage compute_identifier_defer_delete_storage_size() {
-    return compute_defer_delete_storage_size(identifier_defer_delete_storage, sizeof(std::size_t));
-}
 
 VectorMemoryUsage compute_defer_delete_storage_size() {
     return compute_defer_delete_storage_size(defer_delete_storage, sizeof(void*));
@@ -105,7 +100,6 @@ std::string format_memory_usage(const MemoryUsage& usage) {
     const auto& model = usage.model;
     const auto& cache_model = usage.cache_model;
     const auto& stable_pointers = usage.stable_pointers;
-    const auto& stable_identifiers = usage.stable_identifiers;
     const auto& total = usage.compute_total();
     const auto& summary = MemoryUsageSummary(usage);
 
@@ -124,7 +118,6 @@ std::string format_memory_usage(const MemoryUsage& usage) {
     os << "  threads               " << format_memory_usage(cache_model.threads) << "\n";
     os << "  mechanisms            " << format_memory_usage(cache_model.mechanisms) << "\n";
     os << "deferred deletion \n";
-    os << "  stable_identifiers    " << format_memory_usage(stable_identifiers) << "\n";
     os << "  stable_pointers       " << format_memory_usage(stable_pointers) << "\n";
     os << "\n";
     os << "total                   " << format_memory_usage(total) << "\n";

--- a/src/nrnoc/container.cpp
+++ b/src/nrnoc/container.cpp
@@ -18,13 +18,8 @@ Model::Model() {
     // needs some re-organisation if we ever want to support multiple Model instances
     assert(!container::detail::defer_delete_storage);
     container::detail::defer_delete_storage = &m_ptrs_for_deferred_deletion;
-    assert(!container::detail::identifier_defer_delete_storage);
-    container::detail::identifier_defer_delete_storage = &m_identifier_ptrs_for_deferred_deletion;
 }
 Model::~Model() {
-    assert(container::detail::identifier_defer_delete_storage ==
-           &m_identifier_ptrs_for_deferred_deletion);
-    container::detail::identifier_defer_delete_storage = nullptr;
     assert(container::detail::defer_delete_storage == &m_ptrs_for_deferred_deletion);
     container::detail::defer_delete_storage = nullptr;
     std::for_each(m_ptrs_for_deferred_deletion.begin(),
@@ -96,8 +91,6 @@ std::ostream& operator<<(std::ostream& os, generic_data_handle const& dh) {
 }
 }  // namespace neuron::container
 namespace neuron::container::detail {
-// See neuron/container/soa_identifier.hpp
-std::vector<std::unique_ptr<std::size_t>>* identifier_defer_delete_storage{};
 // See neuron/container/soa_container.hpp
 std::vector<void*>* defer_delete_storage{};
 }  // namespace neuron::container::detail

--- a/src/nrnoc/section.h
+++ b/src/nrnoc/section.h
@@ -106,6 +106,7 @@ struct Node {
     // neuron::container::handle::Node, but as an intermediate measure we can
     // add one of those as a member and forward some access/modifications to it.
     neuron::container::Node::owning_handle _node_handle{neuron::model().node_data()};
+
     [[nodiscard]] auto id() {
         return _node_handle.id();
     }

--- a/test/unit_tests/container/container.cpp
+++ b/test/unit_tests/container/container.cpp
@@ -150,20 +150,6 @@ TEST_CASE("soa::get_num_variables", "[Neuron][data_structures]") {
     CHECK(data.get_num_variables<field::DOn>() == 1ul);
 }
 
-TEST_CASE("Identifier defer delete ", "[Neuron][internal][data_structures]") {
-    storage data;
-
-    REQUIRE(detail::identifier_defer_delete_storage != nullptr);
-    auto usage_before = detail::compute_identifier_defer_delete_storage_size();
-    { owning_handle instance{data}; }
-    auto usage_after = detail::compute_identifier_defer_delete_storage_size();
-
-    CHECK(usage_after.size - usage_before.size > 0);
-    CHECK(usage_after.capacity > 0);
-    CHECK(usage_before.size <= usage_before.capacity);
-    CHECK(usage_after.size <= usage_after.capacity);
-}
-
 TEST_CASE("defer delete storage pointer", "[Neuron][internal][data_structures]") {
     REQUIRE(detail::defer_delete_storage != nullptr);
 
@@ -279,7 +265,7 @@ neuron::container::MemoryUsage dummy_memory_usage() {
     auto stable_pointers = neuron::container::VectorMemoryUsage(7, 17);
     auto stable_identifiers = neuron::container::VectorMemoryUsage(8, 18);
 
-    auto memory_usage = MemoryUsage{model, cache_model, stable_pointers, stable_identifiers};
+    auto memory_usage = MemoryUsage{model, cache_model, stable_pointers};
 
     return memory_usage;
 }
@@ -288,8 +274,8 @@ neuron::container::MemoryUsage dummy_memory_usage() {
 TEST_CASE("total memory usage", "[Neuron][internal][data_structures]") {
     auto memory_usage = dummy_memory_usage();
     auto total = memory_usage.compute_total();
-    CHECK(total.size == (8 * 9) / 2);
-    CHECK(total.capacity == total.size + 8 * 10);
+    CHECK(total.size == (7 * 8) / 2);
+    CHECK(total.capacity == total.size + 7 * 10);
 }
 
 TEST_CASE("memory usage summary", "[Neuron][data_structures]") {

--- a/test/unit_tests/container/node.cpp
+++ b/test/unit_tests/container/node.cpp
@@ -273,16 +273,6 @@ TEST_CASE("SOA-backed Node structure", "[Neuron][data_structures][node]") {
             }
         }
     }
-    GIVEN("A node that is deleted without an active deferred-deletion vector") {
-        auto* const old = std::exchange(neuron::container::detail::identifier_defer_delete_storage,
-                                        nullptr);
-        // Because identifier_defer_delete_storage is nullptr, deleting `node` will delete the
-        // heap-allocated std::size_t that the data handles depend on. This touches an otherwise
-        // uncovered code path in soa_identifier.hpp. Meaningfully checking the right code path was
-        // followed seems excessively complicated.
-        { ::Node node{}; }
-        neuron::container::detail::identifier_defer_delete_storage = old;
-    }
     GIVEN("A series of nodes with increasing integer voltages") {
         using neuron::test::get_node_voltages;
         auto nodes_and_voltages = neuron::test::get_nodes_and_reference_voltages();


### PR DESCRIPTION
This PR replaces the leaked stable identifiers with reference counted stable identifiers. The idea is that `non_owning_identifier...` keep the stable index alive. Therefore, as soon as the last copy of `non_owning...` is destroyed, the allocated memory for the stable identifier is also deallocated.

This first implementation focuses on the overall changes need to make `non_owning...` reference counted. The reference counting itself is implemented via a `std::shared_ptr`.

In large BBP internal runs, this decreases memory consumption during model building by roughly 2x; at no obvious increase in runtime.