### PR TITLE
ParallelContext: hoc_ac_ encodes global id of submitted process.

### DIFF
--- a/src/parallel/ocbbs.cpp
+++ b/src/parallel/ocbbs.cpp
@@ -1299,9 +1299,10 @@ std::vector<char> BBSImpl::execute_helper(int id, bool exec) {
             }
             hoc_ac_ = 0.;
         } else {
-            hoc_ac_ = 0.;
             if (exec) {
                 hoc_ac_ = hoc_call_objfunc(fname, narg, ob);
+            } else {
+                hoc_ac_ = 0.;
             }
         }
         for (auto& arg: sarg) {


### PR DESCRIPTION
This bug was introduced in
```
commit 728758db0663f945a6a7a7259ca5adea8bc1a1ae (HEAD)
Author: Michael Hines <michael.hines@yale.edu>
Date:   Thu Dec 21 07:28:01 2017 -0500
```
The documentation https://nrn.readthedocs.io/en/latest/python/modelspec/programmatic/network/parcon.html#ParallelContext.submit
states
> when the task is executed, the hoc_ac_ variable is set to this unique id (positive integer) of the task

With this fix, the output of  ```nrniv src/parallel/test6.hoc``` is now correct again. E.g. the third from last line is now
```
id=19 Test[1]: 361 = f(19, "goodbye", Vector[19])
```
instead of
```
id=0 Test[1]: 361 = f(19, "goodbye", Vector[19])
```
This fix should also be adopted in ```release/8.2```
