### PR TITLE
Initialize `prop_id_` in `NPyMechObj`.

### DIFF
--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -257,14 +257,14 @@ static void NPyRangeVar_dealloc(NPyRangeVar* self) {
 static void NPyMechObj_dealloc(NPyMechObj* self) {
     // printf("NPyMechObj_dealloc %p %s\n", self, self->ob_type->tp_name);
     Py_XDECREF(self->pyseg_);
-    self->~NPyMechObj();
+    self->prop_id_.~non_owning_identifier_without_container();
     ((PyObject*) self)->ob_type->tp_free((PyObject*) self);
 }
 
 static NPyMechObj* new_pymechobj() {
     NPyMechObj* m = PyObject_New(NPyMechObj, pmech_generic_type);
     if (m) {
-        new (m) NPyMechObj;
+        new (&m->prop_id_) neuron::container::non_owning_identifier_without_container;
     }
 
     return m;

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -51,15 +51,15 @@ typedef struct {
     double x_;
 } NPySegObj;
 
-struct NPyMechObj {
+typedef struct {
     PyObject_HEAD
     NPySegObj* pyseg_;
     Prop* prop_;
     // Following cannot be initialized when NPyMechObj allocated by Python. See new_pymechobj
     // wrapper.
-    neuron::container::non_owning_identifier_without_container prop_id_{};
+    neuron::container::non_owning_identifier_without_container prop_id_;
     int type_;
-};
+} NPyMechObj;
 
 typedef struct {
     PyObject_HEAD

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -1921,7 +1921,6 @@ static PyObject* segment_getattro(NPySegObj* self, PyObject* pyname) {
             rv_noexist(sec, n, self->x_, 1);
             result = NULL;
         } else {
-            std::cout << p->id() << std::endl;
             result = (PyObject*) new_pymechobj(self, p);
         }
     } else if ((rv = PyDict_GetItemString(rangevars_, n)) != NULL) {

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -51,23 +51,23 @@ typedef struct {
     double x_;
 } NPySegObj;
 
-typedef struct {
+struct NPyMechObj {
     PyObject_HEAD
     NPySegObj* pyseg_;
     Prop* prop_;
     neuron::container::non_owning_identifier_without_container prop_id_{};
     int type_;
-} NPyMechObj;
+};
 
 typedef struct {
     PyObject_HEAD
-    NPyMechObj* pymech_{};
+    NPyMechObj* pymech_;
 } NPyMechOfSegIter;
 
 typedef struct {
     PyObject_HEAD
-    NPyMechObj* pymech_{};
-    NPyDirectMechFunc* f_{};
+    NPyMechObj* pymech_;
+    NPyDirectMechFunc* f_;
 } NPyMechFunc;
 
 typedef struct {


### PR DESCRIPTION
This PR fixes initialization of `NPyMechObj`. The Python API seems to perform the equivalent of a `malloc` followed by calling a user supplied `init(NPyMechObj *)`. In the `init` function:
https://github.com/neuronsimulator/nrn/blob/fa132e4f0fd7aa379833f8beb3f18888990bfe1e/src/nrnpython/nrnpy_nrn.cpp#L264-L275

assigns a to `prop_id_`, which at that point I believe is filled with random values. This can cause either a segfault, or freeing some random address.

The solution pursued here is to use placement new:
https://en.cppreference.com/w/cpp/language/new
(There's a section "Placement New" halfway down the document.)

and if needed it'll call the destructor manually.