### PR TITLE
Remove useless code from sptree

### DIFF
--- a/src/nrncvode/sptree.hpp
+++ b/src/nrncvode/sptree.hpp
@@ -20,17 +20,17 @@ struct SPTREE {
     int enqcmps; /* compares in spenq */
 };
 
-#define spinit      sptq_spinit
-#define spempty     sptq_spempty
-#define spenq       sptq_spenq
-#define spdeq       sptq_spdeq
-#define splay       sptq_splay
-#define sphead      sptq_sphead
-#define spdelete    sptq_spdelete
-#define splookup    sptq_splookup
-#define spscan  sptq_spscan
-#define spfhead sptq_spfhead
-#define spfnext sptq_spfnext
+#define spinit   sptq_spinit
+#define spempty  sptq_spempty
+#define spenq    sptq_spenq
+#define spdeq    sptq_spdeq
+#define splay    sptq_splay
+#define sphead   sptq_sphead
+#define spdelete sptq_spdelete
+#define splookup sptq_splookup
+#define spscan   sptq_spscan
+#define spfhead  sptq_spfhead
+#define spfnext  sptq_spfnext
 
 /*  Original file: sptree.cpp
  *

--- a/src/nrncvode/sptree.hpp
+++ b/src/nrncvode/sptree.hpp
@@ -100,7 +100,7 @@ void spinit(SPTREE<SPBLK>* q) {
  * spempty() -- is an event-set represented as a splay tree empty?
  */
 template <typename SPBLK>
