### PR TITLE
Only use `nrn_prop_datum_alloc`.

### DIFF
--- a/src/nrniv/hocmech.cpp
+++ b/src/nrniv/hocmech.cpp
@@ -134,7 +134,7 @@ static void alloc_pnt(Prop* p) {
         p->ob = nrn_point_prop_->ob;
         // printf("p->ob comes from nrn_point_prop_ %s\n", hoc_object_name(p->ob));
     } else {
-        p->dparam = (Datum*) hoc_Ecalloc(2, sizeof(Datum));
+        nrn_prop_datum_alloc(p->_type, 2, p);
         if (last_created_pp_ob_) {
             p->ob = last_created_pp_ob_;
             // printf("p->ob comes from last_created %s\n", hoc_object_name(p->ob));


### PR DESCRIPTION
The aim of this refactoring is to make `nrn_prop_datum_alloc` the only function that allocates datums (for `Prop`; I'm not 100% sure about Datums in general).

I've attached a diagram of what I think is currently how `prop.dparam` is allocated and freed. There's still one alternative path remaining, via the global variable `nrn_point_prop_`. However, I suspect this will naturally go away when we store the datums inside the SoA.

![datum-lifecycle](https://github.com/neuronsimulator/nrn/assets/8473921/7c0c6bbf-4020-4ac3-94bd-f0a12fbf8b9d)
