### PR TITLE
Select between rm and remove depending on CMake version

### DIFF
--- a/cmake/MacroHelper.cmake
+++ b/cmake/MacroHelper.cmake
@@ -211,9 +211,9 @@ macro(nocmodl_mod_to_cpp modfile_basename)
   if(NOT MSVC)
     set(NOCMODL_SED_EXPR "'${NOCMODL_SED_EXPR}'")
   endif()
-  set (REMOVE_CMAKE_COMMAND "rm")
-  if (CMAKE_VERSION VERSION_LESS "3.17")
-    set (REMOVE_CMAKE_COMMAND "remove")
+  set(REMOVE_CMAKE_COMMAND "rm")
+  if(CMAKE_VERSION VERSION_LESS "3.17")
+    set(REMOVE_CMAKE_COMMAND "remove")
   endif()
   add_custom_command(
     OUTPUT ${PROJECT_BINARY_DIR}/${modfile_basename}.cpp
@@ -223,7 +223,8 @@ macro(nocmodl_mod_to_cpp modfile_basename)
       ${PROJECT_SOURCE_DIR}/${modfile_basename}.mod
     COMMAND sed ${NOCMODL_SED_EXPR} ${PROJECT_SOURCE_DIR}/${modfile_basename}.cpp >
             ${PROJECT_BINARY_DIR}/${modfile_basename}.cpp
-    COMMAND ${CMAKE_COMMAND} -E ${REMOVE_CMAKE_COMMAND} ${PROJECT_SOURCE_DIR}/${modfile_basename}.cpp
+    COMMAND ${CMAKE_COMMAND} -E ${REMOVE_CMAKE_COMMAND}
+            ${PROJECT_SOURCE_DIR}/${modfile_basename}.cpp
     DEPENDS nocmodl ${PROJECT_SOURCE_DIR}/${modfile_basename}.mod
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src/nrniv)
 endmacro()

--- a/cmake/MacroHelper.cmake
+++ b/cmake/MacroHelper.cmake
@@ -211,6 +211,10 @@ macro(nocmodl_mod_to_cpp modfile_basename)
   if(NOT MSVC)
     set(NOCMODL_SED_EXPR "'${NOCMODL_SED_EXPR}'")
   endif()
+  set (REMOVE_CMAKE_COMMAND "rm")
+  if (CMAKE_VERSION VERSION_LESS "3.17")
+    set (REMOVE_CMAKE_COMMAND "remove")
+  endif()
   add_custom_command(
     OUTPUT ${PROJECT_BINARY_DIR}/${modfile_basename}.cpp
     COMMAND
@@ -219,7 +223,7 @@ macro(nocmodl_mod_to_cpp modfile_basename)
       ${PROJECT_SOURCE_DIR}/${modfile_basename}.mod
     COMMAND sed ${NOCMODL_SED_EXPR} ${PROJECT_SOURCE_DIR}/${modfile_basename}.cpp >
             ${PROJECT_BINARY_DIR}/${modfile_basename}.cpp
-    COMMAND ${CMAKE_COMMAND} -E rm ${PROJECT_SOURCE_DIR}/${modfile_basename}.cpp
+    COMMAND ${CMAKE_COMMAND} -E ${REMOVE_CMAKE_COMMAND} ${PROJECT_SOURCE_DIR}/${modfile_basename}.cpp
     DEPENDS nocmodl ${PROJECT_SOURCE_DIR}/${modfile_basename}.mod
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src/nrniv)
 endmacro()


### PR DESCRIPTION
In https://github.com/neuronsimulator/nrn/blob/6cb0bac3e52f969dc12d921c382413b98df1dfff/cmake/MacroHelper.cmake#L222 there is a command which is only supported [since CMake 3.17](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-E-arg-rm).
Select the correct version of the command depending on the CMake version