### PR TITLE
Convert C++ exception to Python exceptions.

### DIFF
--- a/src/nrnpython/convert_cxx_exceptions.hpp
+++ b/src/nrnpython/convert_cxx_exceptions.hpp
@@ -1,0 +1,56 @@
+#pragma once
+#include <exception>
+#include<stdexcept>
+
+namespace nrn {
+namespace detail {
+template <class T>
+T error_value();
+
+template <>
+inline PyObject* error_value<PyObject*>() {
+    return nullptr;
+}
+
+template <>
+inline int error_value<int>() {
+    return -1;
+}
+
+template <>
+inline long error_value<long>() {
+    return -1;
+}
+
+// template<> ssize_t error_value<ssize_t>() {
+//   return -1;
+// }
+}  // namespace detail
+
+template <class F, class... Args>
+struct convert_cxx_exceptions_trait {
+    using return_type = typename std::result_of<F(Args...)>::type;
+
+    static return_type error_value() {
+        return detail::error_value<return_type>();
+    }
+};
+
+template <class F, class... Args>
+static typename convert_cxx_exceptions_trait<F, Args...>::return_type convert_cxx_exceptions(
+    F f,
+    Args&&... args) {
+    try {
+        return f(std::forward<Args>(args)...);
+    } catch (const std::runtime_error& e) {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+    } catch (std::exception& e) {
+        PyErr_SetString(PyExc_Exception, e.what());
+    } catch (...) {
+        PyErr_SetString(PyExc_Exception, "Unknown C++ exception.");
+    }
+
+    return convert_cxx_exceptions_trait<F, Args...>::error_value();
+}
+}  // namespace nrn
+

