### PR TITLE
Hines/thread padding

### DIFF
--- a/src/neuron/cache/mechanism_range.hpp
+++ b/src/neuron/cache/mechanism_range.hpp
@@ -55,7 +55,7 @@ struct MechanismRange {
                    NrnThread&,
                    Memb_list& ml,
                    int type)
-        : MechanismRange{type, ml.get_storage_offset()} {
+        : MechanismRange{type, ml.get_storage_offset(), ml.m_cache_offset} {
         auto const& ptr_cache = mechanism::_get::_pdata_ptr_cache_data(cache_token, type);
         m_pdata_ptrs = ptr_cache.data();
         assert(ptr_cache.size() <= NumDatumFields);

--- a/src/nrniv/nonlinz.cpp
+++ b/src/nrniv/nonlinz.cpp
@@ -523,6 +523,7 @@ void NonLinImpRep::current(int im, Memb_list* ml, int in) {  // assume there is 
     mfake.nodeindices = ml->nodeindices + in;
     mfake.nodelist = ml->nodelist + in;
     mfake.set_storage_offset(ml->get_storage_offset());
+    mfake.m_cache_offset = ml->m_cache_offset;
     mfake.pdata = ml->pdata + in;
     mfake.prop = ml->prop ? ml->prop + in : nullptr;
     mfake.nodecount = 1;

--- a/src/nrnoc/memblist.cpp
+++ b/src/nrnoc/memblist.cpp
@@ -4,7 +4,7 @@
 #include "nrnassrt.h"
 #include "nrnoc_ml.h"
 
-//warning: deleting pointer to incomplete type 'Prop' may cause undefined behavior
+// warning: deleting pointer to incomplete type 'Prop' may cause undefined behavior
 #include "section.h"
 
 #include <cassert>

--- a/src/nrnoc/memblist.cpp
+++ b/src/nrnoc/memblist.cpp
@@ -4,6 +4,9 @@
 #include "nrnassrt.h"
 #include "nrnoc_ml.h"
 
+//warning: deleting pointer to incomplete type 'Prop' may cause undefined behavior
+#include "section.h"
+
 #include <cassert>
 #include <iterator>  // std::distance, std::next
 #include <numeric>   // std::accumulate
@@ -59,8 +62,12 @@ Memb_list::~Memb_list() noexcept {
     if (m_owns_nodes) {
         nodes_free();
     }
-    for (std::size_t i = 0; i < mech_padding.size(); ++i) {
-        delete mech_padding[i];
+    if (mech_padding) {
+        auto& mp = *mech_padding;
+        for (std::size_t i = 0; i < mp.size(); ++i) {
+            delete mp[i];
+        }
+        mech_padding = nullptr;
     }
 }
 

--- a/src/nrnoc/memblist.cpp
+++ b/src/nrnoc/memblist.cpp
@@ -59,6 +59,9 @@ Memb_list::~Memb_list() noexcept {
     if (m_owns_nodes) {
         nodes_free();
     }
+    for (std::size_t i = 0; i < mech_padding.size(); ++i) {
+        delete mech_padding[i];
+    }
 }
 
 [[nodiscard]] std::vector<double*> Memb_list::data() {

--- a/src/nrnoc/multicore.cpp
+++ b/src/nrnoc/multicore.cpp
@@ -388,7 +388,12 @@ void nrn_threads_free() {
         NrnThread* nt = nrn_threads + it;
         NrnThreadMembList *tml, *tml2;
         if (nt->node_padding) {
+            auto& np = *nt->node_padding;
+            for (std::size_t i = 0; i < np.size(); ++i) {
+                delete np[i];
+            }
             delete nt->node_padding;
+            nt->node_padding = nullptr;
         }
         for (tml = nt->tml; tml; tml = tml2) {
             Memb_list* ml = tml->ml;

--- a/src/nrnoc/multicore.cpp
+++ b/src/nrnoc/multicore.cpp
@@ -334,6 +334,7 @@ void nrn_threads_create(int n, bool parallel) {
                 nt->userpart = 0;
                 nt->ncell = 0;
                 nt->end = 0;
+                nt->padding = 0;
                 for (j = 0; j < BEFORE_AFTER_SIZE; ++j) {
                     nt->tbl[j] = (NrnThreadBAList*) 0;
                 }

--- a/src/nrnoc/multicore.cpp
+++ b/src/nrnoc/multicore.cpp
@@ -326,6 +326,7 @@ void nrn_threads_create(int n, bool parallel) {
                 nt = nrn_threads + i;
                 nt->_t = 0.;
                 nt->_dt = -1e9;
+                nt->node_padding = nullptr;
                 nt->id = i;
                 nt->_stop_stepping = 0;
                 nt->tml = (NrnThreadMembList*) 0;
@@ -334,7 +335,6 @@ void nrn_threads_create(int n, bool parallel) {
                 nt->userpart = 0;
                 nt->ncell = 0;
                 nt->end = 0;
-                nt->padding = 0;
                 for (j = 0; j < BEFORE_AFTER_SIZE; ++j) {
                     nt->tbl[j] = (NrnThreadBAList*) 0;
                 }
@@ -387,6 +387,9 @@ void nrn_threads_free() {
     for (it = 0; it < nrn_nthread; ++it) {
         NrnThread* nt = nrn_threads + it;
         NrnThreadMembList *tml, *tml2;
+        if (nt->node_padding) {
+            delete nt->node_padding;
+        }
         for (tml = nt->tml; tml; tml = tml2) {
             Memb_list* ml = tml->ml;
             tml2 = tml->next;

--- a/src/nrnoc/multicore.h
+++ b/src/nrnoc/multicore.h
@@ -61,23 +61,23 @@ struct NrnThread {
     double cj;
     NrnThreadMembList* tml;
     Memb_list** _ml_list;
-    int ncell;            /* analogous to old rootnodecount */
-    int end;              /* 1 + position of last in v_node array. Now v_node_count. */
+    int ncell; /* analogous to old rootnodecount */
+    int end;   /* 1 + position of last in v_node array. Now v_node_count. */
     std::vector<Node*>* node_padding;
-                          /* Node storage rows after end for padding
-                             Data for all threads is in SoA storage
-                             and threads merely define a permutation that
-                             leaves each thread segregated but adjacent.
-                             To avoid cacheline sharing, we need to ensure
-                             that each (next) thread begins on a cacheline
-                             boundary. See
-                             std::hardware_destructive_interference_size (normally 64 bytes)
-                             I'm hoping that padding can be implemented in a
-                             somewhat isolated way that involves creating SoA
-                             storage rows, permuting them to
-                             the proper index after end, and, at some point,
-                             marking them as deleted.
-                             */
+    /* Node storage rows after end for padding
+       Data for all threads is in SoA storage
+       and threads merely define a permutation that
+       leaves each thread segregated but adjacent.
+       To avoid cacheline sharing, we need to ensure
+       that each (next) thread begins on a cacheline
+       boundary. See
+       std::hardware_destructive_interference_size (normally 64 bytes)
+       I'm hoping that padding can be implemented in a
+       somewhat isolated way that involves creating SoA
+       storage rows, permuting them to
+       the proper index after end, and, at some point,
+       marking them as deleted.
+       */
     int id;               /* this is nrn_threads[id] */
     int _stop_stepping;   /* delivered an all thread HocEvent */
     int _ecell_child_cnt; /* see _ecell_children below */

--- a/src/nrnoc/multicore.h
+++ b/src/nrnoc/multicore.h
@@ -63,7 +63,8 @@ struct NrnThread {
     Memb_list** _ml_list;
     int ncell;            /* analogous to old rootnodecount */
     int end;              /* 1 + position of last in v_node array. Now v_node_count. */
-    int padding;          /* Number of (unused) Soa storage rows after end.
+    std::vector<Node>* node_padding{};
+                          /* Node storage rows after end for padding
                              Data for all threads is in SoA storage
                              and threads merely define a permutation that
                              leaves each thread segregated but adjacent.

--- a/src/nrnoc/multicore.h
+++ b/src/nrnoc/multicore.h
@@ -63,6 +63,20 @@ struct NrnThread {
     Memb_list** _ml_list;
     int ncell;            /* analogous to old rootnodecount */
     int end;              /* 1 + position of last in v_node array. Now v_node_count. */
+    int padding;          /* Number of (unused) Soa storage rows after end.
+                             Data for all threads is in SoA storage
+                             and threads merely define a permutation that
+                             leaves each thread segregated but adjacent.
+                             To avoid cacheline sharing, we need to ensure
+                             that each (next) thread begins on a cacheline
+                             boundary. See
+                             std::hardware_destructive_interference_size (normally 64 bytes)
+                             I'm hoping that padding can be implemented in a
+                             somewhat isolated way that involves creating SoA
+                             storage rows, permuting them to
+                             the proper index after end, and, at some point,
+                             marking them as deleted.
+                             */
     int id;               /* this is nrn_threads[id] */
     int _stop_stepping;   /* delivered an all thread HocEvent */
     int _ecell_child_cnt; /* see _ecell_children below */

--- a/src/nrnoc/multicore.h
+++ b/src/nrnoc/multicore.h
@@ -63,7 +63,7 @@ struct NrnThread {
     Memb_list** _ml_list;
     int ncell;            /* analogous to old rootnodecount */
     int end;              /* 1 + position of last in v_node array. Now v_node_count. */
-    std::vector<Node>* node_padding{};
+    std::vector<Node*>* node_padding;
                           /* Node storage rows after end for padding
                              Data for all threads is in SoA storage
                              and threads merely define a permutation that

--- a/src/nrnoc/nrnoc_ml.h
+++ b/src/nrnoc/nrnoc_ml.h
@@ -79,7 +79,7 @@ struct Memb_list {
                          instance count (in this thread (nodeindices
                          and nodelist are NULL)).
                          */
-    std::vector<Prop*> mech_padding;
+    std::vector<Prop*>* mech_padding{};
                    /* See the multicore.h NrnThread node_padding comment.
                       To avoid false cacheline sharing, need to ensure the
                       next thread data begins on cacheline boundary. Generally,

--- a/src/nrnoc/nrnoc_ml.h
+++ b/src/nrnoc/nrnoc_ml.h
@@ -79,7 +79,8 @@ struct Memb_list {
                          instance count (in this thread (nodeindices
                          and nodelist are NULL)).
                          */
-    int padding{}; /* See the multicore.h NrnThread padding comment.
+    std::vector<Prop*> mech_padding;
+                   /* See the multicore.h NrnThread node_padding comment.
                       To avoid false cacheline sharing, need to ensure the
                       next thread data begins on cacheline boundary. Generally,
                       (nodecount + padding)*sizeof(double)

--- a/src/nrnoc/nrnoc_ml.h
+++ b/src/nrnoc/nrnoc_ml.h
@@ -223,6 +223,11 @@ struct Memb_list {
         m_storage_offset = offset;
     }
 
+    // Part of the storage padding experiment. If worthwhile then make private
+    // and use get_cache_offset() and set_cache_offset(std::size_t) in analogy
+    // with get_ and set_ storage_offset
+    std::size_t m_cache_offset{};
+
     /**
      * @brief Set the pointer to the underlying data container.
      *

--- a/src/nrnoc/nrnoc_ml.h
+++ b/src/nrnoc/nrnoc_ml.h
@@ -75,7 +75,18 @@ struct Memb_list {
     Datum** pdata{};
     Prop** prop{};
     Datum* _thread{}; /* thread specific data (when static is no good) */
-    int nodecount{};
+    int nodecount{};  /* For ARTIFICIAL_CELL, I believe this refers to the
+                         instance count (in this thread (nodeindices
+                         and nodelist are NULL)).
+                         */
+    int padding{}; /* See the multicore.h NrnThread padding comment.
+                      To avoid false cacheline sharing, need to ensure the
+                      next thread data begins on cacheline boundary. Generally,
+                      (nodecount + padding)*sizeof(double)
+                      should be multiple of 64 bytes (8 doubles).
+                      ??? instead of sizeof(double), should it be the minimum
+                      sizeof of an item in the SoA storage row?
+                      */
     /**
      * @brief Get a vector of double* representing the model data.
      *

--- a/src/nrnoc/nrnoc_ml.h
+++ b/src/nrnoc/nrnoc_ml.h
@@ -80,14 +80,14 @@ struct Memb_list {
                          and nodelist are NULL)).
                          */
     std::vector<Prop*>* mech_padding{};
-                   /* See the multicore.h NrnThread node_padding comment.
-                      To avoid false cacheline sharing, need to ensure the
-                      next thread data begins on cacheline boundary. Generally,
-                      (nodecount + padding)*sizeof(double)
-                      should be multiple of 64 bytes (8 doubles).
-                      ??? instead of sizeof(double), should it be the minimum
-                      sizeof of an item in the SoA storage row?
-                      */
+    /* See the multicore.h NrnThread node_padding comment.
+       To avoid false cacheline sharing, need to ensure the
+       next thread data begins on cacheline boundary. Generally,
+       (nodecount + padding)*sizeof(double)
+       should be multiple of 64 bytes (8 doubles).
+       ??? instead of sizeof(double), should it be the minimum
+       sizeof of an item in the SoA storage row?
+       */
     /**
      * @brief Get a vector of double* representing the model data.
      *

--- a/src/nrnoc/treeset.cpp
+++ b/src/nrnoc/treeset.cpp
@@ -74,7 +74,7 @@ extern cTemplate** nrn_pnt_template_;
 #endif
 
 namespace nrn {
-static size_t cacheline_bytesize{64}; // Would like to determine dynamically.
+static size_t cacheline_bytesize{64};  // Would like to determine dynamically.
 size_t xtra_padding(size_t nbytes) {
     auto x = nbytes % cacheline_bytesize;
     return x ? cacheline_bytesize - x : 0;
@@ -86,9 +86,9 @@ size_t xtra_padding(size_t nbytes) {
 static void pr_thread_padding() {
     NrnThread* nt{};
     FOR_THREADS(nt) {
-        if (nt->node_padding) {        
+        if (nt->node_padding) {
             auto& np = *nt->node_padding;
-            for(auto& node: np) {
+            for (auto& node: np) {
                 std::cout << "QQQ tid=" << nt->id << "  " << *node << std::endl;
             }
         }
@@ -109,7 +109,7 @@ static void add_thread_padding() {
     NrnThread* nt;
     FOR_THREADS(nt) {
         auto dsz = sizeof(double);
-        size_t npad = xtra_padding(nt->end*dsz)/dsz;
+        size_t npad = xtra_padding(nt->end * dsz) / dsz;
         if (!nt->node_padding) {
             nt->node_padding = new std::vector<Node*>();
         }
@@ -119,19 +119,19 @@ static void add_thread_padding() {
         }
         np.clear();
         np.reserve(npad);
-        for (size_t i=0; i < npad; ++i) {
+        for (size_t i = 0; i < npad; ++i) {
             np.push_back(new Node());
         }
 
         for (auto tml = nt->tml; tml; tml = tml->next) {
             Memb_list* ml = tml->ml;
-            npad = xtra_padding(ml->nodecount*dsz)/dsz;
+            npad = xtra_padding(ml->nodecount * dsz) / dsz;
             if (!ml->mech_padding) {
                 ml->mech_padding = new std::vector<Prop*>();
             }
             if (ml->mech_padding) {
                 auto& mp = *ml->mech_padding;
-                for(auto& ptr: mp) {
+                for (auto& ptr: mp) {
                     delete ptr;
                 }
                 mp.clear();
@@ -145,7 +145,7 @@ static void add_thread_padding() {
     }
     pr_thread_padding();
 }
-} // namespace nrn
+}  // namespace nrn
 
 /*
 (2002-04-06)
@@ -2233,7 +2233,7 @@ static void nrn_sort_mech_data(
             // permute the padding to global_id
             if (ml && ml->mech_padding) {
                 auto& mp = *ml->mech_padding;
-                for (std::size_t i=0; i < mp.size(); ++i) {
+                for (std::size_t i = 0; i < mp.size(); ++i) {
                     auto ipad = mp[i]->current_row();
                     mech_data_permutation.at(ipad) = global_i++;
                 }
@@ -2358,7 +2358,7 @@ static void nrn_sort_node_data(neuron::container::Node::storage::frozen_token_ty
         }
         if (nt->node_padding) {
             auto& np = *nt->node_padding;
-            for (std::size_t i=0; i < np.size(); ++i) {
+            for (std::size_t i = 0; i < np.size(); ++i) {
                 auto ipad = (*np[i])._node_handle.current_row();
                 node_data_permutation.at(ipad) = global_i++;
             }


### PR DESCRIPTION
An experiment to see if performance improves if destructive (write) cacheline sharing is avoided (cache lines are assumed to be 64bytes).

Using the model of #2787, improvement is small or nonexistent on an Apple M1. Timing results for 8 threads are
```
nthread   8.2.4.   master.  padding(this PR)
8 run.      16.69.   17.57.       17.38
8 solve    15.41     15.56.      15.49
```

Perhaps there is a datahandle overhead for plotting that could be solved by caching.