### PR TITLE
Add setuptools to MacOS in CI

### DIFF
--- a/packaging/python/test_wheels.sh
+++ b/packaging/python/test_wheels.sh
@@ -294,8 +294,8 @@ fi
 $python_exe -m pip install --upgrade pip
 
 
-# install numpy, pytest and neuron
-$python_exe -m pip install numpy pytest
+# install numpy, pytest and neuron (and setuptools until we get rid of pkg_resources)
+$python_exe -m pip install numpy pytest setuptools
 $python_exe -m pip install $python_wheel
 $python_exe -m pip show neuron \
     || $python_exe -m pip show neuron-nightly \


### PR DESCRIPTION
Workaround for Python 3.12 until we remove pkg_resources (this job fails on Azure: https://dev.azure.com/neuronsimulator/nrn/_build/results?buildId=10990&view=logs&j=dc6c1633-f1e0-59f3-8af3-bd684b0342df&t=c5d6bc96-8397-5fac-a158-5afee1af545b).
For context, in Python 3.12+, setuptools is no longer pre-installed when creating a venv (see https://github.com/python/cpython/issues/95299).