### PR TITLE
Use `build` to create wheels

### DIFF
--- a/packaging/python/build_requirements.txt
+++ b/packaging/python/build_requirements.txt
@@ -1,2 +1,4 @@
 cython<3
 packaging
+build
+setuptools_scm

--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -103,7 +103,7 @@ build_wheel_linux() {
     # Workaround for https://github.com/pypa/manylinux/issues/1309
     git config --global --add safe.directory "*"
 
-    python setup.py build_ext --cmake-prefix="/nrnwheel/ncurses;/nrnwheel/readline" --cmake-defs="$CMAKE_DEFS" $setup_args bdist_wheel
+    python -m build --wheel --no-isolation
 
     # For CI runs we skip wheelhouse repairs
     if [ "$SKIP_WHEELHOUSE_REPAIR" = true ] ; then
@@ -175,7 +175,7 @@ build_wheel_osx() {
       fi
     fi
 
-    python setup.py build_ext --cmake-prefix="/opt/nrnwheel/ncurses;/opt/nrnwheel/readline;/usr/x11" --cmake-defs="$CMAKE_DEFS" $setup_args bdist_wheel
+    python -m build --wheel --no-isolation
 
     echo " - Calling delocate-listdeps"
     delocate-listdeps dist/*.whl

--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -103,7 +103,18 @@ build_wheel_linux() {
     # Workaround for https://github.com/pypa/manylinux/issues/1309
     git config --global --add safe.directory "*"
 
-    python -m build --wheel --no-isolation
+    if [ -n "${setup_args}" ]; then
+        python -m build --wheel --no-isolation \
+            --config-setting="--global-option=build_ext" \
+            --config-setting="--global-option=${setup_args}" \
+            --config-setting="--global-option=--cmake-defs=${CMAKE_DEFS}" \
+            --config-setting='--global-option=--cmake-prefix="/nrnwheel/ncurses;/nrnwheel/readline"'
+    else
+        python -m build --wheel --no-isolation \
+            --config-setting="--global-option=build_ext" \
+            --config-setting="--global-option=--cmake-defs=${CMAKE_DEFS}" \
+            --config-setting='--global-option=--cmake-prefix="/nrnwheel/ncurses;/nrnwheel/readline"'
+    fi
 
     # For CI runs we skip wheelhouse repairs
     if [ "$SKIP_WHEELHOUSE_REPAIR" = true ] ; then
@@ -175,7 +186,18 @@ build_wheel_osx() {
       fi
     fi
 
-    python -m build --wheel --no-isolation
+    if [ -n "${setup_args}" ]; then
+        python -m build --wheel --no-isolation \
+            --config-setting="--global-option=build_ext" \
+            --config-setting="--global-option=${setup_args}" \
+            --config-setting="--global-option=--cmake-defs=${CMAKE_DEFS}" \
+            --config-setting='--global-option=--cmake-prefix="/opt/nrnwheel/ncurses;/opt/nrnwheel/readline;/usr/x11"'
+    else
+        python -m build --wheel --no-isolation \
+            --config-setting="--global-option=build_ext" \
+            --config-setting="--global-option=--cmake-defs=${CMAKE_DEFS}" \
+            --config-setting='--global-option=--cmake-prefix="/opt/nrnwheel/ncurses;/opt/nrnwheel/readline;/usr/x11"'
+    fi
 
     echo " - Calling delocate-listdeps"
     delocate-listdeps dist/*.whl


### PR DESCRIPTION
In Python 3.12, calling `python setup.py` to create wheels is deprecated; instead, one should use a "standard-based tool" (whatever that means exactly), like the `build` package from PyPA.
Therefore, instead of calling `setup.py bdist_wheel`, we use `python -m build`, which is the recommended replacement for it (as mentioned here: https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html#summary).
Fixes #2696.

Note that we may need to pin version dependencies due to the comment listed [here](https://gregoryszorc.com/blog/2023/10/30/my-user-experience-porting-off-setup.py/):

> After all, the tools aren't printing anything indicating they are assuming implicit defaults and for all I know the defaults could change in a backwards incompatible manner in any release and break my build. (Although I would hope to see a deprecation warning before that occurs.)

by adding a very minimal `pyproject.toml`.

**EDIT**: Seems we need to pass `--config-setting="--build-option=[OPTION]"` to actually pass the options to the build system.

**EDIT 2**: there's also `--config-setting="--global-option=[OPTION]"` which puts _all_ of the global options _before_ the build ones, so this is a bit of a hack to silence the installer.