### PR TITLE
Add CLI options in nrnivmodl for selecting NMODL binary and flags

### DIFF
--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -46,6 +46,8 @@ LinkCoreNEURON=false
 UserINCFLAGS=""
 UserLDFLAGS=""
 UserCOREFLAGS=()
+UserNMODLBIN=""
+UserNMODLFLAGS=""
 
 # - options come first but can be in any order.
 while [ "$1" ] ; do
@@ -66,6 +68,16 @@ while [ "$1" ] ; do
         UserLDFLAGS="$2"
         # extra lin flags, paths. libraries (CoreNEURON)
         UserCOREFLAGS+=(-l "${2}")
+        shift
+        shift;;
+    -nmodl)
+        UserNMODLBIN="$2"
+        UserNMODLFLAGS="--neuron$UserNMODLFLAGS"
+        shift
+        shift;;
+    -nmodlflags)
+        echo "UserNMODLFLAGS: $2"
+        UserNMODLFLAGS="$UserNMODLFLAGS $2"
         shift
         shift;;
     -*)
@@ -159,7 +171,7 @@ for i in "${files[@]}" ; do
   echo "\
 ./${base_name// /\\ }.cpp: ${f}.mod
 	@printf \" -> \$(C_GREEN)NMODL\$(C_RESET) \$<\\\n\"
-	(cd \"$dir_name\"; @NRN_NOCMODL_SANITIZER_ENVIRONMENT_STRING@ MODLUNIT=\$(NRNUNITS) \$(NOCMODL) \"$base_name.mod\" -o \"$mdir\")
+	(cd \"$dir_name\"; @NRN_NOCMODL_SANITIZER_ENVIRONMENT_STRING@ MODLUNIT=\$(NRNUNITS) \$(NOCMODL) \"$base_name.mod\" -o \"$mdir\" $UserNMODLFLAGS)
 
 ./${base_name// /\\ }.o: ./${base_name// /\\ }.cpp
 	@printf \" -> \$(C_GREEN)Compiling\$(C_RESET) \$<\\\n\"
@@ -246,5 +258,5 @@ if [ "$LinkCoreNEURON" = true ] ; then
   fi
 fi
 
-make -j 4 -f "${bindir}/nrnmech_makefile" "ROOT=${prefix}" "MODOBJFILES=$MODOBJS" "UserLDFLAGS=$UserLDFLAGS" "UserINCFLAGS=$UserINCFLAGS" "LinkCoreNEURON=$LinkCoreNEURON" special &&
+make -j 4 -f "${bindir}/nrnmech_makefile" "ROOT=${prefix}" "MODOBJFILES=$MODOBJS" "UserLDFLAGS=$UserLDFLAGS" "UserINCFLAGS=$UserINCFLAGS" "LinkCoreNEURON=$LinkCoreNEURON" "UserNMODLBIN=$UserNMODLBIN" "UserNMODLFLAGS=$UserNMODLFLAGS" special &&
 echo "Successfully created $MODSUBDIR/special"

--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -76,7 +76,7 @@ while [ "$1" ] ; do
         shift
         shift;;
     -nmodlflags)
-        echo "UserNMODLFLAGS: $2"
+        echo "[NMODL][warning] If sympy is enabled, NMODL needs to be found in PYTHONPATH"
         UserNMODLFLAGS="$UserNMODLFLAGS $2"
         shift
         shift;;

--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -73,7 +73,7 @@ while [ "$1" ] ; do
     -nmodl)
         echo "[NMODL][warning] Code generation with NMODL is pre-alpha, lacks features and is intended only for development use"
         UserNMODLBIN="$2"
-        UserNMODLFLAGS="--neuron$UserNMODLFLAGS"
+        UserNMODLFLAGS="--neuron $UserNMODLFLAGS"
         shift
         shift;;
     -nmodlflags)

--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -71,6 +71,7 @@ while [ "$1" ] ; do
         shift
         shift;;
     -nmodl)
+        echo "[NMODL][warning] Code generation with NMODL is pre-alpha, lacks features and is intended only for development use"
         UserNMODLBIN="$2"
         UserNMODLFLAGS="--neuron$UserNMODLFLAGS"
         shift

--- a/bin/nrnivmodl_makefile_cmake.in
+++ b/bin/nrnivmodl_makefile_cmake.in
@@ -4,6 +4,8 @@
 # UserLDFLAGS
 # UserINCFLAGS
 # LinkCoreNEURON
+# UserNMODLBIN
+# UserNMODLFLAGS
 # Rules to build MODOBJFILES from mod files are found in makemod2c_inc
 
 # Mechanisms version are by default 0.0, but should be overriden
@@ -15,6 +17,7 @@ OUTPUT = .
 DESTDIR =
 UserINCFLAGS =
 UserLDFLAGS =
+UserNMODLBIN =
 
 # install dirs
 bindir := ${ROOT}/@CMAKE_INSTALL_BINDIR@
@@ -67,7 +70,11 @@ CCOMPILE = $(CC) $(CFLAGS) @NRN_COMPILE_DEFS_STRING@ @NRN_COMPILE_FLAGS_STRING@
 CXX_LINK_EXE = $(CXX) $(CXXFLAGS) @CMAKE_EXE_LINKER_FLAGS@ @NRN_LINK_FLAGS_STRING@
 CXX_LINK_SHARED = $(CXX) $(CXXFLAGS) @CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS@ @CMAKE_SHARED_LIBRARY_CXX_FLAGS@ @CMAKE_SHARED_LINKER_FLAGS@ @NRN_LINK_FLAGS_STRING@
 
+ifeq ($(UserNMODLBIN), )
 NOCMODL = $(bindir)/nocmodl
+else
+NOCMODL = $(UserNMODLBIN)
+endif
 NRNUNITS = $(datadir_lib)/nrnunits.lib
 
 # File path config (internal)


### PR DESCRIPTION
Expected usage is:
```
nrnivmodl -nmodl <nmodl_binary_path> -nmodlflags <flags_passed_to_nmodl> <modfile_dir>
```
There might be an issue if `sympy` is needed and `NMODL` is not in the `PYTHONPATH`. We could add some logic or an extra option for appending to the `PYTHONPATH` the needed path but with the current usage we expect `PYTHONPATH` to be automatically and properly set or the developers to be able to set it themselves.

Fixes #2625 