### PR TITLE
Fix master CI: check if coreneuron is loadable for given test

### DIFF
--- a/share/lib/python/neuron/tests/utils/coreneuron_available.py
+++ b/share/lib/python/neuron/tests/utils/coreneuron_available.py
@@ -4,6 +4,7 @@
 
 from neuron import config, h
 
+
 def coreneuron_available():
     if not config.arguments["NRN_ENABLE_CORENEURON"]:
         return False

--- a/share/lib/python/neuron/tests/utils/coreneuron_available.py
+++ b/share/lib/python/neuron/tests/utils/coreneuron_available.py
@@ -1,0 +1,26 @@
+# Check if coreneuron is enabled in the current installation
+# and loadable at runtime. This may not be the case if we
+# build static library of the coreneuron.
+
+from neuron import config, h
+
+def coreneuron_available():
+    if not config.arguments["NRN_ENABLE_CORENEURON"]:
+        return False
+    # But can it be loaded?
+    cvode = h.CVode()
+    pc = h.ParallelContext()
+    h.finitialize()
+    result = 0
+    import sys
+    from io import StringIO
+
+    original_stderr = sys.stderr
+    sys.stderr = StringIO()
+    try:
+        pc.nrncore_run("--tstop 1 --verbose 0")
+        result = 1
+    except Exception as e:
+        pass
+    sys.stderr = original_stderr
+    return result

--- a/test/pytest_coreneuron/test_fast_imem.py
+++ b/test/pytest_coreneuron/test_fast_imem.py
@@ -2,6 +2,7 @@
 # For a demanding test, use a tree with many IClamp and ExpSyn point processes
 # sprinkled on zero and non-zero area nodes.
 from neuron.tests.utils.strtobool import strtobool
+from neuron.tests.utils.coreneuron_available import coreneuron_available
 import os
 
 from neuron import config, gui, h
@@ -207,28 +208,6 @@ def test_fastimem():
         total_syn_g(syns)
         with cvode_enabled(True):
             run(1.0, ics, 1e-12)
-
-
-def coreneuron_available():
-    if not config.arguments["NRN_ENABLE_CORENEURON"]:
-        return False
-    # But can it be loaded?
-    cvode = h.CVode()
-    pc = h.ParallelContext()
-    h.finitialize()
-    result = 0
-    import sys
-    from io import StringIO
-
-    original_stderr = sys.stderr
-    sys.stderr = StringIO()
-    try:
-        pc.nrncore_run("--tstop 1 --verbose 0")
-        result = 1
-    except Exception as e:
-        pass
-    sys.stderr = original_stderr
-    return result
 
 
 def test_fastimem_corenrn():

--- a/test/pytest_coreneuron/test_imem.py
+++ b/test/pytest_coreneuron/test_imem.py
@@ -1,6 +1,8 @@
 # i_membrane + electrode current sums to 0 when electrode parameters are time dependent.
 # This test revealed a fast_imem bug that needed fixing #2733
 
+from neuron.tests.utils.coreneuron_available import coreneuron_available
+
 from neuron import h, gui, config
 from neuron import coreneuron
 import math
@@ -157,7 +159,7 @@ def tst(xtrcell, secondorder, cvactive, corenrn, seclmp):
 def test_imem():
     # tst(xtrcell, secondorder, cvactive, corenrn, seclmp)
     cnlist = [0]
-    if config.arguments["NRN_ENABLE_CORENEURON"]:
+    if coreneuron_available():
         cnlist.append(1)
     for seclmp in [0, 1]:
         tst(1, 0, 0, 0, seclmp)

--- a/test/pytest_coreneuron/test_multigid.py
+++ b/test/pytest_coreneuron/test_multigid.py
@@ -2,35 +2,14 @@
 # pc.cell(gid, h.NetCon(cell.sec(x)._ref_v, None, sec=cell.sec))
 # It is an error to have multiple gids with the same reference.
 
+from neuron.tests.utils.coreneuron_available import coreneuron_available
+
 from neuron import config, h, coreneuron
 from neuron.expect_hocerr import expect_err
 from math import log10
 
 
 pc = h.ParallelContext()
-
-
-def coreneuron_available():
-    if not config.arguments["NRN_ENABLE_CORENEURON"]:
-        return False
-    # But can it be loaded?
-    cvode = h.CVode()
-    pc = h.ParallelContext()
-    h.finitialize()
-    result = 0
-    import sys
-    from io import StringIO
-
-    original_stderr = sys.stderr
-    sys.stderr = StringIO()
-    try:
-        pc.nrncore_run("--tstop 1 --verbose 0")
-        result = 1
-    except Exception as e:
-        pass
-    sys.stderr = original_stderr
-    return result
-
 
 cn_avail = coreneuron_available()
 


### PR DESCRIPTION
- In order to run Python tests with coreneuron, we need to either use special (where coreneuron is linked) or have a shared library build so that coreneuron can be loaded dynamically
- Some builds on GitLab also test builds with static libraries. So the test added in #2733 fails as we don't check for static build.
- In this PR we use the existing mechanism/function to check if coreneuron is usable and then run a test with coreneuron