### PR TITLE
ParallelContext: hoc_ac_ encodes global id of submitted process. (#2965)

### DIFF
--- a/src/parallel/ocbbs.cpp
+++ b/src/parallel/ocbbs.cpp
@@ -1362,9 +1362,10 @@ char* BBSImpl::execute_helper(size_t* size, int id, bool exec) {
             hoc_ac_ = 0.;
         } else {
             // printf("%d exec hoc call %s narg=%d\n", nrnmpi_myid_world, fname->name, narg);
-            hoc_ac_ = 0.;
             if (exec) {
                 hoc_ac_ = hoc_call_objfunc(fname, narg, ob);
+            } else {
+                hoc_ac_ = 0.;
             }
             // printf("%d exec return from hoc call %s narg=%d\n", nrnmpi_myid_world, fname->name,
             // narg);


### PR DESCRIPTION
Third try's the charm.
Cherry-pick from master 6069a3a See #2965

tested with

nrniv src/parallel/test6.hoc
third from last line of output is

id=19 Test[1]: 361 = f(19, "goodbye", Vector[19])