--- a/src/nrnpython/convert_cxx_exceptions.hpp
+++ b/src/nrnpython/convert_cxx_exceptions.hpp
@@ -40,12 +40,25 @@ template <class F, class... Args>
 static typename convert_cxx_exceptions_trait<F, Args...>::return_type convert_cxx_exceptions(
     F f,
     Args&&... args) {
+    // Same mapping of C++ exceptions to Python errors that pybind11 uses.
     try {
         return f(std::forward<Args>(args)...);
-    } catch (const std::runtime_error& e) {
-        PyErr_SetString(PyExc_RuntimeError, e.what());
+    } catch (const std::bad_alloc& e) {
+        PyErr_SetString(PyExc_MemoryError, e.what());
+    } catch (const std::domain_error& e) {
+        PyErr_SetString(PyExc_ValueError, e.what());
+    } catch (const std::invalid_argument& e) {
+        PyErr_SetString(PyExc_ValueError, e.what());
+    } catch (const std::length_error& e) {
+        PyErr_SetString(PyExc_ValueError, e.what());
+    } catch (const std::out_of_range& e) {
+        PyErr_SetString(PyExc_IndexError, e.what());
+    } catch (const std::range_error& e) {
+        PyErr_SetString(PyExc_ValueError, e.what());
+    } catch (const std::overflow_error& e) {
+        PyErr_SetString(PyExc_OverflowError, e.what());
     } catch (std::exception& e) {
-        PyErr_SetString(PyExc_Exception, e.what());
+        PyErr_SetString(PyExc_RuntimeError, e.what());
     } catch (...) {
         PyErr_SetString(PyExc_Exception, "Unknown C++ exception.");
     }

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -6,6 +6,7 @@
 #include "nrnpy.h"
 #include "nrnpy_utils.h"
 #include "nrnpython.h"
+#include "convert_cxx_exceptions.hpp"
 #include <unordered_map>
 
 #include "nrnwrap_dlfcn.h"
@@ -58,8 +59,9 @@ extern PyObject* nrnpy_pushsec(PyObject*);
 extern bool hoc_valid_stmt(const char*, Object*);
 PyObject* nrnpy_nrn();
 extern PyObject* nrnpy_cas(PyObject*, PyObject*);
-extern PyObject* nrnpy_forall(PyObject*, PyObject*);
-extern PyObject* nrnpy_newsecobj(PyObject*, PyObject*, PyObject*);
+extern PyObject* nrnpy_cas_safe(PyObject*, PyObject*);
+extern PyObject* nrnpy_forall_safe(PyObject*, PyObject*);
+extern PyObject* nrnpy_newsecobj_safe(PyObject*, PyObject*, PyObject*);
 extern int section_object_seen;
 extern Symbol* nrn_child_sym;
 extern int nrn_secref_nchild(Section*);
@@ -162,14 +164,22 @@ static PyObject* nrnexec(PyObject* self, PyObject* args) {
     return Py_BuildValue("i", b ? 1 : 0);
 }
 
+static PyObject* nrnexec_safe(PyObject* self, PyObject* args) {
+    return nrn::convert_cxx_exceptions(nrnexec, self, args);
+}
+
 static PyObject* hoc_ac(PyObject* self, PyObject* args) {
     PyArg_ParseTuple(args, "|d", &hoc_ac_);
     return Py_BuildValue("d", hoc_ac_);
 }
 
+static PyObject* hoc_ac_safe(PyObject* self, PyObject* args) {
+    return nrn::convert_cxx_exceptions(hoc_ac, self, args);
+}
+
 static PyMethodDef HocMethods[] = {
-    {"execute", nrnexec, METH_VARARGS, "Execute a hoc command, return 1 on success, 0 on failure."},
-    {"hoc_ac", hoc_ac, METH_VARARGS, "Get (or set) the scalar hoc_ac_."},
+    {"execute", nrnexec_safe, METH_VARARGS, "Execute a hoc command, return 1 on success, 0 on failure."},
+    {"hoc_ac", hoc_ac_safe, METH_VARARGS, "Get (or set) the scalar hoc_ac_."},
     {NULL, NULL, 0, NULL}};
 
 static void hocobj_dealloc(PyHocObject* self) {
@@ -339,6 +349,10 @@ static PyObject* hocobj_name(PyObject* pself, PyObject* args) {
         cp.append("<TopLevelHocInterpreter>");
     }
     return Py_BuildValue("s", cp.c_str());
+}
+
+static PyObject* hocobj_name_safe(PyObject* pself, PyObject* args) {
+    return nrn::convert_cxx_exceptions(hocobj_name, pself, args);
 }
 
 static PyObject* hocobj_repr(PyObject* p) {
@@ -1347,6 +1361,10 @@ static PyObject* hocobj_baseattr(PyObject* subself, PyObject* args) {
     return hocobj_getattr(subself, name);
 }
 
+static PyObject* hocobj_baseattr_safe(PyObject* subself, PyObject* args) {
+    return nrn::convert_cxx_exceptions(hocobj_baseattr, subself, args);
+}
+
 static int refuse_to_look;
 static PyObject* hocobj_getattro(PyObject* subself, PyObject* name) {
     PyObject* result = 0;
@@ -1663,6 +1681,10 @@ PyObject* nrnpy_forall(PyObject* self, PyObject* args) {
     pho->u.its_ = PyHoc::Begin;
     pho->iteritem_ = section_list;
     return po;
+}
+
+PyObject* nrnpy_forall_safe(PyObject* self, PyObject* args) {
+    return nrn::convert_cxx_exceptions(nrnpy_forall, self, args);
 }
 
 static PyObject* hocobj_iter(PyObject* self) {
@@ -2212,6 +2234,10 @@ static PyObject* mkref(PyObject* self, PyObject* args) {
     return NULL;
 }
 
+static PyObject* mkref_safe(PyObject* self, PyObject* args) {
+    return nrn::convert_cxx_exceptions(mkref, self, args);
+}
+
 static PyObject* cpp2refstr(char** cpp) {
     // If cpp is from a hoc_temp_charptr (see src/oc/code.cpp) then create a
     // HocRefStr and copy *cpp. Otherwise, assume it is from a hoc strdef
@@ -2282,6 +2308,11 @@ done:
     return result;
 }
 
+
+static PyObject* setpointer_safe(PyObject* self, PyObject* args) {
+    return nrn::convert_cxx_exceptions(setpointer, self, args);
+}
+
 static PyObject* hocobj_vptr(PyObject* pself, PyObject* args) {
     Object* ho = ((PyHocObject*) pself)->ho_;
     PyObject* po = NULL;
@@ -2292,6 +2323,10 @@ static PyObject* hocobj_vptr(PyObject* pself, PyObject* args) {
         PyErr_SetString(PyExc_TypeError, "HocObject does not wrap a Hoc Object");
     }
     return po;
+}
+
+static PyObject* hocobj_vptr_safe(PyObject* pself, PyObject* args) {
+    return nrn::convert_cxx_exceptions(hocobj_vptr, pself, args);
 }
 
 static long hocobj_hash(PyHocObject* self) {
@@ -2416,6 +2451,10 @@ static PyObject* hocobj_same(PyHocObject* pself, PyObject* args) {
         Py_RETURN_FALSE;
     }
     return NULL;
+}
+
+static PyObject* hocobj_same_safe(PyHocObject* pself, PyObject* args) {
+    return nrn::convert_cxx_exceptions(hocobj_same, pself, args);
 }
 
 static char* double_array_interface(PyObject* po, long& stride) {
@@ -2897,6 +2936,10 @@ static PyObject* hocpickle_reduce(PyObject* self, PyObject* args) {
     return ret;
 }
 
+static PyObject* hocpickle_reduce_safe(PyObject* self, PyObject* args) {
+    return nrn::convert_cxx_exceptions(hocpickle_reduce, self, args);
+}
+
 // following copied (except for nrn_need_byteswap line) from NEURON ivocvect.cpp
 #define BYTEHEADER   \
     uint32_t _II__;  \
@@ -2974,6 +3017,10 @@ static PyObject* hocpickle_setstate(PyObject* self, PyObject* args) {
     return Py_None;
 }
 
+static PyObject* hocpickle_setstate_safe(PyObject* self, PyObject* args) {
+    return nrn::convert_cxx_exceptions(hocpickle_setstate, self, args);
+}
+
 static PyObject* libpython_path(PyObject* self, PyObject* args) {
 #if defined(HAVE_DLFCN_H) && !defined(MINGW)
     Dl_info info;
@@ -2995,31 +3042,35 @@ static PyObject* libpython_path(PyObject* self, PyObject* args) {
 #endif
 }
 
+static PyObject* libpython_path_safe(PyObject* self, PyObject* args) {
+    return nrn::convert_cxx_exceptions(libpython_path, self, args);
+}
+
 // available for every HocObject
 static PyMethodDef hocobj_methods[] = {
-    {"baseattr", hocobj_baseattr, METH_VARARGS, "To allow use of an overrided base method"},
-    {"hocobjptr", hocobj_vptr, METH_NOARGS, "Hoc Object pointer as a long int"},
+    {"baseattr", hocobj_baseattr_safe, METH_VARARGS, "To allow use of an overrided base method"},
+    {"hocobjptr", hocobj_vptr_safe, METH_NOARGS, "Hoc Object pointer as a long int"},
     {"same",
-     (PyCFunction) hocobj_same,
+     (PyCFunction) hocobj_same_safe,
      METH_VARARGS,
      "o1.same(o2) return True if o1 and o2 wrap the same internal HOC Object"},
-    {"hname", hocobj_name, METH_NOARGS, "More specific than __str__() or __attr__()."},
-    {"__reduce__", hocpickle_reduce, METH_VARARGS, "pickle interface"},
-    {"__setstate__", hocpickle_setstate, METH_VARARGS, "pickle interface"},
+    {"hname", hocobj_name_safe, METH_NOARGS, "More specific than __str__() or __attr__()."},
+    {"__reduce__", hocpickle_reduce_safe, METH_VARARGS, "pickle interface"},
+    {"__setstate__", hocpickle_setstate_safe, METH_VARARGS, "pickle interface"},
     {NULL, NULL, 0, NULL}};
 
 // only for a HocTopLevelInterpreter type HocObject
 static PyMethodDef toplevel_methods[] = {
-    {"ref", mkref, METH_VARARGS, "Wrap to allow call by reference in a hoc function"},
-    {"cas", nrnpy_cas, METH_VARARGS, "Return the currently accessed section."},
-    {"allsec", nrnpy_forall, METH_VARARGS, "Return iterator over all sections."},
+    {"ref", mkref_safe, METH_VARARGS, "Wrap to allow call by reference in a hoc function"},
+    {"cas", nrnpy_cas_safe, METH_VARARGS, "Return the currently accessed section."},
+    {"allsec", nrnpy_forall_safe, METH_VARARGS, "Return iterator over all sections."},
     {"Section",
-     (PyCFunction) nrnpy_newsecobj,
+     (PyCFunction) nrnpy_newsecobj_safe,
      METH_VARARGS | METH_KEYWORDS,
      "Return a new Section"},
-    {"setpointer", setpointer, METH_VARARGS, "Assign hoc variable address to NMODL POINTER"},
+    {"setpointer", setpointer_safe, METH_VARARGS, "Assign hoc variable address to NMODL POINTER"},
     {"libpython_path",
-     libpython_path,
+     libpython_path_safe,
      METH_NOARGS,
      "Return full path to file that contains Py_Initialize()"},
     {NULL, NULL, 0, NULL}};

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -178,7 +178,10 @@ static PyObject* hoc_ac_safe(PyObject* self, PyObject* args) {
 }
 
 static PyMethodDef HocMethods[] = {
-    {"execute", nrnexec_safe, METH_VARARGS, "Execute a hoc command, return 1 on success, 0 on failure."},
+    {"execute",
+     nrnexec_safe,
+     METH_VARARGS,
+     "Execute a hoc command, return 1 on success, 0 on failure."},
     {"hoc_ac", hoc_ac_safe, METH_VARARGS, "Get (or set) the scalar hoc_ac_."},
     {NULL, NULL, 0, NULL}};
 

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -935,8 +935,7 @@ static PyObject* NPySecObj_z3d_safe(NPySecObj* self, PyObject* args) {
 }
 
 // returns arc position value at index of 3d list
-static PyObject* NPySecObj_arc3d(NPySecObj* self,
-                                 PyObject* args) {
+static PyObject* NPySecObj_arc3d(NPySecObj* self, PyObject* args) {
     Section* sec = self->sec_;
     CHECK_SEC_INVALID(sec);
     int n, i;
@@ -2818,8 +2817,14 @@ static int rv_setitem_safe(PyObject* self, Py_ssize_t ix, PyObject* value) {
 }
 
 static PyMethodDef NPySecObj_methods[] = {
-    {"name", (PyCFunction) NPySecObj_name_safe, METH_NOARGS, "Section name (same as hoc secname())"},
-    {"hname", (PyCFunction) NPySecObj_name_safe, METH_NOARGS, "Section name (same as hoc secname())"},
+    {"name",
+     (PyCFunction) NPySecObj_name_safe,
+     METH_NOARGS,
+     "Section name (same as hoc secname())"},
+    {"hname",
+     (PyCFunction) NPySecObj_name_safe,
+     METH_NOARGS,
+     "Section name (same as hoc secname())"},
     {"has_membrane",
      (PyCFunction) NPySecObj_has_membrane_safe,
      METH_VARARGS,
@@ -3000,7 +3005,10 @@ static PyMethodDef NPyMechObj_methods[] = {
      (PyCFunction) NPyMechObj_name_safe,
      METH_NOARGS,
      "Mechanism name (same as hoc suffix for density mechanism)"},
-    {"is_ion", (PyCFunction) NPyMechObj_is_ion_safe, METH_NOARGS, "Returns True if an ion mechanism"},
+    {"is_ion",
+     (PyCFunction) NPyMechObj_is_ion_safe,
+     METH_NOARGS,
+     "Returns True if an ion mechanism"},
     {"segment",
      (PyCFunction) NPyMechObj_segment_safe,
      METH_NOARGS,

--- a/src/nrnpython/nrnpy_nrn.h
+++ b/src/nrnpython/nrnpy_nrn.h
@@ -1,17 +1,17 @@
 static PyType_Slot nrnpy_SectionType_slots[] = {
     {Py_tp_dealloc, (void*) NPySecObj_dealloc},
-    {Py_tp_repr, (void*) pysec_repr},
-    {Py_tp_hash, (void*) pysec_hash},
-    {Py_tp_call, (void*) NPySecObj_call},
-    {Py_tp_getattro, (void*) section_getattro},
-    {Py_tp_setattro, (void*) section_setattro},
-    {Py_tp_richcompare, (void*) pysec_richcmp},
-    {Py_tp_iter, (void*) seg_of_section_iter},
+    {Py_tp_repr, (void*) pysec_repr_safe},
+    {Py_tp_hash, (void*) pysec_hash_safe},
+    {Py_tp_call, (void*) NPySecObj_call_safe},
+    {Py_tp_getattro, (void*) section_getattro_safe},
+    {Py_tp_setattro, (void*) section_setattro_safe},
+    {Py_tp_richcompare, (void*) pysec_richcmp_safe},
+    {Py_tp_iter, (void*) seg_of_section_iter_safe},
     {Py_tp_methods, (void*) NPySecObj_methods},
-    {Py_tp_init, (void*) NPySecObj_init},
-    {Py_tp_new, (void*) NPySecObj_new},
+    {Py_tp_init, (void*) NPySecObj_init_safe},
+    {Py_tp_new, (void*) NPySecObj_new_safe},
     {Py_tp_doc, (void*) "Section objects"},
-    {Py_sq_contains, (void*) NPySecObj_contains},
+    {Py_sq_contains, (void*) NPySecObj_contains_safe},
     {0, 0},
 };
 static PyType_Spec nrnpy_SectionType_spec = {
@@ -24,11 +24,11 @@ static PyType_Spec nrnpy_SectionType_spec = {
 
 
 static PyType_Slot nrnpy_AllSegOfSecIterType_slots[] = {
-    {Py_tp_dealloc, (void*) NPyAllSegOfSecIter_dealloc},
-    {Py_tp_iter, (void*) allseg_of_sec_iter},
-    {Py_tp_iternext, (void*) allseg_of_sec_next},
-    {Py_tp_init, (void*) NPyAllSegOfSecIter_init},
-    {Py_tp_new, (void*) NPyAllSegOfSecIter_new},
+    {Py_tp_dealloc, (void*) NPyAllSegOfSecIter_dealloc_safe},
+    {Py_tp_iter, (void*) allseg_of_sec_iter_safe},
+    {Py_tp_iternext, (void*) allseg_of_sec_next_safe},
+    {Py_tp_init, (void*) NPyAllSegOfSecIter_init_safe},
+    {Py_tp_new, (void*) NPyAllSegOfSecIter_new_safe},
     {Py_tp_doc, (void*) "Iterate over all Segments of a Section, including x=0 and 1"},
     {0, 0},
 };
@@ -41,9 +41,9 @@ static PyType_Spec nrnpy_AllSegOfSecIterType_spec = {
 };
 
 static PyType_Slot nrnpy_SegOfSecIterType_slots[] = {
-    {Py_tp_dealloc, (void*) NPySegOfSecIter_dealloc},
+    {Py_tp_dealloc, (void*) NPySegOfSecIter_dealloc_safe},
     {Py_tp_iter, (void*) PyObject_SelfIter},
-    {Py_tp_iternext, (void*) seg_of_sec_next},
+    {Py_tp_iternext, (void*) seg_of_sec_next_safe},
     {Py_tp_doc,
      (void*) "Iterate over nonzero area Segments of a Section (does not include x=0 and 1)"},
     {0, 0},
@@ -57,19 +57,19 @@ static PyType_Spec nrnpy_SegOfSecIterType_spec = {
 };
 
 static PyType_Slot nrnpy_SegmentType_slots[] = {
-    {Py_tp_dealloc, (void*) NPySegObj_dealloc},
-    {Py_tp_repr, (void*) pyseg_repr},
-    {Py_tp_hash, (void*) pyseg_hash},
-    {Py_tp_getattro, (void*) segment_getattro},
-    {Py_tp_setattro, (void*) segment_setattro},
-    {Py_tp_richcompare, (void*) pyseg_richcmp},
-    {Py_tp_iter, (void*) mech_of_segment_iter},
+    {Py_tp_dealloc, (void*) NPySegObj_dealloc_safe},
+    {Py_tp_repr, (void*) pyseg_repr_safe},
+    {Py_tp_hash, (void*) pyseg_hash_safe},
+    {Py_tp_getattro, (void*) segment_getattro_safe},
+    {Py_tp_setattro, (void*) segment_setattro_safe},
+    {Py_tp_richcompare, (void*) pyseg_richcmp_safe},
+    {Py_tp_iter, (void*) mech_of_segment_iter_safe},
     {Py_tp_methods, (void*) NPySegObj_methods},
     {Py_tp_members, (void*) NPySegObj_members},
-    {Py_tp_init, (void*) NPySegObj_init},
-    {Py_tp_new, (void*) NPySegObj_new},
+    {Py_tp_init, (void*) NPySegObj_init_safe},
+    {Py_tp_new, (void*) NPySegObj_new_safe},
     {Py_tp_doc, (void*) "Segment objects"},
-    {Py_sq_contains, (void*) NPySegObj_contains},
+    {Py_sq_contains, (void*) NPySegObj_contains_safe},
     {0, 0},
 };
 static PyType_Spec nrnpy_SegmentType_spec = {
@@ -81,9 +81,9 @@ static PyType_Spec nrnpy_SegmentType_spec = {
 };
 
 static PyType_Slot nrnpy_MechOfSegIterType_slots[] = {
-    {Py_tp_dealloc, (void*) NPyMechOfSegIter_dealloc},
+    {Py_tp_dealloc, (void*) NPyMechOfSegIter_dealloc_safe},
     {Py_tp_iter, (void*) PyObject_SelfIter},
-    {Py_tp_iternext, (void*) mech_of_seg_next},
+    {Py_tp_iternext, (void*) mech_of_seg_next_safe},
     {Py_tp_doc, (void*) "Iterate over Mechanisms in a Segment of a Section"},
     {0, 0},
 };
@@ -96,15 +96,15 @@ static PyType_Spec nrnpy_MechOfSegIterType_spec = {
 };
 
 static PyType_Slot nrnpy_MechanismType_slots[] = {
-    {Py_tp_dealloc, (void*) NPyMechObj_dealloc},
-    {Py_tp_repr, (void*) pymech_repr},
-    {Py_tp_getattro, (void*) mech_getattro},
-    {Py_tp_setattro, (void*) mech_setattro},
-    {Py_tp_iter, (void*) var_of_mech_iter},
+    {Py_tp_dealloc, (void*) NPyMechObj_dealloc_safe},
+    {Py_tp_repr, (void*) pymech_repr_safe},
+    {Py_tp_getattro, (void*) mech_getattro_safe},
+    {Py_tp_setattro, (void*) mech_setattro_safe},
+    {Py_tp_iter, (void*) var_of_mech_iter_safe},
     {Py_tp_methods, (void*) NPyMechObj_methods},
     {Py_tp_members, (void*) NPyMechObj_members},
-    {Py_tp_init, (void*) NPyMechObj_init},
-    {Py_tp_new, (void*) NPyMechObj_new},
+    {Py_tp_init, (void*) NPyMechObj_init_safe},
+    {Py_tp_new, (void*) NPyMechObj_new_safe},
     {Py_tp_doc, (void*) "Mechanism objects"},
     {0, 0},
 };
@@ -117,10 +117,10 @@ static PyType_Spec nrnpy_MechanismType_spec = {
 };
 
 static PyType_Slot nrnpy_MechFuncType_slots[] = {
-    {Py_tp_dealloc, (void*) NPyMechFunc_dealloc},
-    {Py_tp_repr, (void*) pymechfunc_repr},
+    {Py_tp_dealloc, (void*) NPyMechFunc_dealloc_safe},
+    {Py_tp_repr, (void*) pymechfunc_repr_safe},
     {Py_tp_methods, (void*) NPyMechFunc_methods},
-    {Py_tp_call, (void*) NPyMechFunc_call},
+    {Py_tp_call, (void*) NPyMechFunc_call_safe},
     {Py_tp_doc, (void*) "Mechanism Function"},
     {0, 0},
 };
@@ -133,9 +133,9 @@ static PyType_Spec nrnpy_MechFuncType_spec = {
 };
 
 static PyType_Slot nrnpy_VarOfMechIterType_slots[] = {
-    {Py_tp_dealloc, (void*) NPyVarOfMechIter_dealloc},
+    {Py_tp_dealloc, (void*) NPyVarOfMechIter_dealloc_safe},
     {Py_tp_iter, (void*) PyObject_SelfIter},
-    {Py_tp_iternext, (void*) var_of_mech_next},
+    {Py_tp_iternext, (void*) var_of_mech_next_safe},
     {Py_tp_doc, (void*) "Iterate over variables  in a Mechanism"},
     {0, 0},
 };
@@ -148,14 +148,14 @@ static PyType_Spec nrnpy_VarOfMechIterType_spec = {
 };
 
 static PyType_Slot nrnpy_RangeType_slots[] = {
-    {Py_tp_dealloc, (void*) NPyRangeVar_dealloc},
+    {Py_tp_dealloc, (void*) NPyRangeVar_dealloc_safe},
     {Py_tp_methods, (void*) NPyRangeVar_methods},
-    {Py_tp_init, (void*) NPyRangeVar_init},
-    {Py_tp_new, (void*) NPyRangeVar_new},
+    {Py_tp_init, (void*) NPyRangeVar_init_safe},
+    {Py_tp_new, (void*) NPyRangeVar_new_safe},
     {Py_tp_doc, (void*) "Range Variable Array objects"},
-    {Py_sq_length, (void*) rv_len},
-    {Py_sq_item, (void*) rv_getitem},
-    {Py_sq_ass_item, (void*) rv_setitem},
+    {Py_sq_length, (void*) rv_len_safe},
+    {Py_sq_item, (void*) rv_getitem_safe},
+    {Py_sq_ass_item, (void*) rv_setitem_safe},
     {0, 0},
 };
 static PyType_Spec nrnpy_RangeType_spec = {


### PR DESCRIPTION
This PR introduces a wrapper of all C function that are registered with Python. The wrapper catches all exceptions, and converts them to Python exceptions, then it returns a value signaling an error.

The reason we want to convert C++ exceptions to Python errors, is that when a C++ exception occurs, it terminates the program in a manner that makes it very hard to determine which Python code triggered the exception. For example PDB will crash before being able to print a backtrace. Similarly the regular Python exception mechanism will not run; and not print the usual helpful backtraces. Using GDB for example reveals that `PyEval_EvalCode` calls `getattro` for `rng_StochKv3`, but it doesn't help understand what happened in the Python layer, i.e. what lead to calling `getattro`.

With the wrapper we get the following output for #2783:
```
Traceback (most recent call last):
  File "/repro_neuron9_bug/nrn-repro.py", line 20, in <module>
    s.psection()
  File "/build-debug/install/lib/python/neuron/psection.py", line 66, in psection
    pvals.append(getattr(seg, mechname))
                 ^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: generic_data_handle{raw=0x57a598c7f120 type=void*} cannot be converted to data_handle<double>
```
It contains the C++ error message `generic_data_handle bla bla bla` but also the Python backtrace. We get the same behaviour in the more complex reproducer, which allowed us to instantly spot that the bug was indeed in NRN not in the user library. We can now use PDB for debugging:
```
> /build-debug/install/lib/python/neuron/psection.py(66)psection()
-> pvals.append(getattr(seg, mechname))
(Pdb) l
 61  	               mechname = name  # + '_' + mech
 62  	               for seg in sec:
 63  	                   if n > 1:
 64  	                       pvals.append([getattr(seg, mechname)[i] for i in range(n)])
 65  	                   else:
 66  ->	                       pvals.append(getattr(seg, mechname))
 67  	           my_results[
 68  	               name[: -(len(mech) + 1)] if name.endswith("_" + mech) else name
 69  	           ] = pvals
 70  	       # TODO: should be a better way of testing if an ion
 71  	       if mech.endswith("_ion"):
```
If we want to debug the C++ layer we use GDB as before on `x86_64/special`.