### PR TITLE
Backport numpy pinning to 8.2

### DIFF
--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -148,7 +148,7 @@ jobs:
         run: |
           python3 -m venv music-venv
           source music-venv/bin/activate
-          python3 -m pip install mpi4py "cython<3" numpy
+          python3 -m pip install mpi4py "cython<3" "numpy<2"
           sudo mkdir -p $MUSIC_INSTALL_DIR
           sudo chown -R $USER $MUSIC_INSTALL_DIR
           # Stable build: https://github.com/INCF/MUSIC/archive/refs/heads/switch-to-MPI-C-interface.zip  @ f33b66ea9348888eed1761738ab48c23ffc8a0d0

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   WindowsInstaller:
     runs-on: windows-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v4

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,7 +146,7 @@ stages:
           secureFile: 'readline7.0-ncurses6.4.tar.gz'
 
       - script: |
-          export MACOSX_DEPLOYMENT_TARGET=10.9
+          export MACOSX_DEPLOYMENT_TARGET=10.15
           export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
           export NRN_BUILD_FOR_UPLOAD=1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,7 +160,7 @@ stages:
 
     # Jobs to build NEURON installer natively
     - job: 'WindowsInstaller'
-      timeoutInMinutes: 45
+      timeoutInMinutes: 60
       pool:
         vmImage: windows-2019
       variables:

--- a/ci/win_test_installer.cmd
+++ b/ci/win_test_installer.cmd
@@ -23,7 +23,7 @@ C:\Python39\python -c "import neuron; neuron.test(); quit()" || set "errorfound=
 C:\Python310\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
 C:\Python311\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
 :: install numpy dependency
-python -m pip install numpy
+python -m pip install "numpy<2"
 :: run also using whatever is system python
 python --version
 python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"

--- a/ci/win_test_installer_wo_rxd.cmd
+++ b/ci/win_test_installer_wo_rxd.cmd
@@ -27,7 +27,7 @@ C:\Python310\python -c "import neuron; neuron.test(); quit()" || set "errorfound
 C:\Python311\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
 
 :: install numpy dependency
-python -m pip install numpy
+python -m pip install "numpy<2"
 :: run also using whatever is system python
 python --version
 python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -9,9 +9,10 @@ bokeh<3
 # do not check import of next line
 ipython
 plotnine
-numpy
+numpy<2
 plotly
 nbsphinx
 jinja2
 sphinx-design
 packaging==21.3
+tenacity<8.4

--- a/nrn_requirements.txt
+++ b/nrn_requirements.txt
@@ -10,4 +10,4 @@ packaging
 pytest
 pytest-cov
 mpi4py
-numpy
+numpy<2

--- a/packaging/python/test_wheels.sh
+++ b/packaging/python/test_wheels.sh
@@ -298,7 +298,9 @@ $python_exe -m pip install --upgrade setuptools
 
 
 # install numpy, pytest and neuron
-$python_exe -m pip install numpy pytest
+# we install setuptools because since python 3.12 it is no more installed
+# by default
+$python_exe -m pip install "numpy<2" pytest setuptools
 $python_exe -m pip install $python_wheel
 $python_exe -m pip show neuron \
     || $python_exe -m pip show neuron-nightly \

--- a/setup.py
+++ b/setup.py
@@ -403,7 +403,7 @@ def setup_package():
     NRN_COLLECT_DIRS = ["bin", "lib", "include", "share"]
 
     docs_require = []  # sphinx, themes, etc
-    maybe_rxd_reqs = ["numpy", "Cython<3"] if Components.RX3D else []
+    maybe_rxd_reqs = ["numpy<2", "Cython<3"] if Components.RX3D else []
     maybe_docs = docs_require if "docs" in sys.argv else []
     maybe_test_runner = ["pytest-runner"] if "test" in sys.argv else []
 
@@ -566,7 +566,12 @@ def setup_package():
             if f[0] != "_"
         ],
         cmdclass=dict(build_ext=CMakeAugmentedBuilder, docs=Docs),
-        install_requires=["numpy>=1.9.3", "packaging", "find_libpython", "setuptools"]
+        install_requires=[
+            "numpy>=1.9.3,<2",
+            "packaging",
+            "find_libpython",
+            "setuptools",
+        ]
         + maybe_patchelf,
         tests_require=["flake8", "pytest"],
         setup_requires=["wheel"] + maybe_docs + maybe_test_runner + maybe_rxd_reqs,


### PR DESCRIPTION
Backports of #2916 and #2919 to release 8.2. Required to make https://github.com/neuronsimulator/nrn-build-ci/pull/69 green since the testing of the stable version actually checks out the testing scripts on that branch, which doesn't have the pinning.