### PR TITLE
Report Event callback slightly different per report

### DIFF
--- a/src/coreneuron/io/reports/nrnreport.hpp
+++ b/src/coreneuron/io/reports/nrnreport.hpp
@@ -103,6 +103,7 @@ struct ReportConfiguration {
     int num_gids;                         // total number of gids
     int buffer_size;                      // hint on buffer size used for this report
     std::vector<int> target;              // list of gids for this report
+    int report_index;                     // index of the report
 };
 
 void setup_report_engine(double dt_report, double mindelay);

--- a/src/coreneuron/io/reports/report_configuration_parser.cpp
+++ b/src/coreneuron/io/reports/report_configuration_parser.cpp
@@ -113,6 +113,7 @@ std::vector<ReportConfiguration> create_report_configurations(const std::string&
     int num_reports = 0;
     report_conf >> num_reports;
     std::vector<ReportConfiguration> reports(num_reports);
+    int report_index = 0;
     for (auto& report: reports) {
         report.buffer_size = 4;  // default size to 4 Mb
 
@@ -156,6 +157,8 @@ std::vector<ReportConfiguration> create_report_configurations(const std::string&
             // extra new line: skip
             report_conf.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
         }
+        report.report_index = report_index;
+        report_index++;
     }
     // read population information for spike report
     int num_populations;

--- a/src/coreneuron/io/reports/report_event.cpp
+++ b/src/coreneuron/io/reports/report_event.cpp
@@ -117,6 +117,7 @@ void ReportEvent::deliver(double t, NetCvode* nc, NrnThread* nt) {
                                 gids_to_report.size(),
                                 gids_to_report.data(),
                                 report_path.data());
+        nrn_flush_reports(t);
 #endif
         send(t + dt, nc, nt);
         step++;

--- a/src/coreneuron/io/reports/report_event.hpp
+++ b/src/coreneuron/io/reports/report_event.hpp
@@ -37,7 +37,8 @@ class ReportEvent: public DiscreteEvent {
                 const VarsToReport& filtered_gids,
                 const char* name,
                 double report_dt,
-                ReportType type);
+                ReportType type,
+                int report_index);
 
     /** on deliver, call libsonata and setup next event */
     void deliver(double t, NetCvode* nc, NrnThread* nt) override;
@@ -58,6 +59,7 @@ class ReportEvent: public DiscreteEvent {
     double tstart;
     VarsToReport vars_to_report;
     ReportType report_type;
+    double report_t_shift_;
 };
 #endif
 

--- a/src/coreneuron/io/reports/report_handler.cpp
+++ b/src/coreneuron/io/reports/report_handler.cpp
@@ -99,7 +99,8 @@ void ReportHandler::create_report(ReportConfiguration& report_config,
                                                               vars_to_report,
                                                               report_config.output_path.data(),
                                                               report_config.report_dt,
-                                                              report_config.type);
+                                                              report_config.type,
+                                                              report_config.report_index);
             report_event->send(t, net_cvode_instance, &nt);
             m_report_events.push_back(std::move(report_event));
         }

--- a/src/coreneuron/sim/fadvance_core.cpp
+++ b/src/coreneuron/sim/fadvance_core.cpp
@@ -113,7 +113,7 @@ void nrn_fixed_step_minimal() { /* not so minimal anymore with gap junctions */
 #ifdef ENABLE_SONATA_REPORTS
     {
         Instrumentor::phase p("flush_reports");
-        nrn_flush_reports(nrn_threads[0]._t);
+        //nrn_flush_reports(nrn_threads[0]._t);
     }
 #endif
     t = nrn_threads[0]._t;
@@ -165,7 +165,7 @@ void nrn_fixed_step_group_minimal(int total_sim_steps) {
 #ifdef ENABLE_SONATA_REPORTS
         {
             Instrumentor::phase p("flush_reports");
-            nrn_flush_reports(nrn_threads[0]._t);
+            //nrn_flush_reports(nrn_threads[0]._t);
         }
 #endif
         if (stoprun) {

--- a/src/coreneuron/sim/fadvance_core.cpp
+++ b/src/coreneuron/sim/fadvance_core.cpp
@@ -109,13 +109,6 @@ void nrn_fixed_step_minimal() { /* not so minimal anymore with gap junctions */
         nrn_spike_exchange(nrn_threads);
     }
 #endif
-
-#ifdef ENABLE_SONATA_REPORTS
-    {
-        Instrumentor::phase p("flush_reports");
-        //nrn_flush_reports(nrn_threads[0]._t);
-    }
-#endif
     t = nrn_threads[0]._t;
 }
 
@@ -160,13 +153,6 @@ void nrn_fixed_step_group_minimal(int total_sim_steps) {
                             step_group_end);
 #if NRNMPI
         nrn_spike_exchange(nrn_threads);
-#endif
-
-#ifdef ENABLE_SONATA_REPORTS
-        {
-            Instrumentor::phase p("flush_reports");
-            //nrn_flush_reports(nrn_threads[0]._t);
-        }
 #endif
         if (stoprun) {
             break;

--- a/test/coreneuron/unit/lfp/lfp.cpp
+++ b/test/coreneuron/unit/lfp/lfp.cpp
@@ -178,7 +178,8 @@ TEST_CASE("LFP_ReportEvent") {
     ReportType report_type = CompartmentReport;
     const int report_index = 0;
 
-    ReportEvent event(dt, tstart, vars_to_report, report_name.data(), report_dt, report_type, report_index);
+    ReportEvent event(
+        dt, tstart, vars_to_report, report_name.data(), report_dt, report_type, report_index);
     event.lfp_calc(&nt);
 
     REQUIRE_THAT(mapinfo->_lfp[0], Catch::Matchers::WithinAbs(5.5, 1.0));

--- a/test/coreneuron/unit/lfp/lfp.cpp
+++ b/test/coreneuron/unit/lfp/lfp.cpp
@@ -176,8 +176,9 @@ TEST_CASE("LFP_ReportEvent") {
     const double tstart = 0.0;
     const double report_dt = 0.1;
     ReportType report_type = CompartmentReport;
+    const int report_index = 0;
 
-    ReportEvent event(dt, tstart, vars_to_report, report_name.data(), report_dt, report_type);
+    ReportEvent event(dt, tstart, vars_to_report, report_name.data(), report_dt, report_type, report_index);
     event.lfp_calc(&nt);
 
     REQUIRE_THAT(mapinfo->_lfp[0], Catch::Matchers::WithinAbs(5.5, 1.0));


### PR DESCRIPTION
Enforce deterministic report events to avoid deadlocks when calling nrn_flush_reports() after recording data