### PR TITLE
Reduce memory consumption of `NewtonSpace`.

### DIFF
--- a/src/coreneuron/mechanism/capac.cpp
+++ b/src/coreneuron/mechanism/capac.cpp
@@ -15,7 +15,7 @@
 #define _PRAGMA_FOR_INIT_ACC_LOOP_                                                               \
     nrn_pragma_acc(parallel loop present(vdata [0:_cntml_padded * nparm]) if (_nt->compute_gpu)) \
     nrn_pragma_omp(target teams distribute parallel for simd if(_nt->compute_gpu))
-#define _STRIDE _cntml_padded + _iml
+#define CNRN_FLAT_INDEX_IML_ROW(i) ((i) * (_cntml_padded) + (_iml))
 
 namespace coreneuron {
 
@@ -45,8 +45,8 @@ void capacitance_reg(void) {
     hoc_register_prop_size(mechtype, nparm, 0);
 }
 
-#define cm    vdata[0 * _STRIDE]
-#define i_cap vdata[1 * _STRIDE]
+#define cm    vdata[CNRN_FLAT_INDEX_IML_ROW(0)]
+#define i_cap vdata[CNRN_FLAT_INDEX_IML_ROW(1)]
 
 /*
 cj is analogous to 1/dt for cvode and daspk

--- a/src/coreneuron/mechanism/eion.cpp
+++ b/src/coreneuron/mechanism/eion.cpp
@@ -18,7 +18,7 @@
 #include "coreneuron/permute/data_layout.hpp"
 #include "coreneuron/utils/nrnoc_aux.hpp"
 
-#define _STRIDE _cntml_padded + _iml
+#define CNRN_FLAT_INDEX_IML_ROW(i) ((i) * (_cntml_padded) + (_iml))
 
 namespace coreneuron {
 
@@ -142,11 +142,11 @@ the USEION statement of any model using this ion\n",
 }
 
 #if VECTORIZE
-#define erev   pd[0 * _STRIDE] /* From Eion */
-#define conci  pd[1 * _STRIDE]
-#define conco  pd[2 * _STRIDE]
-#define cur    pd[3 * _STRIDE]
-#define dcurdv pd[4 * _STRIDE]
+#define erev   pd[CNRN_FLAT_INDEX_IML_ROW(0)] /* From Eion */
+#define conci  pd[CNRN_FLAT_INDEX_IML_ROW(1)]
+#define conco  pd[CNRN_FLAT_INDEX_IML_ROW(2)]
+#define cur    pd[CNRN_FLAT_INDEX_IML_ROW(3)]
+#define dcurdv pd[CNRN_FLAT_INDEX_IML_ROW(4)]
 
 /*
  handle erev, conci, conc0 "in the right way" according to ion_style

--- a/src/coreneuron/mechanism/mech/mod2c_core_thread.hpp
+++ b/src/coreneuron/mechanism/mech/mod2c_core_thread.hpp
@@ -14,7 +14,7 @@
 
 namespace coreneuron {
 
-#define _STRIDE _cntml_padded + _iml
+#define CNRN_FLAT_INDEX_IML_ROW(i) ((i) * (_cntml_padded) + (_iml))
 
 #define _threadargscomma_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, _ml, _v,
 #define _threadargsprotocomma_                                                                    \
@@ -77,7 +77,7 @@ int euler_thread(int neqn, int* var, int* der, F fun, _threadargsproto_) {
     fun(_threadargs_);  // std::invoke in C++17
     /* update dependent variables */
     for (int i = 0; i < neqn; i++) {
-        _p[var[i] * _STRIDE] += dt * (_p[der[i] * _STRIDE]);
+        _p[CNRN_FLAT_INDEX_IML_ROW(var[i])] += dt * (_p[CNRN_FLAT_INDEX_IML_ROW(der[i])]);
     }
     return 0;
 }

