### PR TITLE
Fixed mod file array variable assignment (seg.mech.array[i] = x)

### DIFF
--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -2223,8 +2223,7 @@ static int rv_setitem(PyObject* self, Py_ssize_t ix, PyObject* value) {
         return -1;
     }
     int err;
-    // Bug that ix is not passed as the last argument?
-    auto const d = nrnpy_rangepointer(sec, r->sym_, r->pymech_->pyseg_->x_, &err, 0 /* idx */);
+    auto const d = nrnpy_rangepointer(sec, r->sym_, r->pymech_->pyseg_->x_, &err, ix);
     if (!d) {
         rv_noexist(sec, r->sym_->name, r->pymech_->pyseg_->x_, err);
         return -1;
@@ -2244,7 +2243,6 @@ static int rv_setitem(PyObject* self, Py_ssize_t ix, PyObject* value) {
                        neuron::container::data_handle<double>{neuron::container::do_not_search, &x},
                        0);
     } else {
-        assert(ix == 0);  // d += ix;
         if (!PyArg_Parse(value, "d", static_cast<double const*>(d))) {
             PyErr_SetString(PyExc_ValueError, "bad value");
             return -1;

--- a/test/hoctests/vardimtests/test2.py
+++ b/test/hoctests/vardimtests/test2.py
@@ -34,3 +34,30 @@ expect_err("h.array = 5")
 h("""objref oarray[4][4]""")
 # cannot reach line we want because of earlier array check
 expect_err("h.oarray[2] = []")
+
+
+# test assignment/evaluation of mod file array variable from python
+s = h.Section()
+s.nseg = 3
+s.insert("atst")
+for seg in s:
+    ar = seg.atst.arrayrng
+    assert len(ar) == 4
+    for i in range(len(ar)):
+        ar[i] = i + seg.x
+        seg.arrayrng_atst[i] = ar[i]
+for seg in s:
+    ar = seg.atst.arrayrng
+    for i in range(len(ar)):
+        assert ar[i] == i + seg.x
+        assert seg.arrayrng_atst[i] == i + seg.x
+
+ar = s.arrayrng_atst
+assert len(ar) == 4
+for i in range(len(ar)):
+    ar[i] = i
+for i in range(len(ar)):
+    assert ar[i] == float(i)
+
+expect_err("print(ar[10])")
+expect_err("ar[10] = 1")


### PR DESCRIPTION
seg.mech.array[i] = x would assert if i > 0

Trivial fix for a bug that was mentioned in a companion comment, along with test of functionality.