### PR TITLE
Add `nrnunits.lib` dependency to `nocmodl_mod_to_cpp` cmake macro

### DIFF
--- a/cmake/MacroHelper.cmake
+++ b/cmake/MacroHelper.cmake
@@ -164,6 +164,7 @@ macro(nocmodl_mod_to_cpp modfile_basename)
     COMMAND ${CMAKE_COMMAND} -E ${REMOVE_CMAKE_COMMAND}
             ${PROJECT_SOURCE_DIR}/${modfile_basename}.cpp
     DEPENDS nocmodl ${PROJECT_SOURCE_DIR}/${modfile_basename}.mod
+            ${PROJECT_BINARY_DIR}/share/nrn/lib/nrnunits.lib
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src/nrniv)
 endmacro()
 


### PR DESCRIPTION
* otherwise, `ninja src/nrniv/CMakeFiles/nrniv_lib.dir/__/nrnoc/hh.cpp.o` fails from a clean build with:
`Error: Bad MODLUNIT environment variable. Cant open: [...]build/share/nrn/lib/nrnunits.lib at line 32 in file [...]nrn/src/nrnoc/oclmp.mod`