### PR TITLE
Add setuptools to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -509,7 +509,7 @@ def setup_package():
             else "node-and-date"
         },
         cmdclass=dict(build_ext=CMakeAugmentedBuilder, docs=Docs),
-        install_requires=["numpy>=1.9.3", "packaging", "find_libpython"],
+        install_requires=["numpy>=1.9.3", "packaging", "find_libpython", "setuptools"],
         tests_require=["flake8", "pytest"],
         setup_requires=["wheel", "setuptools_scm"]
         + maybe_docs


### PR DESCRIPTION
When installing a pre-built wheel in a venv on Python 3.12+, calling `nrniv` fails because the wrapper script uses `setuptools` for some functionality (and it's not added to the venv anymore as of Python 3.12+, see https://github.com/python/cpython/issues/95299), so it should also be added as a runtime dependency of NEURON.

**NOTE**: this should also be backported to 8.2 if we want full Python 3.12 compatibility.