### PR TITLE
CMake: remove --depth for submodule --init as it's not supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,7 +440,7 @@ if(NRN_ENABLE_PYTHON)
   # Make sure the USE_PYTHON macro is defined in the C++ code
   list(APPEND NRN_COMPILE_DEFS USE_PYTHON)
   # Ensure nanobind is there, but dont import, we don't want its CMake
-  nrn_add_external_project(nanobind DISABLE_ADD RECURSIVE SHALLOW)
+  nrn_add_external_project(nanobind DISABLE_ADD RECURSIVE)
   include(NanoBindMinimal)
 endif()
 

--- a/cmake/ExternalProjectHelper.cmake
+++ b/cmake/ExternalProjectHelper.cmake
@@ -23,13 +23,10 @@ endfunction(nrn_submodule_file_not_found)
 
 # initialize submodule with given path
 function(nrn_initialize_submodule path)
-  cmake_parse_arguments(PARSE_ARGV 1 opt "RECURSIVE;SHALLOW" "" "")
+  cmake_parse_arguments(PARSE_ARGV 1 opt "RECURSIVE" "" "")
   set(UPDATE_OPTIONS "")
   if(opt_RECURSIVE)
-    list(APPEND UPDATE_OPTIONS --recursive)
-  endif()
-  if(opt_SHALLOW)
-    list(APPEND UPDATE_OPTIONS --depth 1)
+    string(APPEND UPDATE_OPTIONS "--recursive")
   endif()
   if(NOT ${GIT_FOUND})
     message(
@@ -48,7 +45,7 @@ endfunction()
 
 # check for external project and initialize submodule if it is missing
 function(nrn_add_external_project name)
-  cmake_parse_arguments(PARSE_ARGV 1 opt "RECURSIVE;SHALLOW;DISABLE_ADD" "" "")
+  cmake_parse_arguments(PARSE_ARGV 1 opt "RECURSIVE;DISABLE_ADD" "" "")
   find_path(
     ${name}_PATH
     NAMES CMakeLists.txt
@@ -59,9 +56,6 @@ function(nrn_add_external_project name)
     set(OPTIONS "")
     if(opt_RECURSIVE)
       list(APPEND OPTIONS "RECURSIVE")
-    endif()
-    if(opt_SHALLOW)
-      list(APPEND OPTIONS "SHALLOW")
     endif()
     nrn_initialize_submodule("${THIRD_PARTY_DIRECTORY}/${name}" ${OPTIONS})
   else()

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -2864,9 +2864,10 @@ extern "C" NRN_EXPORT PyObject* get_plotshape_data(PyObject* sp) {
     void* that = pho->ho_->u.this_pointer;
 #if HAVE_IV
     IFGUI
-        spi = ((ShapePlot*) that);
-    } else {
-        spi = ((ShapePlotData*) that);
+    spi = ((ShapePlot*) that);
+}
+else {
+    spi = ((ShapePlotData*) that);
     ENDGUI
 #else
     spi = ((ShapePlotData*) that);


### PR DESCRIPTION
Without this, if I try to use these options, I get:

```console
-- Sub-module : missing /gpfs/bbp.cscs.ch/project/proj16/kumbhar/266806/nrn-home/nrn-master/external/nanobind : running git submodule update --recursive;--depth;1 --init
-- ==> /usr/bin/git submodule update --recursive--depth1" --init -- /gpfs/bbp.cscs.ch/project/proj16/kumbhar/266806/nrn-home/nrn-master/external/nanobind"
usage: git submodule [--quiet] add [-b <branch>] [-f|--force] [--name <name>] [--reference <repository>] [--] <repository> [<path>]
   or: git submodule [--quiet] status [--cached] [--recursive] [--] [<path>...]
   or: git submodule [--quiet] init [--] [<path>...]
   or: git submodule [--quiet] deinit [-f|--force] [--] <path>...
   or: git submodule [--quiet] update [--init] [--remote] [-N|--no-fetch] [-f|--force] [--rebase] [--reference <repository>] [--merge] [--recursive] [--] [<path>...]
   or: git submodule [--quiet] summary [--cached|--files] [--summary-limit <n>] [commit] [--] [<path>...]
   or: git submodule [--quiet] foreach [--recursive] <command>
   or: git submodule [--quiet] sync [--recursive] [--] [<path>...]
CMake Error at cmake/ExternalProjectHelper.cmake:46 (message):
  git submodule init failed
Call Stack (most recent call first):
  cmake/ExternalProjectHelper.cmake:67 (nrn_initialize_submodule)
  CMakeLists.txt:443 (nrn_add_external_project)
```