### PR TITLE
cmake: use more CMake commands, target paths

### DIFF
--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -35,7 +35,7 @@ jobs:
       SDK_ROOT: $(xcrun --sdk macosx --show-sdk-path)
       SKIP_WHEELHOUSE_REPAIR: true
       BUILD_TYPE: Release
-      DESIRED_CMAKE_VERSION: 3.15
+      DESIRED_CMAKE_VERSION: 3.17
       DYNAMIC_PYTHON_CMAKE_VERSION: 3.18
       PY_MIN_VERSION: ${{ matrix.config.python_min_version || '3.8' }}
       PY_MAX_VERSION: ${{ matrix.config.python_max_version || '3.11' }}

--- a/cmake/MacroHelper.cmake
+++ b/cmake/MacroHelper.cmake
@@ -211,11 +211,11 @@ macro(nocmodl_mod_to_cpp modfile_basename)
     OUTPUT ${PROJECT_BINARY_DIR}/${modfile_basename}.cpp
     COMMAND
       ${CMAKE_COMMAND} -E env "MODLUNIT=${PROJECT_BINARY_DIR}/share/nrn/lib/nrnunits.lib"
-      ${NRN_NOCMODL_SANITIZER_ENVIRONMENT} ${PROJECT_BINARY_DIR}/bin/nocmodl
+      ${NRN_NOCMODL_SANITIZER_ENVIRONMENT} $<TARGET_FILE:nocmodl>
       ${PROJECT_SOURCE_DIR}/${modfile_basename}.mod
-    COMMAND sed "'s/_reg()/_reg_()/'" ${PROJECT_SOURCE_DIR}/${modfile_basename}.cpp >
+    COMMAND sed "s/_reg()/_reg_()/" ${PROJECT_SOURCE_DIR}/${modfile_basename}.cpp >
             ${PROJECT_BINARY_DIR}/${modfile_basename}.cpp
-    COMMAND rm ${PROJECT_SOURCE_DIR}/${modfile_basename}.cpp
+    COMMAND ${CMAKE_COMMAND} -E rm ${PROJECT_SOURCE_DIR}/${modfile_basename}.cpp
     DEPENDS nocmodl ${PROJECT_SOURCE_DIR}/${modfile_basename}.mod
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src/nrniv)
 endmacro()

--- a/cmake/MacroHelper.cmake
+++ b/cmake/MacroHelper.cmake
@@ -213,7 +213,7 @@ macro(nocmodl_mod_to_cpp modfile_basename)
       ${CMAKE_COMMAND} -E env "MODLUNIT=${PROJECT_BINARY_DIR}/share/nrn/lib/nrnunits.lib"
       ${NRN_NOCMODL_SANITIZER_ENVIRONMENT} $<TARGET_FILE:nocmodl>
       ${PROJECT_SOURCE_DIR}/${modfile_basename}.mod
-    COMMAND sed "s/_reg()/_reg_()/" ${PROJECT_SOURCE_DIR}/${modfile_basename}.cpp >
+    COMMAND sed "'s/_reg()/_reg_()/'" ${PROJECT_SOURCE_DIR}/${modfile_basename}.cpp >
             ${PROJECT_BINARY_DIR}/${modfile_basename}.cpp
     COMMAND ${CMAKE_COMMAND} -E rm ${PROJECT_SOURCE_DIR}/${modfile_basename}.cpp
     DEPENDS nocmodl ${PROJECT_SOURCE_DIR}/${modfile_basename}.mod

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@ This will install all dependencies needed to build the documentation locally, in
 
 #### Confguring the build
 
-With all dependencies installed, configure project with CMake as described in [CMake Build Options](./cmake_doc/options.rst#nrn-enable-docs-bool-off).
+With all dependencies installed, configure project with CMake (>= v3.17) as described in [CMake Build Options](./cmake_doc/options.rst#nrn-enable-docs-bool-off).
 
 e.g. in your CMake build folder:
 


### PR DESCRIPTION
And try to get away with less quotes for `sed`, which MSVC does not
like.  All in the name of #2293.
