### PR TITLE
NVHPC: Fix issue with the addition of "-A" CXX flag for CMake < 3.19

### DIFF
--- a/cmake/CompilerHelper.cmake
+++ b/cmake/CompilerHelper.cmake
@@ -16,6 +16,15 @@ if(CMAKE_C_COMPILER_ID MATCHES "PGI" OR CMAKE_C_COMPILER_ID MATCHES "NVHPC")
   if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.20" AND ${CMAKE_VERSION} VERSION_LESS "3.20.3")
     string(APPEND CMAKE_DEPFILE_FLAGS_CXX "-MD<DEP_FILE>")
   endif()
+
+  # CMake versions <3.19 used to add -A when using NVHPC/PGI, which makes the compiler excessively
+  # pedantic. See https://gitlab.kitware.com/cmake/cmake/-/issues/20997. Also, stdinit.h include
+  # behaviour is different with -A (ANSI C++) and result into an error mentioned in
+  # https://github.com/neuronsimulator/nrn/issues/2563
+  if(CMAKE_VERSION VERSION_LESS 3.19)
+    list(REMOVE_ITEM CMAKE_CXX17_STANDARD_COMPILE_OPTION -A)
+  endif()
+
   if(${CMAKE_C_COMPILER_VERSION} VERSION_GREATER_EQUAL 20.7)
     # https://forums.developer.nvidia.com/t/many-all-diagnostic-numbers-increased-by-1-from-previous-values/146268/3
     # changed the numbering scheme in newer versions. The following list is from a clean start 16

--- a/src/coreneuron/CMakeLists.txt
+++ b/src/coreneuron/CMakeLists.txt
@@ -180,11 +180,6 @@ if(CORENRN_HAVE_NVHPC_COMPILER)
     # problem. If GPU support is disabled, we define R123_USE_INTRIN_H=0 to avoid the problem.
     list(APPEND CORENRN_COMPILE_DEFS R123_USE_INTRIN_H=0)
   endif()
-  # CMake versions <3.19 used to add -A when using NVHPC/PGI, which makes the compiler excessively
-  # pedantic. See https://gitlab.kitware.com/cmake/cmake/-/issues/20997.
-  if(CMAKE_VERSION VERSION_LESS 3.19)
-    list(REMOVE_ITEM CMAKE_CXX17_STANDARD_COMPILE_OPTION -A)
-  endif()
 endif()
 
 if(CORENRN_ENABLE_SHARED)


### PR DESCRIPTION
- Import fix from CoreNEURON level to NEURON
- The issue also appears with compilation of flex generated lexer files, see #2563

Fixes #2563