### PR TITLE
Add workaround for #2710

### DIFF
--- a/docs/rxd-tutorials/extracellular.ipynb
+++ b/docs/rxd-tutorials/extracellular.ipynb
@@ -420,7 +420,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "runsim(AK, min_conc=0, max_conc=0.01)"
+    "# due to technical problems, this video cannot be shown in the documentation\n",
+    "# for more information, please visit this link:\n",
+    "# https://github.com/neuronsimulator/nrn/issues/2710\n",
+    "# runsim(AK, min_conc=0, max_conc=0.01)"
    ]
   },
   {

--- a/docs/rxd-tutorials/extracellular.ipynb
+++ b/docs/rxd-tutorials/extracellular.ipynb
@@ -420,10 +420,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# due to technical problems, this video cannot be shown in the documentation\n",
-    "# for more information, please visit this link:\n",
-    "# https://github.com/neuronsimulator/nrn/issues/2710\n",
-    "# runsim(AK, min_conc=0, max_conc=0.01)"
+    "runsim(AK, min_conc=0, max_conc=0.01)"
    ]
   },
   {

--- a/docs/rxd-tutorials/extracellular.ipynb
+++ b/docs/rxd-tutorials/extracellular.ipynb
@@ -431,31 +431,6 @@
    "metadata": {},
    "source": [
     "### Inhomogeneities\n",
-    "#### Initial conditions\n",
-    "Initial condition in the ECS need not be a scalar concentration. Suppose we only want to apply the buffer shown above to a sphere in the middle of the ECS, this can be achieved by passing function that takes a node as an argument."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "del A, buffering\n",
-    "A = rxd.Species(\n",
-    "    ecs,\n",
-    "    name=\"buffer\",\n",
-    "    charge=1,\n",
-    "    d=0,\n",
-    "    initial=lambda nd: 10 if (nd.x**2) + (nd.y**2) + nd.x**2 < 25**2 else 0,\n",
-    ")\n",
-    "buffering = rxd.Reaction(k + A, AK, kf, kb)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "#### Anisotropy\n",
     "The diffusion coefficient for a species can be different in each direction. e.g. to limit diffusion to the x,y-plane;"
    ]


### PR DESCRIPTION
Workaround for #2710. The whole subsection "Initial conditions" has been removed to make the RTD build succeed, see: https://readthedocs.org/projects/nrn/builds/23371376/