### PR TITLE
Fix Python3.12 SyntaxWarning: invalid escape sequence '\.'

### DIFF
--- a/bin/nrnpyenv.sh.in
+++ b/bin/nrnpyenv.sh.in
@@ -426,7 +426,7 @@ def nrnpylib_mswin():
   f = os.popen(cmd)
   nrn_pylib = None
   for line in f:
-    if re.search('ython[a-zA-Z0-9_.]*\.dll', line):
+    if re.search(r'ython[a-zA-Z0-9_.]*\.dll', line):
       nrn_pylib = '/'.join(line.split(os.path.sep)).strip()
       nrnpylib_provenance="cygcheck"
   return nrn_pylib
@@ -474,7 +474,7 @@ def nrnpylib_linux():
       if re.search(r'libpython.*\.so', line):
         print ("# from lsof: %s" % line)
         nrn_pylib = line.strip()
-        nrnpylib_provenance = 'lsof search for libpython.*\.so'
+        nrnpylib_provenance = r'lsof search for libpython.*\.so'
         return nrn_pylib
   else: # figure it out from the os path
     p = os.path.sep.join(os.__file__.split(os.path.sep)[:-1])


### PR DESCRIPTION
  Has already been fixed in release/8.2

Without this fix, we see (at least for Python-3.12) and with ```-DNRN_ENABLE_PYTHON_DYNAMIC=ON```
```
$ ctest -R hoctests::test_neurondemo_py
Test project /home/hines/neuron/temp/build
    Start 72: hoctests::test_neurondemo_py
1/1 Test #72: hoctests::test_neurondemo_py .....***Failed    1.84 sec

Output from these tests are in: /home/hines/neuron/temp/build/Testing/Temporary/LastTest.log

stderr: <stdin>:149: SyntaxWarning: invalid escape sequence '\.'
stderr: <stdin>:197: SyntaxWarning: invalid escape sequence '\.'
Traceback (most recent call last):
  File "/home/hines/neuron/temp/build/test/hoctests/test_neurondemo_py/tests/te$
    data = neurondemo(prgraphs, input % i)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hines/neuron/temp/build/test/hoctests/test_neurondemo_py/tests/te$
    raise Exception("Unexpected stderr")
Exception: Unexpected stderr
```

And in other contexts, warnings that can make the user nervous.