### PR TITLE
Improve Py Segments handling with nanobind

### DIFF
--- a/src/coreneuron/utils/memory.h
+++ b/src/coreneuron/utils/memory.h
@@ -192,7 +192,8 @@ inline void alloc_memory(void*& pointer, size_t num_bytes, size_t alignment) {
             fill = alignment * (multiple + 1) - num_bytes;
         }
 #ifndef _WIN32
-        nrn_assert((pointer = std::aligned_alloc(alignment, num_bytes + fill)) != nullptr);
+        pointer = aligned_alloc(alignment, num_bytes + fill);
+        nrn_assert(pointer != nullptr);
 #else   // is _WIN32
         // Windows has _aligned_alloc, but that must be paired with
         // _aligned_free

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -19,6 +19,10 @@
 #include <cmath>
 #include <cstring>
 
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
+
 extern void nrn_pt3dremove(Section* sec, int i0);
 extern void nrn_pt3dinsert(Section* sec, int i0, double x, double y, double z, double d);
 extern void nrn_pt3dchange1(Section* sec, int i, double d);
@@ -614,48 +618,39 @@ static void o2loc(Object* o, Section** psec, double* px) {
     *px = pyseg->x_;
 }
 
+inline nb::object obj_get_segment(nb::object py_obj) {
+    // If object is list of single elem, use it
+    if (PyList_Check(py_obj.ptr())) {
+        nb::list obj_list{std::move(py_obj)};
+        if (obj_list.size() != 1) {
+            hoc_execerror("If a list is supplied, it must be of length 1", 0);
+        }
+        py_obj = obj_list[0];
+    }
+
+    auto seg_obj = py_obj.attr("segment");
+    if (!seg_obj.is_valid()) {
+        hoc_execerror("not a Python nrn.Segment, rxd.node, or other with a segment property", 0);
+    }
+    return seg_obj;
+}
 
 static void o2loc2(Object* o, Section** psec, double* px) {
     bool free_po = false;
     if (o->ctemplate->sym != nrnpy_pyobj_sym_) {
         hoc_execerror("not a Python nrn.Segment, rxd.node, or other with a segment property", 0);
     }
-    PyObject* po = nrnpy_hoc2pyobject(o);
-    if (!PyObject_TypeCheck(po, psegment_type)) {
-        if (PyList_Check(po)) {
-            if (PyList_Size(po) != 1) {
-                hoc_execerror("If a list is supplied, it must be of length 1", 0);
-            } else {
-                PyObject* old_po = po;
-                Py_INCREF(old_po);
-                po = PyList_GetItem(po, 0);
-                Py_DECREF(old_po);
-                free_po = true;
-            }
-        }
-        if (!PyObject_HasAttrString(po, "segment")) {
-            if (free_po) {
-                Py_DECREF(po);
-            }
-            hoc_execerror("not a Python nrn.Segment, rxd.node, or other with a segment property",
-                          0);
-        }
-        PyObject* obj = po;
-        Py_INCREF(obj);
-        po = PyObject_GetAttrString(obj, "segment");
-        Py_DECREF(obj);
-        if (free_po) {
-            // don't need the element from the list anymore
-            Py_DECREF(obj);
-        }
-        free_po = true;
+
+    // track objects with borrow so that ref-count ends up neutral
+    auto py_obj_seg = nb::borrow(nrnpy_hoc2pyobject(o));
+    if (!PyObject_TypeCheck(py_obj_seg.ptr(), psegment_type)) {
+        // Attempt to get a segment from any object. May throw
+        py_obj_seg = obj_get_segment(py_obj_seg);
     }
-    NPySegObj* pyseg = (NPySegObj*) po;
+
+    NPySegObj* pyseg = (NPySegObj*) py_obj_seg.ptr();
     *psec = pyseg->pysec_->sec_;
     *px = pyseg->x_;
-    if (free_po) {
-        Py_DECREF(po);
-    }
     if (!(*psec)->prop) {
         hoc_execerr_ext("nrn.Segment associated with deleted internal Section");
     }

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -624,7 +624,8 @@ inline nb::object obj_get_segment(nb::object py_obj) {
 
     auto seg_obj = py_obj.attr("segment");
     if (!seg_obj.is_valid()) {
-        hoc_execerror("not a Python nrn.Segment, rxd.node, or other with a segment property", nullptr);
+        hoc_execerror("not a Python nrn.Segment, rxd.node, or other with a segment property",
+                      nullptr);
     }
     return seg_obj;
 }
@@ -632,7 +633,8 @@ inline nb::object obj_get_segment(nb::object py_obj) {
 static void o2loc2(Object* o, Section** psec, double* px) {
     bool free_po = false;
     if (o->ctemplate->sym != nrnpy_pyobj_sym_) {
-        hoc_execerror("not a Python nrn.Segment, rxd.node, or other with a segment property", nullptr);
+        hoc_execerror("not a Python nrn.Segment, rxd.node, or other with a segment property",
+                      nullptr);
     }
 
     // track objects with borrow so that ref-count ends up neutral

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -488,27 +488,17 @@ PyObject* nrnpy_newsecobj_safe(PyObject* self, PyObject* args, PyObject* kwds) {
 }
 
 static PyObject* NPySegObj_new(PyTypeObject* type, PyObject* args, PyObject* /* kwds */) {
+    // Just ensure the params are ok, since init is done in its own method
     NPySecObj* pysec;
     double x;
     if (!PyArg_ParseTuple(args, "O!d", psection_type, &pysec, &x)) {
         return NULL;
     }
-    if (x > 1.0 && x < 1.0001) {
-        x = 1.0;
-    }
-    if (x < 0. || x > 1.0) {
+    if (x < 0. || x > 1.0001) {
         PyErr_SetString(PyExc_ValueError, "segment position range is 0 <= x <= 1");
         return NULL;
     }
-    NPySegObj* self;
-    self = (NPySegObj*) type->tp_alloc(type, 0);
-    // printf("NPySegObj_new %p\n", self);
-    if (self != NULL) {
-        self->pysec_ = pysec;
-        self->x_ = x;
-        Py_INCREF(self->pysec_);
-    }
-    return (PyObject*) self;
+    return type->tp_alloc(type, 0);
 }
 
 static PyObject* NPySegObj_new_safe(PyTypeObject* type, PyObject* args, PyObject* kwds) {
@@ -576,9 +566,6 @@ static int NPySegObj_init(NPySegObj* self, PyObject* args, PyObject* kwds) {
         return -1;
     }
     Py_INCREF(pysec);
-    if (self->pysec_) {
-        Py_DECREF(self->pysec_);
-    }
     self->pysec_ = pysec;
     self->x_ = x;
     return 0;

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -502,7 +502,15 @@ static PyObject* NPySegObj_new(PyTypeObject* type, PyObject* args, PyObject* /* 
         PyErr_SetString(PyExc_ValueError, "segment position range is 0 <= x <= 1");
         return NULL;
     }
-    return type->tp_alloc(type, 0);
+    NPySegObj* self;
+    self = (NPySegObj*) type->tp_alloc(type, 0);
+    // printf("NPySegObj_new %p\n", self);
+    if (self != NULL) {
+        self->pysec_ = pysec;
+        self->x_ = x;
+        Py_INCREF(self->pysec_);
+    }
+    return (PyObject*) self;
 }
 
 static PyObject* NPySegObj_new_safe(PyTypeObject* type, PyObject* args, PyObject* kwds) {
@@ -556,27 +564,10 @@ static PyObject* NPyRangeVar_new_safe(PyTypeObject* type, PyObject* args, PyObje
 }
 
 static int NPySegObj_init(NPySegObj* self, PyObject* args, PyObject* kwds) {
-    // printf("NPySegObj_init %p %p\n", self, self->pysec_);
-    NPySecObj* pysec;
-    double x;
-    if (!PyArg_ParseTuple(args, "O!d", psection_type, &pysec, &x)) {
-        return -1;
-    }
-    if (x > 1.0 && x < 1.0001) {
-        x = 1.0;
-    }
-    if (x < 0. || x > 1.0) {
-        PyErr_SetString(PyExc_ValueError, "segment position range is 0 <= x <= 1");
-        return -1;
-    }
-    Py_INCREF(pysec);
-    self->pysec_ = pysec;
-    self->x_ = x;
+    // PySeg objects are fully initialized in _new_
+    // And strangely Python seems to never call this, as if the _new_ objs were not instances
+    // So don't implement anything here
     return 0;
-}
-
-static int NPySegObj_init_safe(NPySegObj* self, PyObject* args, PyObject* kwds) {
-    return nrn::convert_cxx_exceptions(NPySegObj_init, self, args, kwds);
 }
 
 static int ob_is_seg(Object* o) {

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -498,7 +498,10 @@ static PyObject* NPySegObj_new(PyTypeObject* type, PyObject* args, PyObject* /* 
     if (!PyArg_ParseTuple(args, "O!d", psection_type, &pysec, &x)) {
         return NULL;
     }
-    if (x < 0. || x > 1.0001) {
+    if (x > 1.0 && x < 1.0001) {
+        x = 1.0;
+    }
+    if (x < 0. || x > 1.0) {
         PyErr_SetString(PyExc_ValueError, "segment position range is 0 <= x <= 1");
         return NULL;
     }
@@ -621,7 +624,7 @@ inline nb::object obj_get_segment(nb::object py_obj) {
 
     auto seg_obj = py_obj.attr("segment");
     if (!seg_obj.is_valid()) {
-        hoc_execerror("not a Python nrn.Segment, rxd.node, or other with a segment property", 0);
+        hoc_execerror("not a Python nrn.Segment, rxd.node, or other with a segment property", nullptr);
     }
     return seg_obj;
 }
@@ -629,7 +632,7 @@ inline nb::object obj_get_segment(nb::object py_obj) {
 static void o2loc2(Object* o, Section** psec, double* px) {
     bool free_po = false;
     if (o->ctemplate->sym != nrnpy_pyobj_sym_) {
-        hoc_execerror("not a Python nrn.Segment, rxd.node, or other with a segment property", 0);
+        hoc_execerror("not a Python nrn.Segment, rxd.node, or other with a segment property", nullptr);
     }
 
     // track objects with borrow so that ref-count ends up neutral

--- a/src/nrnpython/nrnpy_nrn.h
+++ b/src/nrnpython/nrnpy_nrn.h
@@ -66,7 +66,7 @@ static PyType_Slot nrnpy_SegmentType_slots[] = {
     {Py_tp_iter, (void*) mech_of_segment_iter_safe},
     {Py_tp_methods, (void*) NPySegObj_methods},
     {Py_tp_members, (void*) NPySegObj_members},
-    {Py_tp_init, (void*) NPySegObj_init_safe},
+    {Py_tp_init, (void*) NPySegObj_init},
     {Py_tp_new, (void*) NPySegObj_new_safe},
     {Py_tp_doc, (void*) "Segment objects"},
     {Py_sq_contains, (void*) NPySegObj_contains_safe},


### PR DESCRIPTION
### Context

Improve handling of Python Segment objects leveraging `nanobind`

### Scope

 * Reimplement `o2loc` where a lot of Py refcount was being managed manually. Code got much simplified, without any  manual ref count changing.
 * Make Seg_init an empty stub, since it's never called