### PR TITLE
Downgrade Python 3.8 in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,8 +90,8 @@ stages:
         matrix:
           Python38:
             python.version: '3.8'
-            python.org.version: '3.8.10'
-            python.installer.name: 'macos11.pkg'
+            python.org.version: '3.8.9'
+            python.installer.name: 'macos10.9.pkg'
           Python39:
             python.version: '3.9'
             python.org.version: '3.9.13'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ stages:
           Python38:
             python.version: '3.8'
             python.org.version: '3.8.9'
-            python.installer.name: 'macos10.9.pkg'
+            python.installer.name: 'macosx10.9.pkg'
           Python39:
             python.version: '3.9'
             python.org.version: '3.9.13'


### PR DESCRIPTION
Python 3.8.10 universal2 installer has a deployment target of 11, which is newer than the deployment target we are using for NEURON (10.15), and 3.8.9 supports 10.15.

Note that there are in principle later versions of Python 3.8, but all of them need to be built from source.