### PR TITLE
Mark regular expression as raw string to avoid SyntaxWarning

### DIFF
--- a/share/lib/python/neuron/rxd/species.py
+++ b/share/lib/python/neuron/rxd/species.py
@@ -204,7 +204,7 @@ def _1d_submatrix_n():
 
 
 _ontology_id = re.compile(
-    "^\[[a-zA-Z][a-zA-Z0-9_]*:[a-zA-Z0-9_]*\]|[a-zA-Z][a-zA-Z0-9_]*:[a-zA-Z0-9_]*$"
+    r"^\[[a-zA-Z][a-zA-Z0-9_]*:[a-zA-Z0-9_]*\]|[a-zA-Z][a-zA-Z0-9_]*:[a-zA-Z0-9_]*$"
 )
 
 


### PR DESCRIPTION
Python 3.12 starts to throw syntax warnings now for regex's that are not marked as raw string. Will become a syntax error in the future:
https://docs.python.org/3/whatsnew/3.12.html#other-language-changes