### PR TITLE
Set MPI barrier at the end of coreneuron model writing to avoid race condition

### DIFF
--- a/src/nrniv/nrncore_write.cpp
+++ b/src/nrniv/nrncore_write.cpp
@@ -415,6 +415,7 @@ int nrncore_psolve(double tstop, int file_mode) {
                     CORENRN_DATA_DIR = find_datpath_in_arguments(args);
                 }
                 write_corenrn_model(CORENRN_DATA_DIR);
+                nrnmpi_barrier();
             }
             nrncore_run(args);
             // data return nt._t so copy to t

--- a/src/nrniv/nrncore_write.cpp
+++ b/src/nrniv/nrncore_write.cpp
@@ -415,7 +415,11 @@ int nrncore_psolve(double tstop, int file_mode) {
                     CORENRN_DATA_DIR = find_datpath_in_arguments(args);
                 }
                 write_corenrn_model(CORENRN_DATA_DIR);
-                nrnmpi_barrier();
+#if NRNMPI
+                if (nrnmpi_numprocs > 1) {
+                    nrnmpi_barrier();
+                }
+#endif
             }
             nrncore_run(args);
             // data return nt._t so copy to t

--- a/test/coreneuron/test_spikes.py
+++ b/test/coreneuron/test_spikes.py
@@ -118,7 +118,7 @@ def test_spikes(
     # CORENEURON run
     from neuron import coreneuron
 
-    with coreneuron(enable=True, gpu=enable_gpu, file_mode=file_mode):
+    with coreneuron(enable=True, gpu=enable_gpu, file_mode=file_mode, verbose=0):
         run_modes = [0] if file_mode else [0, 1, 2]
         for mode in run_modes:
             run(mode)

--- a/test/coreneuron/test_spikes.py
+++ b/test/coreneuron/test_spikes.py
@@ -125,6 +125,7 @@ def test_spikes(
             run(mode)
         # Make sure that file mode also works with custom coreneuron.data_path
         if file_mode:
+            coreneuron.file_mode = True
             temp_coreneuron_data_folder = tempfile.TemporaryDirectory(
                 "coreneuron_input"
             )  # auto removed

--- a/test/coreneuron/test_spikes.py
+++ b/test/coreneuron/test_spikes.py
@@ -1,6 +1,5 @@
 from neuron.tests.utils.strtobool import strtobool
 import os
-import tempfile
 
 # Hacky, but it's non-trivial to pass commandline arguments to pytest tests.
 enable_gpu = bool(strtobool(os.environ.get("CORENRN_ENABLE_GPU", "false")))
@@ -119,18 +118,16 @@ def test_spikes(
     # CORENEURON run
     from neuron import coreneuron
 
-    with coreneuron(enable=True, gpu=enable_gpu, file_mode=file_mode, verbose=0):
+    with coreneuron(enable=True, gpu=enable_gpu, file_mode=file_mode):
         run_modes = [0] if file_mode else [0, 1, 2]
         for mode in run_modes:
             run(mode)
-        # Make sure that file mode also works with custom coreneuron.data_path
+        # Make sure that file mode also works with custom coreneuron.model_path
         if file_mode:
-            coreneuron.file_mode = True
-            temp_coreneuron_data_folder = tempfile.TemporaryDirectory(
-                "coreneuron_input"
-            )  # auto removed
-            coreneuron.data_path = temp_coreneuron_data_folder.name
+            coreneuron.model_path = "coreneuron_input"
             run(0)
+            # revert setting for the following coreneuron runs
+            coreneuron._model_path = None
 
     return h
 


### PR DESCRIPTION
This PR fixes the random failure in the unit test `spikes_mpi_file_mode_py_cpu`.  It happened that during the mpi enabled coreneuron run that when rank 0 was writing `files.dat` other ranks started to read it. Therefore, we call `nrnmpi_barrier()` after `write_corenrn_model(...)`.