### PR TITLE
Helvetica no more mandatory.

### DIFF
--- a/share/lib/nrn.defaults.in
+++ b/share/lib/nrn.defaults.in
@@ -78,13 +78,13 @@
 *xvalue_field_size_increase: 10.
 
 // following is historical standard for unix.
-@nrndef_unix@*font: *helvetica-medium-r-normal*--14*
-@nrndef_unix@*MenuBar*font: *-helvetica-bold-o-normal--14*
-@nrndef_unix@*MenuItem*font: *-helvetica-bold-o-normal--14*
+@nrndef_unix@*font: *fixed-medium-r-normal*--14*
+@nrndef_unix@*MenuBar*font: *-fixed-bold-o-normal--14*
+@nrndef_unix@*MenuItem*font: *-fixed-bold-o-normal--14*
 // Mac and mswin internal default is
-@nrndef_mac@*font: *helvetica-medium-r-normal*--14*
-@nrndef_mac@*MenuBar*font: *-helvetica-bold-o-normal--14*
-@nrndef_mac@*MenuItem*font: *-helvetica-bold-o-normal--14*
+@nrndef_mac@*font: *fixed-medium-r-normal*--14*
+@nrndef_mac@*MenuBar*font: *-fixed-bold-o-normal--14*
+@nrndef_mac@*MenuItem*font: *-fixed-bold-o-normal--14*
 @nrndef_mswin@*font: *Arial*bold*--12*
 //*MenuBar*font: *Arial*bold*--12*
 //*MenuItem*font: *Arial*bold*--12*

--- a/src/ivoc/idraw.cpp
+++ b/src/ivoc/idraw.cpp
@@ -152,7 +152,7 @@ void OcIdraw::text(Canvas*,
         out << font->name() << font->size() << "SetF\n";
     } else {
         out << "\
-%I f -*-helvetica-medium-r-normal-*-12-*-*-*-*-*-*-*\n\
+%I f -*-fixed-medium-r-normal-*-12-*-*-*-*-*-*-*\n\
 Helvetica 12 SetF\n\
 ";
     };


### PR DESCRIPTION
Sometimes `helvetica` is not available and it creates an error, we don't care of the typo.