### PR TITLE
Bump `MACOSX_DEPLOYMENT_TARGET` to 11

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,11 +140,10 @@ stages:
         inputs:
           secureFile: 'readline7.0-ncurses6.4.tar.gz'
 
-      # 10.14 is required for full C++17 support according to
-      # https://cibuildwheel.readthedocs.io/en/stable/cpp_standards, but it
-      # seems that 10.15 is actually needed for std::filesystem::path.
+      # we set the minimum MacOS version to 11.0 since Python 3.8 does not
+      # support 10.15 or earlier, and 11 is EOL since 09-2023
       - script: |
-          export MACOSX_DEPLOYMENT_TARGET=10.15
+          export MACOSX_DEPLOYMENT_TARGET=11.0
           export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
           export NRN_BUILD_FOR_UPLOAD=1

--- a/setup.py
+++ b/setup.py
@@ -561,14 +561,14 @@ def mac_osx_setenv():
         # Python framework, or 10.9 if the version targeted by the framework
         # cannot be determined
         if py_osx_framework is None:
-            py_osx_framework = (10, 15)
-        if py_osx_framework < (10, 15):
+            py_osx_framework = (11, 0)
+        if py_osx_framework < (11, 0):
             logging.warning(
                 "C++17 support is required to build NEURON on macOS, "
-                "therefore minimum MACOSX_DEPLOYMENT_TARGET version is 10.15."
+                "therefore minimum MACOSX_DEPLOYMENT_TARGET version is 11.0."
             )
-            py_osx_framework = (10, 15)
-        if py_osx_framework > (10, 15):
+            py_osx_framework = (11, 0)
+        if py_osx_framework > (11, 0):
             logging.warning(
                 "You are building a wheel with a Python built for macOS >={}. "
                 "Your wheel won't run on older versions, consider using an "


### PR DESCRIPTION
The official Python 3.8 installer does not support MacOS 10.15 or below, and MacOS 11 is EOL as of 09-2023.