### PR TITLE
Add setuptools to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -566,7 +566,7 @@ def setup_package():
             if f[0] != "_"
         ],
         cmdclass=dict(build_ext=CMakeAugmentedBuilder, docs=Docs),
-        install_requires=["numpy>=1.9.3", "packaging"] + maybe_patchelf,
+        install_requires=["numpy>=1.9.3", "packaging", "find_libpython", "setuptools"] + maybe_patchelf,
         tests_require=["flake8", "pytest"],
         setup_requires=["wheel"] + maybe_docs + maybe_test_runner + maybe_rxd_reqs,
         dependency_links=[],

--- a/setup.py
+++ b/setup.py
@@ -566,7 +566,8 @@ def setup_package():
             if f[0] != "_"
         ],
         cmdclass=dict(build_ext=CMakeAugmentedBuilder, docs=Docs),
-        install_requires=["numpy>=1.9.3", "packaging", "find_libpython", "setuptools"] + maybe_patchelf,
+        install_requires=["numpy>=1.9.3", "packaging", "find_libpython", "setuptools"]
+        + maybe_patchelf,
         tests_require=["flake8", "pytest"],
         setup_requires=["wheel"] + maybe_docs + maybe_test_runner + maybe_rxd_reqs,
         dependency_links=[],


### PR DESCRIPTION
When installing a pre-built wheel in a venv on Python 3.12, calling `nrniv` fails because the wrapper script uses `setuptools` for some functionality, so it should also be added as a runtime dependency.