### PR TITLE
Use override instead of virtual

### DIFF
--- a/src/parallel/bbsdirect.h
+++ b/src/parallel/bbsdirect.h
@@ -15,43 +15,43 @@ struct bbsmpibuf;
 class BBSDirect: public BBSImpl {
   public:
     BBSDirect();
-    virtual ~BBSDirect();
+    ~BBSDirect() override;
 
-    virtual bool look(const char*);
+    bool look(const char*) override;
 
-    virtual void take(const char*);      /* blocks til something to take */
-    virtual bool look_take(const char*); /* returns false if nothing to take */
+    void take(const char*) override;      /* blocks til something to take */
+    bool look_take(const char*) override; /* returns false if nothing to take */
     // after taking use these
-    virtual int upkint();
-    virtual double upkdouble();
-    virtual void upkvec(int, double*);
-    virtual char* upkstr();            // delete [] char* when finished
-    virtual char* upkpickle(size_t*);  // delete [] char* when finished
+    int upkint() override;
+    double upkdouble() override;
+    void upkvec(int, double*) override;
+    char* upkstr() override;            // delete [] char* when finished
+    char* upkpickle(size_t*) override;  // delete [] char* when finished
 
     // before posting use these
-    virtual void pkbegin();
-    virtual void pkint(int);
-    virtual void pkdouble(double);
-    virtual void pkvec(int, double*);
-    virtual void pkstr(const char*);
-    virtual void pkpickle(const char*, size_t);
-    virtual void post(const char*);
+    void pkbegin() override;
+    void pkint(int) override;
+    void pkdouble(double) override;
+    void pkvec(int, double*) override;
+    void pkstr(const char*) override;
+    void pkpickle(const char*, size_t) override;
+    void post(const char*) override;
 
-    virtual void post_todo(int parentid);
-    virtual void post_result(int id);
-    virtual int look_take_result(int pid);    // returns id, or 0 if nothing
-    virtual int master_take_result(int pid);  // returns id
-    virtual int look_take_todo();             // returns id, or 0 if nothing
-    virtual int take_todo();                  // returns id
-    virtual void save_args(int);
-    virtual void return_args(int);
+    void post_todo(int parentid) override;
+    void post_result(int id) override;
+    int look_take_result(int pid) override;    // returns id, or 0 if nothing
+    int master_take_result(int pid) override;  // returns id
+    int look_take_todo() override;             // returns id, or 0 if nothing
+    int take_todo() override;                  // returns id
+    void save_args(int) override;
+    void return_args(int) override;
 
-    virtual void context();
+    void context() override;
 
-    virtual void start();
-    virtual void done();
+    void start() override;
+    void done() override;
 
-    virtual void perror(const char*);
+    void perror(const char*) override;
 
   private:
     KeepArgs* keepargs_;

--- a/src/parallel/bbslocal.h
+++ b/src/parallel/bbslocal.h
@@ -7,42 +7,42 @@ class KeepArgs;
 class BBSLocal: public BBSImpl {
   public:
     BBSLocal();
-    virtual ~BBSLocal();
+    ~BBSLocal() override;
 
-    virtual bool look(const char*);
+    bool look(const char*) override;
 
-    virtual void take(const char*);      /* blocks til something to take */
-    virtual bool look_take(const char*); /* returns false if nothing to take */
+    void take(const char*) override;      /* blocks til something to take */
+    bool look_take(const char*) override; /* returns false if nothing to take */
     // after taking use these
-    virtual int upkint();
-    virtual double upkdouble();
-    virtual void upkvec(int, double*);
-    virtual char* upkstr();                 // delete [] char* when finished
-    virtual char* upkpickle(size_t* size);  // delete [] char* when finished
+    int upkint() override;
+    double upkdouble() override;
+    void upkvec(int, double*) override;
+    char* upkstr() override;                 // delete [] char* when finished
+    char* upkpickle(size_t* size) override;  // delete [] char* when finished
 
     // before posting use these
-    virtual void pkbegin();
-    virtual void pkint(int);
-    virtual void pkdouble(double);
-    virtual void pkvec(int, double*);
-    virtual void pkstr(const char*);
-    virtual void pkpickle(const char*, size_t);
-    virtual void post(const char*);
+    void pkbegin() override;
+    void pkint(int) override;
+    void pkdouble(double) override;
+    void pkvec(int, double*) override;
+    void pkstr(const char*) override;
+    void pkpickle(const char*, size_t) override;
+    void post(const char*) override;
 
-    virtual void post_todo(int parentid);
-    virtual void post_result(int id);
-    virtual int look_take_result(int pid);  // returns id, or 0 if nothing
-    virtual int look_take_todo();           // returns id, or 0 if nothing
-    virtual int take_todo();                // returns id
-    virtual void save_args(int);
-    virtual void return_args(int);
+    void post_todo(int parentid) override;
+    void post_result(int id) override;
+    int look_take_result(int pid) override;  // returns id, or 0 if nothing
+    int look_take_todo() override;           // returns id, or 0 if nothing
+    int take_todo() override;                // returns id
+    void save_args(int) override;
+    void return_args(int) override;
 
-    virtual void context();
+    void context() override;
 
-    virtual void start();
-    virtual void done();
+    void start() override;
+    void done() override;
 
-    virtual void perror(const char*);
+    void perror(const char*) override;
 
   private:
     KeepArgs* keepargs_;

--- a/src/parallel/bbsrcli.h
+++ b/src/parallel/bbsrcli.h
@@ -8,40 +8,40 @@ struct bbsmpibuf;
 class BBSClient: public BBSImpl {  // implemented as PVM Client
   public:
     BBSClient();
-    virtual ~BBSClient();
+    ~BBSClient() override;
 
-    virtual bool look(const char*);
+    bool look(const char*) override;
 
-    virtual void take(const char*);      /* blocks til something to take */
-    virtual bool look_take(const char*); /* returns false if nothing to take */
+    void take(const char*) override;      /* blocks til something to take */
+    bool look_take(const char*) override; /* returns false if nothing to take */
     // after taking use these
-    virtual int upkint();
-    virtual double upkdouble();
-    virtual void upkvec(int, double*);
-    virtual char* upkstr();            // delete [] char* when finished
-    virtual char* upkpickle(size_t*);  // delete [] char* when finished
+    int upkint() override;
+    double upkdouble() override;
+    void upkvec(int, double*) override;
+    char* upkstr() override;            // delete [] char* when finished
+    char* upkpickle(size_t*) override;  // delete [] char* when finished
 
     // before posting use these
-    virtual void pkbegin();
-    virtual void pkint(int);
-    virtual void pkdouble(double);
-    virtual void pkvec(int, double*);
-    virtual void pkstr(const char*);
-    virtual void pkpickle(const char*, size_t);
-    virtual void post(const char*);
+    void pkbegin() override;
+    void pkint(int) override;
+    void pkdouble(double) override;
+    void pkvec(int, double*) override;
+    void pkstr(const char*) override;
+    void pkpickle(const char*, size_t) override;
+    void post(const char*) override;
 
-    virtual void post_todo(int parentid);
-    virtual void post_result(int id);
-    virtual int look_take_result(int pid);  // returns id, or 0 if nothing
-    virtual int look_take_todo();           // returns id, or 0 if nothing
-    virtual int take_todo();                // returns id
-    virtual void save_args(int);
-    virtual void return_args(int);
+    void post_todo(int parentid) override;
+    void post_result(int id) override;
+    int look_take_result(int pid) override;  // returns id, or 0 if nothing
+    int look_take_todo() override;           // returns id, or 0 if nothing
+    int take_todo() override;                // returns id
+    void save_args(int) override;
+    void return_args(int) override;
 
-    virtual void start();
-    virtual void done();
+    void start() override;
+    void done() override;
 
-    virtual void perror(const char*);
+    void perror(const char*) override;
 
   private:
     int get(const char* key, int type);  // return type


### PR DESCRIPTION
`override` helps the compiler to check if we miss something.