### PR TITLE
Header Hygiene

### DIFF
--- a/src/nrnoc/multicore.cpp
+++ b/src/nrnoc/multicore.cpp
@@ -1,3 +1,5 @@
+#include "multicore.h"
+
 #include <nrnmpi.h>
 
 #include "hoclist.h"
@@ -58,7 +60,6 @@ void (*nrn_mk_transfer_thread_data_)();
 
 static int busywait_;
 static int busywait_main_;
-extern void nrn_thread_error(const char*);
 extern void (*nrn_multisplit_setup_)();
 extern int v_structure_change;
 extern int diam_changed;

--- a/src/nrnoc/multicore.h
+++ b/src/nrnoc/multicore.h
@@ -108,20 +108,25 @@ struct NrnThread {
 
 extern int nrn_nthread;
 extern NrnThread* nrn_threads;
+
+int nrn_allow_busywait(int b);
+int nrn_how_many_processors();
 void nrn_threads_create(int n, bool parallel);
-extern void nrn_thread_error(const char*);
+void nrn_thread_error(const char*);
 using worker_job_t = void* (*) (NrnThread*);
 using worker_job_with_token_t = void (*)(neuron::model_sorted_token const&, NrnThread&);
 void nrn_multithread_job(worker_job_t);
 void nrn_multithread_job(neuron::model_sorted_token const&, worker_job_with_token_t);
-extern void nrn_onethread_job(int, void* (*) (NrnThread*) );
-extern void nrn_wait_for_threads();
+void nrn_onethread_job(int, void* (*) (NrnThread*) );
+void nrn_wait_for_threads();
+Object** nrn_get_thread_partition(int it);
+void nrn_thread_partition(int it, Object* sl);
 void nrn_thread_table_check(neuron::model_sorted_token const&);
-extern void nrn_threads_free();
-extern int nrn_user_partition();
-extern void reorder_secorder();
-extern void nrn_thread_memblist_setup();
-extern std::size_t nof_worker_threads();
+void nrn_threads_free();
+int nrn_user_partition();
+void reorder_secorder();
+void nrn_thread_memblist_setup();
+std::size_t nof_worker_threads();
 
 #define FOR_THREADS(nt) for (nt = nrn_threads; nt < nrn_threads + nrn_nthread; ++nt)
 

--- a/src/parallel/ocbbs.cpp
+++ b/src/parallel/ocbbs.cpp
@@ -1,13 +1,11 @@
 #include <list>
 #include <InterViews/resource.h>
+
 #include "classreg.h"
-#include "oc2iv.h"
 #include "ivocvect.h"
 #include "hoclist.h"
 #include "bbs.h"
 #include "bbsimpl.h"
-#include "ivocvect.h"
-#include "parse.hpp"
 #include "section.h"
 #include "membfunc.h"
 #include "multicore.h"
@@ -15,7 +13,7 @@
 #include "utils/profile/profiler_interface.h"
 #include "node_order_optim/node_order_optim.h"
 #include <nrnmpi.h>
-#include <errno.h>
+#include <cerrno>
 
 #undef MD
 #define MD 2147483647.
@@ -24,7 +22,6 @@ extern int hoc_return_type_code;
 
 extern int vector_arg_px(int, double**);
 Symbol* hoc_which_template(Symbol*);
-void bbs_done();
 extern double t;
 extern void nrnmpi_source_var(), nrnmpi_target_var(), nrnmpi_setup_transfer();
 extern int nrnmpi_spike_compress(int nspike, bool gid_compress, int xchng_meth);
@@ -48,15 +45,12 @@ static void nrnmpi_char_broadcast(char*, int, int) {}
 static void nrnmpi_dbl_broadcast(double*, int, int) {}
 #endif
 extern double* nrn_mech_wtime_;
-extern int nrn_nthread;
-extern void nrn_thread_partition(int, Object*);
-extern Object** nrn_get_thread_partition(int);
-extern int nrn_allow_busywait(int);
-extern int nrn_how_many_processors();
+
+extern bool nrn_trajectory_request_per_time_step_;
+
 extern size_t nrncore_write();
 extern size_t nrnbbcore_register_mapping();
 extern int nrncore_run(const char*);
-extern bool nrn_trajectory_request_per_time_step_;
 extern int nrncore_is_enabled();
 extern int nrncore_is_file_mode();
 extern int nrncore_psolve(double tstop, int file_mode);

--- a/test/common/catch2_main.cpp
+++ b/test/common/catch2_main.cpp
@@ -6,6 +6,7 @@
 #include "nrnmpi.h"
 #include "ocfunc.h"
 #include "section.h"
+#include "multicore.h"
 
 #include <exception>
 
@@ -19,7 +20,6 @@ extern "C" void modl_reg() {}
 void nrnmpi_stubs();
 #endif
 
-extern int nrn_how_many_processors();
 namespace nrn::test {
 int PROCESSORS{0};
 int MAX_PROCESSORS{nrn_how_many_processors()};


### PR DESCRIPTION
* have `multicore.h` declare all the functions that are used elsewhere
* instead of `extern decl;` elsewhere, `#include "multicore.h"`
* cleanup