### PR TITLE
Remove Perl dependency.

### DIFF
--- a/bin/nrnivmodl-core.in
+++ b/bin/nrnivmodl-core.in
@@ -19,15 +19,7 @@ APP_NAME="$(basename "$0")"
 
 # directory and parent directory of this script
 PARENT_DIR="$(dirname "$BASH_SOURCE")/.."
-
-# prefer perl exe set by neuron wrappers in case of wheel
-PERL_EXE="${CORENRN_PERLEXE:-@PERL_EXECUTABLE@}"
-# in case of mac installer, wrapper is not used and hence
-# check if binary exist. otherwise, just rely on perl being
-# in default $PATH
-if [ ! -f "${PERL_EXE}" ]; then PERL_EXE="$(which perl)"; fi
-
-ROOT_DIR="$("${PERL_EXE}" -e "use Cwd 'abs_path'; print abs_path('$PARENT_DIR')")"
+ROOT_DIR="$(readlink -f "$PARENT_DIR")"
 
 # default arguments : number of parallel builds and default mod file path
 PARALLEL_BUILDS=4

--- a/bin/nrnivmodl_core_makefile.in
+++ b/bin/nrnivmodl_core_makefile.in
@@ -57,12 +57,8 @@ endif
 # binary used during build. If they don't exist then simply use python and
 # perl as the name of binaries.
 CORENRN_PYTHONEXE ?= @NRN_DEFAULT_PYTHON_EXECUTABLE@
-CORENRN_PERLEXE ?= @PERL_EXECUTABLE@
 ifeq ($(wildcard $(CORENRN_PYTHONEXE)),)
   CORENRN_PYTHONEXE=python
-endif
-ifeq ($(wildcard $(CORENRN_PERLEXE)),)
-  CORENRN_PERLEXE=perl
 endif
 
 CXXFLAGS = @CORENRN_CXX_FLAGS@
