### PR TITLE
Remove popup of Finder when installing on MacOS

### DIFF
--- a/src/mac/activate-apps-cmake.sh
+++ b/src/mac/activate-apps-cmake.sh
@@ -57,13 +57,6 @@ done
 
 echo "$lst"
 
-osascript -e 'tell application "Finder"'\
- -e 'activate'\
- -e 'make new Finder window'\
- -e 'set target of Finder window 1 to folder '"$lst"' of startup disk'\
- -e 'set target of Finder window 1 to folder "bin" of folder '"$lst"' of startup disk'\
- -e 'end tell'
-
 # force rebuild of the neurondemo (perhaps as universal2)
 DEMO="${NRN_INSTALL}/share/nrn/demo"
 rm -f -r ${DEMO}/neuron ${DEMO}/release/${CPU}


### PR DESCRIPTION
Every time one runs `make install` on MacOS, a popup of the file manager appears, which is very distracting since the window steals focus and disrupts regular development workflow, so unless there is some good reason why this behavior should stay, I say we remove it.