### PR TITLE
Use `char const *` in `oc_popen`.

### DIFF
--- a/src/oc/fileio.cpp
+++ b/src/oc/fileio.cpp
@@ -473,7 +473,7 @@ void hoc_sprint1(char** ppbuf, int argn) { /* convert args to right type for con
 }
 
 #if defined(WIN32)
-static FILE* oc_popen(char* cmd, char* type) {
+static FILE* oc_popen(char const* const cmd, char const* const type) {
     FILE* fp;
     char buf[1024];
     assert(strlen(cmd) + 20 < 1024);


### PR DESCRIPTION
This silences an warning related to `oc_popen(..., "r")`.