### PR TITLE
Accessors for cache pointers.

### DIFF
--- a/src/neuron/cache/mechanism_range.hpp
+++ b/src/neuron/cache/mechanism_range.hpp
@@ -87,6 +87,11 @@ struct MechanismRange {
         return std::next(m_data_ptrs[variable], array_size * (m_offset + instance));
     }
 
+    template <int variable, int array_size>
+    [[nodiscard]] double* data_array_ptr() {
+        return data_array(0);
+    }
+
     /**
      * @brief Get a RANGE variable value.
      * @tparam variable The index of the RANGE variable in the mechanism.
@@ -97,6 +102,11 @@ struct MechanismRange {
     template <int variable>
     [[nodiscard]] double& fpfield(std::size_t instance) {
         return *data_array<variable, 1>(instance);
+    }
+
+    template <int variable>
+    [[nodiscard]] double* fpfield_ptr() {
+        return data_array<variable, 1>(0);
     }
 
     /**
@@ -122,6 +132,12 @@ struct MechanismRange {
     [[nodiscard]] double* dptr_field(std::size_t instance) {
         static_assert(variable < NumDatumFields);
         return m_pdata_ptrs[variable][m_offset + instance];
+    }
+
+    template <int variable>
+    [[nodiscard]] double* const* dptr_field_ptr() {
+        static_assert(variable < NumDatumFields);
+        return m_pdata_ptrs[variable] + m_offset;
     }
 
   protected:


### PR DESCRIPTION
In NMODL we have a struct:

    struct ionic_Instance  {
        double* ena{};
        double* ina{};
        double* v_unused{};
        double* g_unused{};
        const double* const* ion_ina{};
        double* const* ion_ena{};
        ionic_Store* global{&ionic_global};
    };

The pointers are views into contiguous arrays of doubles. While we can the address for parameters like `ena`, we can't get the address of "double pointer" variables, with the previous existing API.