### PR TITLE
Fixup for #2609.

### DIFF
--- a/share/lib/hoc/import3d/import3d_gui.hoc
+++ b/share/lib/hoc/import3d/import3d_gui.hoc
@@ -1237,7 +1237,7 @@ proc contour2centroid() {local i, j, imax, imin, ok  localobj mean, pts, d, max,
 	// minor is normal and in xy plane
 	minor = m.getcol(3-tobj.min_ind-tobj.max_ind)
 	minor.x[2] = 0
-	if (minor.mag == 0.) {
+	if (minor.mag / (major.mag + 1e-100) < 1e-6) {
 		execerror("Failed to compute soma centroid from contour.")
 	}
 	minor.div(minor.mag)


### PR DESCRIPTION
Improves the floating point comparison with zero. The strategy is to use a relative tolerance for the ratio `minor.mag/major.mag`.

The softening constant `1e-100` is chosen such that:
1. If `minor.mag == 0.0` then the ratio is always `0.0` and no division by zero occurs.
2. The value of `major.mag + 1e-100 == major.mag` for all biophysically sensible values of `major.mag`.

If both `minor.mag` and `major.mag` are zero as floating point number, then check may fail to raise a exception.