### PR TITLE
Show full path when compiling MOD files.

### DIFF
--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -170,11 +170,11 @@ for i in "${files[@]}" ; do
   f=${f// /\\ }
   f=${f//:/\\:}
   echo "\
-./${base_name// /\\ }.cpp: ${f}.mod
+\$(PWD)/${base_name// /\\ }.cpp: ${f}.mod
 	@printf \" -> \$(C_GREEN)NMODL\$(C_RESET) \$<\\\n\"
 	(cd \"$dir_name\"; @NRN_NOCMODL_SANITIZER_ENVIRONMENT_STRING@ MODLUNIT=\$(NRNUNITS) \$(NOCMODL) \"$base_name.mod\" -o \"$mdir\" $UserNMODLFLAGS)
 
-./${base_name// /\\ }.o: ./${base_name// /\\ }.cpp
+./${base_name// /\\ }.o: \$(PWD)/${base_name// /\\ }.cpp
 	@printf \" -> \$(C_GREEN)Compiling\$(C_RESET) \$<\\\n\"
 	\$(CXXCOMPILE) -I\"$dir_name\" \$(INCLUDES) @CMAKE_CXX_COMPILE_OPTIONS_PIC@ -c \$< -o \$@
 " >> "$MODMAKE"

--- a/bin/nrnivmodl_makefile_cmake.in
+++ b/bin/nrnivmodl_makefile_cmake.in
@@ -11,9 +11,9 @@
 # Mechanisms version are by default 0.0, but should be overriden
 MECH_NAME =
 MECH_VERSION = 0.0
-MODS_PATH = .
+MODS_PATH = $(PWD)
 # in the @CMAKE_HOST_SYSTEM_PROCESSOR@ folder
-OUTPUT = .
+OUTPUT = $(PWD)
 DESTDIR =
 UserINCFLAGS =
 UserLDFLAGS =
@@ -78,8 +78,8 @@ endif
 NRNUNITS = $(datadir_lib)/nrnunits.lib
 
 # File path config (internal)
-MODC_DIR = .
-OBJS_DIR = .
+MODC_DIR = $(PWD)
+OBJS_DIR = $(PWD)
 mod_objs   = $(MODOBJFILES)
 
 mod_func_o = $(OBJS_DIR)/mod_func.o


### PR DESCRIPTION
Prior to this commit the output on failure would be:

    [ 78%] Built target hoc_module
    hhwatch.cpp: In function ‘void _hoc_destroy_pnt(void*)’:
    hhwatch.cpp:175:61: error: cannot convert ‘DatumHandle’ {aka ‘neuron::container::Mechanism::DatumHandle’} to ‘Datum*’ {aka ‘neuron::container::generic_data_handle*’}

which isn't helpful because it's not obvious which `hhwatch.cpp` contains the faulty code. The solution here is to ensure that the compiler is passed the full path. At least for GCC, this will cause it to use the full path in error messages.