### PR TITLE
Fix segfault on Python 3.12

### DIFF
--- a/src/nrnpython/nrnpython.cpp
+++ b/src/nrnpython/nrnpython.cpp
@@ -172,8 +172,8 @@ extern "C" int nrnpython_start(int b) {
     }
     if (b == 0 && started) {
         PyGILState_STATE gilsav = PyGILState_Ensure();
-        Py_Finalize();
         del_wcargv(nrn_global_argc);
+        Py_Finalize();
         // because of finalize, no PyGILState_Release(gilsav);
         started = 0;
     }


### PR DESCRIPTION
Any Python C API functions should be called before `Py_Finalize`, and `del_wcargv` calls `PyMem_Free`