### PR TITLE
Use raw strings when substituting in paths from CMake.

### DIFF
--- a/cmake_nrnconf.h.in
+++ b/cmake_nrnconf.h.in
@@ -359,7 +359,7 @@
 #include <string_view>
 namespace neuron::config {
 #ifdef USE_PYTHON
-   constexpr std::string_view default_python_executable{"@NRN_DEFAULT_PYTHON_EXECUTABLE@"};
+   constexpr std::string_view default_python_executable{R"(@NRN_DEFAULT_PYTHON_EXECUTABLE@)"};
    constexpr std::array<std::string_view, @NRN_PYTHON_COUNT@> supported_python_versions{@NRN_DYNAMIC_PYTHON_LIST_OF_VERSION_STRINGS@};
 #endif
    constexpr std::string_view shared_library_prefix{"@CMAKE_SHARED_LIBRARY_PREFIX@"};


### PR DESCRIPTION
This will silence a lot of warnings on Windows coming from using \ as a path separator.  Should have no impact on systems posing as UNIX-compatible.