### PR TITLE
Increase memory available for Gitlab CI jobs on BB5

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -167,7 +167,7 @@ simulation_stack:
   variables:
     bb5_ntasks: 2   # so we block 16 cores
     bb5_cpus_per_task: 8 # ninja -j {this}
-    bb5_memory: 76G # ~16*384/80
+    bb5_memory: 120G # ~1.5*16*384/80 (~1.5x more as we have seen OOMs)
 
 .spack_intel:
   variables:
@@ -192,7 +192,7 @@ simulation_stack:
   extends: [.ctest]
   variables:
     bb5_ntasks: 16
-    bb5_memory: 76G # ~16*384/80
+    bb5_memory: 120G # ~1.5*16*384/80 (~1.5x more as we have seen OOMs)
 
 # Build NMODL once with GCC
 build:nmodl:


### PR DESCRIPTION
(copying info from [internal slack discussion](https://bluebrainproject.slack.com/archives/C023T9MRC3B/p1711107158091519?thread_ts=1711050067.602789&cid=C023T9MRC3B))

Looking at CI this failure [like this](https://gist.githubusercontent.com/bbpbuildbot/469341c90842aca76de235c932dda9d4/raw/088a04983eae241b18f25ea805d949267bef40f5/test-neuron-nmodl-nvhpc-omp.txt), the job info was following:

```console
Submitted batch job 2093159
job state: R
sbatch: sbatch -p prod -A proj9998 --ntasks=16 --cpus-per-task=2 --mem=76G --exclusive=user   --job-name=GL_J1216846_PROD_P2160_CP5_C5 -C volta --no-requeue -D /gpfs/bbp.cscs.ch/ssd/gitlab_map_jobs//bbpcihpcproj12/P201727 --time=1:00:00 --wrap="sleep infinity"
Running on r2i3n4 via bbpv1.epfl.ch...
```
 
And cross-checking slurm job info, it states OOM as well:

```console
$ sacct -j 2093159 --format="JobID,JobName,Account,Partition,AllocCPUS,AllocNodes,Submit,Start,End,State"
JobID           JobName    Account  Partition  AllocCPUS AllocNodes              Submit               Start                 End      State
------------ ---------- ---------- ---------- ---------- ---------- ------------------- ------------------- ------------------- ----------
2093159      GL_J12168+   proj9998       prod         32          1        Ystday 21:13        Ystday 21:13        Ystday 21:24 CANCELLED+
2093159.bat+      batch   proj9998                    32          1        Ystday 21:13        Ystday 21:13        Ystday 21:24 OUT_OF_ME+
2093159.ext+     extern   proj9998                    32          1        Ystday 21:13        Ystday 21:13        Ystday 21:24 OUT_OF_ME+
2093159.0       once.sh   proj9998                    32          1        Ystday 21:13        Ystday 21:13        Ystday 21:13  COMPLETED
```

Looking at ~9 PM on Grafana [here](https://monitoring.bbp.epfl.ch/metrics/d/ZJpAQEzYsA/bb5-system-monitoring?orgId=1&var-job=bb5_compute&var-node=r2i3n4.bbp.epfl.ch:9100&var-diskdevices=%5Ba-z%5D%2B%7Cnvme%5B0-9%5D%2Bn%5B0-9%5D%2B%7Cmmcblk%5B0-9%5D%2B&from=1711051313514&to=1711054749878), we do see memory usage > 76GB:

![image](https://github.com/neuronsimulator/nrn/assets/666852/3b40c05d-32c2-48b6-8ed4-6856b5260afd)

I wonder if ctest is launching too many tests in parallel and could end up in situations like this. 

As part of this PR, we can bump memory allocated by ~1.5x. Given the resources available (e.g. ~384GB on the node and no resource contention these days), I would say it's not a problem to bump the memory. If we discover other cause, we can revert this again.
