### PR TITLE
Move NMODL integration to top level CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,6 +505,26 @@ cpp_cc_git_submodule(CLI11 BUILD PACKAGE CLI11 REQUIRED)
 # Enable CoreNEURON support
 # =============================================================================
 if(NRN_ENABLE_CORENEURON)
+  set(CORENRN_NMODL_DIR
+      ""
+      CACHE PATH "Path to nmodl source-to-source compiler installation")
+
+  find_package(nmodl)
+  if(NOT "${CORENRN_NMODL_DIR}" STREQUAL "" AND NOT nmodl_FOUND)
+    message(FATAL_ERROR "Cannot find NMODL in ${CORENRN_NMODL_DIR}")
+  endif()
+  if(nmodl_FOUND)
+    set(CORENRN_NMODL_BINARY ${nmodl_BINARY})
+  else()
+    set(NMODL_ENABLE_PYTHON_BINDINGS
+        OFF
+        CACHE BOOL "Enable NMODL python bindings")
+    nrn_add_external_project(nmodl)
+    set(CORENRN_NMODL_BINARY ${CMAKE_BINARY_DIR}/bin/nmodl${CMAKE_EXECUTABLE_SUFFIX})
+    set(NMODL_TARGET_TO_DEPEND nmodl)
+    set(NMODL_PROJECT_BINARY_DIR ${CMAKE_BINARY_DIR}/external/nmodl)
+  endif()
+
   message(STATUS "Building CoreNEURON")
 
   # =============================================================================
@@ -535,7 +555,6 @@ if(NRN_ENABLE_CORENEURON)
   get_property(CORENRN_LIB_LINK_FLAGS GLOBAL PROPERTY CORENRN_LIB_LINK_FLAGS)
   get_property(CORENRN_NEURON_LINK_FLAGS GLOBAL PROPERTY CORENRN_NEURON_LINK_FLAGS)
   get_property(CORENRN_ENABLE_SHARED GLOBAL PROPERTY CORENRN_ENABLE_SHARED)
-  get_property(CORENRN_NMODL_BINARY GLOBAL PROPERTY CORENRN_NMODL_BINARY)
   # NEURON tests that link against CoreNEURON need to depend on it.
   set(CORENEURON_TARGET_TO_DEPEND coreneuron-for-tests)
 

--- a/src/coreneuron/CMakeLists.txt
+++ b/src/coreneuron/CMakeLists.txt
@@ -43,10 +43,6 @@ option(CORENRN_ENABLE_UNIT_TESTS "Enable unit tests execution" ON)
 option(CORENRN_ENABLE_GPU "Enable GPU support using OpenACC or OpenMP" OFF)
 option(CORENRN_ENABLE_SHARED "Enable shared library build" ON)
 option(CORENRN_ENABLE_PRCELLSTATE "Enable NRN_PRCELLSTATE debug feature" OFF)
-
-set(CORENRN_NMODL_DIR
-    ""
-    CACHE PATH "Path to nmodl source-to-source compiler installation")
 set(LIKWID_DIR
     ""
     CACHE PATH "Path to likwid performance analysis suite")
@@ -248,34 +244,6 @@ endif()
 # =============================================================================
 # NMODL specific options
 # =============================================================================
-find_package(nmodl)
-if(NOT "${CORENRN_NMODL_DIR}" STREQUAL "" AND NOT nmodl_FOUND)
-  message(FATAL_ERROR "Cannot find NMODL in ${CORENRN_NMODL_DIR}")
-endif()
-if(nmodl_FOUND)
-  set(CORENRN_NMODL_BINARY ${nmodl_BINARY})
-else()
-  set(NMODL_ENABLE_PYTHON_BINDINGS
-      OFF
-      CACHE BOOL "Enable NMODL python bindings")
-  nrn_add_external_project(nmodl DISABLE_ADD)
-  add_subdirectory(${PROJECT_SOURCE_DIR}/external/nmodl ${CMAKE_BINARY_DIR}/external/nmodl)
-  set(CORENRN_NMODL_BINARY ${CMAKE_BINARY_DIR}/bin/nmodl${CMAKE_EXECUTABLE_SUFFIX})
-  set(NMODL_TARGET_TO_DEPEND nmodl)
-  set(NMODL_PROJECT_BINARY_DIR ${CMAKE_BINARY_DIR}/external/nmodl)
-  # install nrnunits.lib and libpywrapper.so from external/nmodl
-  install(
-    FILES ${NMODL_PROJECT_BINARY_DIR}/lib/libpywrapper${CMAKE_SHARED_LIBRARY_SUFFIX}
-    DESTINATION lib
-    COMPONENT pywrapper
-    OPTIONAL)
-  install(
-    FILES ${NMODL_PROJECT_BINARY_DIR}/share/nmodl/nrnunits.lib
-    DESTINATION share/nmodl
-    COMPONENT nrnunits)
-endif()
-set_property(GLOBAL PROPERTY CORENRN_NMODL_BINARY "${CORENRN_NMODL_BINARY}")
-
 # set correct arguments for nmodl for cpu/gpu target
 set(CORENRN_NMODL_FLAGS
     ""
@@ -672,9 +640,6 @@ install(
   PATTERN "*.h*"
   PATTERN "*.ipp")
 install(FILES ${MODFUNC_SHELL_SCRIPT} ${ENGINEMECH_CODE_FILE} DESTINATION share/coreneuron)
-
-# copy nmodl for nrnivmodl-core
-install(PROGRAMS ${CORENRN_NMODL_BINARY} DESTINATION bin)
 
 # install nrniv-core app
 install(


### PR DESCRIPTION
Add NMODL that will install its own Python wrapper, and simplify CMake
to let NMODL handle itself completely.
