### PR TITLE
std::signal define the type of the signal handler

### DIFF
--- a/cmake/ConfigFileSetting.cmake
+++ b/cmake/ConfigFileSetting.cmake
@@ -145,11 +145,6 @@ nrn_check_type_exists(sys/types.h size_t "unsigned int" size_t)
 nrn_check_type_exists(sys/types.h uid_t int uid_t)
 
 # =============================================================================
-# Set return type of signal in RETSIGTYPE
-# =============================================================================
-nrn_check_signal_return_type(RETSIGTYPE)
-
-# =============================================================================
 # Generate file from file.in template
 # =============================================================================
 set(version_strs ${NRN_PYTHON_VERSIONS})

--- a/cmake/MacroHelper.cmake
+++ b/cmake/MacroHelper.cmake
@@ -63,23 +63,6 @@ macro(nrn_check_type_exists HEADER TYPE DEFAULT_TYPE VARIABLE)
 endmacro()
 
 # =============================================================================
-# Check return type of signal
-# =============================================================================
-macro(nrn_check_signal_return_type VARIABLE)
-  # code template to check signal support
-  string(CONCAT CONFTEST_RETSIGTYPE "#include <sys/types.h>\n" "#include <signal.h>\n"
-                "int main () {\n" "  return *(signal (0, 0)) (0) == 1\;\n" "}\n")
-  file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/conftest.cpp ${CONFTEST_RETSIGTYPE})
-  try_compile(MY_RESULT_VAR ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/conftest.cpp)
-  if(MY_RESULT_VAR)
-    set(${VARIABLE} int)
-  else()
-    set(${VARIABLE} void)
-  endif()
-  file(REMOVE "conftest.cpp")
-endmacro()
-
-# =============================================================================
 # Perform check_include_files and add it to NRN_HEADERS_INCLUDE_LIST if exist Passing an optional
 # CXX will call check_include_files_cxx instead.
 # =============================================================================

--- a/cmake_nrnconf.h.in
+++ b/cmake_nrnconf.h.in
@@ -81,9 +81,6 @@
 /* Define to the version of this package. */
 #cmakedefine PACKAGE_VERSION @PACKAGE_VERSION@
 
-/* Define as the return type of signal handlers (`int' or `void'). */
-#cmakedefine RETSIGTYPE @RETSIGTYPE@
-
 /* Define SUNDIALS data type 'realtype' as 'long double' */
 #cmakedefine SUNDIALS_DOUBLE_PRECISION @SUNDIALS_DOUBLE_PRECISION@
 

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -188,7 +188,7 @@ static int backslash(int c);
 #endif
 #if HAS_SIGPIPE
 /*ARGSUSED*/
-static RETSIGTYPE sigpipe_handler(int sig) {
+static void sigpipe_handler(int sig) {
     fprintf(stderr, "writing to a broken pipe\n");
     signal(SIGPIPE, sigpipe_handler);
 }
@@ -653,7 +653,7 @@ void hoc_execerror(const char* s, const char* t) /* recover from run-time error 
     hoc_execerror_mes(s, t, hoc_execerror_messages);
 }
 
-RETSIGTYPE onintr(int sig) /* catch interrupt */
+void onintr(int sig) /* catch interrupt */
 {
     /*ARGSUSED*/
     stoprun = 1;
@@ -728,7 +728,7 @@ void print_bt() {
 #endif
 }
 
-RETSIGTYPE fpecatch(int sig) /* catch floating point exceptions */
+void fpecatch(int sig) /* catch floating point exceptions */
 {
     /*ARGSUSED*/
 #if DOS
@@ -746,7 +746,7 @@ RETSIGTYPE fpecatch(int sig) /* catch floating point exceptions */
     execerror("Floating point exception.", (char*) 0);
 }
 
-RETSIGTYPE sigsegvcatch(int sig) /* segmentation violation probably due to arg type error */
+void sigsegvcatch(int sig) /* segmentation violation probably due to arg type error */
 {
     Fprintf(stderr, "Segmentation violation\n");
     print_bt();
@@ -758,7 +758,7 @@ RETSIGTYPE sigsegvcatch(int sig) /* segmentation violation probably due to arg t
 }
 
 #if HAVE_SIGBUS
-RETSIGTYPE sigbuscatch(int sig) {
+void sigbuscatch(int sig) {
     Fprintf(stderr, "Bus error\n");
     print_bt();
     /*ARGSUSED*/
@@ -1170,8 +1170,7 @@ int hoc_moreinput() {
     return 1;
 }
 
-typedef RETSIGTYPE (*SignalType)(int);
-
+using SignalType = void(int);
 static SignalType signals[4];
 
 static void set_signals(void) {


### PR DESCRIPTION
The reference define that the signal handler is of type `void(int)`.
So no need anymore to check it.