### PR TITLE
Replace deprecated `pkg_resources` with `importlib`

### DIFF
--- a/share/lib/python/scripts/_binwrapper.py
+++ b/share/lib/python/scripts/_binwrapper.py
@@ -7,7 +7,10 @@ import os
 import shutil
 import subprocess
 import sys
-from pkg_resources import working_set
+from importlib.metadata import metadata, PackageNotFoundError
+from importlib.util import find_spec
+from pathlib import Path
+
 from setuptools.command.build_ext import new_compiler
 from packaging.version import Version
 from sysconfig import get_config_vars, get_config_var
@@ -63,21 +66,14 @@ def _check_cpp_compiler_version():
 
 def _config_exe(exe_name):
     """Sets the environment to run the real executable (returned)"""
-
-    package_name = "neuron"
-
-    # determine package to find the install location
-    if "neuron-nightly" in working_set.by_key:
+    try:
+        metadata("neuron-nightly")
         print("INFO : Using neuron-nightly Package (Developer Version)")
-        package_name = "neuron-nightly"
-    elif "neuron" in working_set.by_key:
-        package_name = "neuron"
-    else:
-        raise RuntimeError("NEURON package not found! Verify PYTHONPATH")
+    except PackageNotFoundError:
+        pass
 
-    NRN_PREFIX = os.path.join(
-        working_set.by_key[package_name].location, "neuron", ".data"
-    )
+    NRN_PREFIX = str(Path(find_spec("neuron").origin).parent / ".data")
+
     os.environ["NEURONHOME"] = os.path.join(NRN_PREFIX, "share/nrn")
     os.environ["NRNHOME"] = NRN_PREFIX
     os.environ["CORENRNHOME"] = NRN_PREFIX


### PR DESCRIPTION
Alternative implementation of #2778. Fixes #2745.

Note that here we are not using `importlib.resources.files` (as in https://github.com/BlueBrain/nmodl/pull/1166) because I've discovered that `files` actually _imports_ the module first, which causes some strange issues afterwards since the NEURON `__init__.py` sets some env variables. Notably, when running the following (after `pip install`ing NEURON):

```sh
$ nrniv-core --datpath . --mpi-lib=/path/to/libcorenrnmpi_mpich.so
```

the error thrown was:

```plaintext
--mpi-lib: At Most 1 required but received 2
Run with --help for more information.
```

the reason being that NEURON's `__init__.py` sets `MPI_LIB_NRN_PATH` if it's not been set.
The workaround would be to run the binary directly:

```sh
${VIRTUAL_ENV}/lib/python3.x/site-packages/neuron/.data/bin/nrniv-core --datpath . --mpi-lib=/path/to/libcorenrnmpi_mpich.so
```

but this is non-obvious. Fortunately, `importlib.util.find_spec('neuron')` provides the path to `__init__.py` without actually loading it, so we can use that instead.

## Possible discussion items

- the Python docs are unclear whether `importlib.metadata.metadata` is available for sure in Python 3.8 and above; the exact wording is:
  > Changed in version 3.10: importlib.metadata is no longer provisional.
  
  so if it's not actually available in Python 3.8 and 3.9, `setup.py` and `nrn_requirements.txt` also need to be updated, as well as the Spack recipe (I tried locally with 3.8 and `importlib.metadata.metadata` apparently exists)