### PR TITLE
Use `Py_RETURN_NONE` macro when return `Py_None`

### DIFF
--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -572,7 +572,7 @@ Object* nrnpy_po2ho(PyObject* po) {
     // po.
     Object* o;
     if (po == Py_None) {
-        o = 0;
+        o = NULL;
     } else if (PyObject_TypeCheck(po, hocobject_type)) {
         PyHocObject* pho = (PyHocObject*) po;
         if (pho->type_ == PyHoc::HocObject) {
@@ -2263,7 +2263,7 @@ static PyObject* cpp2refstr(char** cpp) {
 }
 
 static PyObject* setpointer(PyObject* self, PyObject* args) {
-    PyObject *ref, *name, *pp, *result = NULL;
+    PyObject *ref, *name, *pp;
     if (PyArg_ParseTuple(args, "O!OO", hocobject_type, &ref, &name, &pp) == 1) {
         PyHocObject* href = (PyHocObject*) ref;
         double** ppd = 0;
@@ -2299,16 +2299,13 @@ static PyObject* setpointer(PyObject* self, PyObject* args) {
             }
         }
         *gh = neuron::container::generic_data_handle{href->u.px_};
-        result = Py_None;
-        Py_INCREF(result);
+        Py_RETURN_NONE;
     }
 done:
-    if (!result) {
-        PyErr_SetString(PyExc_TypeError,
-                        "setpointer(_ref_hocvar, 'POINTER_name', point_process or "
-                        "nrn.Mechanism))");
-    }
-    return result;
+    PyErr_SetString(PyExc_TypeError,
+                    "setpointer(_ref_hocvar, 'POINTER_name', point_process or "
+                    "nrn.Mechanism))");
+    return NULL;
 }
 
 
@@ -3016,8 +3013,8 @@ static PyObject* hocpickle_setstate(PyObject* self, PyObject* args) {
     }
     memcpy((char*) vector_vec(vec), datastr, len);
     Py_DECREF(rawdata);
-    Py_INCREF(Py_None);
-    return Py_None;
+
+    Py_RETURN_NONE;
 }
 
 static PyObject* hocpickle_setstate_safe(PyObject* self, PyObject* args) {
@@ -3040,8 +3037,7 @@ static PyObject* libpython_path(PyObject* self, PyObject* args) {
     }
     return Py_BuildValue("s", info.dli_fname);
 #else
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 #endif
 }
 

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -1070,8 +1070,7 @@ static PyObject* NPySecObj_psection(NPySecObj* self) {
         Py_DECREF(arglist);
         return result;
     }
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyObject* NPySecObj_psection_safe(NPySecObj* self) {
@@ -1122,8 +1121,7 @@ static PyObject* newpyseghelp(Section* sec, double x) {
 static PyObject* pysec_disconnect(NPySecObj* self) {
     CHECK_SEC_INVALID(self->sec_);
     nrn_disconnect(self->sec_);
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyObject* pysec_disconnect_safe(NPySecObj* self) {
@@ -1134,8 +1132,7 @@ static PyObject* pysec_parentseg(NPySecObj* self) {
     CHECK_SEC_INVALID(self->sec_);
     Section* psec = self->sec_->parentsec;
     if (psec == NULL || psec->prop == NULL) {
-        Py_INCREF(Py_None);
-        return Py_None;
+        Py_RETURN_NONE;
     }
     double x = nrn_connection_position(self->sec_);
     return newpyseghelp(psec, x);
@@ -1151,8 +1148,7 @@ static PyObject* pysec_trueparentseg(NPySecObj* self) {
     Section* psec = NULL;
     for (psec = sec->parentsec; psec; psec = psec->parentsec) {
         if (psec == NULL || psec->prop == NULL) {
-            Py_INCREF(Py_None);
-            return Py_None;
+            Py_RETURN_NONE;
         }
         if (nrn_at_beginning(sec)) {
             sec = psec;
@@ -1161,8 +1157,7 @@ static PyObject* pysec_trueparentseg(NPySecObj* self) {
         }
     }
     if (psec == NULL) {
-        Py_INCREF(Py_None);
-        return Py_None;
+        Py_RETURN_NONE;
     }
 
     double x = nrn_connection_position(sec);
@@ -1268,8 +1263,7 @@ static PyObject* pysec2cell(NPySecObj* self) {
     } else if (auto* o = self->sec_->prop->dparam[6].get<Object*>(); self->sec_->prop && o) {
         result = nrnpy_ho2po(o);
     } else {
-        result = Py_None;
-        Py_INCREF(result);
+        Py_RETURN_NONE;
     }
     return result;
 }

--- a/src/nrnpython/nrnpy_p2h.cpp
+++ b/src/nrnpython/nrnpy_p2h.cpp
@@ -1,6 +1,6 @@
 #include <../../nrnconf.h>
 
-#include <stdio.h>
+#include <cstdio>
 #include <InterViews/resource.h>
 #include <nrnoc2iv.h>
 #include <classreg.h>


### PR DESCRIPTION
* for older pythons (ex: 3.8) it increments and returns: https://github.com/python/cpython/blob/3.8/Include/object.h#L564
* In later version of python, since `None` is an immortal singleton, the right thing happens: https://github.com/python/cpython/blob/main/Include/object.h#L644