### PR TITLE
Avoid gpu build issue with the latest NVHPC (>23.1)

### DIFF
--- a/src/coreneuron/utils/randoms/nrnran123.cpp
+++ b/src/coreneuron/utils/randoms/nrnran123.cpp
@@ -88,7 +88,7 @@ namespace random123_global {
 #else
 #define g_k_qualifiers
 #endif
-g_k_qualifiers philox4x32_key_t g_k{};
+g_k_qualifiers philox4x32_key_t g_k{{0, 0}};
 
 // Cannot refer to g_k directly from a nrn_pragma_acc(routine seq) method like
 // coreneuron_random123_philox4x32_helper, and cannot have this inlined there at


### PR DESCRIPTION
* thanks to @matz-e - he pointed out the issue #2563 would be solved by initializing the key with {0, 0}.
* As value initialization is supposed to work, we believe this is a regression in NVHPC.

fixes #2563