### PR TITLE
Fix RX3D test causing the `nrn-build-ci` to fail

### DIFF
--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -1217,7 +1217,7 @@ class _PlotShapePlot(_WrapperPlot):
                 elif val > hi:
                     col = color_to_hex(cmap(255))
                 else:
-                    val = color_to_hex(128)
+                    col = color_to_hex(cmap(128))
             else:
                 col = color_to_hex(
                     cmap(int(255 * (min(max(val, lo), hi) - lo) / (val_range)))


### PR DESCRIPTION
This one line of code causes the `nrn-build-ci` CI run to fail on MacOS 13 (see the log [here](https://github.com/neuronsimulator/nrn-build-ci/actions/runs/7450269179/job/20613410094?pr=62)) with the mysterious error:

```python
test/rxd/test_pltvar.py:57: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../lib/python/neuron/__init__.py:1357: in __call__
    return _do_plot_on_plotly(*args, **kwargs)
../../../lib/python/neuron/__init__.py:1330: in _do_plot_on_plotly
    col = _get_color(variable, val, cmap, lo, hi, val_range)
../../../lib/python/neuron/__init__.py:1220: in _get_color
    val = color_to_hex(128)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

col = 128

    def color_to_hex(col):
>       items = [hex(int(255 * col_item))[2:] for col_item in col][:-1]
E       TypeError: 'int' object is not iterable

../../../lib/python/neuron/__init__.py:1228: TypeError
```

as `int` is indeed not an iterable, but applying `cmap` to it does return one.
Note that this particular line is [not covered](https://app.codecov.io/github/neuronsimulator/nrn/commit/fbacf4f850543aef7695ea78ffc6a9c8c23c9bfa/blob/share/lib/python/neuron/__init__.py#L1220) in the code coverage CI, and this repo's CI doesn't include a MacOS 13 runner, so it doesn't get picked up by the tests.
However, I'm not entirely sure why the MacOS 13 runner _does_ pick it up, but in any case, this fixes the problem (see [here](https://github.com/neuronsimulator/nrn-build-ci/actions/runs/7571076042) for a successful run).