### PR TITLE
Cvode version 2 cannot use IDASolve for interpolation.

### DIFF
--- a/src/nrncvode/nrndaspk.cpp
+++ b/src/nrncvode/nrndaspk.cpp
@@ -348,13 +348,12 @@ int Daspk::advance_tn(double tstop) {
 int Daspk::interpolate(double tt) {
     // printf("Daspk::interpolate %.15g\n", tt);
     assert(tt >= cv_->t0_ && tt <= cv_->tn_);
-    IDASetStopTime(mem_, tt);
-    int ier = IDASolve(mem_, tt, &cv_->t_, cv_->y_, yp_, IDA_NORMAL);
+    int ier = IDAGetSolution(mem_, tt, cv_->y_, yp_);
     if (ier < 0) {
         Printf("DASPK interpolate error\n");
         return ier;
     }
-    assert(MyMath::eq(tt, cv_->t_, NetCvode::eps(cv_->t_)));
+    cv_->t_ = tt;
     // interpolation does not call res. So we have to.
     res_gvardt(cv_->t_, cv_->y_, yp_, delta_, cv_);
     // if(MyMath::eq(t, cv_->t_, NetCvode::eps(cv_->t_))) {

--- a/test/hoctests/tests/test_cvinterp.py
+++ b/test/hoctests/tests/test_cvinterp.py
@@ -1,0 +1,55 @@
+# cvode and ida should interpolate correctly
+# Consider a simulation with linearly increasing solution (charging capacitor)
+# If during a free running large time step, one requests the value of
+# the voltage in the middle of that time step, the voltage should be
+# the average of the voltages at the beginning and end of the time step.
+# Prior to this PR, IDA failed this test
+
+from neuron import h
+
+h.load_file("stdrun.hoc")
+import math
+
+
+def model():
+    s = h.Section(name="s")
+    s.L = s.diam = h.sqrt(100.0 / h.PI)
+    ic = h.IClamp(s(0.5))
+    ic.dur = 10
+    ic.amp = 0.01
+    return s, ic
+
+
+def run(ida):
+    h.cvode_active(1)
+    h.cvode.use_daspk(ida)
+    h.v_init = 0.0
+    h.run()
+
+
+def points(vecs):
+    return [x for x in zip(vecs[0], vecs[1])]
+
+
+def test():
+    m = model()
+    vref = m[0](0.5)._ref_v
+    freerun = [h.Vector().record(h._ref_t), h.Vector().record(vref)]
+    for ida in [0, 1]:
+        run(ida)
+        n = len(freerun[0])
+        pts = points(freerun)[-3:-1]
+        midpnt = [(pts[0][i] + pts[1][i]) / 2 for i in range(2)]
+        trec = h.Vector([midpnt[0]])
+        rec = [h.Vector().record(h._ref_t, trec), h.Vector().record(vref, trec)]
+        run(ida)
+        print(midpnt)
+        print(points(rec))
+
+        assert len(freerun[0]) == n  # rec does not add to original freerun
+        for i in range(2):
+            assert math.isclose(midpnt[i], rec[i][0])
+
+
+if __name__ == "__main__":
+    test()

--- a/test/hoctests/tests/test_cvinterp.py
+++ b/test/hoctests/tests/test_cvinterp.py
@@ -38,6 +38,7 @@ def test():
     for ida in [0, 1]:
         run(ida)
         n = len(freerun[0])
+        std = [v.c() for v in freerun]
         pts = points(freerun)[-3:-1]
         midpnt = [(pts[0][i] + pts[1][i]) / 2 for i in range(2)]
         trec = h.Vector([midpnt[0]])
@@ -47,6 +48,10 @@ def test():
         print(points(rec))
 
         assert len(freerun[0]) == n  # rec does not add to original freerun
+        for i, s in enumerate(std):  # and rec did not affect freerun.
+            for j, v in enumerate(s):
+                assert math.isclose(v, freerun[i][j])
+
         for i in range(2):
             assert math.isclose(midpnt[i], rec[i][0])
 


### PR DESCRIPTION
This bug was found while trying to figure out a way to validate results with different versions of sundials.
The ida in sundials 2 interpolates using IDAGetSolution