### PR TITLE
Set MACOSX_DEPLOYMENT_TARGET in CI to avoid extra warnings

### DIFF
--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -136,6 +136,13 @@ jobs:
           echo CI_OS_NAME=osx >> $GITHUB_ENV
         shell: bash
 
+      - name: Setup MacOS Deployment Target
+        if: startsWith(matrix.os, 'macOS')
+        run: |
+          # Avoid spurious/extra warnings in CIs
+          export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion | awk -F. '{print $1 "." $2}')
+          echo "Setting MACOSX_DEPLOYMENT_TARGET to $MACOSX_DEPLOYMENT_TARGET"
+
       - name: Install apt packages
         if: startsWith(matrix.os, 'ubuntu')
         run: |


### PR DESCRIPTION
* In CI logs, we see the warnings like below (see [this comment](https://github.com/neuronsimulator/nrn/pull/2893#issuecomment-2189083367) and [CI log](https://github.com/neuronsimulator/nrn/actions/runs/9662450338/job/26652360543?pr=2893#step:18:3453)):

```
ld: warning: ld: warning: object file (x86_64/corenrn/build/libcoreneuron-core/capac.cpp.o) was built for newer macOS version (12.7) than being linked (12.0)
object file (x86_64/corenrn/build/libcoreneuron-core/abort.cpp.o) was built for newer macOS version (12.7) than being linked (12.0)
...
```
* Discussion [here](https://github.com/golang/go/issues/43856#issuecomment-765905150) suggests upgrading CommandLineTools should solve the issue.
* As this is for CI runners, I think it's OK to just set latest/compatible deployment target.