### PR TITLE
Allow to run clang-format on nocmodl generated C++ files

### DIFF
--- a/src/nmodl/noccout.cpp
+++ b/src/nmodl/noccout.cpp
@@ -85,10 +85,12 @@ void c_out() {
     P("#undef PI\n");
     P("#define nil 0\n");
     P("#define _pval pval\n");  // due to some old models using _pval
+    P("// clang-format on\n");
     P("#include \"md1redef.h\"\n");
     P("#include \"section_fwd.hpp\"\n");
     P("#include \"nrniv_mf.h\"\n");
     P("#include \"md2redef.h\"\n");
+    P("// clang-format off\n");
     P("#include \"neuron/cache/mechanism_range.hpp\"\n");
     P("#include <vector>\n");
 
@@ -481,10 +483,12 @@ void c_out_vectorize() {
     P("#undef PI\n");
     P("#define nil 0\n");
     P("#define _pval pval\n");  // due to some old models using _pval
+    P("// clang-format off\n");
     P("#include \"md1redef.h\"\n");
     P("#include \"section_fwd.hpp\"\n");
     P("#include \"nrniv_mf.h\"\n");
     P("#include \"md2redef.h\"\n");
+    P("// clang-format on\n");
     P("#include \"neuron/cache/mechanism_range.hpp\"\n");
     printlist(defs_list);
     printlist(firstlist);


### PR DESCRIPTION
With the current master if we run clang-format on the MOD file generated C++ file and try to rebuild the NEURON then we get errors like

```console
src/nrnoc/netstim.cpp:393:28: error: no member named '_prop' in 'Point_process'; did you mean 'prop'?
    auto* const _p = _pnt->_prop;
```

This is because we have some magic header macros that rename certain internal variables.

To avoid the issue, just tell clang-format to avoid sorting these specific headers included.