### PR TITLE
Fix pytest to 8.1.1 due to failure

### DIFF
--- a/nrn_requirements.txt
+++ b/nrn_requirements.txt
@@ -8,7 +8,7 @@ bokeh<3
 ipython
 cython<3
 packaging
-pytest
+pytest==8.1.1 # Bug from 8.2.0 due to parallelism?
 pytest-cov
 mpi4py
 numpy

--- a/nrn_requirements.txt
+++ b/nrn_requirements.txt
@@ -8,7 +8,7 @@ bokeh<3
 ipython
 cython<3
 packaging
-pytest==8.1.1 # Bug from 8.2.0 due to parallelism?
+pytest<=8.1.1 # potential bug from 8.2.0 due to parallelism?
 pytest-cov
 mpi4py
 numpy


### PR DESCRIPTION
- [x] Merge https://github.com/BlueBrain/nmodl/pull/1246 and update submodule