### PR TITLE
Add missing include

### DIFF
--- a/src/neuron/container/soa_container.hpp
+++ b/src/neuron/container/soa_container.hpp
@@ -5,6 +5,7 @@
 #include "neuron/container/generic_data_handle.hpp"
 #include "neuron/container/soa_identifier.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <functional>
 #include <limits>

--- a/src/neuron/container/soa_container.hpp
+++ b/src/neuron/container/soa_container.hpp
@@ -5,7 +5,7 @@
 #include "neuron/container/generic_data_handle.hpp"
 #include "neuron/container/soa_identifier.hpp"
 
-#include <algorithm>
+#include <algorithm>  // std::transform
 #include <cstddef>
 #include <functional>
 #include <limits>


### PR DESCRIPTION
The build CI is experiencing a failure due to `std::transform` not being found: https://github.com/neuronsimulator/nrn-build-ci/actions/runs/8810053915/job/24187016667#step:7:1991.
Note that I'm not sure why the other jobs succeeded though (maybe some compilers are more lenient with includes)?