### PR TITLE
FIX: use canonical paths and a set when checking loaded dlls

### DIFF
--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -315,9 +315,9 @@ def load_mechanisms(path, warn_if_already_loaded=True):
     global nrn_dll_loaded
     path_obj = Path(path).resolve()
     if path_obj.as_posix() in nrn_dll_loaded:
-            if warn_if_already_loaded:
-                print(f"Mechanisms already loaded from path: {path_obj}. Aborting.")
-            return True
+        if warn_if_already_loaded:
+            print(f"Mechanisms already loaded from path: {path_obj}. Aborting.")
+        return True
 
     # in case NEURON is assuming a different architecture to Python,
     # we try multiple possibilities

--- a/share/lib/python/neuron/tests/test_neuron.py
+++ b/share/lib/python/neuron/tests/test_neuron.py
@@ -5,6 +5,7 @@ Items declared in neuron/__init__.py
 $Id$
 """
 
+from pathlib import Path
 import unittest
 import neuron
 from neuron import h
@@ -198,6 +199,14 @@ class NeuronTestCase(unittest.TestCase):
             error = True
         self.assertFalse(error)
         return 0
+
+    def test_load_mechanisms_from_non_existent_path(self):
+        """Assure mechanisms are not loaded from a non-existent directory."""
+        from neuron import load_mechanisms, nrn_dll_loaded
+
+        mech_path1 = "fake_mechanisms_dir"
+        assert not load_mechanisms(mech_path1)
+        assert Path(mech_path1).resolve().as_posix() not in nrn_dll_loaded
 
     def testRxDexistence(self):
         from neuron import config

--- a/share/lib/python/neuron/tests/test_neuron.py
+++ b/share/lib/python/neuron/tests/test_neuron.py
@@ -6,7 +6,9 @@ $Id$
 """
 
 from pathlib import Path
+from tempfile import TemporaryDirectory
 import unittest
+from unittest.mock import patch
 import neuron
 from neuron import h
 
@@ -207,6 +209,23 @@ class NeuronTestCase(unittest.TestCase):
         mech_path1 = "fake_mechanisms_dir"
         assert not load_mechanisms(mech_path1)
         assert Path(mech_path1).resolve().as_posix() not in nrn_dll_loaded
+
+    @patch("pathlib.Path.exists")
+    def test_load_mechanisms_reloading(self, mock_exists):
+        """Assure the same directory is not loaded multiple times."""
+        from neuron import load_mechanisms, nrn_dll_loaded
+
+        mock_exists.return_value = True  # bypass path.exists()
+
+        with TemporaryDirectory() as temp_dir:
+            mech_path1 = Path(temp_dir) / "mechanisms_dir"
+            mech_path1.mkdir()
+            assert load_mechanisms(mech_path1)
+            assert mech_path1.resolve().as_posix() in nrn_dll_loaded
+            assert len(nrn_dll_loaded) == 1
+            mech_path2 = mech_path1 / ".." / "mechanisms_dir"
+            assert load_mechanisms(mech_path2)
+            assert len(nrn_dll_loaded) == 1
 
     def testRxDexistence(self):
         from neuron import config


### PR DESCRIPTION
Uses a set of canonical path strings to fix the checking of already loaded dlls. It prevents the SEGFAULTs raised from trying to load the same dlls/mods using Python API.

Addresses a part of https://github.com/neuronsimulator/nrn/issues/2741. 