### PR TITLE
Backport to 8.2: remove `distutils` usage to support Python 3.12

### DIFF
--- a/nrn_requirements.txt
+++ b/nrn_requirements.txt
@@ -5,7 +5,7 @@ matplotlib
 # bokeh 3 seems to break docs notebooks
 bokeh<3
 ipython
-cython<3
+cython
 packaging
 pytest
 pytest-cov

--- a/packaging/python/build_requirements.txt
+++ b/packaging/python/build_requirements.txt
@@ -1,2 +1,2 @@
-cython<3
+cython
 packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = NEURON
 description = Empirically-based simulator for modeling neurons and networks of neurons
 author = Michael Hines, Yale, Blue Brain Project
-author-email = michael.hines@yale.edu
+author_email = michael.hines@yale.edu
 license = Copyright (c) Michael Hines (BSD compatible)
 url = https://neuron.yale.edu/neuron/
 project_urls =

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ import shutil
 import subprocess
 import sys
 from collections import defaultdict
-from distutils import log
-from distutils.dir_util import copy_tree
-from distutils.version import LooseVersion
+import logging
+from shutil import copytree
+from packaging.version import Version
 from setuptools import Command, Extension
 from setuptools import setup
 
@@ -73,7 +73,7 @@ if Components.RX3D:
         from Cython.Distutils import build_ext
         import numpy
     except ImportError:
-        log.error(
+        logging.error(
             "ERROR: RX3D wheel requires Cython and numpy. Please install beforehand"
         )
         sys.exit(1)
@@ -151,7 +151,7 @@ class CMakeAugmentedBuilder(build_ext):
 
                 # Collect project files to be installed
                 # These go directly into final package, regardless of setuptools filters
-                log.info("\n==> Collecting CMAKE files")
+                logging.info("\n==> Collecting CMAKE files")
                 rel_package = ext.name.split(".")[:-1]
                 package_data_d = os.path.join(
                     self.build_lib, *(rel_package + [".data"])
@@ -162,16 +162,16 @@ class CMakeAugmentedBuilder(build_ext):
                     ext.cmake_install_prefix, ext.cmake_install_python_files
                 )
                 if os.path.isdir(src_py_dir):
-                    copy_tree(src_py_dir, self.build_lib)  # accepts existing dst dir
+                    copytree(src_py_dir, self.build_lib, dirs_exist_ok=True)
                     shutil.rmtree(src_py_dir)  # avoid being collected to data dir
 
                 for d in ext.cmake_collect_dirs:
-                    log.info("  - Collecting %s (and everything under it)", d)
+                    logging.info("  - Collecting %s (and everything under it)", d)
                     src_dir = os.path.join(ext.cmake_install_prefix, d)
                     dst_dir = os.path.join(package_data_d, d)
                     if not os.path.isdir(dst_dir):
                         shutil.copytree(src_dir, dst_dir)
-                log.info("==> Done building CMake project\n.")
+                logging.info("==> Done building CMake project\n.")
 
                 # Make the temp include paths in the building the extension
                 ext.include_dirs += [
@@ -182,7 +182,7 @@ class CMakeAugmentedBuilder(build_ext):
                 ext.cmake_done = True
 
         # Now build the extensions normally
-        log.info("==> Building Python extensions")
+        logging.info("==> Building Python extensions")
         build_ext.run(self, *args, **kw)
 
     def _run_cmake(self, ext):
@@ -190,7 +190,7 @@ class CMakeAugmentedBuilder(build_ext):
         cfg = "Debug" if self.debug else "Release"
         self.outdir = os.path.abspath(ext.cmake_install_prefix)
 
-        log.info("Building lib to: %s", self.outdir)
+        logging.info("Building lib to: %s", self.outdir)
         cmake_args = [
             # Generic options only. project options shall be passed as ext param
             "-DCMAKE_INSTALL_PREFIX=" + self.outdir,
@@ -220,7 +220,9 @@ class CMakeAugmentedBuilder(build_ext):
         try:
             # Configure project
             subprocess.Popen("echo $CXX", shell=True, stdout=subprocess.PIPE)
-            log.info("[CMAKE] cmd: %s", " ".join([cmake, ext.sourcedir] + cmake_args))
+            logging.info(
+                "[CMAKE] cmd: %s", " ".join([cmake, ext.sourcedir] + cmake_args)
+            )
             subprocess.check_call(
                 [cmake, ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env
             )
@@ -279,7 +281,7 @@ class CMakeAugmentedBuilder(build_ext):
                     )
 
         except subprocess.CalledProcessError as exc:
-            log.error("Status : FAIL. Log:\n%s", exc.output)
+            logging.error("Status : FAIL. Logging.\n%s", exc.output)
             raise
 
     @staticmethod
@@ -287,10 +289,10 @@ class CMakeAugmentedBuilder(build_ext):
         for candidate in ["cmake", "cmake3"]:
             try:
                 out = subprocess.check_output([candidate, "--version"])
-                cmake_version = LooseVersion(
+                cmake_version = Version(
                     re.search(r"version\s*([\d.]+)", out.decode()).group(1)
                 )
-                if cmake_version >= "3.15.0":
+                if cmake_version >= Version("3.15.0"):
                     return candidate
             except OSError:
                 pass
@@ -331,6 +333,7 @@ def setup_package():
         "neuron",
         "neuron.neuroml",
         "neuron.tests",
+        "neuron.tests.utils",
         "neuron.rxd",
         "neuron.crxd",
         "neuron.gui2",
@@ -406,7 +409,7 @@ def setup_package():
             )
         )
 
-        log.info("RX3D compile flags %s" % str(rxd_params))
+        logging.info("RX3D compile flags %s" % str(rxd_params))
 
         extensions += [
             CyExtension(
@@ -432,7 +435,7 @@ def setup_package():
             ),
         ]
 
-    log.info("RX3D is %s", "ENABLED" if Components.RX3D else "DISABLED")
+    logging.info("RX3D is %s", "ENABLED" if Components.RX3D else "DISABLED")
 
     # package name
     package_name = "NEURON-gpu" if Components.GPU else "NEURON"
@@ -480,7 +483,7 @@ def mac_osx_setenv():
         .decode()
         .strip()
     )
-    log.info("Setting SDKROOT=%s", sdk_root)
+    logging.info("Setting SDKROOT=%s", sdk_root)
     os.environ["SDKROOT"] = sdk_root
 
     # Match Python OSX framework
@@ -493,9 +496,33 @@ def mac_osx_setenv():
             " for a recent MACOS version (from brew?). Your wheel won't be portable."
             " Consider using an official Python build from python.org"
         )
-    macos_target = "%d.%d" % tuple(py_osx_framework[:2])
-    log.info("Setting MACOSX_DEPLOYMENT_TARGET=%s", macos_target)
-    os.environ["MACOSX_DEPLOYMENT_TARGET"] = macos_target
+        if py_osx_framework is not None and explicit_target > py_osx_framework:
+            logging.warn(
+                "You are building wheels for macOS >={}; this is more "
+                "restrictive than your Python framework, which supports "
+                ">={}".format(fmt(explicit_target), fmt(py_osx_framework))
+            )
+    else:
+        # Target not set explicitly, set MACOSX_DEPLOYMENT_TARGET to match the
+        # Python framework, or 10.9 if the version targeted by the framework
+        # cannot be determined
+        if py_osx_framework is None:
+            py_osx_framework = (10, 15)
+        if py_osx_framework < (10, 15):
+            logging.warn(
+                "C++17 support is required to build NEURON on macOS, "
+                "therefore minimum MACOSX_DEPLOYMENT_TARGET version is 10.15."
+            )
+            py_osx_framework = (10, 15)
+        if py_osx_framework > (10, 15):
+            logging.warn(
+                "You are building a wheel with a Python built for macOS >={}. "
+                "Your wheel won't run on older versions, consider using an "
+                "official Python build from python.org".format(fmt(py_osx_framework))
+            )
+        macos_target = "%d.%d" % tuple(py_osx_framework[:2])
+        logging.warn("Setting MACOSX_DEPLOYMENT_TARGET=%s", macos_target)
+        os.environ["MACOSX_DEPLOYMENT_TARGET"] = macos_target
 
 
 if __name__ == "__main__":

