### PR TITLE
Bug fix: avoid coreneuron file mode to not use in-memory model copy

### DIFF
--- a/src/coreneuron/io/nrn_setup.cpp
+++ b/src/coreneuron/io/nrn_setup.cpp
@@ -44,6 +44,7 @@
 
 /// --> Coreneuron
 bool corenrn_embedded;
+bool corenrn_file_mode;
 int corenrn_embedded_nthread;
 
 void (*nrn2core_group_ids_)(int*);
@@ -170,7 +171,7 @@ std::vector<std::vector<int>> nrnthreads_netcon_negsrcgid_tid;
 /* read files.dat file and distribute cellgroups to all mpi ranks */
 void nrn_read_filesdat(int& ngrp, int*& grp, const char* filesdat) {
     patstimtype = nrn_get_mechtype("PatternStim");
-    if (corenrn_embedded) {
+    if (corenrn_embedded && !corenrn_file_mode) {
         ngrp = corenrn_embedded_nthread;
         grp = new int[ngrp + 1];
         (*nrn2core_group_ids_)(grp);
@@ -473,8 +474,8 @@ void nrn_setup(const char* filesdat,
     // of phase2.  So gap junction setup is deferred to after phase2.
 
     nrnthreads_netcon_negsrcgid_tid.resize(nrn_nthread);
-    if (!corenrn_embedded) {
-        coreneuron::phase_wrapper<coreneuron::phase::one>(userParams);
+    if (corenrn_file_mode) {
+        coreneuron::phase_wrapper<coreneuron::phase::one>(userParams, !corenrn_file_mode);
     } else {
         nrn_multithread_job([](NrnThread* n) {
             Phase1 p1{n->id};
@@ -490,7 +491,7 @@ void nrn_setup(const char* filesdat,
     // read the rest of the gidgroup's data and complete the setup for each
     // thread.
     /* nrn_multithread_job supports serial, pthread, and openmp. */
-    coreneuron::phase_wrapper<coreneuron::phase::two>(userParams, corenrn_embedded);
+    coreneuron::phase_wrapper<coreneuron::phase::two>(userParams, !corenrn_file_mode);
 
     // gap junctions
     // Gaps are done after phase2, in order to use layout and permutation
@@ -917,7 +918,7 @@ void read_phase1(NrnThread& nt, UserParams& userParams) {
 
 void read_phase2(NrnThread& nt, UserParams& userParams) {
     Phase2 p2;
-    if (corenrn_embedded) {
+    if (corenrn_embedded && !corenrn_file_mode) {
         p2.read_direct(nt.id, nt);
     } else {
         p2.read_file(userParams.file_reader[nt.id], nt);

--- a/src/coreneuron/mechanism/mech/enginemech.cpp
+++ b/src/coreneuron/mechanism/mech/enginemech.cpp
@@ -45,6 +45,7 @@ extern "C" {
 
 /// global variables from coreneuron library
 extern bool corenrn_embedded;
+extern bool corenrn_file_mode;
 extern int corenrn_embedded_nthread;
 
 /// parse arguments from neuron and prepare new one for coreneuron
@@ -107,7 +108,8 @@ int corenrn_embedded_run(int nthread,
                          int use_mpi,
                          int use_fast_imem,
                          const char* mpi_lib,
-                         const char* nrn_arg) {
+                         const char* nrn_arg,
+                         int file_mode) {
     bool corenrn_skip_write_model_to_disk = false;
     const std::string corenrn_skip_write_model_to_disk_arg{"--skip-write-model-to-disk"};
     // If "only_simulate_str" exists in "nrn_arg" then avoid transferring any data between NEURON
@@ -123,6 +125,7 @@ int corenrn_embedded_run(int nthread,
     }
     // set coreneuron's internal variable based on neuron arguments
     corenrn_embedded = !corenrn_skip_write_model_to_disk;
+    corenrn_file_mode = file_mode;
     corenrn_embedded_nthread = nthread;
     coreneuron::nrn_have_gaps = have_gaps != 0;
     coreneuron::nrn_use_fast_imem = use_fast_imem != 0;
@@ -180,6 +183,8 @@ int solve_core(int argc, char** argv) {
         args.append(argv[i]);
         args.append(" ");
     }
+
+    corenrn_file_mode = true;
 
     // add mpi library argument
     add_mpi_library_arg("", args);

--- a/src/nrniv/nrncore_write.cpp
+++ b/src/nrniv/nrncore_write.cpp
@@ -270,6 +270,25 @@ static void part2(const char* path) {
 
 
 #if defined(HAVE_DLFCN_H)
+
+/** Return neuron.coreneuron.enable */
+int nrncore_is_enabled() {
+    if (nrnpy_nrncore_enable_value_p_) {
+        int result = (*nrnpy_nrncore_enable_value_p_)();
+        return result;
+    }
+    return 0;
+}
+
+/** Return value of neuron.coreneuron.file_mode flag */
+int nrncore_is_file_mode() {
+    if (nrnpy_nrncore_file_mode_value_p_) {
+        int result = (*nrnpy_nrncore_file_mode_value_p_)();
+        return result;
+    }
+    return 0;
+}
+
 /** Launch CoreNEURON in direct memory mode */
 int nrncore_run(const char* arg) {
     // using direct memory mode
@@ -305,7 +324,7 @@ int nrncore_run(const char* arg) {
     map_coreneuron_callbacks(handle);
 
     // lookup symbol from coreneuron for launching
-    using launcher_t = int (*)(int, int, int, int, const char*, const char*);
+    using launcher_t = int (*)(int, int, int, int, const char*, const char*, int);
     auto* const coreneuron_launcher = reinterpret_cast<launcher_t>(
         dlsym(handle, "corenrn_embedded_run"));
     if (!coreneuron_launcher) {
@@ -334,7 +353,7 @@ int nrncore_run(const char* arg) {
 
     // launch coreneuron
     int result = coreneuron_launcher(
-        nrn_nthread, have_gap, nrnmpi_use, nrn_use_fast_imem, corenrn_mpi_library.c_str(), arg);
+        nrn_nthread, have_gap, nrnmpi_use, nrn_use_fast_imem, corenrn_mpi_library.c_str(), arg, nrncore_is_file_mode());
 
     // close handle and return result
     dlclose(handle);
@@ -351,24 +370,6 @@ int nrncore_run(const char* arg) {
     CellGroup::clean_deferred_netcons();
 
     return result;
-}
-
-/** Return neuron.coreneuron.enable */
-int nrncore_is_enabled() {
-    if (nrnpy_nrncore_enable_value_p_) {
-        int b = (*nrnpy_nrncore_enable_value_p_)();
-        return b;
-    }
-    return 0;
-}
-
-/** Return value of neuron.coreneuron.file_mode flag */
-int nrncore_is_file_mode() {
-    if (nrnpy_nrncore_file_mode_value_p_) {
-        int result = (*nrnpy_nrncore_file_mode_value_p_)();
-        return result;
-    }
-    return 0;
 }
 
 /** Find folder set for --datpath CLI option in CoreNEURON to dump the CoreNEURON data

--- a/src/nrniv/nrncore_write.cpp
+++ b/src/nrniv/nrncore_write.cpp
@@ -352,8 +352,13 @@ int nrncore_run(const char* arg) {
 #endif
 
     // launch coreneuron
-    int result = coreneuron_launcher(
-        nrn_nthread, have_gap, nrnmpi_use, nrn_use_fast_imem, corenrn_mpi_library.c_str(), arg, nrncore_is_file_mode());
+    int result = coreneuron_launcher(nrn_nthread,
+                                     have_gap,
+                                     nrnmpi_use,
+                                     nrn_use_fast_imem,
+                                     corenrn_mpi_library.c_str(),
+                                     arg,
+                                     nrncore_is_file_mode());
 
     // close handle and return result
     dlclose(handle);


### PR DESCRIPTION
- @WeinaJi pointed out that when filemode is set to True, coreneuron was still using "in memory mode" from neuron side.
- This is because "file mode" also part of coreneuron "embeded mode" and we didn't distinguish file mode vs in memory mode in embeded node.
- As part of this PR, we simply pass file mode flag to coreneuron so that we can decide if we should read model from file or memory.