### PR TITLE
pin packaging==21.3

### DIFF
--- a/docs/conda_environment.yml
+++ b/docs/conda_environment.yml
@@ -4,6 +4,7 @@ channels:
   - defaults
 dependencies:
   - python=3.10
+  - packaging=21.3
   - bison
   - cmake
   - xorg-libxcomposite

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -14,3 +14,4 @@ plotly
 nbsphinx
 jinja2
 sphinx-design
+packaging==21.3


### PR DESCRIPTION
22.0 dropped LegacyVersion: https://github.com/pypa/packaging/pull/407 
This makes it so our branches can no longer be parsed as versions