--- a/share/lib/python/neuron/rxd/geometry3d/CMakeLists.txt
+++ b/share/lib/python/neuron/rxd/geometry3d/CMakeLists.txt
@@ -70,7 +70,6 @@ mingw=${MINGW}\n\
 shift\n\
 export LDCSHARED=\"${CMAKE_C_COMPILER} ${CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS}\"\n\
 export LDCXXSHARED=\"${CMAKE_CXX_COMPILER} ${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS}\"\n\
-export SETUPTOOLS_USE_DISTUTILS=stdlib
 if test x$mingw = x1 ; then\n\
   pyver=`$pyexe -c 'import sys; print (sys.version_info[0]); quit()'`\n\
   echo pyver=$pyver\n\

--- a/share/lib/python/neuron/rxd/geometry3d/setup.py.in
+++ b/share/lib/python/neuron/rxd/geometry3d/setup.py.in
@@ -16,16 +16,15 @@ else: # not an absolute path
 
 pgi_compiler_flags = "-noswitcherror"
 
-from distutils.core import setup
-from distutils.extension import Extension
+from setuptools import setup, Extension
 
 def have_vc():
     if not mingw:
         return False
     import traceback
     try:
-        from distutils import spawn
-        x = spawn.find_executable("cl")
+        from shutil import which
+        x = which("cl")
         x = True if x is not None and "Microsoft" in x else False
     except:
         traceback.print_exc()

