### PR TITLE
Regenerated code if code-generator changes.

### DIFF
--- a/bin/nrnivmodl.in
+++ b/bin/nrnivmodl.in
@@ -170,7 +170,7 @@ for i in "${files[@]}" ; do
   f=${f// /\\ }
   f=${f//:/\\:}
   echo "\
-./${base_name// /\\ }.cpp: ${f}.mod
+./${base_name// /\\ }.cpp: ${f}.mod \$(NOCMODL)
 	@printf \" -> \$(C_GREEN)NMODL\$(C_RESET) \$<\\\n\"
 	(cd \"$dir_name\"; @NRN_NOCMODL_SANITIZER_ENVIRONMENT_STRING@ MODLUNIT=\$(NRNUNITS) \$(NOCMODL) \"$base_name.mod\" -o \"$mdir\" $UserNMODLFLAGS)
 


### PR DESCRIPTION
While development, the code-generator might be changed. This could result in different `.cpp` file. However, in the make file snippet generated by `nrnivmodl` the generated `.cpp` file doesn't have  have a
dependency on `nocmodl`. Meaning if it changes the `.cpp` don't need to be recreated. Since `nrnivmodl` is called from `CMakeLists.txt` this can cause broken builds, where changes to the source files aren't reflected
in the generated binaries.