### PR TITLE
Allow choosing specific regions to measure via instrumentation API

### DIFF
--- a/src/coreneuron/utils/profile/profiler_interface.h
+++ b/src/coreneuron/utils/profile/profiler_interface.h
@@ -8,8 +8,12 @@
 
 #pragma once
 
+#include <cstdlib>
 #include <initializer_list>
+#include <sstream>
+#include <string>
 #include <type_traits>
+#include <unordered_set>
 
 #if defined(NRN_CALIPER)
 #include <caliper/cali.h>
@@ -60,7 +64,9 @@ struct Instrumentor {
      *  @param name the (unique) identifier of the code region to be profiled
      */
     inline static void phase_begin(const char* name) {
-        std::initializer_list<int>{(TProfilerImpl::phase_begin(name), 0)...};
+        if (is_region_to_track(name)) {
+            std::initializer_list<int>{(TProfilerImpl::phase_begin(name), 0)...};
+        }
     }
 
     /*! \fn phase_end
@@ -77,7 +83,9 @@ struct Instrumentor {
      *  @param name the (unique) identifier of the code region to be profiled
      */
     inline static void phase_end(const char* name) {
-        std::initializer_list<int>{(TProfilerImpl::phase_end(name), 0)...};
+        if (is_region_to_track(name)) {
+            std::initializer_list<int>{(TProfilerImpl::phase_end(name), 0)...};
+        }
     }
 
     /*! \fn start_profile
@@ -122,6 +130,7 @@ struct Instrumentor {
      *  any memory allocation is done.
      */
     inline static void init_profile() {
+        initialize_regions_from_env();
         std::initializer_list<int>{(TProfilerImpl::init_profile(), 0)...};
     }
 
@@ -139,7 +148,58 @@ struct Instrumentor {
         std::initializer_list<int>{(TProfilerImpl::finalize_profile(), 0)...};
     }
 #pragma clang diagnostic pop
+
+  private:
+    /*!
+     * \brief Initialize regions to track from the NRN_PROFILE_REGIONS environment variable.
+     *
+     * Checks if the `NRN_PROFILE_REGIONS` environment variable is set. If it is set,
+     * splits the value by "," and inserts each split string into the regions that should
+     * be measured during profiling.
+     */
+    static void initialize_regions_from_env() {
+        const char* env_p = std::getenv("NRN_PROFILE_REGIONS");
+        if (env_p) {
+            std::string regions_str(env_p);
+            std::stringstream ss(regions_str);
+            std::string region;
+            regions_to_measure.clear();
+            while (std::getline(ss, region, ',')) {
+                regions_to_measure.insert(region);
+            }
+        }
+    }
+
+    /*!
+     * \brief Check if a given region name should be tracked.
+     *
+     * By default the regions_to_measure set is empty and we measure all functions
+     * instrumented via Caliper instrumentation. But one might want to profile only
+     * particular region or "phase" (e.g. due to profiling overhead) and in that case
+     * we check `NRN_PROFILE_REGIONS` environment variable.
+     *
+     * \param name The name of the region to check.
+     * \return true if the regions set is empty or if the name exists in the regions set, false
+     * otherwise.
+     */
+    inline static bool is_region_to_track(const char* name) {
+        if (regions_to_measure.empty()) {
+            return true;
+        }
+        return regions_to_measure.find(name) != regions_to_measure.end();
+    }
+
+    /*!
+     * \brief Caliper regions that we want to measure.
+     *
+     * Each string in the set represents the name of a region of interest that
+     * we have already defined via Instrumentor::phase API.
+     */
+    static std::unordered_set<std::string> regions_to_measure;
 };
+
+template <class... TProfilerImpl>
+inline std::unordered_set<std::string> Instrumentor<TProfilerImpl...>::regions_to_measure;
 
 #if defined(NRN_CALIPER)
 
@@ -254,6 +314,7 @@ struct Likwid {
         LIKWID_MARKER_CLOSE;
     };
 };
+
 
 #endif
 


### PR DESCRIPTION
- We have Caliper based instrumentation which allows to measure different phases like state updates, solver, current update, spike exchange etc. We also record the calls to each MOD file, e.g. `state-hh`, `cur-hh`.
- If we have large number of MOD files and very few channel instances then such measurement could add significant measurement overhead.
- E.g. In case of LIKWID, we see:

```console
# without profiling
./x86_64/special -python test.py
NEURON RUN with 1 threads took 0.649262

# with likwid profiling
likwid-perfctr -C 0 -m -g FLOPS_DP x86_64/special -python test.py
NEURON RUN with 1 threads took 10.734261

i.e. 0.6 sec vs 10.73 sec
```

- In such case, we want to selectively instrument a specific region. For example, the main `psolve` region or a specific mod file block like `state-hh`. This is now possible with a environmental variable `NRN_PROFILE_REGIONS`:

```console
export NRN_PROFILE_REGIONS=psolve,state-hh
likwid-perfctr -C 0 -m -g FLOPS_DP x86_64/special -python test.py

....
NEURON RUN with 1 threads took 0.836292
...

Region psolve, Group 1: FLOPS_DP
+-------------------+------------+
|    Region Info    | HWThread 0 |
+-------------------+------------+
| RDTSC Runtime [s] |   0.835792 |
|     call count    |          1 |
+-------------------+------------+

+------------------------------------------+---------+------------+
|                   Event                  | Counter | HWThread 0 |
+------------------------------------------+---------+------------+
|             INSTR_RETIRED_ANY            |  FIXC0  | 5336280000 |
|           CPU_CLK_UNHALTED_CORE          |  FIXC1  | 1987773000 |
|           CPU_CLK_UNHALTED_REF           |  FIXC2  | 1523973000 |
| FP_ARITH_INST_RETIRED_128B_PACKED_DOUBLE |   PMC0  |     489202 |
|    FP_ARITH_INST_RETIRED_SCALAR_DOUBLE   |   PMC1  |  729407200 |
| FP_ARITH_INST_RETIRED_256B_PACKED_DOUBLE |   PMC2  |          0 |
| FP_ARITH_INST_RETIRED_512B_PACKED_DOUBLE |   PMC3  |      -     |
+------------------------------------------+---------+------------+
...
Region state-Nav1_6, Group 1: FLOPS_DP
+-------------------+------------+
|    Region Info    | HWThread 0 |
+-------------------+------------+
| RDTSC Runtime [s] |   0.167490 |
|     call count    |        400 |
+-------------------+------------+

+------------------------------------------+---------+------------+
|                   Event                  | Counter | HWThread 0 |
+------------------------------------------+---------+------------+
|             INSTR_RETIRED_ANY            |  FIXC0  | 1341566000 |
|           CPU_CLK_UNHALTED_CORE          |  FIXC1  |  505899600 |
|           CPU_CLK_UNHALTED_REF           |  FIXC2  |  387861900 |
| FP_ARITH_INST_RETIRED_128B_PACKED_DOUBLE |   PMC0  |          0 |
|    FP_ARITH_INST_RETIRED_SCALAR_DOUBLE   |   PMC1  |  224568600 |
| FP_ARITH_INST_RETIRED_256B_PACKED_DOUBLE |   PMC2  |          0 |
| FP_ARITH_INST_RETIRED_512B_PACKED_DOUBLE |   PMC3  |      -     |
+------------------------------------------+---------+------------+
```
i.e. only specified regions are enabled and with less overhead.


`NOTE`: I will document this in the developer docs in a separate PR including LIKWID