@@ -189,7 +185,7 @@ $(mod_cpp_files): $(MOD_TO_CPP_DIR)/%.cpp: $(MODS_PATH)/%.mod | $(MOD_TO_CPP_DIR
 
 # generate mod registration function. Dont overwrite if it's not changed
 $(MOD_FUNC_CPP): build_always | $(MOD_TO_CPP_DIR)
-	$(CORENRN_PERLEXE) $(CORENRN_SHARE_CORENRN_DIR)/mod_func.c.pl $(mod_files_names) > $(MOD_FUNC_CPP).tmp
+	bash $(CORENRN_SHARE_CORENRN_DIR)/mod_func.c.sh $(mod_files_names) > $(MOD_FUNC_CPP).tmp
 	diff -q $(MOD_FUNC_CPP).tmp $(MOD_FUNC_CPP) || \
 	mv $(MOD_FUNC_CPP).tmp $(MOD_FUNC_CPP)
 

--- a/src/coreneuron/CMakeLists.txt
+++ b/src/coreneuron/CMakeLists.txt
@@ -148,11 +148,6 @@ configure_file(${PROJECT_SOURCE_DIR}/src/coreneuron/config/config.cpp.in
 include(OpenAccHelper)
 
 # =============================================================================
-# Common dependencies
-# =============================================================================
-find_package(Perl REQUIRED)
-
-# =============================================================================
 # Common build options
 # =============================================================================
 # build mod files for coreneuron
@@ -367,7 +362,7 @@ list(APPEND CORENEURON_CODE_FILES ${PROJECT_BINARY_DIR}/coreneuron/config/config
 set(ENGINEMECH_CODE_FILE "mechanism/mech/enginemech.cpp")
 
 # for external mod files we need to generate modl_ref function in mod_func.c
-set(MODFUNC_PERL_SCRIPT "mechanism/mech/mod_func.c.pl")
+set(MODFUNC_SHELL_SCRIPT "mechanism/mech/mod_func.c.sh")
 
 set(NMODL_UNITS_FILE "${CMAKE_BINARY_DIR}/share/mod2c/nrnunits.lib")
 
@@ -375,8 +370,8 @@ set(NMODL_UNITS_FILE "${CMAKE_BINARY_DIR}/share/mod2c/nrnunits.lib")
 # Copy files that are required by nrnivmodl-core to the build tree at build time.
 # =============================================================================
 cpp_cc_build_time_copy(
-  INPUT "${CMAKE_CURRENT_SOURCE_DIR}/${MODFUNC_PERL_SCRIPT}"
-  OUTPUT "${CMAKE_BINARY_DIR}/share/coreneuron/mod_func.c.pl"
+  INPUT "${CMAKE_CURRENT_SOURCE_DIR}/${MODFUNC_SHELL_SCRIPT}"
+  OUTPUT "${CMAKE_BINARY_DIR}/share/coreneuron/mod_func.c.sh"
   NO_TARGET)
 cpp_cc_build_time_copy(
   INPUT "${CMAKE_CURRENT_SOURCE_DIR}/${ENGINEMECH_CODE_FILE}"
@@ -387,7 +382,7 @@ cpp_cc_build_time_copy(
   OUTPUT "${CMAKE_BINARY_DIR}/share/coreneuron/coreneuron.cpp"
   NO_TARGET)
 set(nrnivmodl_core_dependencies
-    "${CMAKE_BINARY_DIR}/share/coreneuron/mod_func.c.pl"
+    "${CMAKE_BINARY_DIR}/share/coreneuron/mod_func.c.sh"
     "${CMAKE_BINARY_DIR}/share/coreneuron/enginemech.cpp"
     "${CMAKE_BINARY_DIR}/share/coreneuron/coreneuron.cpp")
 # Set up build rules that copy builtin mod files from src/coreneuron/mechanism/mech/modfile/*.mod to
@@ -706,7 +701,7 @@ install(
   FILES_MATCHING
   PATTERN "*.h*"
   PATTERN "*.ipp")
-install(FILES ${MODFUNC_PERL_SCRIPT} ${ENGINEMECH_CODE_FILE} DESTINATION share/coreneuron)
+install(FILES ${MODFUNC_SHELL_SCRIPT} ${ENGINEMECH_CODE_FILE} DESTINATION share/coreneuron)
 
 # copy nmodl for nrnivmodl-core
 install(PROGRAMS ${CORENRN_NMODL_BINARY} DESTINATION bin)

--- a/src/coreneuron/mechanism/mech/mod_func.c.sh
+++ b/src/coreneuron/mechanism/mech/mod_func.c.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/bin/bash
 #
 # =============================================================================
 # Copyright (c) 2016 - 2021 Blue Brain Project/EPFL
@@ -9,39 +9,48 @@
 #Construct the modl_reg() function from a provided list
 #of modules.
 
-#Usage : mod_func.c.pl[MECH1.mod MECH2.mod...]
+#Usage: mod_func.c.sh [MECH1.mod MECH2.mod...]
 
-@mods = @ARGV;
-s/\.mod$// foreach @mods;
-
-@mods=sort @mods;
-
-if(!@mods) {
-    print STDERR "mod_func.c.pl: No mod files provided";
-    print "// No mod files provided
+if [[ "$#" -eq 0 ]]; then
+    >&2 echo "mod_func.c.sh: No mod files provided";
+    cat <<EOF
+// No mod files provided
 namespace coreneuron {
   void modl_reg() {}
 }
-";
-    exit 0;
-}
+EOF
+    exit 0
+fi
 
-print << "__eof";
+readarray -td '' mods < <(printf '%s\0' "${BASH_ARGV[@]%%.mod}" | env LC_ALL=C sort -z)
+
+cat <<EOF
 #include <cstdio>
 namespace coreneuron {
 extern int nrnmpi_myid;
 extern int nrn_nobanner_;
-extern int @{[join ",\n  ", map{"_${_}_reg(void)"} @mods]};
+$(
+  for mod in "${mods[@]}"; do
+    printf "extern int _%s_reg(void);\n" "$mod"
+  done
+)
 
 void modl_reg() {
     if (!nrn_nobanner_ && nrnmpi_myid < 1) {
         fprintf(stderr, " Additional mechanisms from files\\n");
-        @{[join "\n        ",
-           map{"fprintf(stderr, \" $_.mod\");"} @mods] }
+$(
+  for mod in "${mods[@]}"; do
+    printf "        fprintf(stderr, \" %s.mod\");\n" "$mod"
+  done
+)
         fprintf(stderr, "\\n\\n");
     }
 
-    @{[join "\n    ", map{"_${_}_reg();"} @mods] }
+$(
+  for mod in "${mods[@]}"; do
+    printf "    _%s_reg();\n" "$mod"
+  done
+)
 }
 } //namespace coreneuron
-__eof
+EOF

--- a/src/coreneuron/mechanism/mech/mod_func.c.sh
+++ b/src/coreneuron/mechanism/mech/mod_func.c.sh
@@ -22,14 +22,18 @@ EOF
     exit 0
 fi
 
+# Assume that none of the arguments will contain spaces, as we inject them into C++ code
+# later, anyways.
+mods=$(for m in "$@"; do echo "${m%%.mod}"; done | env LC_ALL=C sort)
+
 decls=""
 prints=""
 regs=""
-while read mod; do
+for mod in $mods; do
     decls="${decls}${decls:+,$'\n'  }_${mod}_reg(void)"
     prints="${prints}${prints:+$'\n'        }fprintf(stderr, \" ${mod}.mod\");"
     regs="${regs}${regs:+$'\n'    }_${mod}_reg();"
-done <<< $(for m in "$@"; do echo "${m%%.mod}"; done | env LC_ALL=C sort)
+done
 
 cat <<EOF
 #include <cstdio>

--- a/src/coreneuron/mechanism/mech/mod_func.c.sh
+++ b/src/coreneuron/mechanism/mech/mod_func.c.sh
@@ -29,7 +29,7 @@ while read mod; do
     decls="${decls}${decls:+,$'\n'  }_${mod}_reg(void)"
     prints="${prints}${prints:+$'\n'        }fprintf(stderr, \" ${mod}.mod\");"
     regs="${regs}${regs:+$'\n'    }_${mod}_reg();"
-done <<< $(printf '%s\n' "${BASH_ARGV[@]%%.mod}" | env LC_ALL=C sort)
+done <<< $(for _ in $(seq 1 $*) do; echo "${1%%.mod}"; shift; done | env LC_ALL=C sort)
 
 cat <<EOF
 #include <cstdio>

--- a/src/coreneuron/mechanism/mech/mod_func.c.sh
+++ b/src/coreneuron/mechanism/mech/mod_func.c.sh
@@ -29,7 +29,7 @@ while read mod; do
     decls="${decls}${decls:+,$'\n'  }_${mod}_reg(void)"
     prints="${prints}${prints:+$'\n'        }fprintf(stderr, \" ${mod}.mod\");"
     regs="${regs}${regs:+$'\n'    }_${mod}_reg();"
-done <<< $(for _ in $(seq 1 $#) do; echo "${1%%.mod}"; shift; done | env LC_ALL=C sort)
+done <<< $(for m in "$@" do; echo "${m%%.mod}"; shift; done | env LC_ALL=C sort)
 
 cat <<EOF
 #include <cstdio>

--- a/src/coreneuron/mechanism/mech/mod_func.c.sh
+++ b/src/coreneuron/mechanism/mech/mod_func.c.sh
@@ -29,7 +29,7 @@ while read mod; do
     decls="${decls}${decls:+,$'\n'  }_${mod}_reg(void)"
     prints="${prints}${prints:+$'\n'        }fprintf(stderr, \" ${mod}.mod\");"
     regs="${regs}${regs:+$'\n'    }_${mod}_reg();"
-done <<< $(for m in "$@" do; echo "${m%%.mod}"; shift; done | env LC_ALL=C sort)
+done <<< $(for m in "$@"; do echo "${m%%.mod}"; done | env LC_ALL=C sort)
 
 cat <<EOF
 #include <cstdio>

--- a/src/coreneuron/mechanism/mech/mod_func.c.sh
+++ b/src/coreneuron/mechanism/mech/mod_func.c.sh
@@ -29,7 +29,7 @@ while read mod; do
     decls="${decls}${decls:+,$'\n'  }_${mod}_reg(void)"
     prints="${prints}${prints:+$'\n'        }fprintf(stderr, \" ${mod}.mod\");"
     regs="${regs}${regs:+$'\n'    }_${mod}_reg();"
-done <<< $(for _ in $(seq 1 $*) do; echo "${1%%.mod}"; shift; done | env LC_ALL=C sort)
+done <<< $(for _ in $(seq 1 $#) do; echo "${1%%.mod}"; shift; done | env LC_ALL=C sort)
 
 cat <<EOF
 #include <cstdio>


### PR DESCRIPTION
No real Perl functionality is required in NEURON, but it adds complexity
to the build, and introduces yet another language.

For MacOS, starting with 12.3, `readlink -f` is supported.  MacOS 11 aka
Big Sur has reached the end of official Apple support in 2023.
