### PR TITLE
Soma summation report fix for SONATA simulations

### DIFF
--- a/src/coreneuron/io/reports/report_handler.cpp
+++ b/src/coreneuron/io/reports/report_handler.cpp
@@ -297,7 +297,8 @@ VarsToReport ReportHandler::get_summation_vars_to_report(
                     if (report.section_type == SectionType::All) {
                         double* variable = report_variable + segment_id;
                         to_report.emplace_back(VarWithMapping(section_id, variable));
-                    } else if (report.section_type == SectionType::Cell) {
+                    } else if (report.section_type == SectionType::Cell ||
+                               report.section_type == SectionType::Soma) {
                         summation_report.gid_segments_[gid].push_back(segment_id);
                     }
                 }


### PR DESCRIPTION
 Addresses https://bbpteam.epfl.ch/project/issues/browse/BBPBGLIB-1107

There were inconsistencies between BlueConfig and SONATA simulations when creating summation reports with Cell targets (BlueConfig) and "sections": "soma" (SONATA).

Both should give the same results, but the proper calculation was only being executed for Cell SectionType.