--- a/src/coreneuron/sim/scopmath/crout_thread.hpp
+++ b/src/coreneuron/sim/scopmath/crout_thread.hpp
@@ -18,8 +18,8 @@ namespace coreneuron {
 #error "naming clash on crout_thread.hpp-internal macros"
 #endif
 #define scopmath_crout_b(arg)  b[scopmath_crout_ix(arg)]
-#define scopmath_crout_ix(arg) ((arg) *_STRIDE)
-#define scopmath_crout_y(arg)  _p[y[arg] * _STRIDE]
+#define scopmath_crout_ix(arg) CNRN_FLAT_INDEX_IML_ROW(arg)
+#define scopmath_crout_y(arg)  _p[CNRN_FLAT_INDEX_IML_ROW(y[arg])]
 
 /**
  * Performs an LU triangular factorization of a real matrix by the Crout

--- a/src/coreneuron/sim/scopmath/newton_struct.h
+++ b/src/coreneuron/sim/scopmath/newton_struct.h
@@ -20,6 +20,7 @@ struct NewtonSpace {
     double* high_value;
     double* low_value;
     double* rowmax;
+    bool compact_memory_layout;
 };
 
 void nrn_newtonspace_copyto_device(NewtonSpace* ns);

--- a/src/coreneuron/sim/scopmath/newton_thread.cpp
+++ b/src/coreneuron/sim/scopmath/newton_thread.cpp
@@ -12,16 +12,17 @@
 #include "coreneuron/utils/nrnoc_aux.hpp"
 
 namespace coreneuron {
-NewtonSpace* nrn_cons_newtonspace(int n, int n_instance) {
+NewtonSpace* nrn_cons_newtonspace(int n, int n_instance, bool compact_memory_layout) {
     NewtonSpace* ns = (NewtonSpace*) emalloc(sizeof(NewtonSpace));
     ns->n = n;
     ns->n_instance = n_instance;
     ns->delta_x = makevector(n * n_instance * sizeof(double));
-    ns->jacobian = makematrix(n, n * n_instance);
+    ns->jacobian = makematrix(n, compact_memory_layout ? n : n * n_instance);
     ns->perm = (int*) emalloc((unsigned) (n * n_instance * sizeof(int)));
     ns->high_value = makevector(n * n_instance * sizeof(double));
     ns->low_value = makevector(n * n_instance * sizeof(double));
     ns->rowmax = makevector(n * n_instance * sizeof(double));
+    ns->compact_memory_layout = compact_memory_layout;
     nrn_newtonspace_copyto_device(ns);
     return ns;
 }

--- a/src/coreneuron/sim/scopmath/newton_thread.cpp
+++ b/src/coreneuron/sim/scopmath/newton_thread.cpp
@@ -14,14 +14,15 @@
 namespace coreneuron {
 NewtonSpace* nrn_cons_newtonspace(int n, int n_instance, bool compact_memory_layout) {
     NewtonSpace* ns = (NewtonSpace*) emalloc(sizeof(NewtonSpace));
+    int m_instance = compact_memory_layout ? 1 : n_instance;
     ns->n = n;
     ns->n_instance = n_instance;
-    ns->delta_x = makevector(n * n_instance * sizeof(double));
-    ns->jacobian = makematrix(n, compact_memory_layout ? n : n * n_instance);
-    ns->perm = (int*) emalloc((unsigned) (n * n_instance * sizeof(int)));
-    ns->high_value = makevector(n * n_instance * sizeof(double));
-    ns->low_value = makevector(n * n_instance * sizeof(double));
-    ns->rowmax = makevector(n * n_instance * sizeof(double));
+    ns->delta_x = makevector(n * m_instance * sizeof(double));
+    ns->jacobian = makematrix(n, n*m_instance);
+    ns->perm = (int*) emalloc((unsigned) (n * m_instance * sizeof(int)));
+    ns->high_value = makevector(n * m_instance * sizeof(double));
+    ns->low_value = makevector(n * m_instance * sizeof(double));
+    ns->rowmax = makevector(n * m_instance * sizeof(double));
     ns->compact_memory_layout = compact_memory_layout;
     nrn_newtonspace_copyto_device(ns);
     return ns;

--- a/src/coreneuron/sim/scopmath/newton_thread.hpp
+++ b/src/coreneuron/sim/scopmath/newton_thread.hpp
@@ -21,9 +21,9 @@ namespace coreneuron {
 #if defined(scopmath_newton_ix) || defined(scopmath_newton_s) || defined(scopmath_newton_x)
 #error "naming clash on newton_thread.hpp-internal macros"
 #endif
-#define scopmath_newton_ix(arg) ((arg) *_STRIDE)
-#define scopmath_newton_s(arg)  _p[s[arg] * _STRIDE]
-#define scopmath_newton_x(arg)  _p[(arg) *_STRIDE]
+#define scopmath_newton_ix(arg) CNRN_FLAT_INDEX_IML_ROW(arg)
+#define scopmath_newton_s(arg)  _p[CNRN_FLAT_INDEX_IML_ROW(s[arg])]
+#define scopmath_newton_x(arg)  _p[CNRN_FLAT_INDEX_IML_ROW(arg)]
 namespace detail {
 /**
  * @brief Calculate the Jacobian matrix using finite central differences.

--- a/src/coreneuron/sim/scopmath/sparse_thread.hpp
+++ b/src/coreneuron/sim/scopmath/sparse_thread.hpp
@@ -436,7 +436,7 @@ inline void init_coef_list(SparseObj* so, int _iml) {
     defined(scopmath_sparse_x)
 #error "naming clash on sparse_thread.hpp-internal macros"
 #endif
-#define scopmath_sparse_ix(arg) ((arg) *_STRIDE)
+#define scopmath_sparse_ix(arg) CNRN_FLAT_INDEX_IML_ROW(arg)
 inline void subrow(SparseObj* so, Elm* pivot, Elm* rowsub, int _iml) {
     unsigned int const _cntml_padded{so->_cntml_padded};
     double const r{rowsub->value[_iml] / pivot->value[_iml]};
@@ -602,7 +602,7 @@ int sparse_thread(SparseObj* so,
 #undef scopmath_sparse_d
 #undef scopmath_sparse_ix
 #undef scopmath_sparse_s
-#define scopmath_sparse_x(arg) _p[x[arg] * _STRIDE]
+#define scopmath_sparse_x(arg) _p[CNRN_FLAT_INDEX_IML_ROW(x[arg])]
 /* for solving ax=b */
 template <typename SPFUN>
 int _cvode_sparse_thread(void** vpr, int n, int* x, SPFUN fun, _threadargsproto_) {

--- a/src/coreneuron/sim/scopmath/ssimplic_thread.hpp
+++ b/src/coreneuron/sim/scopmath/ssimplic_thread.hpp
@@ -13,7 +13,7 @@ namespace coreneuron {
 #if defined(scopmath_ssimplic_s)
 #error "naming clash on ssimplic_thread.hpp-internal macros"
 #endif
-#define scopmath_ssimplic_s(arg) _p[s[arg] * _STRIDE]
+#define scopmath_ssimplic_s(arg) _p[CNRN_FLAT_INDEX_IML_ROW(s[arg])]
 static int check_state(int n, int* s, _threadargsproto_) {
     bool flag{true};
     for (int i = 0; i < n; i++) {

--- a/src/coreneuron/utils/nrnoc_aux.cpp
+++ b/src/coreneuron/utils/nrnoc_aux.cpp
@@ -58,8 +58,9 @@ void freevector(double* p) {
 double** makematrix(size_t nrows, size_t ncols) {
     double** matrix = (double**) emalloc(nrows * sizeof(double*));
     *matrix = (double*) emalloc(nrows * ncols * sizeof(double));
-    for (size_t i = 1; i < nrows; i++)
+    for (size_t i = 1; i < nrows; i++) {
         matrix[i] = matrix[i - 1] + ncols;
+    }
     return (matrix);
 }
 


### PR DESCRIPTION
Currently, we're unconditionally allocating one Jacobian for each instance of a mechanism. On CPUs we only need one per mechanism. Which is also what NRN does.

This PR is a work towards reducing the memory consumption and improving cache efficiency on CPUs. Initially it will ignore GPUs and OMP threads. Once, we can demonstrate the value of these changes we'll consider how to implement the analogous for GPUs and OMP threads.