### PR TITLE
pin packaging to keep LegacyVersion support

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,9 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "mambaforge-22.9"
+
 conda:
   environment: docs/conda_environment.yml

--- a/docs/conda_environment.yml
+++ b/docs/conda_environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - packaging=21.3
   - python=3.11
   - bison
   - cmake

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -15,3 +15,4 @@ plotly
 nbsphinx
 jinja2
 sphinx-design
+packaging==21.3


### PR DESCRIPTION
Support was dropped in 22.0 (see https://packaging.pypa.io/en/latest/changelog.html#id4 ). This breaks our readthedocs build for any branch that does not parse as a clean version number.