### PR TITLE
Fix Apple M1 gitlab CI : ensure pip is setup correctly

### DIFF
--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -173,7 +173,8 @@ jobs:
           curl -L -o MUSIC.zip https://github.com/INCF/MUSIC/archive/refs/tags/${MUSIC_VERSION}.zip
           unzip MUSIC.zip && mv MUSIC-* MUSIC && cd MUSIC
           ./autogen.sh
-          ./configure --with-python-sys-prefix --prefix=$MUSIC_INSTALL_DIR --disable-anysource MPI_CXXFLAGS="-g -O3"
+          # on some systems MPI library detection fails, provide exact flags/compilers
+          ./configure --with-python-sys-prefix --prefix=$MUSIC_INSTALL_DIR --disable-anysource MPI_CXXFLAGS="-g -O3" MPI_CFLAGS="-g -O3" MPI_LDFLAGS=" " CC=mpicc CXX=mpicxx
           make -j install
           deactivate
         working-directory: ${{runner.temp}}

--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -40,7 +40,7 @@ jobs:
       PY_MIN_VERSION: ${{ matrix.config.python_min_version || '3.8' }}
       PY_MAX_VERSION: ${{ matrix.config.python_max_version || '3.11' }}
       MUSIC_INSTALL_DIR: /opt/MUSIC
-      MUSIC_VERSION: 1.2.0
+      MUSIC_VERSION: 1.2.1
 
     strategy:
       matrix:

--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -173,7 +173,7 @@ jobs:
           curl -L -o MUSIC.zip https://github.com/INCF/MUSIC/archive/refs/tags/${MUSIC_VERSION}.zip
           unzip MUSIC.zip && mv MUSIC-* MUSIC && cd MUSIC
           ./autogen.sh
-          ./configure --with-python-sys-prefix --prefix=$MUSIC_INSTALL_DIR --disable-anysource
+          ./configure --with-python-sys-prefix --prefix=$MUSIC_INSTALL_DIR --disable-anysource MPI_CXXFLAGS="-g -O3"
           make -j install
           deactivate
         working-directory: ${{runner.temp}}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,7 @@ mac_m1_cmake_build:
     - real_python=$(python3 resolve_shim.py)
     - echo "python3=$(command -v python3) is really ${real_python}"
     - PYTHONEXECUTABLE=${real_python} ${real_python} -mvenv venv
+    - venv/bin/python3 -m ensurepip --upgrade --default-pip
     - venv/bin/pip install --upgrade pip -r nrn_requirements.txt
     - git submodule update --init --recursive --force --depth 1 -- external/nmodl
     - venv/bin/pip install --upgrade -r external/nmodl/requirements.txt


### PR DESCRIPTION
On MacOS, when we create venv without shims (for sanitizers build) the pip may not be setup under venv:

e.g.

```console
$PYTHONEXECUTABLE=/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python /Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python -m venv vsystem

# no pip here!
$ ls vsystem/bin/
Activate.ps1    Python      activate    activate.csh    activate.fish   python3     python3.
```

Hence, use `ensurepip` module to setup pip.