### PR TITLE
Remove buggy Windows CI.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -76,27 +76,3 @@ jobs:
     - name: live debug session on failure (manual steps required, check `.github/windows.yml`)
       if: failure() && contains(github.event.pull_request.title, 'live-debug-win')
       uses: mxschmitt/action-tmate@v3
-
-    - name: Upload build artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: nrn-nightly-AMD64.exe
-        path: ${{runner.workspace}}\nrn\nrn-nightly-AMD64.exe
-
-    - name: Run installer and launch .hoc associaton test
-      run: .\ci\win_install_neuron.cmd
-      shell: cmd
-      working-directory: ${{runner.workspace}}\nrn
-
-    - name: Test Installer
-      run: .\ci\win_test_installer.cmd
-      shell: cmd
-      working-directory: ${{runner.workspace}}\nrn
-
-    - name: Publish Release Installer
-      working-directory: ${{runner.workspace}}\nrn
-      if: inputs.tag != ''
-      run: |
-        gh release upload ${{ inputs.tag }} nrn-nightly-AMD64.exe
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since we're merging with red CI we might as well turn the problematic parts off; and reactivate them once it works again.