### PR TITLE
Raise a meaningful error in import3d_gui.hoc for invalide soma

### DIFF
--- a/share/lib/hoc/import3d/import3d_gui.hoc
+++ b/share/lib/hoc/import3d/import3d_gui.hoc
@@ -1237,6 +1237,9 @@ proc contour2centroid() {local i, j, imax, imin, ok  localobj mean, pts, d, max,
 	// minor is normal and in xy plane
 	minor = m.getcol(3-tobj.min_ind-tobj.max_ind)
 	minor.x[2] = 0
+	if (minor.mag == 0.) {
+		execerror("Failed to compute soma centroid from contour.")
+	}
 	minor.div(minor.mag)
 	if (g != nil) {
 		g.beginline(4, 3) g.line(mean.x[0], mean.x[1])


### PR DESCRIPTION
Requested by users from the Blue Brain Project.
Fix #2602