### PR TITLE
Create a pointer from `Prop` to `Node`.

### DIFF
--- a/src/nrnoc/membfunc.cpp
+++ b/src/nrnoc/membfunc.cpp
@@ -20,6 +20,11 @@ void Memb_func::invoke_initialize(neuron::model_sorted_token const& sorted_token
 long& _nrn_mechanism_access_alloc_seq(Prop* prop) {
     return prop->_alloc_seq;
 }
+
+Node* _nrn_mechanism_access_node(Prop* prop) {
+    return prop->node;
+}
+
 double& _nrn_mechanism_access_a(Node* node) {
     return node->a();
 }

--- a/src/nrnoc/membfunc.h
+++ b/src/nrnoc/membfunc.h
@@ -296,6 +296,7 @@ namespace _get {
 // See https://github.com/neuronsimulator/nrn/issues/2234 for context of how this might be done
 // better in future...
 [[nodiscard]] long& _nrn_mechanism_access_alloc_seq(Prop*);
+[[nodiscard]] Node* _nrn_mechanism_access_node(Prop* prop);
 [[nodiscard]] double& _nrn_mechanism_access_a(Node*);
 [[nodiscard]] double& _nrn_mechanism_access_b(Node*);
 [[nodiscard]] double& _nrn_mechanism_access_d(Node*);

--- a/src/nrnoc/section.h
+++ b/src/nrnoc/section.h
@@ -226,17 +226,20 @@ struct Node {
 #include "hocdec.h" /* Prop needs Datum and Datum needs Symbol */
 #endif
 
+
 #define PROP_PY_INDEX 10
 struct Prop {
     // Working assumption is that we can safely equate "Prop" with "instance
     // of a mechanism" apart from a few special cases like CABLESECTION
-    Prop(short type)
-        : _type{type} {
+    Prop(Node* node, short type)
+        : node(node)
+        , _type{type} {
         if (type != CABLESECTION) {
             m_mech_handle = neuron::container::Mechanism::owning_handle{
                 neuron::model().mechanism_data(type)};
         }
     }
+    Node* node;      /* The node this property belongs to. */
     Prop* next;      /* linked list of properties */
     short _type;     /* type of membrane, e.g. passive, HH, etc. */
     int dparam_size; /* for notifying hoc_free_val_array */

--- a/src/nrnoc/treeset.cpp
+++ b/src/nrnoc/treeset.cpp
@@ -674,7 +674,7 @@ Prop* prop_alloc(Prop** pp, int type, Node* nd) {
     nrn_alloc_node_ = nd;  // this might be null
     v_structure_change = 1;
     current_prop_list = pp;
-    auto* p = new Prop{static_cast<short>(type)};
+    auto* p = new Prop{nd, static_cast<short>(type)};
     p->next = *pp;
     p->ob = nullptr;
     p->_alloc_seq = -1;


### PR DESCRIPTION
When generating code to call processes from HOC or Python one difficulty can be obtaining the voltage. The voltage is associated with the Node. In the generated code we only have access to the Prop.

We don't have access to the voltage via `Memb_list::nodeindices`. When generating code for NRN with NMODL, we don't populate what CoreNEURON calls `v_unused`.