### PR TITLE
Allow dev versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ try:
 
     # if version is not a valid PEP440 version, then create a bogus version
     # that will be used only for development purposes which appends the commit hash
-    if not re.match(r"^\d+(\.\d+)*$", __version__):
+    if not re.match(r"^\d+(\.\d+)*(.?dev[0-9]*)?$", __version__):
         __version__ = "0.0.dev0+g" + (
             subprocess.run(
                 ["git", "rev-parse", "--short", "HEAD"], stdout=subprocess.PIPE

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ try:
 
     # if version is not a valid PEP440 version, then create a bogus version
     # that will be used only for development purposes which appends the commit hash
-    if not re.match(r"^\d+(\.\d+)*(.?dev[0-9]*)?$", __version__):
+    if not re.match(r"^\d+(\.\d+)*(\.dev)?$", __version__):
         __version__ = "0.0.dev0+g" + (
             subprocess.run(
                 ["git", "rev-parse", "--short", "HEAD"], stdout=subprocess.PIPE


### PR DESCRIPTION
The release workflow seems to work with it: https://github.com/neuronsimulator/nrn/actions/runs/8338658007
We might want to create `.devX` versions to ensure the azure pipeline builds the expected wheel: https://dev.azure.com/neuronsimulator/nrn/_build/results?buildId=11324&view=results (to be determined)