-int spempty(SPTREE<SPBLK>* q) {
+bool spempty(SPTREE<SPBLK>* q) {
     return (q == nullptr || q->root == nullptr);
 }
 

--- a/src/nrncvode/sptree.hpp
+++ b/src/nrncvode/sptree.hpp
@@ -9,70 +9,28 @@
 **  with the compare function applied to the addresses of two keys.
 */
 
-#ifndef SPTREE_H
-#define SPTREE_H
+#pragma once
 
-#ifndef NULL
-#define NULL 0
-#endif
-
-#if 0
-#define STRCMP(a, b) ((Sct = *(a) - *(b)) ? Sct : strcmp((a), (b)))
-#else
 #define STRCMP(a, b) (a - b)
-#endif
-
-#if 0
-typedef struct _spblk
-{
-    struct _spblk	* leftlink;
-    struct _spblk	* rightlink;
-    struct _spblk	* uplink;
-    int		cnt;
-
-    char	* key;		/* formerly time/timetyp */
-    char	* data;		/* formerly aux/auxtype */
-    char	* datb;
-} SPBLK;
-#endif
 
 template <typename SPBLK>
 struct SPTREE {
     SPBLK* root; /* root node */
 
-    /* Statistics, not strictly necessary, but handy for tuning  */
-
-    int lookups; /* number of splookup()s */
-    int lkpcmps; /* number of lookup comparisons */
-
-    int enqs;    /* number of spenq()s */
     int enqcmps; /* compares in spenq */
-
-    int splays;
-    int splayloops;
 };
 
 #define spinit      sptq_spinit
 #define spempty     sptq_spempty
 #define spenq       sptq_spenq
 #define spdeq       sptq_spdeq
-#define spenqprior  sptq_spenqprior
 #define splay       sptq_splay
 #define sphead      sptq_sphead
 #define spdelete    sptq_spdelete
-#define spnext      sptq_spnext
-#define spprev      sptq_spprev
-#define spenqbefore sptq_spenqbefore
-#define spenqafter  sptq_spenqafter
 #define splookup    sptq_splookup
-/*#define spinstall sptq_spinstall*/
-#define sptail  sptq_sptail
 #define spscan  sptq_spscan
-#define sprscan sptq_sprscan
 #define spfhead sptq_spfhead
 #define spfnext sptq_spfnext
-#define spfprev sptq_spfprev
-#define spstats sptq_spstats
 
 /*  Original file: sptree.cpp
  *
@@ -84,7 +42,6 @@ Hines changed to void spinit(SPTREE<SPBLK>**) for use with TQueue.
  *  int spempty();		Is tree empty?
  *  SPBLK *spenq( n, q )	Insert n in q after all equal keys.
  *  SPBLK *spdeq( np )		Return first key under *np, removing it.
- *  SPBLK *spenqprior( n, q )	Insert n in q before all equal keys.
  *  void splay( n, q )		n (already in q) becomes the root.
  *
  *  In the above, n points to an SPBLK type, while q points to an
@@ -134,13 +91,8 @@ Hines changed to void spinit(SPTREE<SPBLK>**) for use with TQueue.
  */
 template <typename SPBLK>
 void spinit(SPTREE<SPBLK>* q) {
-    q->lookups = 0;
-    q->lkpcmps = 0;
-    q->enqs = 0;
     q->enqcmps = 0;
-    q->splays = 0;
-    q->splayloops = 0;
-    q->root = NULL;
+    q->root = nullptr;
 }
 
 /*----------------
@@ -149,7 +101,7 @@ void spinit(SPTREE<SPBLK>* q) {
  */
 template <typename SPBLK>
 int spempty(SPTREE<SPBLK>* q) {
-    return (q == NULL || q->root == NULL);
+    return (q == nullptr || q->root == nullptr);
 }
 
 
@@ -175,14 +127,13 @@ SPBLK* spenq(SPBLK* n, SPTREE<SPBLK>* q) {
     double key;
     int Sct; /* Strcmp value */
 
-    q->enqs++;
-    n->uplink = NULL;
+    n->uplink = nullptr;
     next = q->root;
     q->root = n;
-    if (next == NULL) /* trivial enq */
+    if (next == nullptr) /* trivial enq */
     {
-        n->leftlink = NULL;
-        n->rightlink = NULL;
+        n->leftlink = nullptr;
+        n->rightlink = nullptr;
     } else /* difficult enq */
     {
         key = n->key;
@@ -202,10 +153,10 @@ SPBLK* spenq(SPBLK* n, SPTREE<SPBLK>* q) {
         do /* walk to the right in the left tree */
         {
             temp = next->rightlink;
-            if (temp == NULL) {
+            if (temp == nullptr) {
                 left->rightlink = next;
                 next->uplink = left;
-                right->leftlink = NULL;
+                right->leftlink = nullptr;
                 goto done; /* job done, entire tree split */
             }
 
@@ -219,7 +170,7 @@ SPBLK* spenq(SPBLK* n, SPTREE<SPBLK>* q) {
             }
 
             next->rightlink = temp->leftlink;
-            if (temp->leftlink != NULL)
+            if (temp->leftlink != nullptr)
                 temp->leftlink->uplink = next;
             left->rightlink = temp;
             temp->uplink = left;
@@ -227,8 +178,8 @@ SPBLK* spenq(SPBLK* n, SPTREE<SPBLK>* q) {
             next->uplink = temp;
             left = temp;
             next = temp->rightlink;
-            if (next == NULL) {
-                right->leftlink = NULL;
+            if (next == nullptr) {
+                right->leftlink = nullptr;
                 goto done; /* job done, entire tree split */
             }
 
@@ -241,10 +192,10 @@ SPBLK* spenq(SPBLK* n, SPTREE<SPBLK>* q) {
         do /* walk to the left in the right tree */
         {
             temp = next->leftlink;
-            if (temp == NULL) {
+            if (temp == nullptr) {
                 right->leftlink = next;
                 next->uplink = right;
-                left->rightlink = NULL;
+                left->rightlink = nullptr;
                 goto done; /* job done, entire tree split */
             }
 
@@ -257,7 +208,7 @@ SPBLK* spenq(SPBLK* n, SPTREE<SPBLK>* q) {
                 goto one; /* change sides */
             }
             next->leftlink = temp->rightlink;
-            if (temp->rightlink != NULL)
+            if (temp->rightlink != nullptr)
                 temp->rightlink->uplink = next;
             right->leftlink = temp;
             temp->uplink = right;
@@ -265,8 +216,8 @@ SPBLK* spenq(SPBLK* n, SPTREE<SPBLK>* q) {
             next->uplink = temp;
             right = temp;
             next = temp->leftlink;
-            if (next == NULL) {
-                left->rightlink = NULL;
+            if (next == nullptr) {
+                left->rightlink = nullptr;
                 goto done; /* job done, entire tree split */
             }
 
@@ -307,37 +258,37 @@ SPBLK* spdeq(SPBLK** np) /* pointer to a node pointer */
     SPBLK* farleft;    /* the left child of left */
     SPBLK* farfarleft; /* the left child of farleft */
 
-    if (np == NULL || *np == NULL) {
-        deq = NULL;
+    if (np == nullptr || *np == nullptr) {
+        deq = nullptr;
     } else {
         next = *np;
         left = next->leftlink;
-        if (left == NULL) {
+        if (left == nullptr) {
             deq = next;
             *np = next->rightlink;
 
-            if (*np != NULL)
-                (*np)->uplink = NULL;
+            if (*np != nullptr)
+                (*np)->uplink = nullptr;
 
         } else
             for (;;) /* left is not null */
             {
-                /* next is not it, left is not NULL, might be it */
+                /* next is not it, left is not nullptr, might be it */
                 farleft = left->leftlink;
-                if (farleft == NULL) {
+                if (farleft == nullptr) {
                     deq = left;
                     next->leftlink = left->rightlink;
-                    if (left->rightlink != NULL)
+                    if (left->rightlink != nullptr)
                         left->rightlink->uplink = next;
                     break;
                 }
 
-                /* next, left are not it, farleft is not NULL, might be it */
+                /* next, left are not it, farleft is not nullptr, might be it */
                 farfarleft = farleft->leftlink;
-                if (farfarleft == NULL) {
+                if (farfarleft == nullptr) {
                     deq = farleft;
                     left->leftlink = farleft->rightlink;
-                    if (farleft->rightlink != NULL)
+                    if (farleft->rightlink != nullptr)
                         farleft->rightlink->uplink = left;
                     break;
                 }
@@ -346,7 +297,7 @@ SPBLK* spdeq(SPBLK** np) /* pointer to a node pointer */
                 next->leftlink = farleft;
                 farleft->uplink = next;
                 left->leftlink = farleft->rightlink;
-                if (farleft->rightlink != NULL)
+                if (farleft->rightlink != nullptr)
                     farleft->rightlink->uplink = left;
                 farleft->rightlink = left;
                 left->uplink = farleft;
@@ -362,130 +313,6 @@ SPBLK* spdeq(SPBLK** np) /* pointer to a node pointer */
 
 /*----------------
  *
- *  spenqprior() -- insert into tree before other equal keys.
- *
- *  put n in q before all other nodes with the same key; after this is
- *  done, n will be the root of the splay tree representing q, all nodes in
- *  q with keys less than that of n will be in the left subtree, all with
- *  greater or equal keys will be in the right subtree; the tree is split
- *  into these subtrees from the top down, with rotations performed along
- *  the way to shorten the left branch of the right subtree and the right
- *  branch of the left subtree; the logic of spenqprior is exactly the
- *  same as that of spenq except for a substitution of comparison
- *  operators
- */
-template <typename SPBLK>
-SPBLK* spenqprior(SPBLK* n, SPTREE<SPBLK>* q) {
-    SPBLK* left;  /* the rightmost node in the left tree */
-    SPBLK* right; /* the leftmost node in the right tree */
-    SPBLK* next;  /* the root of unsplit part of tree */
-    SPBLK* temp;
-    int Sct; /* Strcmp value */
-    double key;
-
-    n->uplink = NULL;
-    next = q->root;
-    q->root = n;
-    if (next == NULL) /* trivial enq */
-    {
-        n->leftlink = NULL;
-        n->rightlink = NULL;
-    } else /* difficult enq */
-    {
-        key = n->key;
-        left = n;
-        right = n;
-
-        /* n's left and right children will hold the right and left
-       splayed trees resulting from splitting on n->key;
-       note that the children will be reversed! */
-
-        if (STRCMP(next->key, key) >= 0)
-            goto two;
-
-    one: /* assert next->key < key */
-
-        do /* walk to the right in the left tree */
-        {
-            temp = next->rightlink;
-            if (temp == NULL) {
-                left->rightlink = next;
-                next->uplink = left;
-                right->leftlink = NULL;
-                goto done; /* job done, entire tree split */
-            }
-            if (STRCMP(temp->key, key) >= 0) {
-                left->rightlink = next;
-                next->uplink = left;
-                left = next;
-                next = temp;
-                goto two; /* change sides */
-            }
-            next->rightlink = temp->leftlink;
-            if (temp->leftlink != NULL)
-                temp->leftlink->uplink = next;
-            left->rightlink = temp;
-            temp->uplink = left;
-            temp->leftlink = next;
-            next->uplink = temp;
-            left = temp;
-            next = temp->rightlink;
-            if (next == NULL) {
-                right->leftlink = NULL;
-                goto done; /* job done, entire tree split */
-            }
-
-        } while (STRCMP(next->key, key) < 0); /* change sides */
-
-    two: /* assert next->key >= key */
-
-        do /* walk to the left in the right tree */
-        {
-            temp = next->leftlink;
-            if (temp == NULL) {
-                right->leftlink = next;
-                next->uplink = right;
-                left->rightlink = NULL;
-                goto done; /* job done, entire tree split */
-            }
-            if (STRCMP(temp->key, key) < 0) {
-                right->leftlink = next;
-                next->uplink = right;
-                right = next;
-                next = temp;
-                goto one; /* change sides */
-            }
-            next->leftlink = temp->rightlink;
-            if (temp->rightlink != NULL)
-                temp->rightlink->uplink = next;
-            right->leftlink = temp;
-            temp->uplink = right;
-            temp->rightlink = next;
-            next->uplink = temp;
-            right = temp;
-            next = temp->leftlink;
-            if (next == NULL) {
-                left->rightlink = NULL;
-                goto done; /* job done, entire tree split */
-            }
-
-        } while (STRCMP(next->key, key) >= 0); /* change sides */
-
-        goto one;
-
-    done: /* split is done, branches of n need reversal */
-
-        temp = n->leftlink;
-        n->leftlink = n->rightlink;
-        n->rightlink = temp;
-    }
-
-    return (n);
-
-} /* spenqprior */
-
-/*----------------
- *
  *  splay() -- reorganize the tree.
  *
  *  the tree is reorganized so that n is the root of the
@@ -496,7 +323,7 @@ SPBLK* spenqprior(SPBLK* n, SPTREE<SPBLK>* q) {
  *  the right subtree and the right branch of the left subtree are
  *  shortened in the process
  *
- *  this code assumes that n is not NULL and is in q; it can sometimes
+ *  this code assumes that n is not nullptr and is in q; it can sometimes
  *  detect n not in q and complain
  */
 
@@ -515,26 +342,22 @@ void splay(SPBLK* n, SPTREE<SPBLK>* q) {
     prev = n;
     up = prev->uplink;
 
-    q->splays++;
-
-    while (up != NULL) {
-        q->splayloops++;
-
+    while (up != nullptr) {
         /* walk up the tree towards the root, splaying all to the left of
        n into the left subtree, all to right into the right subtree */
 
         upup = up->uplink;
         if (up->leftlink == prev) /* up is to the right of n */
         {
-            if (upup != NULL && upup->leftlink == up) /* rotate */
+            if (upup != nullptr && upup->leftlink == up) /* rotate */
             {
                 upupup = upup->uplink;
                 upup->leftlink = up->rightlink;
-                if (upup->leftlink != NULL)
+                if (upup->leftlink != nullptr)
                     upup->leftlink->uplink = upup;
                 up->rightlink = upup;
                 upup->uplink = up;
-                if (upupup == NULL)
+                if (upupup == nullptr)
                     q->root = up;
                 else if (upupup->leftlink == upup)
                     upupup->leftlink = up;
@@ -544,21 +367,21 @@ void splay(SPBLK* n, SPTREE<SPBLK>* q) {
                 upup = upupup;
             }
             up->leftlink = right;
-            if (right != NULL)
+            if (right != nullptr)
                 right->uplink = up;
             right = up;
 
         } else /* up is to the left of n */
         {
-            if (upup != NULL && upup->rightlink == up) /* rotate */
+            if (upup != nullptr && upup->rightlink == up) /* rotate */
             {
                 upupup = upup->uplink;
                 upup->rightlink = up->leftlink;
-                if (upup->rightlink != NULL)
+                if (upup->rightlink != nullptr)
                     upup->rightlink->uplink = upup;
                 up->leftlink = upup;
                 upup->uplink = up;
-                if (upupup == NULL)
+                if (upupup == nullptr)
                     q->root = up;
                 else if (upupup->rightlink == upup)
                     upupup->rightlink = up;
@@ -568,7 +391,7 @@ void splay(SPBLK* n, SPTREE<SPBLK>* q) {
                 upup = upupup;
             }
             up->rightlink = left;
-            if (left != NULL)
+            if (left != nullptr)
                 left->uplink = up;
             left = up;
         }
@@ -585,12 +408,12 @@ void splay(SPBLK* n, SPTREE<SPBLK>* q) {
 
     n->leftlink = left;
     n->rightlink = right;
-    if (left != NULL)
+    if (left != nullptr)
         left->uplink = n;
-    if (right != NULL)
+    if (right != nullptr)
         right->uplink = n;
     q->root = n;
-    n->uplink = NULL;
+    n->uplink = nullptr;
 
 } /* splay */
 
@@ -602,10 +425,6 @@ void splay(SPBLK* n, SPTREE<SPBLK>* q) {
 
   n = sphead( q )		n is the head item in q (not removed).
   spdelete( n, q )		n is removed from q.
-  n = spnext( np, q )		n is the successor of np in q.
-  n = spprev( np, q )		n is the predecessor of np in q.
-  spenqbefore( n, np, q )	n becomes the predecessor of np in q.
-  spenqafter( n, np, q )	n becomes the successor of np in q.
 
   In the above, n and np are pointers to single items (type
   SPBLK *); q is an event-set (type SPTREE *),
@@ -689,23 +508,17 @@ SPBLK* sphead(SPTREE<SPBLK>* q) {
 
     /* splay version, good amortized bound */
     x = spdeq(&q->root);
-    if (x != NULL) {
+    if (x != nullptr) {
         x->rightlink = q->root;
-        x->leftlink = NULL;
-        x->uplink = NULL;
-        if (q->root != NULL)
+        x->leftlink = nullptr;
+        x->uplink = nullptr;
+        if (q->root != nullptr)
             q->root->uplink = x;
     }
     q->root = x;
 
     /* alternative version, bad amortized bound,
        but faster on the average */
-
-#if 0
-    x = q->root;
-    while( x->leftlink != NULL )
-	x = x->leftlink;
-#endif
 
     return (x);
 
@@ -726,158 +539,24 @@ void spdelete(SPBLK* n, SPTREE<SPBLK>* q) {
 
     splay(n, q);
     x = spdeq(&q->root->rightlink);
-    if (x == NULL) /* empty right subtree */
+    if (x == nullptr) /* empty right subtree */
     {
         q->root = q->root->leftlink;
         if (q->root)
-            q->root->uplink = NULL;
+            q->root->uplink = nullptr;
     } else /* non-empty right subtree */
     {
-        x->uplink = NULL;
+        x->uplink = nullptr;
         x->leftlink = q->root->leftlink;
         x->rightlink = q->root->rightlink;
-        if (x->leftlink != NULL)
+        if (x->leftlink != nullptr)
             x->leftlink->uplink = x;
-        if (x->rightlink != NULL)
+        if (x->rightlink != nullptr)
             x->rightlink->uplink = x;
         q->root = x;
     }
 
 } /* spdelete */
-
-
-/*----------------
- *
- * spnext() -- return next higer item in the tree, or NULL.
- *
- *	return the successor of n in q, represented as a splay tree; the
- *	successor becomes the root; two alternate versions are provided,
- *	one which is shorter, but slower, and one which is faster on the
- *	average because it does not do any splaying
- *
- */
-template <typename SPBLK>
-SPBLK* spnext(SPBLK* n, SPTREE<SPBLK>* q) {
-    SPBLK* next;
-    SPBLK* x;
-
-    /* splay version */
-    splay(n, q);
-    x = spdeq(&n->rightlink);
-    if (x != NULL) {
-        x->leftlink = n;
-        n->uplink = x;
-        x->rightlink = n->rightlink;
-        n->rightlink = NULL;
-        if (x->rightlink != NULL)
-            x->rightlink->uplink = x;
-        q->root = x;
-        x->uplink = NULL;
-    }
-    next = x;
-
-    /* shorter slower version;
-       deleting last "if" undoes the amortized bound */
-
-#if 0
-    splay( n, q );
-    x = n->rightlink;
-    if( x != NULL )
-	while( x->leftlink != NULL )
-	    x = x->leftlink;
-    next = x;
-    if( x != NULL )
-	splay( x, q );
-#endif
-
-    return (next);
-
-} /* spnext */
-
-
-/*----------------
- *
- * spprev() -- return previous node in a tree, or NULL.
- *
- *	return the predecessor of n in q, represented as a splay tree;
- *	the predecessor becomes the root; an alternate version is
- *	provided which is faster on the average because it does not do
- *	any splaying
- *
- */
-template <typename SPBLK>
-SPBLK* spprev(SPBLK* n, SPTREE<SPBLK>* q) {
-    SPBLK* prev;
-    SPBLK* x;
-
-    /* splay version;
-       note: deleting the last "if" undoes the amortized bound */
-
-    splay(n, q);
-    x = n->leftlink;
-    if (x != NULL)
-        while (x->rightlink != NULL)
-            x = x->rightlink;
-    prev = x;
-    if (x != NULL)
-        splay(x, q);
-
-    return (prev);
-
-} /* spprev */
-
-
-/*----------------
- *
- * spenqbefore() -- insert node before another in a tree.
- *
- *	returns pointer to n.
- *
- *	event n is entered in the splay tree q as the immediate
- *	predecessor of n1; in doing so, n1 becomes the root of the tree
- *	with n as its left son
- *
- */
-template <typename SPBLK>
-SPBLK* spenqbefore(SPBLK* n, SPBLK* n1, SPTREE<SPBLK>* q) {
-    splay(n1, q);
-    n->key = n1->key;
-    n->leftlink = n1->leftlink;
-    if (n->leftlink != NULL)
-        n->leftlink->uplink = n;
-    n->rightlink = NULL;
-    n->uplink = n1;
-    n1->leftlink = n;
-
-    return (n);
-
-} /* spenqbefore */
-
-
-/*----------------
- *
- * spenqafter() -- enter n after n1 in tree q.
- *
- *	returns a pointer to n.
- *
- *	event n is entered in the splay tree q as the immediate
- *	successor of n1; in doing so, n1 becomes the root of the tree
- *	with n as its right son
- */
-template <typename SPBLK>
-SPBLK* spenqafter(SPBLK* n, SPBLK* n1, SPTREE<SPBLK>* q) {
-    splay(n1, q);
-    n->key = n1->key;
-    n->rightlink = n1->rightlink;
-    if (n->rightlink != NULL)
-        n->rightlink->uplink = n;
-    n->leftlink = NULL;
-    n->uplink = n1;
-    n1->rightlink = n;
-
-    return (n);
-
-} /* spenqafter */
 
 
 /* Original file: spdaveb.cpp
@@ -889,14 +568,9 @@ SPBLK* spenqafter(SPBLK* n, SPBLK* n1, SPTREE<SPBLK>* q) {
  * replacement of one by the other.  Hey, it worked for me!
  *
  * splookup() -- given a key, find a node in a tree.
- * spinstall() -- install an item in the tree, overwriting existing value.
  * spfhead() -- fast (non-splay) find the first node in a tree.
- * spftail() -- fast (non-splay) find the last node in a tree.
  * spscan() -- forward scan tree from the head.
- * sprscan() -- reverse scan tree from the tail.
  * spfnext() -- non-splaying next.
- * spfprev() -- non-splaying prev.
- * spstats() -- make char string of stats for a tree.
  *
  * Written by David Brower, daveb@rtech.uucp 1/88.
  */
@@ -912,64 +586,20 @@ template <typename SPBLK>
 SPBLK* splookup(double key, SPTREE<SPBLK>* q) {
     SPBLK* n;
     int Sct;
-    int c;
 
     /* find node in the tree */
     n = q->root;
-    c = ++(q->lkpcmps);
-    q->lookups++;
     //    while( n && (Sct = STRCMP( key, n->key ) ) )
     while (n && (Sct = key != n->key)) {
-        c++;
         n = (Sct < 0) ? n->leftlink : n->rightlink;
     }
-    q->lkpcmps = c;
 
     /* reorganize tree around this node */
-    if (n != NULL)
+    if (n != nullptr)
         splay(n, q);
 
     return (n);
 }
-
-
-#if 0
-
-/*----------------
- *
- * spinstall() -- install an entry in a tree, overwriting any existing node.
- *
- *	If the node already exists, replace its contents.
- *	If it does not exist, then allocate a new node and fill it in.
- */
-
-SPBLK *
-spinstall( key, data, datb, q )
-
-char * key;
-char * data;
-char * datb;
-SPTREE *q;
-
-{
-    SPBLK *n;
-
-    if( NULL == ( n = splookup( key, q ) ) )
-    {
-	n = (SPBLK *) emalloc( sizeof( *n ) );
-	n->key = key;
-	n->leftlink = NULL;
-	n->rightlink = NULL;
-	n->uplink = NULL;
-	spenq( n, q );
-    }
-
-    n->data = data;
-    n->datb = datb;
-
-    return( n );
-}
-#endif
 
 
 /*----------------
@@ -984,8 +614,8 @@ template <typename SPBLK>
 SPBLK* spfhead(SPTREE<SPBLK>* q) {
     SPBLK* x;
 
-    if (NULL != (x = q->root))
-        while (x->leftlink != NULL)
+    if (nullptr != (x = q->root))
+        while (x->leftlink != nullptr)
             x = x->leftlink;
 
     return (x);
@@ -995,61 +625,22 @@ SPBLK* spfhead(SPTREE<SPBLK>* q) {
 
 /*----------------
  *
- * spftail() -- find the last node in a tree.
- *
- *	Fast version does not splay result or intermediate steps.
- */
-template <typename SPBLK>
-SPBLK* spftail(SPTREE<SPBLK>* q) {
-    SPBLK* x;
-
-
-    if (NULL != (x = q->root))
-        while (x->rightlink != NULL)
-            x = x->rightlink;
-
-    return (x);
-
-} /* spftail */
-
-
-/*----------------
- *
  * spscan() -- apply a function to nodes in ascending order.
  *
  *	if n is given, start at that node, otherwise start from
  *	the head.
  */
-class TQItem;
-
 template <typename SPBLK>
 void spscan(void (*f)(const SPBLK*, int), SPBLK* n, SPTREE<SPBLK>* q) {
     SPBLK* x;
 
-    for (x = n != NULL ? n : spfhead<SPBLK>(q); x != NULL; x = spfnext(x))
+    for (x = n != nullptr ? n : spfhead<SPBLK>(q); x != nullptr; x = spfnext(x))
         (*f)(x, 0);
 }
 
-
 /*----------------
  *
- * sprscan() -- apply a function to nodes in descending order.
- *
- *	if n is given, start at that node, otherwise start from
- *	the tail.
- */
-template <typename SPBLK>
-void sprscan(void (*f)(const TQItem*, int), SPBLK* n, SPTREE<SPBLK>* q) {
-    SPBLK* x;
-
-    for (x = n != NULL ? n : spftail<SPBLK>(q); x != NULL; x = spfprev(x))
-        (*f)(x, 0);
-}
-
-
-/*----------------
- *
- * spfnext() -- fast return next higer item in the tree, or NULL.
+ * spfnext() -- fast return next higer item in the tree, or nullptr.
  *
  *	return the successor of n in q, represented as a splay tree.
  *	This is a fast (on average) version that does not splay.
@@ -1063,22 +654,22 @@ SPBLK* spfnext(SPBLK* n) {
      * poor amortized bound
      */
 
-    if (n == NULL)
+    if (n == nullptr)
         return (n);
 
     x = n->rightlink;
-    if (x != NULL) {
-        while (x->leftlink != NULL)
+    if (x != nullptr) {
+        while (x->leftlink != nullptr)
             x = x->leftlink;
         next = x;
-    } else /* x == NULL */
+    } else /* x == nullptr */
     {
         x = n->uplink;
-        next = NULL;
-        while (x != NULL) {
+        next = nullptr;
+        while (x != nullptr) {
             if (x->leftlink == n) {
                 next = x;
-                x = NULL;
+                x = nullptr;
             } else {
                 n = x;
                 x = n->uplink;
@@ -1089,76 +680,3 @@ SPBLK* spfnext(SPBLK* n) {
     return (next);
 
 } /* spfnext */
-
-
-/*----------------
- *
- * spfprev() -- return fast previous node in a tree, or NULL.
- *
- *	return the predecessor of n in q, represented as a splay tree.
- *	This is a fast (on average) version that does not splay.
- */
-template <typename SPBLK>
-SPBLK* spfprev(SPBLK* n) {
-    SPBLK* prev;
-    SPBLK* x;
-
-    /* a long version,
-     * avoids splaying for fast average, poor amortized bound
-     */
-
-    if (n == NULL)
-        return (n);
-
-    x = n->leftlink;
-    if (x != NULL) {
-        while (x->rightlink != NULL)
-            x = x->rightlink;
-        prev = x;
-    } else {
-        x = n->uplink;
-        prev = NULL;
-        while (x != NULL) {
-            if (x->rightlink == n) {
-                prev = x;
-                x = NULL;
-            } else {
-                n = x;
-                x = n->uplink;
-            }
-        }
-    }
-
-    return (prev);
-
-} /* spfprev */
-
-
-template <typename SPBLK>
-const char* spstats(SPTREE<SPBLK>* q) {
-    static char buf[128];
-    float llen;
-    float elen;
-    float sloops;
-
-    if (q == NULL)
-        return ("");
-
-    llen = q->lookups ? (float) q->lkpcmps / q->lookups : 0;
-    elen = q->enqs ? (float) q->enqcmps / q->enqs : 0;
-    sloops = q->splays ? (float) q->splayloops / q->splays : 0;
-
-    Sprintf(buf,
-            "f(%d %4.2f) i(%d %4.2f) s(%d %4.2f)",
-            q->lookups,
-            llen,
-            q->enqs,
-            elen,
-            q->splays,
-            sloops);
-
-    return (const char*) buf;
-}
-
-
-#endif

--- a/src/nrncvode/tqueue.cpp
+++ b/src/nrncvode/tqueue.cpp
@@ -334,7 +334,7 @@ void TQueue::remove(TQItem* q) {
     STAT(nrem);
     if (q) {
         if (q == least_) {
-            if (sptree_->root) {
+            if (spempty(sptree_) != 0) {
                 least_ = spdeq(&sptree_->root);
             } else {
                 least_ = nullptr;
@@ -355,7 +355,7 @@ TQItem* TQueue::atomic_dq(double tt) {
     if (least_ && least_->t_ <= tt) {
         q = least_;
         STAT(nrem);
-        if (sptree_->root) {
+        if (spempty(sptree_) != 0) {
             least_ = spdeq(&sptree_->root);
         } else {
             least_ = nullptr;

--- a/src/nrncvode/tqueue.cpp
+++ b/src/nrncvode/tqueue.cpp
@@ -334,7 +334,7 @@ void TQueue::remove(TQItem* q) {
     STAT(nrem);
     if (q) {
         if (q == least_) {
-            if (spempty(sptree_) != 0) {
+            if (!spempty(sptree_)) {
                 least_ = spdeq(&sptree_->root);
             } else {
                 least_ = nullptr;
@@ -355,7 +355,7 @@ TQItem* TQueue::atomic_dq(double tt) {
     if (least_ && least_->t_ <= tt) {
         q = least_;
         STAT(nrem);
-        if (spempty(sptree_) != 0) {
+        if (!spempty(sptree_)) {
             least_ = spdeq(&sptree_->root);
         } else {
             least_ = nullptr;


### PR DESCRIPTION
Before cleaning `sptree` class remove code that is unused.

`SPTree` is only a library class to do [Splay Tree](https://en.wikipedia.org/wiki/Splay_tree).