### PR TITLE
Install ONE requirements file with all requirements.

### DIFF
--- a/ci/win_install_deps.cmd
+++ b/ci/win_install_deps.cmd
@@ -28,7 +28,8 @@ C:\Python39\python.exe -m pip install  numpy==1.19.3 "cython < 3" || goto :error
 C:\Python310\python.exe -m pip install numpy==1.21.3 "cython < 3" || goto :error
 C:\Python311\python.exe -m pip install numpy==1.23.5 "cython < 3" || goto :error
 C:\Python312\python.exe -m pip install numpy==1.26.3 "cython < 3" || goto :error
-C:\Python312\python.exe -m pip install setuptools || goto :error
+:: setuptools 70.2 leads to an error
+C:\Python312\python.exe -m pip install setuptools==70.1.1 || goto :error
 
 :: install nsis
 nsis-3.05-setup.exe /S || goto :error

--- a/packaging/python/build_requirements.txt
+++ b/packaging/python/build_requirements.txt
@@ -1,2 +1,8 @@
 cython<3
 packaging
+numpy==1.17.5;python_version=='3.8'
+numpy==1.19.3;python_version=='3.9' and platform_machine=='x86_64'
+numpy==1.21.3;python_version=='3.9' and platform_machine=='arm64'
+numpy==1.21.3;python_version=='3.10'
+numpy==1.23.5;python_version=='3.11'
+numpy==1.26.0;python_version=='3.12'

--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -53,25 +53,6 @@ setup_venv() {
 }
 
 
-python_version_check() {
-    case "$py_ver" in
-      38) numpy_ver="numpy==1.17.5" ;;
-      39) numpy_ver="numpy==1.19.3" ;;
-      310) numpy_ver="numpy==1.21.3" ;;
-      311) numpy_ver="numpy==1.23.5" ;;
-      312) numpy_ver="numpy==1.26.0" ;;
-      *) echo "Error: numpy version not specified for this python!" && exit 1;;
-    esac
-
-    # older version for apple m1 as building from source fails
-    if [[ `uname -m` == 'arm64' && "$py_ver" == "39" ]]; then
-      numpy_ver="numpy==1.21.3"
-    fi
-
-    echo " - pip install $numpy_ver"
-    pip install $numpy_ver
-}
-
 build_wheel_linux() {
     echo "[BUILD WHEEL] Building with interpreter $1"
     local skip=

--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -25,7 +25,7 @@ fi
 
 py_ver=""
 
-clone_install_nmodl_requirements() {
+clone_nmodl_and_add_requirements() {
     git config --global --add safe.directory /root/nrn
     git submodule update --init --recursive --force --depth 1 -- external/nmodl
     # We only want the _build_ dependencies
@@ -70,7 +70,7 @@ build_wheel_linux() {
 
     if [ "$2" == "coreneuron" ]; then
         setup_args="--enable-coreneuron"
-        clone_install_nmodl_requirements
+        clone_nmodl_and_add_requirements
         CMAKE_DEFS="${CMAKE_DEFS},LINK_AGAINST_PYTHON=OFF"
     fi
 
@@ -120,7 +120,7 @@ build_wheel_osx() {
 
     if [ "$2" == "coreneuron" ]; then
         setup_args="--enable-coreneuron"
-        clone_install_nmodl_requirements
+        clone_nmodl_and_add_requirements
         CMAKE_DEFS="${CMAKE_DEFS},LINK_AGAINST_PYTHON=OFF"
     fi
 


### PR DESCRIPTION
When installing NMODL requirements after the fixed numpy version,
NMODLs lesser constrained dependencies take precedence over the
currently installed packages.

This PR:

* Will consider only the build dependencies of NMODL
* Construct one requirements file with the merged requirements of
NMODL, NEURON
* Fix a `setuptools` requirement for Python 3.12 and Windows that broke with a newer version