### PR TITLE
Remove __MWERKS__ code

### DIFF
--- a/src/coreneuron/mpi/nrnmpiuse.h
+++ b/src/coreneuron/mpi/nrnmpiuse.h
@@ -24,6 +24,3 @@
 
 /* define to the dll path if you want to load automatically */
 #undef DLL_DEFAULT_FNAME
-
-/* Number of times to retry a failed open */
-#undef FILE_OPEN_RETRY

--- a/src/ivoc/ocfile.cpp
+++ b/src/ivoc/ocfile.cpp
@@ -325,14 +325,7 @@ void OcFile::binary_mode() {
  Use File.seek(0) after opening or use a binary style read/write as first\n\
  access to file.");
         }
-#if defined(__MWERKS__)
-        // printf("can't switch to binary mode. No setmode\n");
-        mode_[1] = 'b';
-        mode_[2] = '\0';
-        file_ = freopen(filename_.c_str(), mode_, file());
-#else
         setmode(fileno(file()), O_BINARY);
-#endif
         binary_ = true;
     }
 }

--- a/src/ivoc/ocfile.cpp
+++ b/src/ivoc/ocfile.cpp
@@ -338,20 +338,6 @@ bool OcFile::open(const char* name, const char* type) {
     strcpy(mode_, type);
 #endif
     file_ = fopen(expand_env_var(name), type);
-#if defined(FILE_OPEN_RETRY) && FILE_OPEN_RETRY > 0
-    int i;
-    for (i = 0; !file_ && i < FILE_OPEN_RETRY; ++i) {
-        // retry occasionally needed on BlueGene
-        file_ = fopen(expand_env_var(name), type);
-    }
-    if (i > 0) {
-        if (file_) {
-            printf("%d opened %s after %d retries\n", nrnmpi_myid_world, name, i);
-        } else {
-            printf("%d open %s failed after %d retries\n", nrnmpi_myid_world, name, i);
-        }
-    }
-#endif
     return is_open();
 }
 

--- a/src/ivoc/pwman.cpp
+++ b/src/ivoc/pwman.cpp
@@ -3340,13 +3340,6 @@ char* ivoc_get_temp_file() {
     if (!tdir) {
         tdir = "/tmp";
     }
-#if defined(WIN32) && defined(__MWERKS__)
-    char tname[L_tmpnam + 1];
-    tmpnam(tname);
-    auto const length = strlen(tdir) + 1 + strlen(tname) + 1;
-    tmpfile = new char[length];
-    std::snprintf(tmpfile, length, "%s/%s", tdir, tname);
-#else
     auto const length = strlen(tdir) + 1 + 9 + 1;
     tmpfile = new char[length];
     std::snprintf(tmpfile, length, "%s/nrnXXXXXX", tdir);
@@ -3358,7 +3351,6 @@ char* ivoc_get_temp_file() {
     close(fd);
 #else
     mktemp(tmpfile);
-#endif
 #endif
 #if defined(WIN32)
     tmpfile = hoc_back2forward(tmpfile);

--- a/src/ivoc/rect.h
+++ b/src/ivoc/rect.h
@@ -36,11 +36,6 @@ class Appear: public Glyph {
     static const Brush* db_;
 };
 
-#if defined(__MWERKS__)
-#undef Rect
-#define Rect ivoc_Rect
-#endif
-
 class Rect: public Appear {
   public:
     Rect(Coord left,
@@ -62,11 +57,6 @@ class Rect: public Appear {
   private:
     Coord l_, b_, w_, h_;
 };
-
-#if defined(__MWERKS__)
-#undef Line
-#define Line ivoc_Line
-#endif
 
 class Line: public Appear {
   public:
@@ -116,11 +106,6 @@ class Triangle: public Appear {
     float side_;
     bool filled_;
 };
-
-#if defined(__MWERKS__)
-#undef Rectangle
-#define Rectangle ivoc_Rectangle
-#endif
 
 class Rectangle: public Appear {
   public:

--- a/src/mswin/mwprefix.h
+++ b/src/mswin/mwprefix.h
@@ -1,9 +1,5 @@
 /* auto include file for metrowerks codewarrior for all nrn */
-#if __MWERKS__ >= 7
-#define _MSL_DIRENT_H
-#else
 #include <Win32Headers.mch>
-#endif
 #pragma once off
 #ifndef __WIN32__
 #define __WIN32__ 1

--- a/src/nrniv/kschan.cpp
+++ b/src/nrniv/kschan.cpp
@@ -11,10 +11,6 @@
 #include "nrniv_mf.h"
 
 #define NSingleIndex 0
-#if defined(__MWERKS__) && !defined(_MSC_VER)
-#include <extras.h>
-#define strdup _strdup
-#endif
 
 using KSChanList = std::vector<KSChan*>;
 static KSChanList* channels;

--- a/src/oc/mswinprt.cpp
+++ b/src/oc/mswinprt.cpp
@@ -148,11 +148,9 @@ void hoc_win_exec(void) {
 
 void hoc_winio_show(int b) {}
 
-#if !defined(__MWERKS__)
 int getpid() {
     return 1;
 }
-#endif
 
 void hoc_Plt() {
     TRY_GUI_REDIRECT_DOUBLE("plt", NULL);

--- a/src/oc/nrnmpiuse.h.in
+++ b/src/oc/nrnmpiuse.h.in
@@ -16,7 +16,4 @@
 /* define if needed */
 #undef ALWAYS_CALL_MPI_INIT
 
-/* Number of times to retry a failed open */
-#undef FILE_OPEN_RETRY
-
 #endif


### PR DESCRIPTION
`__MWERKS__` is a macro to detect a compiler named CodeWarrior developed by MetroWerks. The last release of this compiler was in 2004.