--- a/share/lib/python/neuron/tests/utils/strtobool.py
+++ b/share/lib/python/neuron/tests/utils/strtobool.py
@@ -1,0 +1,16 @@
+# Own implementation of distutils.util.strtobool
+# See PEP632 for more info.
+def strtobool(val) -> bool:
+    """Convert a string representation of truth to True or False.
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        raise ValueError("invalid truth value %r" % (val,))

--- a/src/neuronmusic/CMakeLists.txt
+++ b/src/neuronmusic/CMakeLists.txt
@@ -26,7 +26,6 @@ mingw=${MINGW}\n\
 shift\n\
 export LDCSHARED=\"${CMAKE_C_COMPILER} ${CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS}\"\n\
 export LDCXXSHARED=\"${CMAKE_CXX_COMPILER} ${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS}\"\n\
-export SETUPTOOLS_USE_DISTUTILS=stdlib
 if test x$mingw = x1 ; then\n\
   pyver=`$pyexe -c 'import sys; print (sys.version_info[0]); quit()'`\n\
   echo pyver=$pyver\n\
@@ -82,37 +81,7 @@ fi\n\
   endforeach(pyexe)
 
   add_dependencies(neuronmusicextension nrniv_lib neuronmusic_cython_generated)
-
-  # ~~~
-  # (Copied from src/nrnpython/CMakeLists.txt)
-  # neuron module (possibly with multiple extension versions) was built
-  # in NRN_PYTHON_BUILD_LIB. Not a problem if install overwrites multiple
-  # times to same install folder or if each install ends up in different
-  # place.
-  # ~~~
-  file(
-    WRITE ${CMAKE_CURRENT_BINARY_DIR}/neuronmusic_module_install.sh
-    "\
-#!bash\n\
-echo 'Installing python module using:'\n\
-set -ex\n\
-cd ${CMAKE_CURRENT_BINARY_DIR}\n\
-export SETUPTOOLS_USE_DISTUTILS=stdlib
-$1 setup.py --quiet build --build-lib=${NRN_PYTHON_BUILD_LIB} install ${NRN_MODULE_INSTALL_OPTIONS}\n\
-")
-  foreach(pyexe ${NRN_PYTHON_EXE_LIST})
-    # install(CODE ...) only takes a single CMake code expression, so we can't easily roll our own
-    # check on the return code. Modern CMake versions support the COMMAND_ERROR_IS_FATAL option,
-    # which will cause the installation to abort if the shell script returns an error code.
-    if(${CMAKE_VERSION} VERSION_LESS "3.19")
-      install(
-        CODE "execute_process(COMMAND bash ${CMAKE_CURRENT_BINARY_DIR}/neuronmusic_module_install.sh ${pyexe})"
-      )
-    else()
-      install(
-        CODE "execute_process(COMMAND bash ${CMAKE_CURRENT_BINARY_DIR}/neuronmusic_module_install.sh ${pyexe} COMMAND_ERROR_IS_FATAL LAST)"
-      )
-    endif()
-  endforeach(pyexe)
+  # install modules from NRN_PYTHON_BUILD_LIB
+  install(DIRECTORY ${NRN_PYTHON_BUILD_LIB} DESTINATION lib)
 
 endif()

--- a/src/neuronmusic/setup.py.in
+++ b/src/neuronmusic/setup.py.in
@@ -1,5 +1,5 @@
 #setup.py for neuronmusic extension
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 nrn_srcdir = "@NRN_SRCDIR@"
 instdir = "@prefix@"

--- a/src/nrnpython/CMakeLists.txt
+++ b/src/nrnpython/CMakeLists.txt
@@ -220,11 +220,6 @@ if(NRN_ENABLE_MODULE_INSTALL)
   # =============================================================================
   # for each python detected / provided by user, install module at install time
 
-  # Workaround for: https://github.com/neuronsimulator/nrn/issues/1605 See:
-  # https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html
-  # https://setuptools.pypa.io/en/latest/history.html#id228
-  set(extra_env ${CMAKE_COMMAND} -E env "SETUPTOOLS_USE_DISTUTILS=stdlib")
-
   if(NRN_SANITIZERS)
     # Make sure the same compiler (currently always clang in the sanitizer builds) is used to link
     # as was used to build. By default, Python will try to use the compiler that was used to build
@@ -252,35 +247,6 @@ if(NRN_ENABLE_MODULE_INSTALL)
   if(NRN_ENABLE_RX3D)
     add_dependencies(hoc_module rxd_cython_generated)
   endif()
-
-  # ~~~
-  # neuron module (possibly with multiple extension versions) was built
-  # in NRN_PYTHON_BUILD_LIB. Not a problem if install overwrites multiple
-  # times to same install folder or if each install ends up in different
-  # place.
-  # ~~~
-  file(
-    WRITE ${CMAKE_CURRENT_BINARY_DIR}/neuron_module_install.sh
-    "\
-#!bash\n\
-echo 'Installing python module using:'\n\
-set -ex\n\
-cd ${CMAKE_CURRENT_BINARY_DIR}\n\
-export SETUPTOOLS_USE_DISTUTILS=stdlib
-$1 setup.py --quiet build --build-lib=${NRN_PYTHON_BUILD_LIB} install ${NRN_MODULE_INSTALL_OPTIONS}\n\
-")
-  foreach(pyexe ${NRN_PYTHON_EXE_LIST})
-    # install(CODE ...) only takes a single CMake code expression, so we can't easily roll our own
-    # check on the return code. Modern CMake versions support the COMMAND_ERROR_IS_FATAL option,
-    # which will cause the installation to abort if the shell script returns an error code.
-    if(${CMAKE_VERSION} VERSION_LESS "3.19")
-      install(
-        CODE "execute_process(COMMAND bash ${CMAKE_CURRENT_BINARY_DIR}/neuron_module_install.sh ${pyexe})"
-      )
-    else()
-      install(
-        CODE "execute_process(COMMAND bash ${CMAKE_CURRENT_BINARY_DIR}/neuron_module_install.sh ${pyexe} COMMAND_ERROR_IS_FATAL LAST)"
-      )
-    endif()
-  endforeach(pyexe)
+  # install modules from NRN_PYTHON_BUILD_LIB
+  install(DIRECTORY ${NRN_PYTHON_BUILD_LIB} DESTINATION lib)
 endif()

--- a/src/nrnpython/setup.py.in
+++ b/src/nrnpython/setup.py.in
@@ -1,5 +1,5 @@
 #setup.py
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 from sysconfig import get_python_version
 
 import sys
@@ -82,26 +82,6 @@ if using_pgi:
   os.environ["LDSHARED"] = os.environ['CC'] + " -shared"
   os.environ["LDCXXSHARED"] = os.environ["CXX"] + " -shared"
 
-# apparently we do not need the following
-#################################
-## following http://code.google.com/p/maroonmpi/wiki/Installation
-## hack into distutils to replace the compiler in "linker_so" with mpicxx_bin
-#
-#import distutils
-#import distutils.unixccompiler
-#
-#class MPI_UnixCCompiler(distutils.unixccompiler.UnixCCompiler):
-#    __set_executable = distutils.unixccompiler.UnixCCompiler.set_executable
-#
-#    def set_executable(self,key,value):
-#	print "MPI_UnixCCompiler ", key, " | ", value
-#        if key == 'linker_so' and type(value) == str:
-#            value = mpicxx_bin + ' ' + ' '.join(value.split()[1:])
-#
-#        return self.__set_executable(key,value)
-#    
-#distutils.unixccompiler.UnixCCompiler = MPI_UnixCCompiler
-#################################
 
 #include_dirs for hoc module
 include_dirs = [nrn_srcdir+'/src/nrnpython', nrn_srcdir+'/src/oc', '../oc', nrn_srcdir+'/src/nrnmpi']
@@ -161,12 +141,6 @@ hoc_module = Extension(
     define_macros=defines
     )
 
-# specify that the data_files paths are relative to same place as python files
-# from http://stackoverflow.com/questions/1612733/including-non-python-files-with-setup-py
-from distutils.command.install import INSTALL_SCHEMES
-for scheme in list(INSTALL_SCHEMES.values()):
-    scheme['data'] = scheme['purelib']
-
 ext_modules = [hoc_module]
 
 # The rx3d extensions are built using the setup.py.in in
@@ -214,7 +188,7 @@ if build_rx3d:
   except:
     pass
 
-packages=['neuron','neuron.neuroml','neuron.tests', 'neuron.rxd', 'neuron.crxd', 'neuron.gui2']
+packages=['neuron','neuron.neuroml','neuron.tests', 'neuron.tests.utils', 'neuron.rxd', 'neuron.crxd', 'neuron.gui2']
 if build_rx3d:
   packages +=['neuron.rxd.geometry3d']
 

--- a/test/coreneuron/test_datareturn.py
+++ b/test/coreneuron/test_datareturn.py
@@ -1,5 +1,5 @@
 # Test of data return covering most of the functionality.
-import distutils.util
+from neuron.tests.utils.strtobool import strtobool
 import itertools
 import os
 
@@ -175,9 +175,7 @@ def test_datareturn():
     h.CVode().cache_efficient(1)
     coreneuron.enable = True
     coreneuron.verbose = 0
-    coreneuron.gpu = bool(
-        distutils.util.strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false"))
-    )
+    coreneuron.gpu = bool(strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false")))
 
     results = []
     cell_permute_values = (1, 2) if coreneuron.gpu else (0, 1)

--- a/test/coreneuron/test_direct.hoc
+++ b/test/coreneuron/test_direct.hoc
@@ -53,7 +53,7 @@ proc test_direct_memory_transfer() { localobj po, pc, ic, tv, vvec, i_mem, tvstd
 
     po = new PythonObject()
     po.coreneuron.enable = 1
-    nrnpython("import distutils.util; import os; coreneuron.gpu=bool(distutils.util.strtobool(os.environ.get('CORENRN_ENABLE_GPU', 'false')))")
+    nrnpython("from neuron.tests.utils.strtobool import strtobool; import os; coreneuron.gpu=bool(strtobool(os.environ.get('CORENRN_ENABLE_GPU', 'false')))")
     printf("nrncore_arg: |%s|\n", po.coreneuron.nrncore_arg(tstop))
 
     pc = new ParallelContext()

--- a/test/coreneuron/test_direct.py
+++ b/test/coreneuron/test_direct.py
@@ -1,4 +1,4 @@
-import distutils.util
+from neuron.tests.utils.strtobool import strtobool
 import os
 
 from neuron import h, gui
@@ -38,9 +38,7 @@ def test_direct_memory_transfer():
     coreneuron.enable = True
     coreneuron.verbose = 0
     coreneuron.model_stats = True
-    coreneuron.gpu = bool(
-        distutils.util.strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false"))
-    )
+    coreneuron.gpu = bool(strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false")))
     coreneuron.num_gpus = 1
 
     pc = h.ParallelContext()

--- a/test/coreneuron/test_fornetcon.py
+++ b/test/coreneuron/test_fornetcon.py
@@ -1,7 +1,7 @@
 # Basically want to test that FOR_NETCONS statement works when
 # the NetCons connecting to ForNetConTest instances are created
 # in random order.
-import distutils.util
+from neuron.tests.utils.strtobool import strtobool
 import os
 
 from neuron import h
@@ -85,9 +85,7 @@ def test_fornetcon():
     print("CoreNEURON run")
     h.CVode().cache_efficient(1)
     coreneuron.enable = True
-    coreneuron.gpu = bool(
-        distutils.util.strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false"))
-    )
+    coreneuron.gpu = bool(strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false")))
 
     def runassert(mode):
         spiketime.resize(0)

--- a/test/coreneuron/test_netmove.py
+++ b/test/coreneuron/test_netmove.py
@@ -1,6 +1,6 @@
 # Basically want to test that net_move statement doesn't get
 # mixed up with other instances.
-import distutils.util
+from neuron.tests.utils.strtobool import strtobool
 import os
 
 from neuron import h
@@ -79,9 +79,7 @@ def test_netmove():
     h.CVode().cache_efficient(1)
     coreneuron.enable = True
     coreneuron.verbose = 0
-    coreneuron.gpu = bool(
-        distutils.util.strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false"))
-    )
+    coreneuron.gpu = bool(strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false")))
 
     def runassert(mode):
         run(tstop, mode)

--- a/test/coreneuron/test_psolve.py
+++ b/test/coreneuron/test_psolve.py
@@ -1,4 +1,4 @@
-import distutils.util
+from neuron.tests.utils.strtobool import strtobool
 import os
 
 from neuron import h, gui
@@ -47,9 +47,7 @@ def test_psolve():
 
     coreneuron.enable = True
     coreneuron.verbose = 0
-    coreneuron.gpu = bool(
-        distutils.util.strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false"))
-    )
+    coreneuron.gpu = bool(strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false")))
     h.CVode().cache_efficient(True)
     run(h.tstop)
     if vvec_std.eq(vvec) == 0:

--- a/test/coreneuron/test_spikes.py
+++ b/test/coreneuron/test_spikes.py
@@ -1,18 +1,12 @@
-import distutils.util
+from neuron.tests.utils.strtobool import strtobool
 import os
 
 # Hacky, but it's non-trivial to pass commandline arguments to pytest tests.
-enable_gpu = bool(
-    distutils.util.strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false"))
-)
-mpi4py_option = bool(
-    distutils.util.strtobool(os.environ.get("NRN_TEST_SPIKES_MPI4PY", "false"))
-)
-file_mode_option = bool(
-    distutils.util.strtobool(os.environ.get("NRN_TEST_SPIKES_FILE_MODE", "false"))
-)
+enable_gpu = bool(strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false")))
+mpi4py_option = bool(strtobool(os.environ.get("NRN_TEST_SPIKES_MPI4PY", "false")))
+file_mode_option = bool(strtobool(os.environ.get("NRN_TEST_SPIKES_FILE_MODE", "false")))
 nrnmpi_init_option = bool(
-    distutils.util.strtobool(os.environ.get("NRN_TEST_SPIKES_NRNMPI_INIT", "false"))
+    strtobool(os.environ.get("NRN_TEST_SPIKES_NRNMPI_INIT", "false"))
 )
 
 # following at top level and early enough avoids...

--- a/test/coreneuron/test_units.py
+++ b/test/coreneuron/test_units.py
@@ -1,4 +1,4 @@
-import distutils.util
+from neuron.tests.utils.strtobool import strtobool
 import os
 
 from neuron import h
@@ -20,9 +20,7 @@ def test_units():
 
     h.CVode().cache_efficient(1)
     coreneuron.enable = True
-    coreneuron.gpu = bool(
-        distutils.util.strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false"))
-    )
+    coreneuron.gpu = bool(strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false")))
     pc.set_maxstep(10)
     h.finitialize(-65)
     pc.psolve(h.dt)

--- a/test/coreneuron/test_watchrange.py
+++ b/test/coreneuron/test_watchrange.py
@@ -1,6 +1,6 @@
 # Basically want to test that net_move statement doesn't get
 # mixed up with other instances.
-import distutils.util
+from neuron.tests.utils.strtobool import strtobool
 import os
 
 from neuron import h
@@ -91,9 +91,7 @@ def test_watchrange():
     h.CVode().cache_efficient(1)
     coreneuron.enable = True
     coreneuron.verbose = 0
-    coreneuron.gpu = bool(
-        distutils.util.strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false"))
-    )
+    coreneuron.gpu = bool(strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false")))
 
     def runassert(mode):
         run(tstop, mode)

--- a/test/pynrn/test_fast_imem.py
+++ b/test/pynrn/test_fast_imem.py
@@ -1,7 +1,7 @@
 # Sum of all i_membrane_ should equal sum of all ElectrodeCurrent
 # For a demanding test, use a tree with many IClamp and ExpSyn point processes
 # sprinkled on zero and non-zero area nodes.
-import distutils.util
+from neuron.tests.utils.strtobool import strtobool
 import os
 
 from neuron import h
@@ -310,9 +310,7 @@ def test_fastimem_corenrn():
 
     coreneuron.enable = True
     coreneuron.verbose = 0
-    coreneuron.gpu = distutils.util.strtobool(
-        os.environ.get("CORENRN_ENABLE_GPU", "false")
-    )
+    coreneuron.gpu = strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false"))
     run(tstop)
     compare()
     coreneuron.enable = False

--- a/test/pynrn/test_version_macros.py
+++ b/test/pynrn/test_version_macros.py
@@ -1,4 +1,4 @@
-import distutils.util
+from neuron.tests.utils.strtobool import strtobool
 import os
 from neuron import coreneuron, h
 
@@ -17,7 +17,7 @@ def test_version_macros():
     s = h.Section()
     s.insert("VersionMacros")
     coreneuron.enable = bool(
-        distutils.util.strtobool(os.environ.get("NRN_CORENEURON_ENABLE", "false"))
+        strtobool(os.environ.get("NRN_CORENEURON_ENABLE", "false"))
     )
     coreneuron.verbose = True
     h.CVode().cache_efficient(True)


### PR DESCRIPTION
Backported by cherry-picking parts of af37b3f28d61b4a0d04c64f87d170e6ddf3b2a8c and 799a104f42c88dd19d54ada4b5f8d26bff0169b1.

* remove `distutils` usage
  * follow PEP632
  * add own `strtobool`
  * use `new_compiler` from `setuptools.build_ext` for now

* drop `SETUPTOOLS_USE_DISTUTILS=stdlib`