### PR TITLE
Refactor `DatumIndices`.

### DIFF
--- a/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
+++ b/src/nrniv/nrncore_write/callbacks/nrncore_callbacks.cpp
@@ -632,16 +632,15 @@ int* datum2int(int type,
         int ioff = i * sz;
         for (int j = 0; j < sz; ++j) {
             int jj = ioff + j;
-            int etype = di.ion_type[jj];
-            int eindex = di.ion_index[jj];
+            int etype = di.datum_type[jj];
+            int eindex = di.datum_index[jj];
             const int seman = semantics[j];
             // Would probably be more clear if use seman for as many as
             // possible of the cases
             // below and within each case deal with etype appropriately.
-            // ion_type and ion_index have become misnomers as they no longer
-            // refer to ions specificially but the mechanism type where the
+            // datum_type and datum_index refer to mechanism type where the
             // range variable lives (and otherwise is generally the same as
-            // seman). And ion_index refers to the index of the range variable
+            // seman). And datum_index refers to the index of the range variable
             // within the mechanism (or voltage, area, etc.)
             if (seman == -5) {  // POINTER to range variable (e.g. voltage)
                 pdata[jj] = eindex;

--- a/src/nrniv/nrncore_write/data/cell_group.cpp
+++ b/src/nrniv/nrncore_write/data/cell_group.cpp
@@ -227,8 +227,8 @@ void CellGroup::datumtransform(CellGroup* cgs) {
                 DatumIndices& di = cg.datumindices[i++];
                 di.type = type;
                 int n = ml->nodecount * sz;
-                di.ion_type = new int[n];
-                di.ion_index = new int[n];
+                di.datum_type = new int[n];
+                di.datum_index = new int[n];
                 // fill the indices.
                 // had tointroduce a memb_func[i].dparam_semantics registered by each mod file.
                 datumindex_fill(ith, cg, di, ml);
@@ -361,8 +361,8 @@ void CellGroup::datumindex_fill(int ith, CellGroup& cg, DatumIndices& di, Memb_l
                 Sprintf(errmes, "Unknown semantics type %d for dparam item %d of", dmap[j], j);
                 hoc_execerror(errmes, memb_func[di.type].sym->name);
             }
-            di.ion_type[offset + j] = etype;
-            di.ion_index[offset + j] = eindex;
+            di.datum_type[offset + j] = etype;
+            di.datum_index[offset + j] = eindex;
         }
     }
 }

--- a/src/nrniv/nrncore_write/data/datum_indices.cpp
+++ b/src/nrniv/nrncore_write/data/datum_indices.cpp
@@ -1,13 +1,6 @@
 #include "datum_indices.h"
 
-DatumIndices::DatumIndices() {
-    type = -1;
-    ion_type = ion_index = 0;
-}
-
 DatumIndices::~DatumIndices() {
-    if (ion_type)
-        delete[] ion_type;
-    if (ion_index)
-        delete[] ion_index;
+    delete[] datum_type;
+    delete[] datum_index;
 }

--- a/src/nrniv/nrncore_write/data/datum_indices.h
+++ b/src/nrniv/nrncore_write/data/datum_indices.h
@@ -6,10 +6,16 @@
 // NrnThread.NrnThreadMembList.Memb_List.data and pdata etc.
 class DatumIndices {
   public:
-    DatumIndices();
+    DatumIndices() = default;
     virtual ~DatumIndices();
-    int type;
+
+    // These are the datum of mechanism `type`.
+    int type = -1;
+
+    // `datum_index[i]` is the index of datum `i` inside the mechanism
+    // `datum_type[i]`.
+    //
     // ordering as though pdata[i][j] was pdata[0][i*sz+j]
-    int* ion_type;   // negative codes semantics, positive codes mechanism type
-    int* ion_index;  // index of range variable relative to beginning of that type
+    int* datum_type = nullptr;   // negative codes semantics, positive codes mechanism type
+    int* datum_index = nullptr;  // index of range variable relative to beginning of that type
 };


### PR DESCRIPTION
The names of the members `ion_{type,index}` were confusing and have been renamed.