### PR TITLE
Close Instrumentor properly when application calls h.quit()

### DIFF
--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -2864,9 +2864,10 @@ extern "C" NRN_EXPORT PyObject* get_plotshape_data(PyObject* sp) {
     void* that = pho->ho_->u.this_pointer;
 #if HAVE_IV
     IFGUI
-        spi = ((ShapePlot*) that);
-    } else {
-        spi = ((ShapePlotData*) that);
+    spi = ((ShapePlot*) that);
+}
+else {
+    spi = ((ShapePlotData*) that);
     ENDGUI
 #else
     spi = ((ShapePlotData*) that);

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -24,6 +24,8 @@
 #include "nrnfilewrap.h"
 #include "../nrniv/backtrace_utils.h"
 
+#include "../utils/profile/profiler_interface.h"
+
 #include <cfenv>
 #include <condition_variable>
 #include <iostream>
@@ -1002,6 +1004,7 @@ void hoc_quit(void) {
     }
 #endif
     int exit_code = ifarg(1) ? int(*getarg(1)) : 0;
+    nrn::Instrumentor::finalize_profile();
     exit(exit_code);
 }
 


### PR DESCRIPTION
- Certain profiling tools, such as LIKWID, require calling finalization routines like `LIKWID_MARKER_CLOSE` before the application terminates.
- When NEURON applications call `h.quit()`, this finalization call is missing, leading to errors such as:

```console
$ likwid-perfctr -C 0 -m -g FLOPS_DP ./x86_64/special -python test.py
...
...
Marker API result file does not exist. This may happen if the
application has not called LIKWID_MARKER_CLOSE.
```