### PR TITLE
Pin version of `delocate` Python package

### DIFF
--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -135,7 +135,7 @@ build_wheel_osx() {
     (( $skip )) && return 0
 
     echo " - Installing build requirements"
-    pip install -U delocate -r packaging/python/build_requirements.txt
+    pip install -U 'delocate<0.11' -r packaging/python/build_requirements.txt
     pip_numpy_install
 
     echo " - Building..."


### PR DESCRIPTION
When building a wheel on MacOS with Python 3.8, we get the following error (see for instance [here](https://dev.azure.com/neuronsimulator/nrn/_build/results?buildId=11389&view=logs&j=713a6984-22e2-5234-5410-899d552a9beb&t=d71782e7-1d7c-56f6-aecf-2e4b860255c3&l=7674)):

```plaintext
delocate.libsana.DelocationError: Library dependencies do not satisfy target MacOS version 10.15:
/wheel/neuron/.dylibs/Python has a minimum target of 11.0
```

As the previous version of `delocate` worked fine, we pin that version as a workaround for now.