### PR TITLE
Bump minimum required CMake version to 3.17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
 # Note that this needs to happen **before** the call to project(...). This is because CMake reads
 # the CRAYPE_LINK_TYPE environment variable inside the call to project(...) and sets various flags
 # and properties based on its value. Because we are so early in the CMake processing, we have to


### PR DESCRIPTION
In https://github.com/neuronsimulator/nrn/blob/6cb0bac3e52f969dc12d921c382413b98df1dfff/cmake/MacroHelper.cmake#L222 there is a command which is only supported [since CMake 3.17](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-E-arg-rm)
I created this PR as a suggestion to bump the minimum CMake version however I don't know all the implications this might have.
If there is an issue with bumping the CMake minimum version we should find another alternarive