### PR TITLE
Pin numpy max version to <2

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           python3 -m venv music-venv
           source music-venv/bin/activate
-          python3 -m pip install mpi4py "cython<3" numpy setuptools
+          python3 -m pip install mpi4py "cython<3" 'numpy<2' setuptools
           sudo mkdir -p $MUSIC_INSTALL_DIR
           sudo chown -R $USER $MUSIC_INSTALL_DIR
           curl -L -o MUSIC.zip https://github.com/INCF/MUSIC/archive/refs/tags/${MUSIC_VERSION}.zip

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -91,9 +91,9 @@ jobs:
       - name: Install Python@${{ env.PY_MIN_VERSION }} dependencies
         working-directory: ${{runner.workspace}}/nrn
         run: |
-          python -m pip install --upgrade pip -r nrn_requirements.txt
           python -m pip install --upgrade -r external/nmodl/requirements.txt
           python -m pip install --upgrade -r ci_requirements.txt
+          python -m pip install --upgrade pip -r nrn_requirements.txt
 
       - name: Set up Python@${{ env.PY_MID_VERSION }}
         uses: actions/setup-python@v5
@@ -108,9 +108,9 @@ jobs:
       - name: Install Python@${{ env.PY_MAX_VERSION }} dependencies
         working-directory: ${{runner.workspace}}/nrn
         run: |
-          python -m pip install --upgrade pip -r nrn_requirements.txt
           python -m pip install --upgrade -r external/nmodl/requirements.txt
           python -m pip install --upgrade -r ci_requirements.txt
+          python -m pip install --upgrade pip -r nrn_requirements.txt
 
 
       - name: Build & Test

--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -207,7 +207,7 @@ jobs:
         run: |
           python3 -m venv music-venv
           source music-venv/bin/activate
-          python3 -m pip install mpi4py "cython<3" numpy setuptools
+          python3 -m pip install mpi4py "cython<3" 'numpy<2' setuptools
           sudo mkdir -p $MUSIC_INSTALL_DIR
           sudo chown -R $USER $MUSIC_INSTALL_DIR
           curl -L -o MUSIC.zip https://github.com/INCF/MUSIC/archive/refs/tags/${MUSIC_VERSION}.zip

--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -172,7 +172,7 @@ jobs:
         working-directory: ${{runner.workspace}}/nrn
         run: |
           python -m pip install --upgrade pip -r nrn_requirements.txt
-          python -m pip install --upgrade -r external/nmodl/requirements.txt
+          python -m pip install -r external/nmodl/requirements.txt
           python -m pip install --upgrade -r ci_requirements.txt
 
       - name: Set up Python@${{ env.PY_MAX_VERSION }}

--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -171,9 +171,9 @@ jobs:
         if: ${{ matrix.config.python_dynamic == 'ON' }}
         working-directory: ${{runner.workspace}}/nrn
         run: |
-          python -m pip install --upgrade pip -r nrn_requirements.txt
-          python -m pip install -r external/nmodl/requirements.txt
+          python -m pip install --upgrade -r external/nmodl/requirements.txt
           python -m pip install --upgrade -r ci_requirements.txt
+          python -m pip install --upgrade pip -r nrn_requirements.txt
 
       - name: Set up Python@${{ env.PY_MAX_VERSION }}
         uses: actions/setup-python@v5

--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -183,9 +183,9 @@ jobs:
       - name: Install Python@${{ env.PY_MAX_VERSION }} dependencies
         working-directory: ${{runner.workspace}}/nrn
         run: |
-          python -m pip install --upgrade pip -r nrn_requirements.txt
           python -m pip install --upgrade -r external/nmodl/requirements.txt
           python -m pip install --upgrade -r ci_requirements.txt
+          python -m pip install --upgrade pip -r nrn_requirements.txt
 
       - name: Install a new automake
         # A new automake is needed for python 3.12 because it generate a python script

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,9 +53,9 @@ mac_m1_cmake_build:
     - echo "python3=$(command -v python3) is really ${real_python}"
     - PYTHONEXECUTABLE=${real_python} ${real_python} -mvenv venv
     - venv/bin/python3 -m ensurepip --upgrade --default-pip
-    - venv/bin/pip install --upgrade pip -r nrn_requirements.txt
     - git submodule update --init --recursive --force --depth 1 -- external/nmodl
     - venv/bin/pip install --upgrade -r external/nmodl/requirements.txt
+    - venv/bin/pip install --upgrade pip -r nrn_requirements.txt
     - source ./venv/bin/activate
     - export PYTHON=${PWD}/venv/bin/python
     - ${PYTHON} --version

--- a/ci/win_test_installer.cmd
+++ b/ci/win_test_installer.cmd
@@ -22,7 +22,7 @@ C:\Python39\python -c "import neuron; neuron.test(); quit()" || set "errorfound=
 C:\Python310\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
 C:\Python311\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
 :: install numpy dependency
-python -m pip install 'numpy<2'
+python -m pip install "numpy<2"
 :: run also using whatever is system python
 python --version
 python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"

--- a/ci/win_test_installer.cmd
+++ b/ci/win_test_installer.cmd
@@ -22,7 +22,7 @@ C:\Python39\python -c "import neuron; neuron.test(); quit()" || set "errorfound=
 C:\Python310\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
 C:\Python311\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
 :: install numpy dependency
-python -m pip install numpy
+python -m pip install 'numpy<2'
 :: run also using whatever is system python
 python --version
 python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"

--- a/ci_requirements.txt
+++ b/ci_requirements.txt
@@ -1,2 +1,3 @@
 plotly
 ipywidgets>=7.0.0
+tenacity<8.4 # needed until plotly fixes it upstream

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -10,7 +10,7 @@ bokeh<3
 # do not check import of next line
 ipython
 plotnine
-numpy
+numpy<2
 plotly
 nbsphinx
 jinja2

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -16,3 +16,4 @@ nbsphinx
 jinja2
 sphinx-design
 packaging==21.3
+tenacity<8.4

--- a/nrn_requirements.txt
+++ b/nrn_requirements.txt
@@ -11,5 +11,5 @@ packaging
 pytest<=8.1.1 # potential bug from 8.2.0 due to parallelism?
 pytest-cov
 mpi4py
-numpy
+numpy<2
 find_libpython

--- a/setup.py
+++ b/setup.py
@@ -354,7 +354,7 @@ def setup_package():
     NRN_COLLECT_DIRS = ["bin", "lib", "include", "share"]
 
     docs_require = []  # sphinx, themes, etc
-    maybe_rxd_reqs = ["numpy", "Cython<3"] if Components.RX3D else []
+    maybe_rxd_reqs = ["numpy<2", "Cython<3"] if Components.RX3D else []
     maybe_docs = docs_require if "docs" in sys.argv else []
     maybe_test_runner = ["pytest-runner"] if "test" in sys.argv else []
 
@@ -510,7 +510,7 @@ def setup_package():
         },
         cmdclass=dict(build_ext=CMakeAugmentedBuilder, docs=Docs),
         install_requires=[
-            "numpy>=1.9.3",
+            "numpy>=1.9.3,<2",
             "packaging",
             "find_libpython",
             "setuptools",


### PR DESCRIPTION
Numpy 2 is [out](https://github.com/numpy/numpy/releases/tag/v2.0.0), and consequently, most of the scheduled CI jobs [broke](https://github.com/neuronsimulator/nrn-build-ci/actions/runs/9541053487) due to binary incompatibility:

```plaintext
'from neuron import rxd' failed numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```

As a workaround we can pin the version to `numpy<2` everywhere.