### PR TITLE
fix some warnings (gcc 11.4.0)

### DIFF
--- a/src/nrniv/nrncore_write/io/nrncore_io.cpp
+++ b/src/nrniv/nrncore_write/io/nrncore_io.cpp
@@ -549,7 +549,7 @@ void nrn_write_mapping_info(const char* path, int gid, NrnMappingInfo& minfo) {
     /** number of gids in NrnThread */
     int count;
     nrnthread_dat3_cell_count(count);
-    fprintf(f, "%zd\n", count);
+    fprintf(f, "%d\n", count);
 
     /** all cells mapping information in NrnThread */
     for (size_t i = 0; i < count; i++) {
@@ -559,7 +559,7 @@ void nrn_write_mapping_info(const char* path, int gid, NrnMappingInfo& minfo) {
         int n_seclist;
         nrnthread_dat3_cellmapping(i, cgid, t_sec, t_seg, n_seclist);
         /** gid, #section, #compartments,  #sectionlists */
-        fprintf(f, "%d %d %d %zd\n", cgid, t_sec, t_seg, n_seclist);
+        fprintf(f, "%d %d %d %d\n", cgid, t_sec, t_seg, n_seclist);
 
         for (size_t j = 0; j < n_seclist; j++) {
             std::string sclname;
@@ -582,7 +582,7 @@ void nrn_write_mapping_info(const char* path, int gid, NrnMappingInfo& minfo) {
                                       data_lfp);
             /** section list name, number of sections, number of segments */
             fprintf(f,
-                    "%s %d %zd %zd %d\n",
+                    "%s %d %d %zd %d\n",
                     sclname.c_str(),
                     nsec,
                     nseg,

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -984,7 +984,9 @@ void hoc_final_exit(void) {
     std::string cmd{neuron_home};
     cmd += "/lib/cleanup ";
     cmd += std::to_string(hoc_pid());
-    system(cmd.c_str());
+    if (system(cmd.c_str())) {  // fix warning: ignoring return value
+        return;
+    }
 #endif
 }
 

--- a/src/oc/mk_hocusr_h.py
+++ b/src/oc/mk_hocusr_h.py
@@ -25,7 +25,7 @@ def processvar(a, names):
 
 def remove_multiline_comments(string):
     # remove all occurance comments (/*COMMENT */) from string
-    string = re.sub(re.compile("/\*.*?\*/", re.DOTALL), "", string)
+    string = re.sub(re.compile(r"/\*.*?\*/", re.DOTALL), "", string)
     return string
 
 

--- a/src/oc/mk_hocusr_h.py
+++ b/src/oc/mk_hocusr_h.py
@@ -25,8 +25,7 @@ def processvar(a, names):
 
 def remove_multiline_comments(string):
     # remove all occurance comments (/*COMMENT */) from string
-    string = re.sub(re.compile(r"/\*.*?\*/", re.DOTALL), "", string)
-    return string
+    return re.sub(r"/\*.*?\*/", "", string, 0, re.DOTALL)
 
 
 types = {}


### PR DESCRIPTION
But not sure what to do about

```
src/nrnpython/nrnpython.cpp:152:13: warning: ‘Py_NoSiteFlag’ is deprecated [-Wdeprecated-declarations]
```

```
WARNING setuptools_scm.pyproject_reading toml section missing 'pyproject.toml does not contain a tool.setuptools_scm section'
```