### PR TITLE
clang-format problems with IFGUI...ENDGUI

### DIFF
--- a/src/ivoc/graph.cpp
+++ b/src/ivoc/graph.cpp
@@ -199,7 +199,7 @@ bool NewLabelHandler::event(Event& e) {
 
 // Graph registration for oc
 static void gr_axis(Graph* g, DimensionName d) {
-    IFGUI
+    if (hoc_usegui) {
     int ntic = -1;
     int nminor = 0;
     int invert = 0;
@@ -250,7 +250,7 @@ static void gr_axis(Graph* g, DimensionName d) {
         number = false;
     }
     g->axis(d, x1, x2, pos, ntic, nminor, invert, number);
-    ENDGUI
+    }
 }
 #endif /* HAVE_IV */
 
@@ -275,7 +275,7 @@ static double gr_yaxis(void* v) {
 static double gr_save_name(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.save_name", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Graph* g = (Graph*) v;
     g->name(gargstr(1));
     if (ifarg(2) && (chkarg(2, 0, 1) == 1.) && Oc::save_stream) {
@@ -289,7 +289,7 @@ static double gr_save_name(void* v) {
         g->save_phase2(*Oc::save_stream);
         g->Scene::mark(true);
     }
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -310,13 +310,13 @@ static void move_label(Graph* g, const GLabel* lab, int ioff = 0) {
 static double gr_family(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.family", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     if (hoc_is_str_arg(1)) {
         ((Graph*) v)->family(gargstr(1));
     } else {
         ((Graph*) v)->family(int(chkarg(1, 0, 1)));
     }
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -326,7 +326,7 @@ static double gr_family(void* v) {
 double ivoc_gr_menu_action(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.menu_action", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     HocCommand* hc;
     if (hoc_is_object_arg(2)) {
         hc = new HocCommand(*hoc_objgetarg(2));
@@ -334,7 +334,7 @@ double ivoc_gr_menu_action(void* v) {
         hc = new HocCommand(gargstr(2));
     }
     ((Scene*) v)->picker()->add_menu(gargstr(1), new HocCommandAction(hc));
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -344,7 +344,7 @@ double ivoc_gr_menu_action(void* v) {
 double ivoc_gr_menu_tool(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.menu_tool", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     if (hoc_is_object_arg(2)) {  // python style
         HocPanel::paneltool(gargstr(1),
                             NULL,
@@ -358,7 +358,7 @@ double ivoc_gr_menu_tool(void* v) {
                             ifarg(3) ? gargstr(3) : NULL,
                             ((Scene*) v)->picker());
     }
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -368,7 +368,7 @@ double ivoc_gr_menu_tool(void* v) {
 double ivoc_view_info(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.view_info", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     int i;
     Scene* s = (Scene*) v;
     XYView* view;
@@ -443,7 +443,7 @@ double ivoc_view_info(void* v) {
             return b.ascent() + b.descent();
         }
     }
-    ENDGUI
+    }
 #endif /* HAVE_IV  */
     return -1.;
 }
@@ -451,14 +451,14 @@ double ivoc_view_info(void* v) {
 double ivoc_view_size(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.view_size", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     int i;
     Scene* s = (Scene*) v;
     XYView* view;
     view = s->sceneview(int(chkarg(1, 0, s->view_count() - 1)));
     view->size(*getarg(2), *getarg(4), *getarg(3), *getarg(5));
     view->damage_all();
-    ENDGUI
+    }
 #endif /* HAVE_IV  */
     return 0.;
 }
@@ -466,7 +466,7 @@ double ivoc_view_size(void* v) {
 double gr_line_info(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.line_info", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Graph* g = (Graph*) v;
     GlyphIndex i, cnt;
     double* p;
@@ -495,14 +495,14 @@ double gr_line_info(void* v) {
             return (double) i;
         }
     }
-    ENDGUI
+    }
 #endif /* HAVE_IV  */
     return -1.;
 }
 
 #if HAVE_IV
 static void gr_add(void* v, bool var) {
-    IFGUI
+    if (hoc_usegui) {
     Graph* g = (Graph*) v;
     GraphLine* gl;
     Object* obj = NULL;
@@ -563,7 +563,7 @@ static void gr_add(void* v, bool var) {
         gl = g->add_var(expr, g->color(), g->brush(), var, fixtype, pd, lab, obj);
     }
     move_label(g, gl->label(), ioff);
-    ENDGUI
+    }
 }
 #endif /* HAVE_IV */
 static double gr_addvar(void* v) {
@@ -587,7 +587,7 @@ static double gr_addexpr(void* v) {
 static double gr_addobject(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.addobject", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Graph* g = (Graph*) v;
     Object* obj = *hoc_objgetarg(1);
     if (is_obj_type(obj, "RangeVarPlot")) {
@@ -608,7 +608,7 @@ static double gr_addobject(void* v) {
     } else {
         hoc_execerror("Don't know how to plot this object type", 0);
     }
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -618,7 +618,7 @@ static double gr_addobject(void* v) {
 static double gr_vector(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.vector", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Graph* g = (Graph*) v;
     int n = int(chkarg(1, 1., 1.e5));
     double* x = hoc_pgetarg(2);
@@ -637,7 +637,7 @@ static double gr_vector(void* v) {
     //	GLabel* glab = g->label(gv->name());
     //	((GraphItem*)g->component(g->glyph_index(glab)))->save(false);
     g->append(new GPolyLineItem(gv));
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -647,14 +647,14 @@ static double gr_vector(void* v) {
 static double gr_xexpr(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.xexpr", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Graph* g = (Graph*) v;
     int i = 0;
     if (ifarg(2)) {
         i = int(chkarg(2, 0, 1));
     }
     g->x_expr(gargstr(1), i);
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -664,8 +664,8 @@ static double gr_xexpr(void* v) {
 static double gr_begin(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.begin", v);
 #if HAVE_IV
-    IFGUI((Graph*) v)->begin();
-    ENDGUI
+    if (hoc_usegui) {((Graph*) v)->begin();
+    }
     return 1.;
 #else
     return 0.;
@@ -675,8 +675,8 @@ static double gr_begin(void* v) {
 static double gr_plot(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.plot", v);
 #if HAVE_IV
-    IFGUI((Graph*) v)->plot(*getarg(1));
-    ENDGUI
+    if (hoc_usegui) {((Graph*) v)->plot(*getarg(1));
+    }
     return 1.;
 #else
     return 0.;
@@ -686,8 +686,8 @@ static double gr_plot(void* v) {
 static double gr_simgraph(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.simgraph", v);
 #if HAVE_IV
-    IFGUI((Graph*) v)->simgraph();
-    ENDGUI
+    if (hoc_usegui) {((Graph*) v)->simgraph();
+    }
     return 1.;
 #else
     return 0.;
@@ -697,7 +697,7 @@ static double gr_simgraph(void* v) {
 double ivoc_gr_begin_line(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.beginline", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Graph* g = (Graph*) v;
     int i = 1;
     char* s = NULL;
@@ -709,7 +709,7 @@ double ivoc_gr_begin_line(void* v) {
     } else {
         g->begin_line(s);
     }
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -718,8 +718,8 @@ double ivoc_gr_begin_line(void* v) {
 double ivoc_gr_line(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.line", v);
 #if HAVE_IV
-    IFGUI((Graph*) v)->line(*getarg(1), *getarg(2));
-    ENDGUI
+    if (hoc_usegui) {((Graph*) v)->line(*getarg(1), *getarg(2));
+    }
     return 1.;
 #else
     return 0.;
@@ -729,8 +729,8 @@ static double gr_flush(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.flush", v);
 
 #if HAVE_IV
-    IFGUI((Graph*) v)->flush();
-    ENDGUI
+    if (hoc_usegui) {((Graph*) v)->flush();
+    }
     return 1.;
 #else
     return 0.;
@@ -740,8 +740,8 @@ static double gr_fast_flush(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.fast_flush", v);
 
 #if HAVE_IV
-    IFGUI((Graph*) v)->fast_flush();
-    ENDGUI
+    if (hoc_usegui) {((Graph*) v)->fast_flush();
+    }
     return 1.;
 #else
     return 0.;
@@ -750,8 +750,8 @@ static double gr_fast_flush(void* v) {
 double ivoc_gr_erase(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.erase", v);
 #if HAVE_IV
-    IFGUI((Graph*) v)->erase_lines();
-    ENDGUI
+    if (hoc_usegui) {((Graph*) v)->erase_lines();
+    }
     return 1.;
 #else
     return 0.;
@@ -761,8 +761,8 @@ double ivoc_gr_erase(void* v) {
 double ivoc_erase_all(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.erase_all", v);
 #if HAVE_IV
-    IFGUI((Graph*) v)->erase_all();
-    ENDGUI
+    if (hoc_usegui) {((Graph*) v)->erase_all();
+    }
     return 1.;
 #else
     return 0.;
@@ -772,7 +772,7 @@ double ivoc_erase_all(void* v) {
 double ivoc_gr_gif(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.gif", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Graph* g = (Graph*) v;
     Glyph* i = gif_image(gargstr(1));
     if (i) {
@@ -799,7 +799,7 @@ double ivoc_gr_gif(void* v) {
         }
         return 1.;
     }
-    ENDGUI
+    }
 #endif /* HAVE_IV  */
     return 0.;
 }
@@ -807,7 +807,7 @@ double ivoc_gr_gif(void* v) {
 double ivoc_gr_size(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.size", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Coord x1, y1, x2, y2;
     Graph* g = (Graph*) v;
     XYView* view = g->sceneview(0);
@@ -850,7 +850,7 @@ double ivoc_gr_size(void* v) {
         }
         return x;
     }
-    ENDGUI
+    }
     return 0.;
 #else
     return 0.;
@@ -860,7 +860,7 @@ double ivoc_gr_size(void* v) {
 double ivoc_gr_label(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.label", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Graph* g = (Graph*) v;
     if (ifarg(8)) {
         g->label(*getarg(1),
@@ -880,7 +880,7 @@ double ivoc_gr_label(void* v) {
     } else {
         g->label(gargstr(1));
     }
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -889,13 +889,13 @@ double ivoc_gr_label(void* v) {
 static double gr_fixed(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.fixed", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     float scale = 1;
     if (ifarg(1)) {
         scale = chkarg(1, .01, 100);
     }
     ((Graph*) v)->fixed(scale);
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -904,13 +904,13 @@ static double gr_fixed(void* v) {
 static double gr_vfixed(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.vfixed", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     float scale = 1;
     if (ifarg(1)) {
         scale = chkarg(1, .01, 100);
     }
     ((Graph*) v)->vfixed(scale);
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -919,13 +919,13 @@ static double gr_vfixed(void* v) {
 static double gr_relative(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.relative", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     float scale = 1.;
     if (ifarg(1)) {
         scale = chkarg(1, .01, 100.);
     }
     ((Graph*) v)->relative(scale);
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -934,7 +934,7 @@ static double gr_relative(void* v) {
 static double gr_align(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.align", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     float x = 0, y = 0;
     if (ifarg(1)) {
         x = chkarg(1, -10, 10);
@@ -943,7 +943,7 @@ static double gr_align(void* v) {
         y = chkarg(2, -10, 10);
     }
     ((Graph*) v)->align(x, y);
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -952,7 +952,7 @@ static double gr_align(void* v) {
 static double gr_color(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.color", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     int i = 1;
     if (ifarg(2)) {
         colors->color(int(chkarg(1, 2, ColorPalette::COLOR_SIZE - 1)), gargstr(2));
@@ -962,7 +962,7 @@ static double gr_color(void* v) {
         i = int(chkarg(1, -1, ColorPalette::COLOR_SIZE - 1));
     }
     ((Graph*) v)->color(i);
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -971,7 +971,7 @@ static double gr_color(void* v) {
 static double gr_brush(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.brush", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     int i = 0;
     if (ifarg(3)) {
         brushes->brush(int(chkarg(1, 1, BrushPalette::BRUSH_SIZE - 1)),
@@ -983,7 +983,7 @@ static double gr_brush(void* v) {
         i = int(chkarg(1, -1, 20));
     }
     ((Graph*) v)->brush(i);
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -993,7 +993,7 @@ static double gr_brush(void* v) {
 static double gr_view(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.view", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Graph* g = (Graph*) v;
     if (ifarg(8)) {
         Coord x[8];
@@ -1014,7 +1014,7 @@ static double gr_view(void* v) {
         ViewWindow* w = new ViewWindow(view, hoc_object_name(g->hoc_obj_ptr()));
         w->map();
     }
-    ENDGUI
+    }
 
     return 1.;
 #else
@@ -1025,7 +1025,7 @@ static double gr_view(void* v) {
 double ivoc_gr_mark(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.mark", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Graph* g = (Graph*) v;
     Coord x = *getarg(1);
     Coord y = *getarg(2);
@@ -1049,7 +1049,7 @@ double ivoc_gr_mark(void* v) {
                 colors->color(int(*getarg(5))),
                 brushes->brush(int(*getarg(6))));
     }
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -1061,9 +1061,9 @@ static double gr_view_count(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.view_count", v);
 #if HAVE_IV
     int n = 0;
-    IFGUI
+    if (hoc_usegui) {
     n = ((Scene*) v)->view_count();
-    ENDGUI
+    }
     return double(n);
 #else
     return 0.;
@@ -1073,10 +1073,10 @@ static double gr_view_count(void* v) {
 static double gr_unmap(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.unmap", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Graph* g = (Graph*) v;
     g->dismiss();
-    ENDGUI
+    }
     return 0.;
 #else
     return 0.;
@@ -1086,7 +1086,7 @@ static double gr_unmap(void* v) {
 static double gr_set_cross_action(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.crosshair_action", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Graph* g = (Graph*) v;
     bool vector_copy = false;
     if (ifarg(2)) {
@@ -1097,7 +1097,7 @@ static double gr_set_cross_action(void* v) {
     } else {
         g->set_cross_action(NULL, *hoc_objgetarg(1), vector_copy);
     }
-    ENDGUI
+    }
     return 0.;
 #else
     return 0.;
@@ -1107,10 +1107,10 @@ static double gr_set_cross_action(void* v) {
 static double gr_printfile(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.printfile", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Graph* g = (Graph*) v;
     g->printfile(gargstr(1));
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -1120,8 +1120,8 @@ static double gr_printfile(void* v) {
 static double exec_menu(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.exec_menu", v);
 #if HAVE_IV
-    IFGUI((Scene*) v)->picker()->exec_item(gargstr(1));
-    ENDGUI
+    if (hoc_usegui) {((Scene*) v)->picker()->exec_item(gargstr(1));
+    }
 #endif
     return 0.;
 }
@@ -1129,8 +1129,8 @@ static double exec_menu(void* v) {
 double ivoc_gr_menu_remove(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.menu_remove", v);
 #if HAVE_IV
-    IFGUI((Scene*) v)->picker()->remove_item(gargstr(1));
-    ENDGUI
+    if (hoc_usegui) {((Scene*) v)->picker()->remove_item(gargstr(1));
+    }
 #endif
     return 0.;
 }
@@ -1190,7 +1190,7 @@ static void* gr_cons(Object* ho) {
     TRY_GUI_REDIRECT_OBJ("Graph", NULL);
 #if HAVE_IV
     Graph* g = NULL;
-    IFGUI
+    if (hoc_usegui) {
     int i = 1;
     if (ifarg(1)) {
         i = (int) chkarg(1, 0, 1);
@@ -1198,7 +1198,7 @@ static void* gr_cons(Object* ho) {
     g = new Graph(i);
     g->ref();
     g->hoc_obj_ptr(ho);
-    ENDGUI
+    }
     return (void*) g;
 #else
     return (void*) 0;
@@ -1207,21 +1207,21 @@ static void* gr_cons(Object* ho) {
 static void gr_destruct(void* v) {
     TRY_GUI_REDIRECT_NO_RETURN("~Graph", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Graph* g = (Graph*) v;
     g->dismiss();
     Resource::unref(g);
-    ENDGUI
+    }
 #endif /* HAVE_IV */
 }
 void Graph_reg() {
     // printf("Graph_reg\n");
     class2oc("Graph", gr_cons, gr_destruct, gr_members, NULL, NULL, NULL);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     colors = new ColorPalette();
     brushes = new BrushPalette();
-    ENDGUI
+    }
 #endif
 }
 #if HAVE_IV
@@ -1253,12 +1253,12 @@ ColorPalette::~ColorPalette() {
 }
 
 const Color* ColorPalette::color(int i) const {
-    IFGUI
+    if (hoc_usegui) {
     if (i < 0)
         i = 1;
     i = i % COLOR_SIZE;
     return color_palette[i];
-    ENDGUI else return NULL;
+    } else return NULL;
 }
 const Color* ColorPalette::color(int i, const char* name) {
     const Color* c = Color::lookup(Session::instance()->default_display(), name);
@@ -1311,12 +1311,12 @@ BrushPalette::~BrushPalette() {
 }
 
 const Brush* BrushPalette::brush(int i) const {
-    IFGUI
+    if (hoc_usegui) {
     if (i < 0)
         i = 1;
     i = i % BRUSH_SIZE;
     return brush_palette[i];
-    ENDGUI else return NULL;
+    } else return NULL;
 }
 const Brush* BrushPalette::brush(int i, int pattern, Coord width) {
     Brush* b;

--- a/src/ivoc/graph.cpp
+++ b/src/ivoc/graph.cpp
@@ -200,56 +200,56 @@ bool NewLabelHandler::event(Event& e) {
 // Graph registration for oc
 static void gr_axis(Graph* g, DimensionName d) {
     if (hoc_usegui) {
-    int ntic = -1;
-    int nminor = 0;
-    int invert = 0;
-    bool number = true;
-    float x1 = 0;
-    float x2 = -1;
-    float pos = 0.;
-    if (!ifarg(2)) {
-        int i = 0;
-        if (ifarg(1)) {
-            i = int(chkarg(1, 0, 3));
+        int ntic = -1;
+        int nminor = 0;
+        int invert = 0;
+        bool number = true;
+        float x1 = 0;
+        float x2 = -1;
+        float pos = 0.;
+        if (!ifarg(2)) {
+            int i = 0;
+            if (ifarg(1)) {
+                i = int(chkarg(1, 0, 3));
+            }
+            switch (i) {
+            case 0:
+                g->view_axis();
+                break;
+            case 1:
+                g->erase_axis();
+                g->axis(Dimension_X, x1, x2, pos, ntic, nminor, invert, number);
+                g->axis(Dimension_Y, x1, x2, pos, ntic, nminor, invert, number);
+                break;
+            case 2:
+                g->view_box();
+                break;
+            case 3:
+                g->erase_axis();
+                break;
+            }
+            return;
         }
-        switch (i) {
-        case 0:
-            g->view_axis();
-            break;
-        case 1:
-            g->erase_axis();
-            g->axis(Dimension_X, x1, x2, pos, ntic, nminor, invert, number);
-            g->axis(Dimension_Y, x1, x2, pos, ntic, nminor, invert, number);
-            break;
-        case 2:
-            g->view_box();
-            break;
-        case 3:
-            g->erase_axis();
-            break;
+        if (ifarg(3)) {
+            pos = *getarg(3);
         }
-        return;
-    }
-    if (ifarg(3)) {
-        pos = *getarg(3);
-    }
-    if (ifarg(4)) {
-        ntic = int(chkarg(4, -1, 100));
-    }
-    if (ifarg(2)) {
-        x1 = *getarg(1);
-        x2 = *getarg(2);
-    }
-    if (ifarg(5)) {
-        nminor = int(chkarg(5, 0, 100));
-    }
-    if (ifarg(6)) {
-        invert = int(chkarg(6, -1, 1));
-    }
-    if (ifarg(7) && !int(chkarg(7, 0, 1))) {
-        number = false;
-    }
-    g->axis(d, x1, x2, pos, ntic, nminor, invert, number);
+        if (ifarg(4)) {
+            ntic = int(chkarg(4, -1, 100));
+        }
+        if (ifarg(2)) {
+            x1 = *getarg(1);
+            x2 = *getarg(2);
+        }
+        if (ifarg(5)) {
+            nminor = int(chkarg(5, 0, 100));
+        }
+        if (ifarg(6)) {
+            invert = int(chkarg(6, -1, 1));
+        }
+        if (ifarg(7) && !int(chkarg(7, 0, 1))) {
+            number = false;
+        }
+        g->axis(d, x1, x2, pos, ntic, nminor, invert, number);
     }
 }
 #endif /* HAVE_IV */
@@ -276,19 +276,19 @@ static double gr_save_name(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.save_name", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Graph* g = (Graph*) v;
-    g->name(gargstr(1));
-    if (ifarg(2) && (chkarg(2, 0, 1) == 1.) && Oc::save_stream) {
-        char buf[80];
-        *Oc::save_stream << "{\nsave_window_=" << gargstr(1) << std::endl;
-        *Oc::save_stream << "save_window_.size(" << g->x1() << "," << g->x2() << "," << g->y1()
-                         << "," << g->y2() << ")\n";
-        long i = Scene::scene_list_index(g);
-        Sprintf(buf, "scene_vector_[%ld] = save_window_", i);
-        *Oc::save_stream << buf << std::endl;
-        g->save_phase2(*Oc::save_stream);
-        g->Scene::mark(true);
-    }
+        Graph* g = (Graph*) v;
+        g->name(gargstr(1));
+        if (ifarg(2) && (chkarg(2, 0, 1) == 1.) && Oc::save_stream) {
+            char buf[80];
+            *Oc::save_stream << "{\nsave_window_=" << gargstr(1) << std::endl;
+            *Oc::save_stream << "save_window_.size(" << g->x1() << "," << g->x2() << "," << g->y1()
+                             << "," << g->y2() << ")\n";
+            long i = Scene::scene_list_index(g);
+            Sprintf(buf, "scene_vector_[%ld] = save_window_", i);
+            *Oc::save_stream << buf << std::endl;
+            g->save_phase2(*Oc::save_stream);
+            g->Scene::mark(true);
+        }
     }
     return 1.;
 #else
@@ -311,11 +311,11 @@ static double gr_family(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.family", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    if (hoc_is_str_arg(1)) {
-        ((Graph*) v)->family(gargstr(1));
-    } else {
-        ((Graph*) v)->family(int(chkarg(1, 0, 1)));
-    }
+        if (hoc_is_str_arg(1)) {
+            ((Graph*) v)->family(gargstr(1));
+        } else {
+            ((Graph*) v)->family(int(chkarg(1, 0, 1)));
+        }
     }
     return 1.;
 #else
@@ -327,13 +327,13 @@ double ivoc_gr_menu_action(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.menu_action", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    HocCommand* hc;
-    if (hoc_is_object_arg(2)) {
-        hc = new HocCommand(*hoc_objgetarg(2));
-    } else {
-        hc = new HocCommand(gargstr(2));
-    }
-    ((Scene*) v)->picker()->add_menu(gargstr(1), new HocCommandAction(hc));
+        HocCommand* hc;
+        if (hoc_is_object_arg(2)) {
+            hc = new HocCommand(*hoc_objgetarg(2));
+        } else {
+            hc = new HocCommand(gargstr(2));
+        }
+        ((Scene*) v)->picker()->add_menu(gargstr(1), new HocCommandAction(hc));
     }
     return 1.;
 #else
@@ -345,19 +345,19 @@ double ivoc_gr_menu_tool(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.menu_tool", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    if (hoc_is_object_arg(2)) {  // python style
-        HocPanel::paneltool(gargstr(1),
-                            NULL,
-                            NULL,
-                            ((Scene*) v)->picker(),
-                            *hoc_objgetarg(2),
-                            ifarg(3) ? *hoc_objgetarg(3) : NULL);
-    } else {
-        HocPanel::paneltool(gargstr(1),
-                            gargstr(2),
-                            ifarg(3) ? gargstr(3) : NULL,
-                            ((Scene*) v)->picker());
-    }
+        if (hoc_is_object_arg(2)) {  // python style
+            HocPanel::paneltool(gargstr(1),
+                                NULL,
+                                NULL,
+                                ((Scene*) v)->picker(),
+                                *hoc_objgetarg(2),
+                                ifarg(3) ? *hoc_objgetarg(3) : NULL);
+        } else {
+            HocPanel::paneltool(gargstr(1),
+                                gargstr(2),
+                                ifarg(3) ? gargstr(3) : NULL,
+                                ((Scene*) v)->picker());
+        }
     }
     return 1.;
 #else
@@ -369,80 +369,80 @@ double ivoc_view_info(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.view_info", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    int i;
-    Scene* s = (Scene*) v;
-    XYView* view;
-    if (!ifarg(1)) {
-        view = XYView::current_pick_view();
-        for (i = 0; i < s->view_count(); ++i) {
-            if (s->sceneview(i) == view) {
-                return double(i);
+        int i;
+        Scene* s = (Scene*) v;
+        XYView* view;
+        if (!ifarg(1)) {
+            view = XYView::current_pick_view();
+            for (i = 0; i < s->view_count(); ++i) {
+                if (s->sceneview(i) == view) {
+                    return double(i);
+                }
+            }
+            return -1.;
+        }
+        view = s->sceneview(int(chkarg(1, 0, s->view_count() - 1)));
+        float x1, y1, x2, y2;
+        i = int(chkarg(2, 1, 15));
+        switch (i) {
+        case 1:  // width
+            return view->width();
+        case 2:  // height
+            return view->height();
+        case 3:  // point width
+            view->view_ratio(0., 0., x1, y1);
+            view->view_ratio(1., 1., x2, y2);
+            return x2 - x1;
+        case 4:  // point height
+            view->view_ratio(0., 0., x1, y1);
+            view->view_ratio(1., 1., x2, y2);
+            return y2 - y1;
+        case 5:  // left
+            return view->left();
+        case 6:  // right
+            return view->right();
+        case 7:  // bottom
+            return view->bottom();
+        case 8:  // top
+            return view->top();
+        case 9:  // model x distance for one point
+            view->view_ratio(0., 0., x1, y1);
+            view->view_ratio(1., 1., x2, y2);
+            if (x2 > x1) {
+                return view->width() / (x2 - x1);
+            } else {
+                return 1.;
+            }
+        case 10:  // model y distance for one point
+            view->view_ratio(0., 0., x1, y1);
+            view->view_ratio(1., 1., x2, y2);
+            if (y2 > y1) {
+                return view->height() / (y2 - y1);
+            } else {
+                return 1.;
+            }
+        case 11:  // relative x location (from x model coord)
+            return (*getarg(3) - view->left()) / view->width();
+        case 12:  // relative y location (from y model coord)
+            return (*getarg(3) - view->bottom()) / view->height();
+        case 13:  // points from left (from x model coord)
+            x1 = (*getarg(3) - view->left()) / view->width();
+            view->view_ratio(x1, 1., x2, y2);
+            view->view_ratio(0., 1., x1, y1);
+            return x2 - x1;
+        case 14:  // points from top (from y model coord)
+            y1 = (*getarg(3) - view->bottom()) / view->height();
+            view->view_ratio(1., y1, x2, y2);
+            view->view_ratio(1., 1., x1, y1);
+            return y1 - y2;
+        case 15:  // label height in points
+            // return WidgetKit::instance()->font()->size();
+            {
+                FontBoundingBox b;
+                WidgetKit::instance()->font()->font_bbox(b);
+                return b.ascent() + b.descent();
             }
         }
-        return -1.;
-    }
-    view = s->sceneview(int(chkarg(1, 0, s->view_count() - 1)));
-    float x1, y1, x2, y2;
-    i = int(chkarg(2, 1, 15));
-    switch (i) {
-    case 1:  // width
-        return view->width();
-    case 2:  // height
-        return view->height();
-    case 3:  // point width
-        view->view_ratio(0., 0., x1, y1);
-        view->view_ratio(1., 1., x2, y2);
-        return x2 - x1;
-    case 4:  // point height
-        view->view_ratio(0., 0., x1, y1);
-        view->view_ratio(1., 1., x2, y2);
-        return y2 - y1;
-    case 5:  // left
-        return view->left();
-    case 6:  // right
-        return view->right();
-    case 7:  // bottom
-        return view->bottom();
-    case 8:  // top
-        return view->top();
-    case 9:  // model x distance for one point
-        view->view_ratio(0., 0., x1, y1);
-        view->view_ratio(1., 1., x2, y2);
-        if (x2 > x1) {
-            return view->width() / (x2 - x1);
-        } else {
-            return 1.;
-        }
-    case 10:  // model y distance for one point
-        view->view_ratio(0., 0., x1, y1);
-        view->view_ratio(1., 1., x2, y2);
-        if (y2 > y1) {
-            return view->height() / (y2 - y1);
-        } else {
-            return 1.;
-        }
-    case 11:  // relative x location (from x model coord)
-        return (*getarg(3) - view->left()) / view->width();
-    case 12:  // relative y location (from y model coord)
-        return (*getarg(3) - view->bottom()) / view->height();
-    case 13:  // points from left (from x model coord)
-        x1 = (*getarg(3) - view->left()) / view->width();
-        view->view_ratio(x1, 1., x2, y2);
-        view->view_ratio(0., 1., x1, y1);
-        return x2 - x1;
-    case 14:  // points from top (from y model coord)
-        y1 = (*getarg(3) - view->bottom()) / view->height();
-        view->view_ratio(1., y1, x2, y2);
-        view->view_ratio(1., 1., x1, y1);
-        return y1 - y2;
-    case 15:  // label height in points
-        // return WidgetKit::instance()->font()->size();
-        {
-            FontBoundingBox b;
-            WidgetKit::instance()->font()->font_bbox(b);
-            return b.ascent() + b.descent();
-        }
-    }
     }
 #endif /* HAVE_IV  */
     return -1.;
@@ -452,12 +452,12 @@ double ivoc_view_size(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.view_size", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    int i;
-    Scene* s = (Scene*) v;
-    XYView* view;
-    view = s->sceneview(int(chkarg(1, 0, s->view_count() - 1)));
-    view->size(*getarg(2), *getarg(4), *getarg(3), *getarg(5));
-    view->damage_all();
+        int i;
+        Scene* s = (Scene*) v;
+        XYView* view;
+        view = s->sceneview(int(chkarg(1, 0, s->view_count() - 1)));
+        view->size(*getarg(2), *getarg(4), *getarg(3), *getarg(5));
+        view->damage_all();
     }
 #endif /* HAVE_IV  */
     return 0.;
@@ -467,34 +467,34 @@ double gr_line_info(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.line_info", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Graph* g = (Graph*) v;
-    GlyphIndex i, cnt;
-    double* p;
-    cnt = g->count();
-    i = (int) chkarg(1, -1, cnt);
-    if (i < 0 || i > cnt - 1) {
-        i = -1;
-    }
-    Vect* x = vector_arg(2);
-    for (i += 1; i < cnt; ++i) {
-        GraphItem* gi = (GraphItem*) g->component(i);
-        if (gi->is_polyline()) {
-            GPolyLine* gpl = (GPolyLine*) gi->body();
-            x->resize(5);
-            p = vector_vec(x);
-            p[0] = colors->color(gpl->color());
-            p[1] = brushes->brush(gpl->brush());
-            if (gpl->label()) {
-                Coord a, b;
-                x->label(gpl->label()->text());
-                g->location(g->glyph_index(gpl->label()), a, b);
-                p[2] = a;
-                p[3] = b;
-                p[4] = gpl->label()->fixtype();
-            }
-            return (double) i;
+        Graph* g = (Graph*) v;
+        GlyphIndex i, cnt;
+        double* p;
+        cnt = g->count();
+        i = (int) chkarg(1, -1, cnt);
+        if (i < 0 || i > cnt - 1) {
+            i = -1;
         }
-    }
+        Vect* x = vector_arg(2);
+        for (i += 1; i < cnt; ++i) {
+            GraphItem* gi = (GraphItem*) g->component(i);
+            if (gi->is_polyline()) {
+                GPolyLine* gpl = (GPolyLine*) gi->body();
+                x->resize(5);
+                p = vector_vec(x);
+                p[0] = colors->color(gpl->color());
+                p[1] = brushes->brush(gpl->brush());
+                if (gpl->label()) {
+                    Coord a, b;
+                    x->label(gpl->label()->text());
+                    g->location(g->glyph_index(gpl->label()), a, b);
+                    p[2] = a;
+                    p[3] = b;
+                    p[4] = gpl->label()->fixtype();
+                }
+                return (double) i;
+            }
+        }
     }
 #endif /* HAVE_IV  */
     return -1.;
@@ -503,66 +503,66 @@ double gr_line_info(void* v) {
 #if HAVE_IV
 static void gr_add(void* v, bool var) {
     if (hoc_usegui) {
-    Graph* g = (Graph*) v;
-    GraphLine* gl;
-    Object* obj = NULL;
-    char* lab = NULL;
-    char* expr = NULL;
-    int ioff = 0;  // deal with 0, 1, or 2 optional arguments after first
-    // pointer to varname if second arg is varname string
-    neuron::container::data_handle<double> pd{};
-    int fixtype = g->labeltype();
-    // organize args for backward compatibility and the new
-    // addexpr("label, "expr", obj,.... style
-    if (ifarg(2)) {
-        if (var) {  // if string or address then variable and 1 was label
-            expr = hoc_gargstr(1);
-            if (hoc_is_str_arg(2)) {
-                pd = hoc_val_handle(hoc_gargstr(2));
+        Graph* g = (Graph*) v;
+        GraphLine* gl;
+        Object* obj = NULL;
+        char* lab = NULL;
+        char* expr = NULL;
+        int ioff = 0;  // deal with 0, 1, or 2 optional arguments after first
+        // pointer to varname if second arg is varname string
+        neuron::container::data_handle<double> pd{};
+        int fixtype = g->labeltype();
+        // organize args for backward compatibility and the new
+        // addexpr("label, "expr", obj,.... style
+        if (ifarg(2)) {
+            if (var) {  // if string or address then variable and 1 was label
+                expr = hoc_gargstr(1);
+                if (hoc_is_str_arg(2)) {
+                    pd = hoc_val_handle(hoc_gargstr(2));
+                    ioff += 1;
+                } else if (hoc_is_pdouble_arg(2)) {
+                    pd = hoc_hgetarg<double>(2);
+                    ioff += 1;
+                }
+            } else if (hoc_is_str_arg(2)) {  // 1 label, 2 expression
+                lab = hoc_gargstr(1);
+                expr = hoc_gargstr(2);
                 ioff += 1;
-            } else if (hoc_is_pdouble_arg(2)) {
-                pd = hoc_hgetarg<double>(2);
+                if (ifarg(3) && hoc_is_object_arg(3)) {  // object context
+                    obj = *hoc_objgetarg(3);
+                    ioff += 1;
+                }
+            } else if (hoc_is_object_arg(2)) {  // 1 expr, 2 object context
+                expr = hoc_gargstr(1);
+                obj = *hoc_objgetarg(2);
                 ioff += 1;
+            } else {
+                expr = hoc_gargstr(1);
             }
-        } else if (hoc_is_str_arg(2)) {  // 1 label, 2 expression
-            lab = hoc_gargstr(1);
-            expr = hoc_gargstr(2);
-            ioff += 1;
-            if (ifarg(3) && hoc_is_object_arg(3)) {  // object context
-                obj = *hoc_objgetarg(3);
-                ioff += 1;
-            }
-        } else if (hoc_is_object_arg(2)) {  // 1 expr, 2 object context
-            expr = hoc_gargstr(1);
-            obj = *hoc_objgetarg(2);
-            ioff += 1;
         } else {
             expr = hoc_gargstr(1);
         }
-    } else {
-        expr = hoc_gargstr(1);
-    }
-    if (ifarg(3 + ioff)) {
-        if (ifarg(6 + ioff)) {
-            fixtype = int(chkarg(6 + ioff, 0, 2));
-        } else if (ifarg(4 + ioff)) {
-            // old versions did not have the fixtype and for
-            // backward compatibility it must therefore be
-            // fixed.
-            fixtype = 1;
+        if (ifarg(3 + ioff)) {
+            if (ifarg(6 + ioff)) {
+                fixtype = int(chkarg(6 + ioff, 0, 2));
+            } else if (ifarg(4 + ioff)) {
+                // old versions did not have the fixtype and for
+                // backward compatibility it must therefore be
+                // fixed.
+                fixtype = 1;
+            }
+            gl = g->add_var(expr,
+                            colors->color(int(*getarg(2 + ioff))),
+                            brushes->brush(int(*getarg(3 + ioff))),
+                            var,
+                            fixtype,
+                            pd,
+                            lab,
+                            obj);
+        } else {
+            gl = g->add_var(expr, g->color(), g->brush(), var, fixtype, pd, lab, obj);
         }
-        gl = g->add_var(expr,
-                        colors->color(int(*getarg(2 + ioff))),
-                        brushes->brush(int(*getarg(3 + ioff))),
-                        var,
-                        fixtype,
-                        pd,
-                        lab,
-                        obj);
-    } else {
-        gl = g->add_var(expr, g->color(), g->brush(), var, fixtype, pd, lab, obj);
-    }
-    move_label(g, gl->label(), ioff);
+        move_label(g, gl->label(), ioff);
     }
 }
 #endif /* HAVE_IV */
@@ -588,26 +588,26 @@ static double gr_addobject(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.addobject", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Graph* g = (Graph*) v;
-    Object* obj = *hoc_objgetarg(1);
-    if (is_obj_type(obj, "RangeVarPlot")) {
-        GraphVector* gv = (GraphVector*) obj->u.this_pointer;
-        if (ifarg(3)) {
-            gv->color(colors->color(int(*getarg(2))));
-            gv->brush(brushes->brush(int(*getarg(3))));
+        Graph* g = (Graph*) v;
+        Object* obj = *hoc_objgetarg(1);
+        if (is_obj_type(obj, "RangeVarPlot")) {
+            GraphVector* gv = (GraphVector*) obj->u.this_pointer;
+            if (ifarg(3)) {
+                gv->color(colors->color(int(*getarg(2))));
+                gv->brush(brushes->brush(int(*getarg(3))));
+            } else {
+                gv->color(g->color());
+                gv->brush(g->brush());
+            }
+            g->append(new VectorLineItem(gv));
+            GLabel* glab = g->label(gv->name());
+            gv->label(glab);
+            ((GraphItem*) g->component(g->glyph_index(glab)))->save(false);
+            g->see_range_plot(gv);
+            move_label(g, glab);
         } else {
-            gv->color(g->color());
-            gv->brush(g->brush());
+            hoc_execerror("Don't know how to plot this object type", 0);
         }
-        g->append(new VectorLineItem(gv));
-        GLabel* glab = g->label(gv->name());
-        gv->label(glab);
-        ((GraphItem*) g->component(g->glyph_index(glab)))->save(false);
-        g->see_range_plot(gv);
-        move_label(g, glab);
-    } else {
-        hoc_execerror("Don't know how to plot this object type", 0);
-    }
     }
     return 1.;
 #else
@@ -619,24 +619,24 @@ static double gr_vector(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.vector", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Graph* g = (Graph*) v;
-    int n = int(chkarg(1, 1., 1.e5));
-    double* x = hoc_pgetarg(2);
-    auto y_handle = hoc_hgetarg<double>(3);
-    GraphVector* gv = new GraphVector("");
-    if (ifarg(4)) {
-        gv->color(colors->color(int(*getarg(4))));
-        gv->brush(brushes->brush(int(*getarg(5))));
-    } else {
-        gv->color(g->color());
-        gv->brush(g->brush());
-    }
-    for (int i = 0; i < n; ++i) {
-        gv->add(x[i], y_handle.next_array_element(i));
-    }
-    //	GLabel* glab = g->label(gv->name());
-    //	((GraphItem*)g->component(g->glyph_index(glab)))->save(false);
-    g->append(new GPolyLineItem(gv));
+        Graph* g = (Graph*) v;
+        int n = int(chkarg(1, 1., 1.e5));
+        double* x = hoc_pgetarg(2);
+        auto y_handle = hoc_hgetarg<double>(3);
+        GraphVector* gv = new GraphVector("");
+        if (ifarg(4)) {
+            gv->color(colors->color(int(*getarg(4))));
+            gv->brush(brushes->brush(int(*getarg(5))));
+        } else {
+            gv->color(g->color());
+            gv->brush(g->brush());
+        }
+        for (int i = 0; i < n; ++i) {
+            gv->add(x[i], y_handle.next_array_element(i));
+        }
+        //	GLabel* glab = g->label(gv->name());
+        //	((GraphItem*)g->component(g->glyph_index(glab)))->save(false);
+        g->append(new GPolyLineItem(gv));
     }
     return 1.;
 #else
@@ -648,12 +648,12 @@ static double gr_xexpr(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.xexpr", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Graph* g = (Graph*) v;
-    int i = 0;
-    if (ifarg(2)) {
-        i = int(chkarg(2, 0, 1));
-    }
-    g->x_expr(gargstr(1), i);
+        Graph* g = (Graph*) v;
+        int i = 0;
+        if (ifarg(2)) {
+            i = int(chkarg(2, 0, 1));
+        }
+        g->x_expr(gargstr(1), i);
     }
     return 1.;
 #else
@@ -664,7 +664,8 @@ static double gr_xexpr(void* v) {
 static double gr_begin(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.begin", v);
 #if HAVE_IV
-    if (hoc_usegui) {((Graph*) v)->begin();
+    if (hoc_usegui) {
+        ((Graph*) v)->begin();
     }
     return 1.;
 #else
@@ -675,7 +676,8 @@ static double gr_begin(void* v) {
 static double gr_plot(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.plot", v);
 #if HAVE_IV
-    if (hoc_usegui) {((Graph*) v)->plot(*getarg(1));
+    if (hoc_usegui) {
+        ((Graph*) v)->plot(*getarg(1));
     }
     return 1.;
 #else
@@ -686,7 +688,8 @@ static double gr_plot(void* v) {
 static double gr_simgraph(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.simgraph", v);
 #if HAVE_IV
-    if (hoc_usegui) {((Graph*) v)->simgraph();
+    if (hoc_usegui) {
+        ((Graph*) v)->simgraph();
     }
     return 1.;
 #else
@@ -698,17 +701,17 @@ double ivoc_gr_begin_line(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.beginline", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Graph* g = (Graph*) v;
-    int i = 1;
-    char* s = NULL;
-    if (ifarg(i) && hoc_is_str_arg(1)) {
-        s = gargstr(i++);
-    }
-    if (ifarg(i)) {
-        g->begin_line(colors->color(int(*getarg(i))), brushes->brush(int(*getarg(i + 1))), s);
-    } else {
-        g->begin_line(s);
-    }
+        Graph* g = (Graph*) v;
+        int i = 1;
+        char* s = NULL;
+        if (ifarg(i) && hoc_is_str_arg(1)) {
+            s = gargstr(i++);
+        }
+        if (ifarg(i)) {
+            g->begin_line(colors->color(int(*getarg(i))), brushes->brush(int(*getarg(i + 1))), s);
+        } else {
+            g->begin_line(s);
+        }
     }
     return 1.;
 #else
@@ -718,7 +721,8 @@ double ivoc_gr_begin_line(void* v) {
 double ivoc_gr_line(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.line", v);
 #if HAVE_IV
-    if (hoc_usegui) {((Graph*) v)->line(*getarg(1), *getarg(2));
+    if (hoc_usegui) {
+        ((Graph*) v)->line(*getarg(1), *getarg(2));
     }
     return 1.;
 #else
@@ -729,7 +733,8 @@ static double gr_flush(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.flush", v);
 
 #if HAVE_IV
-    if (hoc_usegui) {((Graph*) v)->flush();
+    if (hoc_usegui) {
+        ((Graph*) v)->flush();
     }
     return 1.;
 #else
@@ -740,7 +745,8 @@ static double gr_fast_flush(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.fast_flush", v);
 
 #if HAVE_IV
-    if (hoc_usegui) {((Graph*) v)->fast_flush();
+    if (hoc_usegui) {
+        ((Graph*) v)->fast_flush();
     }
     return 1.;
 #else
@@ -750,7 +756,8 @@ static double gr_fast_flush(void* v) {
 double ivoc_gr_erase(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.erase", v);
 #if HAVE_IV
-    if (hoc_usegui) {((Graph*) v)->erase_lines();
+    if (hoc_usegui) {
+        ((Graph*) v)->erase_lines();
     }
     return 1.;
 #else
@@ -761,7 +768,8 @@ double ivoc_gr_erase(void* v) {
 double ivoc_erase_all(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.erase_all", v);
 #if HAVE_IV
-    if (hoc_usegui) {((Graph*) v)->erase_all();
+    if (hoc_usegui) {
+        ((Graph*) v)->erase_all();
     }
     return 1.;
 #else
@@ -773,32 +781,32 @@ double ivoc_gr_gif(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.gif", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Graph* g = (Graph*) v;
-    Glyph* i = gif_image(gargstr(1));
-    if (i) {
-        Transformer t;
-        if (ifarg(4)) {
-            Coord x = *getarg(4);
-            Coord y = *getarg(5);
-            Requisition r;
-            i->request(r);
-            t.scale(x / r.x_requirement().natural(), y / r.y_requirement().natural());
-            i = new TransformSetter(i, t);
-        }
-        if (!ifarg(2)) {  // resize if smaller than gif
-            Requisition r;
-            i->request(r);
-            if (r.x_requirement().natural() > (g->x2() - g->x1()) ||
-                r.y_requirement().natural() > (g->y2() - g->y1())) {
-                g->new_size(0, 0, r.x_requirement().natural(), r.y_requirement().natural());
+        Graph* g = (Graph*) v;
+        Glyph* i = gif_image(gargstr(1));
+        if (i) {
+            Transformer t;
+            if (ifarg(4)) {
+                Coord x = *getarg(4);
+                Coord y = *getarg(5);
+                Requisition r;
+                i->request(r);
+                t.scale(x / r.x_requirement().natural(), y / r.y_requirement().natural());
+                i = new TransformSetter(i, t);
             }
+            if (!ifarg(2)) {  // resize if smaller than gif
+                Requisition r;
+                i->request(r);
+                if (r.x_requirement().natural() > (g->x2() - g->x1()) ||
+                    r.y_requirement().natural() > (g->y2() - g->y1())) {
+                    g->new_size(0, 0, r.x_requirement().natural(), r.y_requirement().natural());
+                }
+            }
+            g->append(new GraphItem(i, false, false));
+            if (ifarg(2)) {
+                g->move(g->count() - 1, *getarg(2), *getarg(3));
+            }
+            return 1.;
         }
-        g->append(new GraphItem(i, false, false));
-        if (ifarg(2)) {
-            g->move(g->count() - 1, *getarg(2), *getarg(3));
-        }
-        return 1.;
-    }
     }
 #endif /* HAVE_IV  */
     return 0.;
@@ -808,48 +816,48 @@ double ivoc_gr_size(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.size", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Coord x1, y1, x2, y2;
-    Graph* g = (Graph*) v;
-    XYView* view = g->sceneview(0);
-    if (ifarg(2)) {
-        g->new_size(*getarg(1), *getarg(3), *getarg(2), *getarg(4));
-    }
-    if (hoc_is_pdouble_arg(1)) {
-        g->wholeplot(x1, y1, x2, y2);
-        double* x = hoc_pgetarg(1);
-        x[0] = x1;
-        x[1] = x2;
-        x[2] = y1;
-        x[3] = y2;
-        return 0.;
-    }
-    if (!view) {
-        return 0.;
-    }
-
-    if (ifarg(2)) {
-        view->zout(x1, y1, x2, y2);
-        view->size(x1, y1, x2, y2);
-        return 1.;
-    } else {
-        view->zin(x1, y1, x2, y2);
-        double x = 0.;
-        switch (int(chkarg(1, 1., 4.))) {
-        case 1:
-            x = x1;
-            break;
-        case 2:
-            x = x2;
-            break;
-        case 3:
-            x = y1;
-            break;
-        case 4:
-            x = y2;
-            break;
+        Coord x1, y1, x2, y2;
+        Graph* g = (Graph*) v;
+        XYView* view = g->sceneview(0);
+        if (ifarg(2)) {
+            g->new_size(*getarg(1), *getarg(3), *getarg(2), *getarg(4));
         }
-        return x;
-    }
+        if (hoc_is_pdouble_arg(1)) {
+            g->wholeplot(x1, y1, x2, y2);
+            double* x = hoc_pgetarg(1);
+            x[0] = x1;
+            x[1] = x2;
+            x[2] = y1;
+            x[3] = y2;
+            return 0.;
+        }
+        if (!view) {
+            return 0.;
+        }
+
+        if (ifarg(2)) {
+            view->zout(x1, y1, x2, y2);
+            view->size(x1, y1, x2, y2);
+            return 1.;
+        } else {
+            view->zin(x1, y1, x2, y2);
+            double x = 0.;
+            switch (int(chkarg(1, 1., 4.))) {
+            case 1:
+                x = x1;
+                break;
+            case 2:
+                x = x2;
+                break;
+            case 3:
+                x = y1;
+                break;
+            case 4:
+                x = y2;
+                break;
+            }
+            return x;
+        }
     }
     return 0.;
 #else
@@ -861,25 +869,25 @@ double ivoc_gr_label(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.label", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Graph* g = (Graph*) v;
-    if (ifarg(8)) {
-        g->label(*getarg(1),
-                 *getarg(2),
-                 gargstr(3),
-                 int(*getarg(4)),
-                 *getarg(5),
-                 *getarg(6),
-                 *getarg(7),
-                 colors->color(int(*getarg(8))));
-    } else if (ifarg(2)) {
-        char* s = NULL;
-        if (ifarg(3)) {
-            s = gargstr(3);
+        Graph* g = (Graph*) v;
+        if (ifarg(8)) {
+            g->label(*getarg(1),
+                     *getarg(2),
+                     gargstr(3),
+                     int(*getarg(4)),
+                     *getarg(5),
+                     *getarg(6),
+                     *getarg(7),
+                     colors->color(int(*getarg(8))));
+        } else if (ifarg(2)) {
+            char* s = NULL;
+            if (ifarg(3)) {
+                s = gargstr(3);
+            }
+            g->label(*getarg(1), *getarg(2), s);
+        } else {
+            g->label(gargstr(1));
         }
-        g->label(*getarg(1), *getarg(2), s);
-    } else {
-        g->label(gargstr(1));
-    }
     }
     return 1.;
 #else
@@ -890,11 +898,11 @@ static double gr_fixed(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.fixed", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    float scale = 1;
-    if (ifarg(1)) {
-        scale = chkarg(1, .01, 100);
-    }
-    ((Graph*) v)->fixed(scale);
+        float scale = 1;
+        if (ifarg(1)) {
+            scale = chkarg(1, .01, 100);
+        }
+        ((Graph*) v)->fixed(scale);
     }
     return 1.;
 #else
@@ -905,11 +913,11 @@ static double gr_vfixed(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.vfixed", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    float scale = 1;
-    if (ifarg(1)) {
-        scale = chkarg(1, .01, 100);
-    }
-    ((Graph*) v)->vfixed(scale);
+        float scale = 1;
+        if (ifarg(1)) {
+            scale = chkarg(1, .01, 100);
+        }
+        ((Graph*) v)->vfixed(scale);
     }
     return 1.;
 #else
@@ -920,11 +928,11 @@ static double gr_relative(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.relative", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    float scale = 1.;
-    if (ifarg(1)) {
-        scale = chkarg(1, .01, 100.);
-    }
-    ((Graph*) v)->relative(scale);
+        float scale = 1.;
+        if (ifarg(1)) {
+            scale = chkarg(1, .01, 100.);
+        }
+        ((Graph*) v)->relative(scale);
     }
     return 1.;
 #else
@@ -935,14 +943,14 @@ static double gr_align(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.align", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    float x = 0, y = 0;
-    if (ifarg(1)) {
-        x = chkarg(1, -10, 10);
-    }
-    if (ifarg(2)) {
-        y = chkarg(2, -10, 10);
-    }
-    ((Graph*) v)->align(x, y);
+        float x = 0, y = 0;
+        if (ifarg(1)) {
+            x = chkarg(1, -10, 10);
+        }
+        if (ifarg(2)) {
+            y = chkarg(2, -10, 10);
+        }
+        ((Graph*) v)->align(x, y);
     }
     return 1.;
 #else
@@ -953,15 +961,15 @@ static double gr_color(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.color", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    int i = 1;
-    if (ifarg(2)) {
-        colors->color(int(chkarg(1, 2, ColorPalette::COLOR_SIZE - 1)), gargstr(2));
-        return 1.;
-    }
-    if (ifarg(1)) {
-        i = int(chkarg(1, -1, ColorPalette::COLOR_SIZE - 1));
-    }
-    ((Graph*) v)->color(i);
+        int i = 1;
+        if (ifarg(2)) {
+            colors->color(int(chkarg(1, 2, ColorPalette::COLOR_SIZE - 1)), gargstr(2));
+            return 1.;
+        }
+        if (ifarg(1)) {
+            i = int(chkarg(1, -1, ColorPalette::COLOR_SIZE - 1));
+        }
+        ((Graph*) v)->color(i);
     }
     return 1.;
 #else
@@ -972,17 +980,17 @@ static double gr_brush(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.brush", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    int i = 0;
-    if (ifarg(3)) {
-        brushes->brush(int(chkarg(1, 1, BrushPalette::BRUSH_SIZE - 1)),
-                       int(*getarg(2)),
-                       float(chkarg(3, 0, 1000)));
-        return 1.;
-    }
-    if (ifarg(1)) {
-        i = int(chkarg(1, -1, 20));
-    }
-    ((Graph*) v)->brush(i);
+        int i = 0;
+        if (ifarg(3)) {
+            brushes->brush(int(chkarg(1, 1, BrushPalette::BRUSH_SIZE - 1)),
+                           int(*getarg(2)),
+                           float(chkarg(3, 0, 1000)));
+            return 1.;
+        }
+        if (ifarg(1)) {
+            i = int(chkarg(1, -1, 20));
+        }
+        ((Graph*) v)->brush(i);
     }
     return 1.;
 #else
@@ -994,26 +1002,26 @@ static double gr_view(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.view", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Graph* g = (Graph*) v;
-    if (ifarg(8)) {
-        Coord x[8];
-        int i;
-        for (i = 0; i < 8; ++i) {
-            x[i] = *getarg(i + 1);
+        Graph* g = (Graph*) v;
+        if (ifarg(8)) {
+            Coord x[8];
+            int i;
+            for (i = 0; i < 8; ++i) {
+                x[i] = *getarg(i + 1);
+            }
+            XYView* view = new XYView(x[0], x[1], x[2], x[3], g, x[6], x[7]);
+            Coord x1, x2, y1, y2;
+            view->zout(x1, y1, x2, y2);
+            view->size(x1, y1, x2, y2);
+            // printf("%g %g %g %g\n", view->left(), view->bottom(), view->right(), view->top());
+            ViewWindow* w = new ViewWindow(view, hoc_object_name(g->hoc_obj_ptr()));
+            w->xplace(int(x[4]), int(x[5]));
+            w->map();
+        } else if (ifarg(1) && *getarg(1) == 2.) {
+            View* view = new View(g);
+            ViewWindow* w = new ViewWindow(view, hoc_object_name(g->hoc_obj_ptr()));
+            w->map();
         }
-        XYView* view = new XYView(x[0], x[1], x[2], x[3], g, x[6], x[7]);
-        Coord x1, x2, y1, y2;
-        view->zout(x1, y1, x2, y2);
-        view->size(x1, y1, x2, y2);
-        // printf("%g %g %g %g\n", view->left(), view->bottom(), view->right(), view->top());
-        ViewWindow* w = new ViewWindow(view, hoc_object_name(g->hoc_obj_ptr()));
-        w->xplace(int(x[4]), int(x[5]));
-        w->map();
-    } else if (ifarg(1) && *getarg(1) == 2.) {
-        View* view = new View(g);
-        ViewWindow* w = new ViewWindow(view, hoc_object_name(g->hoc_obj_ptr()));
-        w->map();
-    }
     }
 
     return 1.;
@@ -1026,29 +1034,29 @@ double ivoc_gr_mark(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.mark", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Graph* g = (Graph*) v;
-    Coord x = *getarg(1);
-    Coord y = *getarg(2);
-    char style = '+';
-    if (ifarg(3)) {
-        if (hoc_is_str_arg(3)) {
-            style = *gargstr(3);
-        } else {
-            style = char(chkarg(3, 0, 10));
+        Graph* g = (Graph*) v;
+        Coord x = *getarg(1);
+        Coord y = *getarg(2);
+        char style = '+';
+        if (ifarg(3)) {
+            if (hoc_is_str_arg(3)) {
+                style = *gargstr(3);
+            } else {
+                style = char(chkarg(3, 0, 10));
+            }
         }
-    }
-    if (!ifarg(4)) {
-        g->mark(x, y, style);
-    } else if (!ifarg(5)) {
-        g->mark(x, y, style, chkarg(4, .1, 100.), g->color(), g->brush());
-    } else {
-        g->mark(x,
-                y,
-                style,
-                chkarg(4, .1, 100.),
-                colors->color(int(*getarg(5))),
-                brushes->brush(int(*getarg(6))));
-    }
+        if (!ifarg(4)) {
+            g->mark(x, y, style);
+        } else if (!ifarg(5)) {
+            g->mark(x, y, style, chkarg(4, .1, 100.), g->color(), g->brush());
+        } else {
+            g->mark(x,
+                    y,
+                    style,
+                    chkarg(4, .1, 100.),
+                    colors->color(int(*getarg(5))),
+                    brushes->brush(int(*getarg(6))));
+        }
     }
     return 1.;
 #else
@@ -1062,7 +1070,7 @@ static double gr_view_count(void* v) {
 #if HAVE_IV
     int n = 0;
     if (hoc_usegui) {
-    n = ((Scene*) v)->view_count();
+        n = ((Scene*) v)->view_count();
     }
     return double(n);
 #else
@@ -1074,8 +1082,8 @@ static double gr_unmap(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.unmap", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Graph* g = (Graph*) v;
-    g->dismiss();
+        Graph* g = (Graph*) v;
+        g->dismiss();
     }
     return 0.;
 #else
@@ -1087,16 +1095,16 @@ static double gr_set_cross_action(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.crosshair_action", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Graph* g = (Graph*) v;
-    bool vector_copy = false;
-    if (ifarg(2)) {
-        vector_copy = int(chkarg(2, 0, 1));
-    }
-    if (hoc_is_str_arg(1)) {
-        g->set_cross_action(gargstr(1), NULL, vector_copy);
-    } else {
-        g->set_cross_action(NULL, *hoc_objgetarg(1), vector_copy);
-    }
+        Graph* g = (Graph*) v;
+        bool vector_copy = false;
+        if (ifarg(2)) {
+            vector_copy = int(chkarg(2, 0, 1));
+        }
+        if (hoc_is_str_arg(1)) {
+            g->set_cross_action(gargstr(1), NULL, vector_copy);
+        } else {
+            g->set_cross_action(NULL, *hoc_objgetarg(1), vector_copy);
+        }
     }
     return 0.;
 #else
@@ -1108,8 +1116,8 @@ static double gr_printfile(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.printfile", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Graph* g = (Graph*) v;
-    g->printfile(gargstr(1));
+        Graph* g = (Graph*) v;
+        g->printfile(gargstr(1));
     }
     return 1.;
 #else
@@ -1120,7 +1128,8 @@ static double gr_printfile(void* v) {
 static double exec_menu(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.exec_menu", v);
 #if HAVE_IV
-    if (hoc_usegui) {((Scene*) v)->picker()->exec_item(gargstr(1));
+    if (hoc_usegui) {
+        ((Scene*) v)->picker()->exec_item(gargstr(1));
     }
 #endif
     return 0.;
@@ -1129,7 +1138,8 @@ static double exec_menu(void* v) {
 double ivoc_gr_menu_remove(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.menu_remove", v);
 #if HAVE_IV
-    if (hoc_usegui) {((Scene*) v)->picker()->remove_item(gargstr(1));
+    if (hoc_usegui) {
+        ((Scene*) v)->picker()->remove_item(gargstr(1));
     }
 #endif
     return 0.;
@@ -1191,13 +1201,13 @@ static void* gr_cons(Object* ho) {
 #if HAVE_IV
     Graph* g = NULL;
     if (hoc_usegui) {
-    int i = 1;
-    if (ifarg(1)) {
-        i = (int) chkarg(1, 0, 1);
-    }
-    g = new Graph(i);
-    g->ref();
-    g->hoc_obj_ptr(ho);
+        int i = 1;
+        if (ifarg(1)) {
+            i = (int) chkarg(1, 0, 1);
+        }
+        g = new Graph(i);
+        g->ref();
+        g->hoc_obj_ptr(ho);
     }
     return (void*) g;
 #else
@@ -1208,9 +1218,9 @@ static void gr_destruct(void* v) {
     TRY_GUI_REDIRECT_NO_RETURN("~Graph", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Graph* g = (Graph*) v;
-    g->dismiss();
-    Resource::unref(g);
+        Graph* g = (Graph*) v;
+        g->dismiss();
+        Resource::unref(g);
     }
 #endif /* HAVE_IV */
 }
@@ -1219,8 +1229,8 @@ void Graph_reg() {
     class2oc("Graph", gr_cons, gr_destruct, gr_members, NULL, NULL, NULL);
 #if HAVE_IV
     if (hoc_usegui) {
-    colors = new ColorPalette();
-    brushes = new BrushPalette();
+        colors = new ColorPalette();
+        brushes = new BrushPalette();
     }
 #endif
 }
@@ -1254,11 +1264,12 @@ ColorPalette::~ColorPalette() {
 
 const Color* ColorPalette::color(int i) const {
     if (hoc_usegui) {
-    if (i < 0)
-        i = 1;
-    i = i % COLOR_SIZE;
-    return color_palette[i];
-    } else return NULL;
+        if (i < 0)
+            i = 1;
+        i = i % COLOR_SIZE;
+        return color_palette[i];
+    } else
+        return NULL;
 }
 const Color* ColorPalette::color(int i, const char* name) {
     const Color* c = Color::lookup(Session::instance()->default_display(), name);
@@ -1312,11 +1323,12 @@ BrushPalette::~BrushPalette() {
 
 const Brush* BrushPalette::brush(int i) const {
     if (hoc_usegui) {
-    if (i < 0)
-        i = 1;
-    i = i % BRUSH_SIZE;
-    return brush_palette[i];
-    } else return NULL;
+        if (i < 0)
+            i = 1;
+        i = i % BRUSH_SIZE;
+        return brush_palette[i];
+    } else
+        return NULL;
 }
 const Brush* BrushPalette::brush(int i, int pattern, Coord width) {
     Brush* b;

--- a/src/ivoc/grglyph.cpp
+++ b/src/ivoc/grglyph.cpp
@@ -29,7 +29,7 @@ class GrGlyph: public Resource {
 double gr_addglyph(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.addglyph", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Graph* g = (Graph*) v;
     Object* obj = *hoc_objgetarg(1);
     check_obj_type(obj, "Glyph");
@@ -53,7 +53,7 @@ double gr_addglyph(void* v) {
         break;
     }
     g->move(g->count() - 1, x, y);
-    ENDGUI
+    }
 #endif
     return 0.;
 }
@@ -62,9 +62,9 @@ static Object** g_new_path(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_OBJ("Glyph.path", v);
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     g->new_path();
-    ENDGUI
+    }
 #endif
     return g->temp_objvar();
 }
@@ -73,9 +73,9 @@ static Object** g_move_to(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_OBJ("Glyph.m", v);
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     g->move_to(*getarg(1), *getarg(2));
-    ENDGUI
+    }
 #endif
     return g->temp_objvar();
 }
@@ -84,9 +84,9 @@ static Object** g_line_to(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_OBJ("Glyph.l", v);
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     g->line_to(*getarg(1), *getarg(2));
-    ENDGUI
+    }
 #endif
     return g->temp_objvar();
 }
@@ -95,9 +95,9 @@ static Object** g_control_point(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_OBJ("Glyph.cpt", v);
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     g->control_point(*getarg(1), *getarg(2));
-    ENDGUI
+    }
 #endif
     return g->temp_objvar();
 }
@@ -106,9 +106,9 @@ static Object** g_curve_to(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_OBJ("Glyph.curve", v);
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     g->curve_to(*getarg(1), *getarg(2), *getarg(3), *getarg(4), *getarg(5), *getarg(6));
-    ENDGUI
+    }
 #endif
     return g->temp_objvar();
 }
@@ -117,11 +117,11 @@ static Object** g_stroke(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_OBJ("Glyph.s", v);
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     int ci = ifarg(1) ? int(chkarg(1, 0, 10000)) : 1;
     int bi = ifarg(2) ? int(chkarg(2, 0, 10000)) : 0;
     g->stroke(ci, bi);
-    ENDGUI
+    }
 #endif
     return g->temp_objvar();
 }
@@ -130,9 +130,9 @@ static Object** g_close_path(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_OBJ("Glyph.close", v);
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     g->close_path();
-    ENDGUI
+    }
 #endif
     return g->temp_objvar();
 }
@@ -141,10 +141,10 @@ static Object** g_fill(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_OBJ("Glyph.fill", v);
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     int ci = ifarg(1) ? int(chkarg(1, 0, 10000)) : 1;
     g->fill(ci);
-    ENDGUI
+    }
 #endif
     return g->temp_objvar();
 }
@@ -153,9 +153,9 @@ static Object** g_erase(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_OBJ("Glyph.erase", v);
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     g->erase();
-    ENDGUI
+    }
 #endif
     return g->temp_objvar();
 }
@@ -164,9 +164,9 @@ static Object** g_circle(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_OBJ("Glyph.circle", v);
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     g->circle(*getarg(1), *getarg(2), *getarg(3));
-    ENDGUI
+    }
 #endif
     return g->temp_objvar();
 }
@@ -175,9 +175,9 @@ static Object** g_gif(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_OBJ("Glyph.gif", v);
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     g->gif(gargstr(1));
-    ENDGUI
+    }
 #endif
     return g->temp_objvar();
 }
@@ -220,7 +220,7 @@ void GrGlyph_reg() {
 GrGlyph::GrGlyph(Object* o) {
     obj_ = o;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     type_ = new DataVec(10);
     x_ = new DataVec(10);
     y_ = new DataVec(10);
@@ -228,18 +228,18 @@ GrGlyph::GrGlyph(Object* o) {
     x_->ref();
     y_->ref();
     gif_ = NULL;
-    ENDGUI
+    }
 #endif
 }
 
 GrGlyph::~GrGlyph() {
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     type_->unref();
     x_->unref();
     y_->unref();
     Resource::unref(gif_);
-    ENDGUI
+    }
 #endif
 }
 

--- a/src/ivoc/grglyph.cpp
+++ b/src/ivoc/grglyph.cpp
@@ -30,29 +30,29 @@ double gr_addglyph(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Graph.addglyph", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Graph* g = (Graph*) v;
-    Object* obj = *hoc_objgetarg(1);
-    check_obj_type(obj, "Glyph");
-    GrGlyph* gl = (GrGlyph*) (obj->u.this_pointer);
-    Coord x = *getarg(2);
-    Coord y = *getarg(3);
-    Coord sx = ifarg(4) ? *getarg(4) : 1.;
-    Coord sy = ifarg(5) ? *getarg(5) : 1.;
-    Coord rot = ifarg(6) ? *getarg(6) : 0.;
-    int fix = ifarg(7) ? int(chkarg(7, 0, 2)) : 0;
-    GrGlyphItem* ggi = new GrGlyphItem(gl, sx, sy, rot);
-    switch (fix) {
-    case 0:
-        g->append(ggi);
-        break;
-    case 1:
-        g->append_fixed(ggi);
-        break;
-    case 2:
-        g->append_viewfixed(ggi);
-        break;
-    }
-    g->move(g->count() - 1, x, y);
+        Graph* g = (Graph*) v;
+        Object* obj = *hoc_objgetarg(1);
+        check_obj_type(obj, "Glyph");
+        GrGlyph* gl = (GrGlyph*) (obj->u.this_pointer);
+        Coord x = *getarg(2);
+        Coord y = *getarg(3);
+        Coord sx = ifarg(4) ? *getarg(4) : 1.;
+        Coord sy = ifarg(5) ? *getarg(5) : 1.;
+        Coord rot = ifarg(6) ? *getarg(6) : 0.;
+        int fix = ifarg(7) ? int(chkarg(7, 0, 2)) : 0;
+        GrGlyphItem* ggi = new GrGlyphItem(gl, sx, sy, rot);
+        switch (fix) {
+        case 0:
+            g->append(ggi);
+            break;
+        case 1:
+            g->append_fixed(ggi);
+            break;
+        case 2:
+            g->append_viewfixed(ggi);
+            break;
+        }
+        g->move(g->count() - 1, x, y);
     }
 #endif
     return 0.;
@@ -63,7 +63,7 @@ static Object** g_new_path(void* v) {
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
     if (hoc_usegui) {
-    g->new_path();
+        g->new_path();
     }
 #endif
     return g->temp_objvar();
@@ -74,7 +74,7 @@ static Object** g_move_to(void* v) {
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
     if (hoc_usegui) {
-    g->move_to(*getarg(1), *getarg(2));
+        g->move_to(*getarg(1), *getarg(2));
     }
 #endif
     return g->temp_objvar();
@@ -85,7 +85,7 @@ static Object** g_line_to(void* v) {
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
     if (hoc_usegui) {
-    g->line_to(*getarg(1), *getarg(2));
+        g->line_to(*getarg(1), *getarg(2));
     }
 #endif
     return g->temp_objvar();
@@ -96,7 +96,7 @@ static Object** g_control_point(void* v) {
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
     if (hoc_usegui) {
-    g->control_point(*getarg(1), *getarg(2));
+        g->control_point(*getarg(1), *getarg(2));
     }
 #endif
     return g->temp_objvar();
@@ -107,7 +107,7 @@ static Object** g_curve_to(void* v) {
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
     if (hoc_usegui) {
-    g->curve_to(*getarg(1), *getarg(2), *getarg(3), *getarg(4), *getarg(5), *getarg(6));
+        g->curve_to(*getarg(1), *getarg(2), *getarg(3), *getarg(4), *getarg(5), *getarg(6));
     }
 #endif
     return g->temp_objvar();
@@ -118,9 +118,9 @@ static Object** g_stroke(void* v) {
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
     if (hoc_usegui) {
-    int ci = ifarg(1) ? int(chkarg(1, 0, 10000)) : 1;
-    int bi = ifarg(2) ? int(chkarg(2, 0, 10000)) : 0;
-    g->stroke(ci, bi);
+        int ci = ifarg(1) ? int(chkarg(1, 0, 10000)) : 1;
+        int bi = ifarg(2) ? int(chkarg(2, 0, 10000)) : 0;
+        g->stroke(ci, bi);
     }
 #endif
     return g->temp_objvar();
@@ -131,7 +131,7 @@ static Object** g_close_path(void* v) {
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
     if (hoc_usegui) {
-    g->close_path();
+        g->close_path();
     }
 #endif
     return g->temp_objvar();
@@ -142,8 +142,8 @@ static Object** g_fill(void* v) {
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
     if (hoc_usegui) {
-    int ci = ifarg(1) ? int(chkarg(1, 0, 10000)) : 1;
-    g->fill(ci);
+        int ci = ifarg(1) ? int(chkarg(1, 0, 10000)) : 1;
+        g->fill(ci);
     }
 #endif
     return g->temp_objvar();
@@ -154,7 +154,7 @@ static Object** g_erase(void* v) {
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
     if (hoc_usegui) {
-    g->erase();
+        g->erase();
     }
 #endif
     return g->temp_objvar();
@@ -165,7 +165,7 @@ static Object** g_circle(void* v) {
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
     if (hoc_usegui) {
-    g->circle(*getarg(1), *getarg(2), *getarg(3));
+        g->circle(*getarg(1), *getarg(2), *getarg(3));
     }
 #endif
     return g->temp_objvar();
@@ -176,7 +176,7 @@ static Object** g_gif(void* v) {
     GrGlyph* g = (GrGlyph*) v;
 #if HAVE_IV
     if (hoc_usegui) {
-    g->gif(gargstr(1));
+        g->gif(gargstr(1));
     }
 #endif
     return g->temp_objvar();
@@ -221,13 +221,13 @@ GrGlyph::GrGlyph(Object* o) {
     obj_ = o;
 #if HAVE_IV
     if (hoc_usegui) {
-    type_ = new DataVec(10);
-    x_ = new DataVec(10);
-    y_ = new DataVec(10);
-    type_->ref();
-    x_->ref();
-    y_->ref();
-    gif_ = NULL;
+        type_ = new DataVec(10);
+        x_ = new DataVec(10);
+        y_ = new DataVec(10);
+        type_->ref();
+        x_->ref();
+        y_->ref();
+        gif_ = NULL;
     }
 #endif
 }
@@ -235,10 +235,10 @@ GrGlyph::GrGlyph(Object* o) {
 GrGlyph::~GrGlyph() {
 #if HAVE_IV
     if (hoc_usegui) {
-    type_->unref();
-    x_->unref();
-    y_->unref();
-    Resource::unref(gif_);
+        type_->unref();
+        x_->unref();
+        y_->unref();
+        Resource::unref(gif_);
     }
 #endif
 }

--- a/src/ivoc/ivoc.cpp
+++ b/src/ivoc/ivoc.cpp
@@ -182,11 +182,11 @@ void nrniv_bind_thread() {
 void nrn_err_dialog(const char* mes) {
 #if HAVE_IV
     if (hoc_usegui) {
-    if (nrn_err_dialog_active_ && !Session::instance()->done()) {
-        char m[1024];
-        Sprintf(m, "%s (See terminal window)", mes);
-        continue_dialog(m);
-    }
+        if (nrn_err_dialog_active_ && !Session::instance()->done()) {
+            char m[1024];
+            Sprintf(m, "%s (See terminal window)", mes);
+            continue_dialog(m);
+        }
     }
 #endif
 }
@@ -240,11 +240,11 @@ bool setAcceptInputCallback(bool b) {
 void ivoc_style() {
     TRY_GUI_REDIRECT_DOUBLE("ivoc_style", NULL);
     if (hoc_usegui) {
-    if (Session::instance()) {
-        Style* s = Session::instance()->style();
-        s->remove_attribute(gargstr(1));
-        s->attribute(gargstr(1), gargstr(2), -5);
-    }
+        if (Session::instance()) {
+            Style* s = Session::instance()->style();
+            s->remove_attribute(gargstr(1));
+            s->attribute(gargstr(1), gargstr(2), -5);
+        }
 #if 0
 String s;
 if (WidgetKit::instance()->style()->find_attribute(gargstr(1)+1, s)) {
@@ -489,19 +489,19 @@ extern void nrniv_bind_call(void);
 void hoc_notify_iv() {
     if (hoc_usegui) {
 #ifdef MINGW
-    if (!nrn_is_gui_thread()) {
-        // allow gui thread to run
-        nrnpy_pass();
-        hoc_pushx(0.);
-        hoc_ret();
-        return;
-    }
-    nrniv_bind_call();
+        if (!nrn_is_gui_thread()) {
+            // allow gui thread to run
+            nrnpy_pass();
+            hoc_pushx(0.);
+            hoc_ret();
+            return;
+        }
+        nrniv_bind_call();
 #endif
-    Resource::flush();
-    Oc oc;
-    oc.notify();
-    single_event_run();
+        Resource::flush();
+        Oc oc;
+        oc.notify();
+        single_event_run();
     }
     hoc_pushx(1.);
     hoc_ret();

--- a/src/ivoc/ivoc.cpp
+++ b/src/ivoc/ivoc.cpp
@@ -181,13 +181,13 @@ void nrniv_bind_thread() {
 
 void nrn_err_dialog(const char* mes) {
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     if (nrn_err_dialog_active_ && !Session::instance()->done()) {
         char m[1024];
         Sprintf(m, "%s (See terminal window)", mes);
         continue_dialog(m);
     }
-    ENDGUI
+    }
 #endif
 }
 
@@ -239,7 +239,7 @@ bool setAcceptInputCallback(bool b) {
 
 void ivoc_style() {
     TRY_GUI_REDIRECT_DOUBLE("ivoc_style", NULL);
-    IFGUI
+    if (hoc_usegui) {
     if (Session::instance()) {
         Style* s = Session::instance()->style();
         s->remove_attribute(gargstr(1));
@@ -253,7 +253,7 @@ if (WidgetKit::instance()->style()->find_attribute(gargstr(1)+1, s)) {
 	printf("couldn't find %s\n", gargstr(1));
 }
 #endif
-    ENDGUI
+    }
     hoc_ret();
     hoc_pushx(1.);
 }
@@ -487,7 +487,7 @@ extern void nrniv_bind_call(void);
 #endif
 
 void hoc_notify_iv() {
-    IFGUI
+    if (hoc_usegui) {
 #ifdef MINGW
     if (!nrn_is_gui_thread()) {
         // allow gui thread to run
@@ -502,7 +502,7 @@ void hoc_notify_iv() {
     Oc oc;
     oc.notify();
     single_event_run();
-    ENDGUI
+    }
     hoc_pushx(1.);
     hoc_ret();
 }

--- a/src/ivoc/ivocmain.cpp
+++ b/src/ivoc/ivocmain.cpp
@@ -544,11 +544,11 @@ int ivocmain_session(int argc, const char** argv, const char** env, int start_se
     session = new Session("NEURON", our_argc, our_argv, options, properties);
 #else
 #if defined(WIN32)
-    IFGUI
+    if (hoc_usegui) {
     session = new Session("NEURON", our_argc, (char**) our_argv, options, properties);
-    ENDGUI
+    }
 #else
-    IFGUI
+    if (hoc_usegui) {
     if (getenv("DISPLAY")) {
         session = new Session("NEURON", our_argc, (char**) our_argv, options, properties);
     } else {
@@ -557,7 +557,7 @@ int ivocmain_session(int argc, const char** argv, const char** env, int start_se
 \n--No graphics will be displayed.\n");
         hoc_usegui = 0;
     }
-    ENDGUI
+    }
 #endif
     auto const nrn_props_size = strlen(neuron_home) + 20;
     char* nrn_props = new char[nrn_props_size];
@@ -599,11 +599,11 @@ int ivocmain_session(int argc, const char** argv, const char** env, int start_se
     if (session) {
         session->style()->find_attribute("NSTACK", hoc_nstack);
         session->style()->find_attribute("NFRAME", hoc_nframe);
-        IFGUI
+        if (hoc_usegui) {
         if (session->style()->value_is_on("err_dialog")) {
             nrn_err_dialog_active_ = 1;
         }
-        ENDGUI
+        }
     } else
 #endif  // HAVE_IV
     {
@@ -637,7 +637,7 @@ int ivocmain_session(int argc, const char** argv, const char** env, int start_se
 #endif  // USE_PYTHON
 
 #if defined(WIN32) && HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     double scale = 1.;
     int pw = GetSystemMetrics(SM_CXVIRTUALSCREEN);
     if (pw < 1100) {
@@ -645,7 +645,7 @@ int ivocmain_session(int argc, const char** argv, const char** env, int start_se
     }
     session->style()->find_attribute("mswin_scale", scale);
     iv_display_scale(float(scale));
-    ENDGUI
+    }
 #endif
 
     // just eliminate from arg list
@@ -777,11 +777,11 @@ extern void hoc_ret(), hoc_pushx(double);
 
 void hoc_single_event_run() {
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     void single_event_run();
 
     single_event_run();
-    ENDGUI
+    }
 #endif
     hoc_ret();
     hoc_pushx(1.);

--- a/src/ivoc/ivocmain.cpp
+++ b/src/ivoc/ivocmain.cpp
@@ -545,18 +545,18 @@ int ivocmain_session(int argc, const char** argv, const char** env, int start_se
 #else
 #if defined(WIN32)
     if (hoc_usegui) {
-    session = new Session("NEURON", our_argc, (char**) our_argv, options, properties);
+        session = new Session("NEURON", our_argc, (char**) our_argv, options, properties);
     }
 #else
     if (hoc_usegui) {
-    if (getenv("DISPLAY")) {
-        session = new Session("NEURON", our_argc, (char**) our_argv, options, properties);
-    } else {
-        fprintf(stderr,
-                "Warning: no DISPLAY environment variable.\
+        if (getenv("DISPLAY")) {
+            session = new Session("NEURON", our_argc, (char**) our_argv, options, properties);
+        } else {
+            fprintf(stderr,
+                    "Warning: no DISPLAY environment variable.\
 \n--No graphics will be displayed.\n");
-        hoc_usegui = 0;
-    }
+            hoc_usegui = 0;
+        }
     }
 #endif
     auto const nrn_props_size = strlen(neuron_home) + 20;
@@ -600,9 +600,9 @@ int ivocmain_session(int argc, const char** argv, const char** env, int start_se
         session->style()->find_attribute("NSTACK", hoc_nstack);
         session->style()->find_attribute("NFRAME", hoc_nframe);
         if (hoc_usegui) {
-        if (session->style()->value_is_on("err_dialog")) {
-            nrn_err_dialog_active_ = 1;
-        }
+            if (session->style()->value_is_on("err_dialog")) {
+                nrn_err_dialog_active_ = 1;
+            }
         }
     } else
 #endif  // HAVE_IV
@@ -638,13 +638,13 @@ int ivocmain_session(int argc, const char** argv, const char** env, int start_se
 
 #if defined(WIN32) && HAVE_IV
     if (hoc_usegui) {
-    double scale = 1.;
-    int pw = GetSystemMetrics(SM_CXVIRTUALSCREEN);
-    if (pw < 1100) {
-        scale = 1200. / double(pw);
-    }
-    session->style()->find_attribute("mswin_scale", scale);
-    iv_display_scale(float(scale));
+        double scale = 1.;
+        int pw = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+        if (pw < 1100) {
+            scale = 1200. / double(pw);
+        }
+        session->style()->find_attribute("mswin_scale", scale);
+        iv_display_scale(float(scale));
     }
 #endif
 
@@ -778,9 +778,9 @@ extern void hoc_ret(), hoc_pushx(double);
 void hoc_single_event_run() {
 #if HAVE_IV
     if (hoc_usegui) {
-    void single_event_run();
+        void single_event_run();
 
-    single_event_run();
+        single_event_run();
     }
 #endif
     hoc_ret();

--- a/src/ivoc/ivocvect.cpp
+++ b/src/ivoc/ivocvect.cpp
@@ -937,7 +937,7 @@ static Object** v_plot(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_OBJ("Vector.plot", svec_, v);
     Vect* vp = (Vect*) v;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     int i;
     double* y = vp->data();
     auto n = vp->size();
@@ -996,7 +996,7 @@ static Object** v_plot(void* v) {
     g->append(new GPolyLineItem(gv));
 
     g->flush();
-    ENDGUI
+    }
 #endif
     return vp->temp_objvar();
 }
@@ -1005,7 +1005,7 @@ static Object** v_ploterr(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_OBJ("Vector.ploterr", svec_, v);
     Vect* vp = (Vect*) v;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     int n = vp->size();
 
     Object* ob1 = *hoc_objgetarg(1);
@@ -1041,7 +1041,7 @@ static Object** v_ploterr(void* v) {
     }
 
     g->flush();
-    ENDGUI
+    }
 #endif
     return vp->temp_objvar();
 }
@@ -1050,7 +1050,7 @@ static Object** v_line(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_OBJ("Vector.line", svec_, v);
     Vect* vp = (Vect*) v;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     int i;
     auto n = vp->size();
 
@@ -1091,7 +1091,7 @@ static Object** v_line(void* v) {
     }
 
     g->flush();
-    ENDGUI
+    }
 #endif
     return vp->temp_objvar();
 }
@@ -1101,7 +1101,7 @@ static Object** v_mark(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_OBJ("Vector.mark", svec_, v);
     Vect* vp = (Vect*) v;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     int i;
     int n = vp->size();
 
@@ -1142,7 +1142,7 @@ static Object** v_mark(void* v) {
             g->mark(i * interval, vp->elem(i), style, size, color, brush);
         }
     }
-    ENDGUI
+    }
 #endif
     return vp->temp_objvar();
 }

--- a/src/ivoc/ivocvect.cpp
+++ b/src/ivoc/ivocvect.cpp
@@ -938,64 +938,64 @@ static Object** v_plot(void* v) {
     Vect* vp = (Vect*) v;
 #if HAVE_IV
     if (hoc_usegui) {
-    int i;
-    double* y = vp->data();
-    auto n = vp->size();
+        int i;
+        double* y = vp->data();
+        auto n = vp->size();
 
-    Object* ob1 = *hoc_objgetarg(1);
-    check_obj_type(ob1, "Graph");
-    Graph* g = (Graph*) (ob1->u.this_pointer);
+        Object* ob1 = *hoc_objgetarg(1);
+        check_obj_type(ob1, "Graph");
+        Graph* g = (Graph*) (ob1->u.this_pointer);
 
-    GraphVector* gv = new GraphVector("");
+        GraphVector* gv = new GraphVector("");
 
-    if (ifarg(5)) {
-        hoc_execerror("Vector.line:", "too many arguments");
-    }
-    if (narg() == 3) {
-        gv->color((colors->color(int(*getarg(2)))));
-        gv->brush((brushes->brush(int(*getarg(3)))));
-    } else if (narg() == 4) {
-        gv->color((colors->color(int(*getarg(3)))));
-        gv->brush((brushes->brush(int(*getarg(4)))));
-    }
+        if (ifarg(5)) {
+            hoc_execerror("Vector.line:", "too many arguments");
+        }
+        if (narg() == 3) {
+            gv->color((colors->color(int(*getarg(2)))));
+            gv->brush((brushes->brush(int(*getarg(3)))));
+        } else if (narg() == 4) {
+            gv->color((colors->color(int(*getarg(3)))));
+            gv->brush((brushes->brush(int(*getarg(4)))));
+        }
 
-    if (narg() == 2 || narg() == 4) {
-        // passed a vector or xinterval and possibly line attributes
-        if (hoc_is_object_arg(2)) {
-            // passed a vector
-            Vect* vp2 = vector_arg(2);
-            n = std::min(n, vp2->size());
-            for (i = 0; i < n; ++i) {
-                gv->add(vp2->elem(i),
-                        neuron::container::data_handle<double>{neuron::container::do_not_search,
-                                                               y + i});
+        if (narg() == 2 || narg() == 4) {
+            // passed a vector or xinterval and possibly line attributes
+            if (hoc_is_object_arg(2)) {
+                // passed a vector
+                Vect* vp2 = vector_arg(2);
+                n = std::min(n, vp2->size());
+                for (i = 0; i < n; ++i) {
+                    gv->add(vp2->elem(i),
+                            neuron::container::data_handle<double>{neuron::container::do_not_search,
+                                                                   y + i});
+                }
+            } else {
+                // passed xinterval
+                double interval = *getarg(2);
+                for (i = 0; i < n; ++i) {
+                    gv->add(i * interval,
+                            neuron::container::data_handle<double>{neuron::container::do_not_search,
+                                                                   y + i});
+                }
             }
         } else {
-            // passed xinterval
-            double interval = *getarg(2);
+            // passed line attributes or nothing
             for (i = 0; i < n; ++i) {
-                gv->add(i * interval,
+                gv->add(i,
                         neuron::container::data_handle<double>{neuron::container::do_not_search,
                                                                y + i});
             }
         }
-    } else {
-        // passed line attributes or nothing
-        for (i = 0; i < n; ++i) {
-            gv->add(i,
-                    neuron::container::data_handle<double>{neuron::container::do_not_search,
-                                                           y + i});
+
+        if (vp->label_) {
+            GLabel* glab = g->label(vp->label_);
+            gv->label(glab);
+            ((GraphItem*) g->component(g->glyph_index(glab)))->save(false);
         }
-    }
+        g->append(new GPolyLineItem(gv));
 
-    if (vp->label_) {
-        GLabel* glab = g->label(vp->label_);
-        gv->label(glab);
-        ((GraphItem*) g->component(g->glyph_index(glab)))->save(false);
-    }
-    g->append(new GPolyLineItem(gv));
-
-    g->flush();
+        g->flush();
     }
 #endif
     return vp->temp_objvar();
@@ -1006,41 +1006,41 @@ static Object** v_ploterr(void* v) {
     Vect* vp = (Vect*) v;
 #if HAVE_IV
     if (hoc_usegui) {
-    int n = vp->size();
+        int n = vp->size();
 
-    Object* ob1 = *hoc_objgetarg(1);
-    check_obj_type(ob1, "Graph");
-    Graph* g = (Graph*) (ob1->u.this_pointer);
+        Object* ob1 = *hoc_objgetarg(1);
+        check_obj_type(ob1, "Graph");
+        Graph* g = (Graph*) (ob1->u.this_pointer);
 
-    char style = '-';
-    double size = 4;
-    if (ifarg(4))
-        size = chkarg(4, 0.1, 100.);
-    const ivColor* color = g->color();
-    const ivBrush* brush = g->brush();
-    if (ifarg(5)) {
-        color = colors->color(int(*getarg(5)));
-        brush = brushes->brush(int(*getarg(6)));
-    }
+        char style = '-';
+        double size = 4;
+        if (ifarg(4))
+            size = chkarg(4, 0.1, 100.);
+        const ivColor* color = g->color();
+        const ivBrush* brush = g->brush();
+        if (ifarg(5)) {
+            color = colors->color(int(*getarg(5)));
+            brush = brushes->brush(int(*getarg(6)));
+        }
 
-    Vect* vp2 = vector_arg(2);
-    if (vp2->size() < n)
-        n = vp2->size();
+        Vect* vp2 = vector_arg(2);
+        if (vp2->size() < n)
+            n = vp2->size();
 
-    Vect* vp3 = vector_arg(3);
-    if (vp3->size() < n)
-        n = vp3->size();
+        Vect* vp3 = vector_arg(3);
+        if (vp3->size() < n)
+            n = vp3->size();
 
-    for (int i = 0; i < n; ++i) {
-        g->begin_line();
+        for (int i = 0; i < n; ++i) {
+            g->begin_line();
 
-        g->line(vp2->elem(i), vp->elem(i) - vp3->elem(i));
-        g->line(vp2->elem(i), vp->elem(i) + vp3->elem(i));
-        g->mark(vp2->elem(i), vp->elem(i) - vp3->elem(i), style, size, color, brush);
-        g->mark(vp2->elem(i), vp->elem(i) + vp3->elem(i), style, size, color, brush);
-    }
+            g->line(vp2->elem(i), vp->elem(i) - vp3->elem(i));
+            g->line(vp2->elem(i), vp->elem(i) + vp3->elem(i));
+            g->mark(vp2->elem(i), vp->elem(i) - vp3->elem(i), style, size, color, brush);
+            g->mark(vp2->elem(i), vp->elem(i) + vp3->elem(i), style, size, color, brush);
+        }
 
-    g->flush();
+        g->flush();
     }
 #endif
     return vp->temp_objvar();
@@ -1051,46 +1051,46 @@ static Object** v_line(void* v) {
     Vect* vp = (Vect*) v;
 #if HAVE_IV
     if (hoc_usegui) {
-    int i;
-    auto n = vp->size();
+        int i;
+        auto n = vp->size();
 
-    Object* ob1 = *hoc_objgetarg(1);
-    check_obj_type(ob1, "Graph");
-    Graph* g = (Graph*) (ob1->u.this_pointer);
-    char* s = vp->label_;
+        Object* ob1 = *hoc_objgetarg(1);
+        check_obj_type(ob1, "Graph");
+        Graph* g = (Graph*) (ob1->u.this_pointer);
+        char* s = vp->label_;
 
-    if (ifarg(5)) {
-        hoc_execerror("Vector.line:", "too many arguments");
-    }
-    if (narg() == 3) {
-        g->begin_line(colors->color(int(*getarg(2))), brushes->brush(int(*getarg(3))), s);
-    } else if (narg() == 4) {
-        g->begin_line(colors->color(int(*getarg(3))), brushes->brush(int(*getarg(4))), s);
-    } else {
-        g->begin_line(s);
-    }
-
-    if (narg() == 2 || narg() == 4) {
-        // passed a vector or xinterval and possibly line attributes
-        if (hoc_is_object_arg(2)) {
-            // passed a vector
-            Vect* vp2 = vector_arg(2);
-            n = std::min(n, vp2->size());
-            for (i = 0; i < n; ++i)
-                g->line(vp2->elem(i), vp->elem(i));
-        } else {
-            // passed xinterval
-            double interval = *getarg(2);
-            for (i = 0; i < n; ++i)
-                g->line(i * interval, vp->elem(i));
+        if (ifarg(5)) {
+            hoc_execerror("Vector.line:", "too many arguments");
         }
-    } else {
-        // passed line attributes or nothing
-        for (i = 0; i < n; ++i)
-            g->line(i, vp->elem(i));
-    }
+        if (narg() == 3) {
+            g->begin_line(colors->color(int(*getarg(2))), brushes->brush(int(*getarg(3))), s);
+        } else if (narg() == 4) {
+            g->begin_line(colors->color(int(*getarg(3))), brushes->brush(int(*getarg(4))), s);
+        } else {
+            g->begin_line(s);
+        }
 
-    g->flush();
+        if (narg() == 2 || narg() == 4) {
+            // passed a vector or xinterval and possibly line attributes
+            if (hoc_is_object_arg(2)) {
+                // passed a vector
+                Vect* vp2 = vector_arg(2);
+                n = std::min(n, vp2->size());
+                for (i = 0; i < n; ++i)
+                    g->line(vp2->elem(i), vp->elem(i));
+            } else {
+                // passed xinterval
+                double interval = *getarg(2);
+                for (i = 0; i < n; ++i)
+                    g->line(i * interval, vp->elem(i));
+            }
+        } else {
+            // passed line attributes or nothing
+            for (i = 0; i < n; ++i)
+                g->line(i, vp->elem(i));
+        }
+
+        g->flush();
     }
 #endif
     return vp->temp_objvar();
@@ -1102,46 +1102,46 @@ static Object** v_mark(void* v) {
     Vect* vp = (Vect*) v;
 #if HAVE_IV
     if (hoc_usegui) {
-    int i;
-    int n = vp->size();
+        int i;
+        int n = vp->size();
 
-    Object* ob1 = *hoc_objgetarg(1);
-    check_obj_type(ob1, "Graph");
-    Graph* g = (Graph*) (ob1->u.this_pointer);
+        Object* ob1 = *hoc_objgetarg(1);
+        check_obj_type(ob1, "Graph");
+        Graph* g = (Graph*) (ob1->u.this_pointer);
 
-    char style = '+';
-    if (ifarg(3)) {
-        if (hoc_is_str_arg(3)) {
-            style = *gargstr(3);
+        char style = '+';
+        if (ifarg(3)) {
+            if (hoc_is_str_arg(3)) {
+                style = *gargstr(3);
+            } else {
+                style = char(chkarg(3, 0, 10));
+            }
+        }
+        double size = 12;
+        if (ifarg(4))
+            size = chkarg(4, 0.1, 100.);
+        const ivColor* color = g->color();
+        if (ifarg(5))
+            color = colors->color(int(*getarg(5)));
+        const ivBrush* brush = g->brush();
+        if (ifarg(6))
+            brush = brushes->brush(int(*getarg(6)));
+
+        if (hoc_is_object_arg(2)) {
+            // passed a vector
+            Vect* vp2 = vector_arg(2);
+
+            for (i = 0; i < n; ++i) {
+                g->mark(vp2->elem(i), vp->elem(i), style, size, color, brush);
+            }
+
         } else {
-            style = char(chkarg(3, 0, 10));
+            // passed xinterval
+            double interval = *getarg(2);
+            for (i = 0; i < n; ++i) {
+                g->mark(i * interval, vp->elem(i), style, size, color, brush);
+            }
         }
-    }
-    double size = 12;
-    if (ifarg(4))
-        size = chkarg(4, 0.1, 100.);
-    const ivColor* color = g->color();
-    if (ifarg(5))
-        color = colors->color(int(*getarg(5)));
-    const ivBrush* brush = g->brush();
-    if (ifarg(6))
-        brush = brushes->brush(int(*getarg(6)));
-
-    if (hoc_is_object_arg(2)) {
-        // passed a vector
-        Vect* vp2 = vector_arg(2);
-
-        for (i = 0; i < n; ++i) {
-            g->mark(vp2->elem(i), vp->elem(i), style, size, color, brush);
-        }
-
-    } else {
-        // passed xinterval
-        double interval = *getarg(2);
-        for (i = 0; i < n; ++i) {
-            g->mark(i * interval, vp->elem(i), style, size, color, brush);
-        }
-    }
     }
 #endif
     return vp->temp_objvar();

--- a/src/ivoc/ivocwin.cpp
+++ b/src/ivoc/ivocwin.cpp
@@ -274,11 +274,11 @@ void nrniv_bind_call() {
 void nrniv_bind_thread() {
 #if HAVE_IV
     if (hoc_usegui) {
-    bind_tid_ = int(*hoc_getarg(1));
-    // printf("nrniv_bind_thread %d\n", bind_tid_);
-    iv_bind_enqueue_ = iv_bind_enqueue;
-    cond_ = std::make_unique<std::condition_variable>();
-    w_ = NULL;
+        bind_tid_ = int(*hoc_getarg(1));
+        // printf("nrniv_bind_thread %d\n", bind_tid_);
+        iv_bind_enqueue_ = iv_bind_enqueue;
+        cond_ = std::make_unique<std::condition_variable>();
+        w_ = NULL;
     }
 #endif
     hoc_pushx(1.);
@@ -288,12 +288,12 @@ void nrniv_bind_thread() {
 int stdin_event_ready() {
 #if HAVE_IV
     if (hoc_usegui) {
-    static DWORD main_threadid = -1;
-    if (main_threadid == -1) {
-        main_threadid = GetCurrentThreadId();
-        return 1;
-    }
-    PostThreadMessage(main_threadid, WM_QUIT, 0, 0);
+        static DWORD main_threadid = -1;
+        if (main_threadid == -1) {
+            main_threadid = GetCurrentThreadId();
+            return 1;
+        }
+        PostThreadMessage(main_threadid, WM_QUIT, 0, 0);
     }
 #endif
     return 1;

--- a/src/ivoc/ivocwin.cpp
+++ b/src/ivoc/ivocwin.cpp
@@ -273,13 +273,13 @@ void nrniv_bind_call() {
 
 void nrniv_bind_thread() {
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     bind_tid_ = int(*hoc_getarg(1));
     // printf("nrniv_bind_thread %d\n", bind_tid_);
     iv_bind_enqueue_ = iv_bind_enqueue;
     cond_ = std::make_unique<std::condition_variable>();
     w_ = NULL;
-    ENDGUI
+    }
 #endif
     hoc_pushx(1.);
     hoc_ret();
@@ -287,14 +287,14 @@ void nrniv_bind_thread() {
 
 int stdin_event_ready() {
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     static DWORD main_threadid = -1;
     if (main_threadid == -1) {
         main_threadid = GetCurrentThreadId();
         return 1;
     }
     PostThreadMessage(main_threadid, WM_QUIT, 0, 0);
-    ENDGUI
+    }
 #endif
     return 1;
 }

--- a/src/ivoc/mlinedit.cpp
+++ b/src/ivoc/mlinedit.cpp
@@ -44,21 +44,21 @@ static double map(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("TextEditor.map", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcMLineEditor* e = (OcMLineEditor*) v;
-    PrintableWindow* w;
-    if (ifarg(3)) {
-        w = e->make_window(float(*getarg(2)),
-                           float(*getarg(3)),
-                           float(*getarg(4)),
-                           float(*getarg(5)));
-    } else {
-        w = e->make_window();
-    }
-    if (ifarg(1)) {
-        char* name = gargstr(1);
-        w->name(name);
-    }
-    w->map();
+        OcMLineEditor* e = (OcMLineEditor*) v;
+        PrintableWindow* w;
+        if (ifarg(3)) {
+            w = e->make_window(float(*getarg(2)),
+                               float(*getarg(3)),
+                               float(*getarg(4)),
+                               float(*getarg(5)));
+        } else {
+            w = e->make_window();
+        }
+        if (ifarg(1)) {
+            char* name = gargstr(1);
+            w->name(name);
+        }
+        w->map();
     }
     return 0.;
 #else
@@ -70,12 +70,12 @@ static double readonly(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("TextEditor.readonly", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcMLineEditor* e = (OcMLineEditor*) v;
-    hoc_return_type_code = 2;  // boolean
-    if (ifarg(1)) {
-        e->txt_->readOnly(int(chkarg(1, 0, 1)));
-    }
-    return double(e->txt_->readOnly());
+        OcMLineEditor* e = (OcMLineEditor*) v;
+        hoc_return_type_code = 2;  // boolean
+        if (ifarg(1)) {
+            e->txt_->readOnly(int(chkarg(1, 0, 1)));
+        }
+        return double(e->txt_->readOnly());
     }
 #endif
     return 0.;
@@ -85,16 +85,16 @@ static const char** v_text(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_STR("TextEditor.text", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcMLineEditor* e = (OcMLineEditor*) v;
-    TextBuffer* tb = e->txt_->editBuffer();
-    if (ifarg(1)) {
-        e->txt_->reset();
-        const char* s = gargstr(1);
-        tb->Insert(0, s, strlen(s));
-    }
-    char** p = hoc_temp_charptr();
-    *p = (char*) tb->Text();
-    return (const char**) p;
+        OcMLineEditor* e = (OcMLineEditor*) v;
+        TextBuffer* tb = e->txt_->editBuffer();
+        if (ifarg(1)) {
+            e->txt_->reset();
+            const char* s = gargstr(1);
+            tb->Insert(0, s, strlen(s));
+        }
+        char** p = hoc_temp_charptr();
+        *p = (char*) tb->Text();
+        return (const char**) p;
     }
 #endif
     return 0;
@@ -109,19 +109,19 @@ static void* cons(Object*) {
     TRY_GUI_REDIRECT_OBJ("TextEditor", NULL);
 #if HAVE_IV
     if (hoc_usegui) {
-    const char* buf = "";
-    unsigned row = 5;
-    unsigned col = 30;
-    if (ifarg(1)) {
-        buf = gargstr(1);
-    }
-    if (ifarg(2)) {
-        row = unsigned(chkarg(2, 1, 1000));
-        col = unsigned(chkarg(3, 1, 1000));
-    }
-    OcMLineEditor* e = new OcMLineEditor(row, col, buf);
-    e->ref();
-    return (void*) e;
+        const char* buf = "";
+        unsigned row = 5;
+        unsigned col = 30;
+        if (ifarg(1)) {
+            buf = gargstr(1);
+        }
+        if (ifarg(2)) {
+            row = unsigned(chkarg(2, 1, 1000));
+            col = unsigned(chkarg(3, 1, 1000));
+        }
+        OcMLineEditor* e = new OcMLineEditor(row, col, buf);
+        e->ref();
+        return (void*) e;
     }
 #endif /* HAVE_IV  */
     return nullptr;
@@ -131,11 +131,11 @@ static void destruct(void* v) {
     TRY_GUI_REDIRECT_NO_RETURN("~TextEditor", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcMLineEditor* e = (OcMLineEditor*) v;
-    if (e->has_window()) {
-        e->window()->dismiss();
-    }
-    e->unref();
+        OcMLineEditor* e = (OcMLineEditor*) v;
+        if (e->has_window()) {
+            e->window()->dismiss();
+        }
+        e->unref();
     }
 #endif /* HAVE_IV */
 }

--- a/src/ivoc/mlinedit.cpp
+++ b/src/ivoc/mlinedit.cpp
@@ -43,7 +43,7 @@ class OcMLineEditor: public OcGlyph {
 static double map(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("TextEditor.map", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcMLineEditor* e = (OcMLineEditor*) v;
     PrintableWindow* w;
     if (ifarg(3)) {
@@ -59,7 +59,7 @@ static double map(void* v) {
         w->name(name);
     }
     w->map();
-    ENDGUI
+    }
     return 0.;
 #else
     return 0.;
@@ -69,14 +69,14 @@ static double map(void* v) {
 static double readonly(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("TextEditor.readonly", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcMLineEditor* e = (OcMLineEditor*) v;
     hoc_return_type_code = 2;  // boolean
     if (ifarg(1)) {
         e->txt_->readOnly(int(chkarg(1, 0, 1)));
     }
     return double(e->txt_->readOnly());
-    ENDGUI
+    }
 #endif
     return 0.;
 }
@@ -84,7 +84,7 @@ static double readonly(void* v) {
 static const char** v_text(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_STR("TextEditor.text", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcMLineEditor* e = (OcMLineEditor*) v;
     TextBuffer* tb = e->txt_->editBuffer();
     if (ifarg(1)) {
@@ -95,7 +95,7 @@ static const char** v_text(void* v) {
     char** p = hoc_temp_charptr();
     *p = (char*) tb->Text();
     return (const char**) p;
-    ENDGUI
+    }
 #endif
     return 0;
 }
@@ -108,7 +108,7 @@ static Member_ret_str_func retstr_members[] = {{"text", v_text}, {0, 0}};
 static void* cons(Object*) {
     TRY_GUI_REDIRECT_OBJ("TextEditor", NULL);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     const char* buf = "";
     unsigned row = 5;
     unsigned col = 30;
@@ -122,7 +122,7 @@ static void* cons(Object*) {
     OcMLineEditor* e = new OcMLineEditor(row, col, buf);
     e->ref();
     return (void*) e;
-    ENDGUI
+    }
 #endif /* HAVE_IV  */
     return nullptr;
 }
@@ -130,13 +130,13 @@ static void* cons(Object*) {
 static void destruct(void* v) {
     TRY_GUI_REDIRECT_NO_RETURN("~TextEditor", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcMLineEditor* e = (OcMLineEditor*) v;
     if (e->has_window()) {
         e->window()->dismiss();
     }
     e->unref();
-    ENDGUI
+    }
 #endif /* HAVE_IV */
 }
 

--- a/src/ivoc/ocbox.cpp
+++ b/src/ivoc/ocbox.cpp
@@ -153,9 +153,9 @@ static void destruct(void* v) {
 #if HAVE_IV
     OcBox* b = (OcBox*) v;
     if (hoc_usegui) {
-    if (b->has_window()) {
-        b->window()->dismiss();
-    }
+        if (b->has_window()) {
+            b->window()->dismiss();
+        }
     }
     b->unref();
 #endif /* HAVE_IV */
@@ -165,7 +165,8 @@ static double intercept(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.intercept", v);
 #if HAVE_IV
     bool b = int(chkarg(1, 0., 1.));
-    if (hoc_usegui) {((OcBox*) v)->intercept(b);
+    if (hoc_usegui) {
+        ((OcBox*) v)->intercept(b);
     }
     return double(b);
 #else
@@ -177,7 +178,8 @@ static double ses_pri(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.priority", v);
 #if HAVE_IV
     int p = int(chkarg(1, -1000, 10000));
-    if (hoc_usegui) {((OcBox*) v)->session_priority(p);
+    if (hoc_usegui) {
+        ((OcBox*) v)->session_priority(p);
     }
     return double(p);
 #else
@@ -189,27 +191,27 @@ static double map(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.map", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcBox* b = (OcBox*) v;
-    PrintableWindow* w;
-    b->premap();
-    if (ifarg(3)) {
-        w = b->make_window(float(*getarg(2)),
-                           float(*getarg(3)),
-                           float(*getarg(4)),
-                           float(*getarg(5)));
-    } else {
-        w = b->make_window();
-    }
-    if (ifarg(1)) {
-        char* name = gargstr(1);
-        w->name(name);
-    }
-    b->dismissing(false);
-    w->map();
-    if (b->full_request() && b->has_window()) {
-        b->window()->request_on_resize(true);
-    }
-    b->dismiss_action(NULL);
+        OcBox* b = (OcBox*) v;
+        PrintableWindow* w;
+        b->premap();
+        if (ifarg(3)) {
+            w = b->make_window(float(*getarg(2)),
+                               float(*getarg(3)),
+                               float(*getarg(4)),
+                               float(*getarg(5)));
+        } else {
+            w = b->make_window();
+        }
+        if (ifarg(1)) {
+            char* name = gargstr(1);
+            w->name(name);
+        }
+        b->dismissing(false);
+        w->map();
+        if (b->full_request() && b->has_window()) {
+            b->window()->request_on_resize(true);
+        }
+        b->dismiss_action(NULL);
     }
     return 1.;
 #else
@@ -222,18 +224,18 @@ static double dialog(void* v) {
 #if HAVE_IV
     bool r = false;
     if (hoc_usegui) {
-    OcBox* b = (OcBox*) v;
-    const char* a = "Accept";
-    const char* c = "Cancel";
-    if (ifarg(2)) {
-        a = gargstr(2);
-    }
-    if (ifarg(3)) {
-        c = gargstr(3);
-    }
-    Oc oc;
-    oc.notify();
-    r = b->dialog(gargstr(1), a, c);
+        OcBox* b = (OcBox*) v;
+        const char* a = "Accept";
+        const char* c = "Cancel";
+        if (ifarg(2)) {
+            a = gargstr(2);
+        }
+        if (ifarg(3)) {
+            c = gargstr(3);
+        }
+        Oc oc;
+        oc.notify();
+        r = b->dialog(gargstr(1), a, c);
     }
     return double(r);
 #else
@@ -245,22 +247,22 @@ static double unmap(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.unmap", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcBox* b = (OcBox*) v;
-    bool accept = true;
-    if (ifarg(1)) {
-        accept = (bool) chkarg(1, 0, 1);
-    }
-    if (b->dialog_dismiss(accept)) {
-        return 0.;
-    }
-    if (b->has_window()) {
-        b->ref();
-        b->dismissing(true);
-        b->window()->dismiss();
-        b->window(NULL);  // so we don't come back here again before
-                          // printable window destructor called
-        b->unref();
-    }
+        OcBox* b = (OcBox*) v;
+        bool accept = true;
+        if (ifarg(1)) {
+            accept = (bool) chkarg(1, 0, 1);
+        }
+        if (b->dialog_dismiss(accept)) {
+            return 0.;
+        }
+        if (b->has_window()) {
+            b->ref();
+            b->dismissing(true);
+            b->window()->dismiss();
+            b->window(NULL);  // so we don't come back here again before
+                              // printable window destructor called
+            b->unref();
+        }
     }
     return 0.;
 #else
@@ -274,7 +276,7 @@ static double ismapped(void* v) {
 #if HAVE_IV
     bool b = false;
     if (hoc_usegui) {
-    b = ((OcBox*) v)->has_window();
+        b = ((OcBox*) v)->has_window();
     }
     return double(b);
 #else
@@ -285,7 +287,8 @@ static double ismapped(void* v) {
 static double adjuster(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.adjuster", v);
 #if HAVE_IV
-    if (hoc_usegui) {((OcBox*) v)->adjuster(chkarg(1, -1., 1e5));
+    if (hoc_usegui) {
+        ((OcBox*) v)->adjuster(chkarg(1, -1., 1e5));
     }
 #endif /* HAVE_IV  */
     return 0.;
@@ -295,11 +298,11 @@ static double adjust(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.adjust", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    int index = 0;
-    if (ifarg(2)) {
-        index = (int) chkarg(2, 0, 1000);
-    }
-    ((OcBox*) v)->adjust(chkarg(1, -1., 1e5), index);
+        int index = 0;
+        if (ifarg(2)) {
+            index = (int) chkarg(2, 0, 1000);
+        }
+        ((OcBox*) v)->adjust(chkarg(1, -1., 1e5), index);
     }
 #endif /* HAVE_IV  */
     return 0.;
@@ -309,12 +312,12 @@ static double full_request(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.full_request", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcBox* b = (OcBox*) v;
-    if (ifarg(1)) {
-        bool x = ((int) chkarg(1, 0, 1) != 0) ? true : false;
-        b->full_request(x);
-    }
-    return (b->full_request() ? 1. : 0.);
+        OcBox* b = (OcBox*) v;
+        if (ifarg(1)) {
+            bool x = ((int) chkarg(1, 0, 1) != 0) ? true : false;
+            b->full_request(x);
+        }
+        return (b->full_request() ? 1. : 0.);
     }
 #endif /* HAVE_IV  */
     return 0.;
@@ -324,14 +327,14 @@ static double b_size(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.size", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    double* p = hoc_pgetarg(1);  // array for at least 4 numbers
-    OcBox* b = (OcBox*) v;
-    if (b->has_window()) {
-        p[0] = b->window()->save_left();
-        p[1] = b->window()->save_bottom();
-        p[2] = b->window()->width();
-        p[3] = b->window()->height();
-    }
+        double* p = hoc_pgetarg(1);  // array for at least 4 numbers
+        OcBox* b = (OcBox*) v;
+        if (b->has_window()) {
+            p[0] = b->window()->save_left();
+            p[1] = b->window()->save_bottom();
+            p[2] = b->window()->width();
+            p[3] = b->window()->height();
+        }
     }
 #endif
     return 0.;
@@ -343,24 +346,24 @@ static double save(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.save", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcBox* b = (OcBox*) v;
-    char buf[256];
-    if (hoc_is_object_arg(1)) {
-        b->save_action(0, *hoc_objgetarg(1));
-        return 1.;
-    } else if (ifarg(2)) {
-        if (hoc_is_double_arg(2)) {  // return save session file name
-            hoc_assign_str(hoc_pgargstr(1), pwm_session_filename());
+        OcBox* b = (OcBox*) v;
+        char buf[256];
+        if (hoc_is_object_arg(1)) {
+            b->save_action(0, *hoc_objgetarg(1));
             return 1.;
+        } else if (ifarg(2)) {
+            if (hoc_is_double_arg(2)) {  // return save session file name
+                hoc_assign_str(hoc_pgargstr(1), pwm_session_filename());
+                return 1.;
+            } else {
+                Sprintf(buf, "execute(\"%s\", %s)", gargstr(1), gargstr(2));
+            }
         } else {
-            Sprintf(buf, "execute(\"%s\", %s)", gargstr(1), gargstr(2));
+            // Sprintf(buf, "%s", gargstr(1));
+            b->save_action(gargstr(1), 0);
+            return 1.0;
         }
-    } else {
-        // Sprintf(buf, "%s", gargstr(1));
-        b->save_action(gargstr(1), 0);
-        return 1.0;
-    }
-    b->save_action(buf, 0);
+        b->save_action(buf, 0);
     }
     return 1.;
 #else
@@ -397,12 +400,12 @@ static double dismiss_action(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.dismiss_action", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcBox* b = (OcBox*) v;
-    if (hoc_is_object_arg(1)) {
-        b->dismiss_action(0, *hoc_objgetarg(1));
-    } else {
-        b->dismiss_action(gargstr(1));
-    }
+        OcBox* b = (OcBox*) v;
+        if (hoc_is_object_arg(1)) {
+            b->dismiss_action(0, *hoc_objgetarg(1));
+        } else {
+            b->dismiss_action(gargstr(1));
+        }
     }
     return 0.;
 #else
@@ -470,34 +473,34 @@ OcBox::OcBox(int type, int frame, bool scroll)
     Resource::ref(bi_->ocglyph_list_);
     bi_->box_ = NULL;
     if (hoc_usegui) {
-    WidgetKit& wk = *WidgetKit::instance();
-    LayoutKit& lk = *LayoutKit::instance();
-    if (type == H) {
-        box = bi_->box_ = lk.hbox(3);
-    } else {
-        if (scroll) {
-            bi_->box_ = sb = lk.vscrollbox(10);
-            box = lk.hbox(sb, lk.hspace(4), wk.vscroll_bar(sb));
+        WidgetKit& wk = *WidgetKit::instance();
+        LayoutKit& lk = *LayoutKit::instance();
+        if (type == H) {
+            box = bi_->box_ = lk.hbox(3);
         } else {
-            box = bi_->box_ = lk.vbox(3);
+            if (scroll) {
+                bi_->box_ = sb = lk.vscrollbox(10);
+                box = lk.hbox(sb, lk.hspace(4), wk.vscroll_bar(sb));
+            } else {
+                box = bi_->box_ = lk.vbox(3);
+            }
         }
-    }
-    Resource::ref(bi_->box_);
+        Resource::ref(bi_->box_);
 
-    switch (frame) {
-    case INSET:
-        body(new Background(wk.inset_frame(lk.variable_span(box)), wk.background()));
-        break;
-    case OUTSET:
-        body(new Background(wk.outset_frame(lk.variable_span(box)), wk.background()));
-        break;
-    case BRIGHT_INSET:
-        body(new Background(wk.bright_inset_frame(lk.variable_span(box)), wk.background()));
-        break;
-    case FLAT:
-        body(new Background(lk.variable_span(box), wk.background()));
-        break;
-    }
+        switch (frame) {
+        case INSET:
+            body(new Background(wk.inset_frame(lk.variable_span(box)), wk.background()));
+            break;
+        case OUTSET:
+            body(new Background(wk.outset_frame(lk.variable_span(box)), wk.background()));
+            break;
+        case BRIGHT_INSET:
+            body(new Background(wk.bright_inset_frame(lk.variable_span(box)), wk.background()));
+            break;
+        case FLAT:
+            body(new Background(lk.variable_span(box), wk.background()));
+            break;
+        }
     }
     bi_->type_ = type;
     bi_->oc_ref_ = NULL;

--- a/src/ivoc/ocbox.cpp
+++ b/src/ivoc/ocbox.cpp
@@ -152,11 +152,11 @@ static void destruct(void* v) {
     TRY_GUI_REDIRECT_NO_RETURN("~Box", v);
 #if HAVE_IV
     OcBox* b = (OcBox*) v;
-    IFGUI
+    if (hoc_usegui) {
     if (b->has_window()) {
         b->window()->dismiss();
     }
-    ENDGUI
+    }
     b->unref();
 #endif /* HAVE_IV */
 }
@@ -165,8 +165,8 @@ static double intercept(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.intercept", v);
 #if HAVE_IV
     bool b = int(chkarg(1, 0., 1.));
-    IFGUI((OcBox*) v)->intercept(b);
-    ENDGUI
+    if (hoc_usegui) {((OcBox*) v)->intercept(b);
+    }
     return double(b);
 #else
     return 0.;
@@ -177,8 +177,8 @@ static double ses_pri(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.priority", v);
 #if HAVE_IV
     int p = int(chkarg(1, -1000, 10000));
-    IFGUI((OcBox*) v)->session_priority(p);
-    ENDGUI
+    if (hoc_usegui) {((OcBox*) v)->session_priority(p);
+    }
     return double(p);
 #else
     return 0.;
@@ -188,7 +188,7 @@ static double ses_pri(void* v) {
 static double map(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.map", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcBox* b = (OcBox*) v;
     PrintableWindow* w;
     b->premap();
@@ -210,7 +210,7 @@ static double map(void* v) {
         b->window()->request_on_resize(true);
     }
     b->dismiss_action(NULL);
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -221,7 +221,7 @@ static double dialog(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.dialog", v);
 #if HAVE_IV
     bool r = false;
-    IFGUI
+    if (hoc_usegui) {
     OcBox* b = (OcBox*) v;
     const char* a = "Accept";
     const char* c = "Cancel";
@@ -234,7 +234,7 @@ static double dialog(void* v) {
     Oc oc;
     oc.notify();
     r = b->dialog(gargstr(1), a, c);
-    ENDGUI
+    }
     return double(r);
 #else
     return 0.;
@@ -244,7 +244,7 @@ static double dialog(void* v) {
 static double unmap(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.unmap", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcBox* b = (OcBox*) v;
     bool accept = true;
     if (ifarg(1)) {
@@ -261,7 +261,7 @@ static double unmap(void* v) {
                           // printable window destructor called
         b->unref();
     }
-    ENDGUI
+    }
     return 0.;
 #else
     return 0.;
@@ -273,9 +273,9 @@ static double ismapped(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.ismapped", v);
 #if HAVE_IV
     bool b = false;
-    IFGUI
+    if (hoc_usegui) {
     b = ((OcBox*) v)->has_window();
-    ENDGUI
+    }
     return double(b);
 #else
     return 0.;
@@ -285,8 +285,8 @@ static double ismapped(void* v) {
 static double adjuster(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.adjuster", v);
 #if HAVE_IV
-    IFGUI((OcBox*) v)->adjuster(chkarg(1, -1., 1e5));
-    ENDGUI
+    if (hoc_usegui) {((OcBox*) v)->adjuster(chkarg(1, -1., 1e5));
+    }
 #endif /* HAVE_IV  */
     return 0.;
 }
@@ -294,13 +294,13 @@ static double adjuster(void* v) {
 static double adjust(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.adjust", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     int index = 0;
     if (ifarg(2)) {
         index = (int) chkarg(2, 0, 1000);
     }
     ((OcBox*) v)->adjust(chkarg(1, -1., 1e5), index);
-    ENDGUI
+    }
 #endif /* HAVE_IV  */
     return 0.;
 }
@@ -308,14 +308,14 @@ static double adjust(void* v) {
 static double full_request(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.full_request", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcBox* b = (OcBox*) v;
     if (ifarg(1)) {
         bool x = ((int) chkarg(1, 0, 1) != 0) ? true : false;
         b->full_request(x);
     }
     return (b->full_request() ? 1. : 0.);
-    ENDGUI
+    }
 #endif /* HAVE_IV  */
     return 0.;
 }
@@ -323,7 +323,7 @@ static double full_request(void* v) {
 static double b_size(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.size", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     double* p = hoc_pgetarg(1);  // array for at least 4 numbers
     OcBox* b = (OcBox*) v;
     if (b->has_window()) {
@@ -332,7 +332,7 @@ static double b_size(void* v) {
         p[2] = b->window()->width();
         p[3] = b->window()->height();
     }
-    ENDGUI
+    }
 #endif
     return 0.;
 }
@@ -342,7 +342,7 @@ const char* pwm_session_filename();
 static double save(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.save", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcBox* b = (OcBox*) v;
     char buf[256];
     if (hoc_is_object_arg(1)) {
@@ -361,7 +361,7 @@ static double save(void* v) {
         return 1.0;
     }
     b->save_action(buf, 0);
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -396,14 +396,14 @@ static double ref(void* v) {
 static double dismiss_action(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Box.dismiss_action", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcBox* b = (OcBox*) v;
     if (hoc_is_object_arg(1)) {
         b->dismiss_action(0, *hoc_objgetarg(1));
     } else {
         b->dismiss_action(gargstr(1));
     }
-    ENDGUI
+    }
     return 0.;
 #else
     return 0.;
@@ -469,7 +469,7 @@ OcBox::OcBox(int type, int frame, bool scroll)
     bi_->ba_list_ = NULL;
     Resource::ref(bi_->ocglyph_list_);
     bi_->box_ = NULL;
-    IFGUI
+    if (hoc_usegui) {
     WidgetKit& wk = *WidgetKit::instance();
     LayoutKit& lk = *LayoutKit::instance();
     if (type == H) {
@@ -498,7 +498,7 @@ OcBox::OcBox(int type, int frame, bool scroll)
         body(new Background(lk.variable_span(box), wk.background()));
         break;
     }
-    ENDGUI
+    }
     bi_->type_ = type;
     bi_->oc_ref_ = NULL;
     bi_->save_action_ = NULL;

--- a/src/ivoc/ocdeck.cpp
+++ b/src/ivoc/ocdeck.cpp
@@ -73,8 +73,8 @@ static void* cons(Object*) {
 #if HAVE_IV
     OcDeck* b = NULL;
     if (hoc_usegui) {
-    b = new OcDeck();
-    b->ref();
+        b = new OcDeck();
+        b->ref();
     }
     return (void*) b;
 #else
@@ -86,11 +86,11 @@ static void destruct(void* v) {
     TRY_GUI_REDIRECT_NO_RETURN("~Deck", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcDeck* b = (OcDeck*) v;
-    if (b->has_window()) {
-        b->window()->dismiss();
-    }
-    b->unref();
+        OcDeck* b = (OcDeck*) v;
+        if (b->has_window()) {
+            b->window()->dismiss();
+        }
+        b->unref();
     }
 #endif /* HAVE_IV  */
 }
@@ -99,7 +99,8 @@ static double intercept(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Deck.intercept", v);
 #if HAVE_IV
     bool b = int(chkarg(1, 0., 1.));
-    if (hoc_usegui) {((OcDeck*) v)->intercept(b);
+    if (hoc_usegui) {
+        ((OcDeck*) v)->intercept(b);
     }
     return double(b);
 #else
@@ -111,21 +112,21 @@ static double map(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Deck.map", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcDeck* b = (OcDeck*) v;
-    PrintableWindow* w;
-    if (ifarg(3)) {
-        w = b->make_window(float(*getarg(2)),
-                           float(*getarg(3)),
-                           float(*getarg(4)),
-                           float(*getarg(5)));
-    } else {
-        w = b->make_window();
-    }
-    if (ifarg(1)) {
-        char* name = gargstr(1);
-        w->name(name);
-    }
-    w->map();
+        OcDeck* b = (OcDeck*) v;
+        PrintableWindow* w;
+        if (ifarg(3)) {
+            w = b->make_window(float(*getarg(2)),
+                               float(*getarg(3)),
+                               float(*getarg(4)),
+                               float(*getarg(5)));
+        } else {
+            w = b->make_window();
+        }
+        if (ifarg(1)) {
+            char* name = gargstr(1);
+            w->name(name);
+        }
+        w->map();
     }
     return 1.;
 #else
@@ -137,10 +138,10 @@ static double unmap(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Deck.unmap", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcDeck* b = (OcDeck*) v;
-    if (b->has_window()) {
-        b->window()->dismiss();
-    }
+        OcDeck* b = (OcDeck*) v;
+        if (b->has_window()) {
+            b->window()->dismiss();
+        }
     }
     return 0.;
 #else
@@ -152,7 +153,7 @@ static double save(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Deck.save", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcDeck* b = (OcDeck*) v;
+        OcDeck* b = (OcDeck*) v;
 #if 0
 	int i;
 	Object* o[4];
@@ -165,7 +166,7 @@ static double save(void* v) {
 	}
 	b->save_action(gargstr(1), o[0]);
 #else
-    b->save_action(gargstr(1), 0);
+        b->save_action(gargstr(1), 0);
 #endif
     }
     return 1.;
@@ -179,9 +180,9 @@ static double flip_to(void* v) {
 #if HAVE_IV
     int i = -1;
     if (hoc_usegui) {
-    OcDeck* b = (OcDeck*) v;
-    i = int(chkarg(1, -1, b->count() - 1));
-    b->flip_to(i);
+        OcDeck* b = (OcDeck*) v;
+        i = int(chkarg(1, -1, b->count() - 1));
+        b->flip_to(i);
     }
     return double(i);
 #else
@@ -192,7 +193,8 @@ static double flip_to(void* v) {
 static double remove_last(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Deck.remove_last", v);
 #if HAVE_IV
-    if (hoc_usegui) {((OcDeck*) v)->remove_last();
+    if (hoc_usegui) {
+        ((OcDeck*) v)->remove_last();
     }
     return 0.;
 #else
@@ -204,8 +206,8 @@ static double remove(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Deck.remove", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcDeck* b = (OcDeck*) v;
-    b->remove((int) chkarg(1, 0, b->count() - 1));
+        OcDeck* b = (OcDeck*) v;
+        b->remove((int) chkarg(1, 0, b->count() - 1));
     }
     return 0.;
 #else
@@ -217,8 +219,8 @@ static double move_last(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Deck.move_last", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcDeck* b = (OcDeck*) v;
-    b->move_last((int) chkarg(1, 0, b->count() - 1));
+        OcDeck* b = (OcDeck*) v;
+        b->move_last((int) chkarg(1, 0, b->count() - 1));
     }
     return 0.;
 #else

--- a/src/ivoc/ocdeck.cpp
+++ b/src/ivoc/ocdeck.cpp
@@ -72,10 +72,10 @@ static void* cons(Object*) {
     TRY_GUI_REDIRECT_OBJ("Deck", NULL);
 #if HAVE_IV
     OcDeck* b = NULL;
-    IFGUI
+    if (hoc_usegui) {
     b = new OcDeck();
     b->ref();
-    ENDGUI
+    }
     return (void*) b;
 #else
     return nullptr;
@@ -85,13 +85,13 @@ static void* cons(Object*) {
 static void destruct(void* v) {
     TRY_GUI_REDIRECT_NO_RETURN("~Deck", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcDeck* b = (OcDeck*) v;
     if (b->has_window()) {
         b->window()->dismiss();
     }
     b->unref();
-    ENDGUI
+    }
 #endif /* HAVE_IV  */
 }
 
@@ -99,8 +99,8 @@ static double intercept(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Deck.intercept", v);
 #if HAVE_IV
     bool b = int(chkarg(1, 0., 1.));
-    IFGUI((OcDeck*) v)->intercept(b);
-    ENDGUI
+    if (hoc_usegui) {((OcDeck*) v)->intercept(b);
+    }
     return double(b);
 #else
     return 0.;
@@ -110,7 +110,7 @@ static double intercept(void* v) {
 static double map(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Deck.map", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcDeck* b = (OcDeck*) v;
     PrintableWindow* w;
     if (ifarg(3)) {
@@ -126,7 +126,7 @@ static double map(void* v) {
         w->name(name);
     }
     w->map();
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -136,12 +136,12 @@ static double map(void* v) {
 static double unmap(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Deck.unmap", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcDeck* b = (OcDeck*) v;
     if (b->has_window()) {
         b->window()->dismiss();
     }
-    ENDGUI
+    }
     return 0.;
 #else
     return 0.;
@@ -151,7 +151,7 @@ static double unmap(void* v) {
 static double save(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Deck.save", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcDeck* b = (OcDeck*) v;
 #if 0
 	int i;
@@ -167,7 +167,7 @@ static double save(void* v) {
 #else
     b->save_action(gargstr(1), 0);
 #endif
-    ENDGUI
+    }
     return 1.;
 #else
     return 0.;
@@ -178,11 +178,11 @@ static double flip_to(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Deck.flip_to", v);
 #if HAVE_IV
     int i = -1;
-    IFGUI
+    if (hoc_usegui) {
     OcDeck* b = (OcDeck*) v;
     i = int(chkarg(1, -1, b->count() - 1));
     b->flip_to(i);
-    ENDGUI
+    }
     return double(i);
 #else
     return 0.;
@@ -192,8 +192,8 @@ static double flip_to(void* v) {
 static double remove_last(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Deck.remove_last", v);
 #if HAVE_IV
-    IFGUI((OcDeck*) v)->remove_last();
-    ENDGUI
+    if (hoc_usegui) {((OcDeck*) v)->remove_last();
+    }
     return 0.;
 #else
     return 0.;
@@ -203,10 +203,10 @@ static double remove_last(void* v) {
 static double remove(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Deck.remove", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcDeck* b = (OcDeck*) v;
     b->remove((int) chkarg(1, 0, b->count() - 1));
-    ENDGUI
+    }
     return 0.;
 #else
     return 0.;
@@ -216,10 +216,10 @@ static double remove(void* v) {
 static double move_last(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Deck.move_last", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcDeck* b = (OcDeck*) v;
     b->move_last((int) chkarg(1, 0, b->count() - 1));
-    ENDGUI
+    }
     return 0.;
 #else
     return 0.;

--- a/src/ivoc/ocfile.cpp
+++ b/src/ivoc/ocfile.cpp
@@ -187,34 +187,34 @@ static double f_chooser(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_DOUBLE("File.chooser", file_class_sym_, v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcFile* f = (OcFile*) v;
-    f->close();
+        OcFile* f = (OcFile*) v;
+        f->close();
 
-    if (!ifarg(1)) {
-        return double(f->file_chooser_popup());
-    }
+        if (!ifarg(1)) {
+            return double(f->file_chooser_popup());
+        }
 
-    char *type, *banner, *filter, *bopen, *cancel;
-    banner = filter = bopen = cancel = NULL;
-    const char* path = ".";
-    type = gargstr(1);
-    if (ifarg(2)) {
-        banner = gargstr(2);
-    }
-    if (ifarg(3)) {
-        filter = gargstr(3);
-    }
-    if (ifarg(4)) {
-        bopen = gargstr(4);
-    }
-    if (ifarg(5)) {
-        cancel = gargstr(5);
-    }
-    if (ifarg(6)) {
-        path = gargstr(6);
-    }
+        char *type, *banner, *filter, *bopen, *cancel;
+        banner = filter = bopen = cancel = NULL;
+        const char* path = ".";
+        type = gargstr(1);
+        if (ifarg(2)) {
+            banner = gargstr(2);
+        }
+        if (ifarg(3)) {
+            filter = gargstr(3);
+        }
+        if (ifarg(4)) {
+            bopen = gargstr(4);
+        }
+        if (ifarg(5)) {
+            cancel = gargstr(5);
+        }
+        if (ifarg(6)) {
+            path = gargstr(6);
+        }
 
-    f->file_chooser_style(type, path, banner, filter, bopen, cancel);
+        f->file_chooser_style(type, path, banner, filter, bopen, cancel);
     }
 #endif
     return 1.;

--- a/src/ivoc/ocfile.cpp
+++ b/src/ivoc/ocfile.cpp
@@ -186,7 +186,7 @@ static const char** f_dir(void* v) {
 static double f_chooser(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_DOUBLE("File.chooser", file_class_sym_, v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcFile* f = (OcFile*) v;
     f->close();
 
@@ -215,7 +215,7 @@ static double f_chooser(void* v) {
     }
 
     f->file_chooser_style(type, path, banner, filter, bopen, cancel);
-    ENDGUI
+    }
 #endif
     return 1.;
 }

--- a/src/ivoc/oclist.cpp
+++ b/src/ivoc/oclist.cpp
@@ -244,27 +244,27 @@ static double l_browser(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_DOUBLE("List.browser", list_class_sym_, v);
 #if HAVE_IV
     if (hoc_usegui) {
-    char* s = 0;
-    char* i = 0;
-    char** p = 0;
-    OcList* o = (OcList*) v;
-    if (ifarg(1)) {
-        s = gargstr(1);
-    }
-    if (ifarg(3)) {
-        i = gargstr(3);
-        p = hoc_pgargstr(2);
-        o->create_browser(s, p, i);
-        return 1.;
-    }
-    if (ifarg(2)) {
-        if (hoc_is_object_arg(2)) {
-            o->create_browser(s, NULL, *hoc_objgetarg(2));
+        char* s = 0;
+        char* i = 0;
+        char** p = 0;
+        OcList* o = (OcList*) v;
+        if (ifarg(1)) {
+            s = gargstr(1);
+        }
+        if (ifarg(3)) {
+            i = gargstr(3);
+            p = hoc_pgargstr(2);
+            o->create_browser(s, p, i);
             return 1.;
         }
-        i = gargstr(2);
-    }
-    o->create_browser(s, i);
+        if (ifarg(2)) {
+            if (hoc_is_object_arg(2)) {
+                o->create_browser(s, NULL, *hoc_objgetarg(2));
+                return 1.;
+            }
+            i = gargstr(2);
+        }
+        o->create_browser(s, i);
     }
 #endif
     return 1.;
@@ -274,11 +274,11 @@ static double l_select(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_DOUBLE("List.select", list_class_sym_, v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcListBrowser* b = ((OcList*) v)->browser();
-    long i = (long) (*getarg(1));
-    if (b) {
-        b->select_and_adjust(i);
-    }
+        OcListBrowser* b = ((OcList*) v)->browser();
+        long i = (long) (*getarg(1));
+        if (b) {
+            b->select_and_adjust(i);
+        }
     }
 #endif
     return 1.;
@@ -287,18 +287,18 @@ static double l_select_action(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_DOUBLE("List.select_action", list_class_sym_, v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcListBrowser* b = ((OcList*) v)->browser();
-    if (b) {
-        bool on_rel = false;
-        if (ifarg(2)) {
-            on_rel = (bool) chkarg(2, 0, 1);
+        OcListBrowser* b = ((OcList*) v)->browser();
+        if (b) {
+            bool on_rel = false;
+            if (ifarg(2)) {
+                on_rel = (bool) chkarg(2, 0, 1);
+            }
+            if (hoc_is_object_arg(1)) {
+                b->set_select_action(NULL, on_rel, *hoc_objgetarg(1));
+            } else {
+                b->set_select_action(gargstr(1), on_rel);
+            }
         }
-        if (hoc_is_object_arg(1)) {
-            b->set_select_action(NULL, on_rel, *hoc_objgetarg(1));
-        } else {
-            b->set_select_action(gargstr(1), on_rel);
-        }
-    }
     }
 #endif
     return 1.;
@@ -309,12 +309,12 @@ static double l_selected(void* v) {
 #if HAVE_IV
     long i = -1;
     if (hoc_usegui) {
-    OcListBrowser* b = ((OcList*) v)->browser();
-    if (b) {
-        i = b->selected();
-    } else {
-        i = -1;
-    }
+        OcListBrowser* b = ((OcList*) v)->browser();
+        if (b) {
+            i = b->selected();
+        } else {
+            i = -1;
+        }
     }
     return (double) i;
 #else
@@ -325,14 +325,14 @@ static double l_accept_action(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_DOUBLE("List.accept_action", list_class_sym_, v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcListBrowser* b = ((OcList*) v)->browser();
-    if (b) {
-        if (hoc_is_object_arg(1)) {
-            b->set_accept_action(NULL, *hoc_objgetarg(1));
-        } else {
-            b->set_accept_action(gargstr(1));
+        OcListBrowser* b = ((OcList*) v)->browser();
+        if (b) {
+            if (hoc_is_object_arg(1)) {
+                b->set_accept_action(NULL, *hoc_objgetarg(1));
+            } else {
+                b->set_accept_action(gargstr(1));
+            }
         }
-    }
     }
 #endif
     return 1.;
@@ -342,19 +342,19 @@ static double l_scroll_pos(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_DOUBLE("List.scroll_pos", list_class_sym_, v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcList* o = (OcList*) v;
-    OcListBrowser* b = o->browser();
-    if (b) {
-        Adjustable* a = b->adjustable();
-        if (ifarg(1)) {
-            Coord c = (Coord) chkarg(1, 0, 1e9);
-            c = (double) o->count() - a->cur_length(Dimension_Y) - c;
-            a->scroll_to(Dimension_Y, c);
+        OcList* o = (OcList*) v;
+        OcListBrowser* b = o->browser();
+        if (b) {
+            Adjustable* a = b->adjustable();
+            if (ifarg(1)) {
+                Coord c = (Coord) chkarg(1, 0, 1e9);
+                c = (double) o->count() - a->cur_length(Dimension_Y) - c;
+                a->scroll_to(Dimension_Y, c);
+            }
+            // printf("%g %g %g %g\n", (double)o->count(), a->cur_lower(Dimension_Y),
+            // a->cur_upper(Dimension_Y), a->cur_length(Dimension_Y));
+            return (double) (o->count() - 1) - (double) a->cur_upper(Dimension_Y);
         }
-        // printf("%g %g %g %g\n", (double)o->count(), a->cur_lower(Dimension_Y),
-        // a->cur_upper(Dimension_Y), a->cur_length(Dimension_Y));
-        return (double) (o->count() - 1) - (double) a->cur_upper(Dimension_Y);
-    }
     }
 #endif
     return -1.;

--- a/src/ivoc/oclist.cpp
+++ b/src/ivoc/oclist.cpp
@@ -243,7 +243,7 @@ void OcList::remove_all() {
 static double l_browser(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_DOUBLE("List.browser", list_class_sym_, v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     char* s = 0;
     char* i = 0;
     char** p = 0;
@@ -265,7 +265,7 @@ static double l_browser(void* v) {
         i = gargstr(2);
     }
     o->create_browser(s, i);
-    ENDGUI
+    }
 #endif
     return 1.;
 }
@@ -273,20 +273,20 @@ static double l_browser(void* v) {
 static double l_select(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_DOUBLE("List.select", list_class_sym_, v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcListBrowser* b = ((OcList*) v)->browser();
     long i = (long) (*getarg(1));
     if (b) {
         b->select_and_adjust(i);
     }
-    ENDGUI
+    }
 #endif
     return 1.;
 }
 static double l_select_action(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_DOUBLE("List.select_action", list_class_sym_, v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcListBrowser* b = ((OcList*) v)->browser();
     if (b) {
         bool on_rel = false;
@@ -299,7 +299,7 @@ static double l_select_action(void* v) {
             b->set_select_action(gargstr(1), on_rel);
         }
     }
-    ENDGUI
+    }
 #endif
     return 1.;
 }
@@ -308,14 +308,14 @@ static double l_selected(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_DOUBLE("List.selected", list_class_sym_, v);
 #if HAVE_IV
     long i = -1;
-    IFGUI
+    if (hoc_usegui) {
     OcListBrowser* b = ((OcList*) v)->browser();
     if (b) {
         i = b->selected();
     } else {
         i = -1;
     }
-    ENDGUI
+    }
     return (double) i;
 #else
     return 0.;
@@ -324,7 +324,7 @@ static double l_selected(void* v) {
 static double l_accept_action(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_DOUBLE("List.accept_action", list_class_sym_, v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcListBrowser* b = ((OcList*) v)->browser();
     if (b) {
         if (hoc_is_object_arg(1)) {
@@ -333,7 +333,7 @@ static double l_accept_action(void* v) {
             b->set_accept_action(gargstr(1));
         }
     }
-    ENDGUI
+    }
 #endif
     return 1.;
 }
@@ -341,7 +341,7 @@ static double l_accept_action(void* v) {
 static double l_scroll_pos(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_DOUBLE("List.scroll_pos", list_class_sym_, v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcList* o = (OcList*) v;
     OcListBrowser* b = o->browser();
     if (b) {
@@ -355,7 +355,7 @@ static double l_scroll_pos(void* v) {
         // a->cur_upper(Dimension_Y), a->cur_length(Dimension_Y));
         return (double) (o->count() - 1) - (double) a->cur_upper(Dimension_Y);
     }
-    ENDGUI
+    }
 #endif
     return -1.;
 }

--- a/src/ivoc/ocptrvector.cpp
+++ b/src/ivoc/ocptrvector.cpp
@@ -142,56 +142,56 @@ static double ptr_plot(void* v) {
     OcPtrVector* opv = (OcPtrVector*) v;
 #if HAVE_IV
     if (hoc_usegui) {
-    int i;
-    auto const& y = opv->pd_;
-    auto n = opv->size();
-    char* label = opv->label_;
+        int i;
+        auto const& y = opv->pd_;
+        auto n = opv->size();
+        char* label = opv->label_;
 
-    Object* ob1 = *hoc_objgetarg(1);
-    check_obj_type(ob1, "Graph");
-    Graph* g = (Graph*) (ob1->u.this_pointer);
+        Object* ob1 = *hoc_objgetarg(1);
+        check_obj_type(ob1, "Graph");
+        Graph* g = (Graph*) (ob1->u.this_pointer);
 
-    GraphVector* gv = new GraphVector("");
+        GraphVector* gv = new GraphVector("");
 
-    if (ifarg(5)) {
-        hoc_execerror("PtrVector.plot:", "too many arguments");
-    }
-    if (narg() == 3) {
-        gv->color((colors->color(int(*getarg(2)))));
-        gv->brush((brushes->brush(int(*getarg(3)))));
-    } else if (narg() == 4) {
-        gv->color((colors->color(int(*getarg(3)))));
-        gv->brush((brushes->brush(int(*getarg(4)))));
-    }
-
-    if (narg() == 2 || narg() == 4) {
-        // passed a vector or xinterval and possibly line attributes
-        if (hoc_is_object_arg(2)) {
-            // passed a vector
-            Vect* vp2 = vector_arg(2);
-            n = std::min(n, vp2->size());
-            for (i = 0; i < n; ++i)
-                gv->add(vp2->elem(i), y[i]);
-        } else {
-            // passed xinterval
-            double interval = *getarg(2);
-            for (i = 0; i < n; ++i)
-                gv->add(i * interval, y[i]);
+        if (ifarg(5)) {
+            hoc_execerror("PtrVector.plot:", "too many arguments");
         }
-    } else {
-        // passed line attributes or nothing
-        for (i = 0; i < n; ++i)
-            gv->add(i, y[i]);
-    }
+        if (narg() == 3) {
+            gv->color((colors->color(int(*getarg(2)))));
+            gv->brush((brushes->brush(int(*getarg(3)))));
+        } else if (narg() == 4) {
+            gv->color((colors->color(int(*getarg(3)))));
+            gv->brush((brushes->brush(int(*getarg(4)))));
+        }
 
-    if (label) {
-        GLabel* glab = g->label(label);
-        gv->label(glab);
-        ((GraphItem*) g->component(g->glyph_index(glab)))->save(false);
-    }
-    g->append(new GPolyLineItem(gv));
+        if (narg() == 2 || narg() == 4) {
+            // passed a vector or xinterval and possibly line attributes
+            if (hoc_is_object_arg(2)) {
+                // passed a vector
+                Vect* vp2 = vector_arg(2);
+                n = std::min(n, vp2->size());
+                for (i = 0; i < n; ++i)
+                    gv->add(vp2->elem(i), y[i]);
+            } else {
+                // passed xinterval
+                double interval = *getarg(2);
+                for (i = 0; i < n; ++i)
+                    gv->add(i * interval, y[i]);
+            }
+        } else {
+            // passed line attributes or nothing
+            for (i = 0; i < n; ++i)
+                gv->add(i, y[i]);
+        }
 
-    g->flush();
+        if (label) {
+            GLabel* glab = g->label(label);
+            gv->label(glab);
+            ((GraphItem*) g->component(g->glyph_index(glab)))->save(false);
+        }
+        g->append(new GPolyLineItem(gv));
+
+        g->flush();
     }
 #endif
     return 0.0;

--- a/src/ivoc/ocptrvector.cpp
+++ b/src/ivoc/ocptrvector.cpp
@@ -141,7 +141,7 @@ static double ptr_plot(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_DOUBLE("PtrVector.plot", pv_class_sym_, v);
     OcPtrVector* opv = (OcPtrVector*) v;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     int i;
     auto const& y = opv->pd_;
     auto n = opv->size();
@@ -192,7 +192,7 @@ static double ptr_plot(void* v) {
     g->append(new GPolyLineItem(gv));
 
     g->flush();
-    ENDGUI
+    }
 #endif
     return 0.0;
 }

--- a/src/ivoc/pwman.cpp
+++ b/src/ivoc/pwman.cpp
@@ -429,7 +429,7 @@ static void* pwman_cons(Object*) {
     void* v = NULL;
 #if HAVE_IV
     if (hoc_usegui) {
-    v = (void*) PrintableWindowManager::current();
+        v = (void*) PrintableWindowManager::current();
     }
 #endif
     return v;
@@ -444,8 +444,8 @@ static double pwman_count(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.count", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    PWMImpl* p = PrintableWindowManager::current()->pwmi_;
-    cnt = p->screen()->count();
+        PWMImpl* p = PrintableWindowManager::current()->pwmi_;
+        cnt = p->screen()->count();
     }
 #endif
     return double(cnt);
@@ -455,12 +455,12 @@ static double pwman_is_mapped(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.is_mapped", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    PWMImpl* p = PrintableWindowManager::current()->pwmi_;
-    int i = (int) chkarg(1, 0, p->screen()->count() - 1);
-    ScreenItem* si = (ScreenItem*) p->screen()->component(i);
-    if (si->window()) {
-        return double(si->window()->is_mapped());
-    }
+        PWMImpl* p = PrintableWindowManager::current()->pwmi_;
+        int i = (int) chkarg(1, 0, p->screen()->count() - 1);
+        ScreenItem* si = (ScreenItem*) p->screen()->component(i);
+        if (si->window()) {
+            return double(si->window()->is_mapped());
+        }
     }
 #endif
     return 0.;
@@ -469,12 +469,12 @@ static double pwman_map(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.map", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    PWMImpl* p = PrintableWindowManager::current()->pwmi_;
-    int i = (int) chkarg(1, 0, p->screen()->count() - 1);
-    ScreenItem* si = (ScreenItem*) p->screen()->component(i);
-    if (si->window()) {
-        si->window()->map();
-    }
+        PWMImpl* p = PrintableWindowManager::current()->pwmi_;
+        int i = (int) chkarg(1, 0, p->screen()->count() - 1);
+        ScreenItem* si = (ScreenItem*) p->screen()->component(i);
+        if (si->window()) {
+            si->window()->map();
+        }
     }
 #endif
     return 0.;
@@ -483,12 +483,12 @@ static double pwman_hide(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.hide", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    PWMImpl* p = PrintableWindowManager::current()->pwmi_;
-    int i = (int) chkarg(1, 0, p->screen()->count() - 1);
-    ScreenItem* si = (ScreenItem*) p->screen()->component(i);
-    if (si->window()) {
-        si->window()->hide();
-    }
+        PWMImpl* p = PrintableWindowManager::current()->pwmi_;
+        int i = (int) chkarg(1, 0, p->screen()->count() - 1);
+        ScreenItem* si = (ScreenItem*) p->screen()->component(i);
+        if (si->window()) {
+            si->window()->hide();
+        }
     }
 #endif
     return 0.;
@@ -497,14 +497,14 @@ static const char** pwman_name(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_STR("PWManager.name", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    PWMImpl* p = PrintableWindowManager::current()->pwmi_;
-    int i = (int) chkarg(1, 0, p->screen()->count() - 1);
-    ScreenItem* si = (ScreenItem*) p->screen()->component(i);
-    char** ps = hoc_temp_charptr();
-    if (si->window()) {
-        *ps = (char*) si->window()->name();
-    }
-    return (const char**) ps;
+        PWMImpl* p = PrintableWindowManager::current()->pwmi_;
+        int i = (int) chkarg(1, 0, p->screen()->count() - 1);
+        ScreenItem* si = (ScreenItem*) p->screen()->component(i);
+        char** ps = hoc_temp_charptr();
+        if (si->window()) {
+            *ps = (char*) si->window()->name();
+        }
+        return (const char**) ps;
     }
 #endif
     return 0;
@@ -513,13 +513,13 @@ static double pwman_close(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.close", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    PWMImpl* p = PrintableWindowManager::current()->pwmi_;
-    int i = (int) chkarg(1, 0, p->screen()->count() - 1);
-    ScreenItem* si = (ScreenItem*) p->screen()->component(i);
-    if (p->window() == si->window()) {
-        p->window(NULL);
-    }
-    si->window()->dismiss();
+        PWMImpl* p = PrintableWindowManager::current()->pwmi_;
+        int i = (int) chkarg(1, 0, p->screen()->count() - 1);
+        ScreenItem* si = (ScreenItem*) p->screen()->component(i);
+        if (p->window() == si->window()) {
+            p->window(NULL);
+        }
+        si->window()->dismiss();
     }
 #endif
     return 0.;
@@ -527,7 +527,8 @@ static double pwman_close(void* v) {
 #ifdef MINGW
 static void pwman_iconify1(void* v) {
 #if HAVE_IV
-    if (hoc_usegui) {((PrintableWindow*) v)->dismiss();
+    if (hoc_usegui) {
+        ((PrintableWindow*) v)->dismiss();
     }
 #endif
 }
@@ -537,14 +538,14 @@ static double pwman_iconify(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.iconify", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    PrintableWindow* pw = PrintableWindow::leader();
+        PrintableWindow* pw = PrintableWindow::leader();
 #ifdef MINGW
-    if (!nrn_is_gui_thread()) {
-        nrn_gui_exec(pwman_iconify1, pw);
-        return 0.;
-    }
+        if (!nrn_is_gui_thread()) {
+            nrn_gui_exec(pwman_iconify1, pw);
+            return 0.;
+        }
 #endif
-    pw->dismiss();
+        pw->dismiss();
     }
 #endif
     return 0.;
@@ -553,8 +554,8 @@ static double pwman_deiconify(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.deiconify", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    PrintableWindow* pw = PrintableWindow::leader();
-    pw->map();
+        PrintableWindow* pw = PrintableWindow::leader();
+        pw->map();
     }
 #endif
     return 0.;
@@ -564,15 +565,15 @@ static double pwman_leader(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.leader", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    PWMImpl* p = PrintableWindowManager::current()->pwmi_;
-    PrintableWindow* pw = PrintableWindow::leader();
-    int i, cnt = p->screen()->count();
-    for (i = 0; i < cnt; ++i) {
-        ScreenItem* si = (ScreenItem*) p->screen()->component(i);
-        if (si->window() == pw) {
-            return double(i);
+        PWMImpl* p = PrintableWindowManager::current()->pwmi_;
+        PrintableWindow* pw = PrintableWindow::leader();
+        int i, cnt = p->screen()->count();
+        for (i = 0; i < cnt; ++i) {
+            ScreenItem* si = (ScreenItem*) p->screen()->component(i);
+            if (si->window() == pw) {
+                return double(i);
+            }
         }
-    }
     }
 #endif
     return -1.;
@@ -582,15 +583,15 @@ static double pwman_manager(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.manager", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    PWMImpl* p = PrintableWindowManager::current()->pwmi_;
-    PrintableWindow* pw = p->window();
-    int i, cnt = p->screen()->count();
-    for (i = 0; i < cnt; ++i) {
-        ScreenItem* si = (ScreenItem*) p->screen()->component(i);
-        if (si->window() == pw) {
-            return double(i);
+        PWMImpl* p = PrintableWindowManager::current()->pwmi_;
+        PrintableWindow* pw = p->window();
+        int i, cnt = p->screen()->count();
+        for (i = 0; i < cnt; ++i) {
+            ScreenItem* si = (ScreenItem*) p->screen()->component(i);
+            if (si->window() == pw) {
+                return double(i);
+            }
         }
-    }
     }
 #endif
     return -1.;
@@ -601,18 +602,18 @@ static double pwman_save(void* v) {
     int n = 0;
 #if HAVE_IV
     if (hoc_usegui) {
-    // if arg2 is an object then save all windows with that group_obj
-    // if arg2 is 1 then save all windows.
-    // if arg2 is 0 then save selected (on paper) windows.
-    PWMImpl* p = PrintableWindowManager::current()->pwmi_;
-    if (ifarg(2)) {
-        if (hoc_is_object_arg(2)) {
-            n = p->save_group(*hoc_objgetarg(2), gargstr(1));
-        } else {
-            n = (int) chkarg(2, 0, 1);
-            p->save_session((n ? 2 : 0), gargstr(1), (ifarg(3) ? gargstr(3) : NULL));
+        // if arg2 is an object then save all windows with that group_obj
+        // if arg2 is 1 then save all windows.
+        // if arg2 is 0 then save selected (on paper) windows.
+        PWMImpl* p = PrintableWindowManager::current()->pwmi_;
+        if (ifarg(2)) {
+            if (hoc_is_object_arg(2)) {
+                n = p->save_group(*hoc_objgetarg(2), gargstr(1));
+            } else {
+                n = (int) chkarg(2, 0, 1);
+                p->save_session((n ? 2 : 0), gargstr(1), (ifarg(3) ? gargstr(3) : NULL));
+            }
         }
-    }
     }
 #endif
     return (double) n;
@@ -622,16 +623,16 @@ static Object** pwman_group(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_OBJ("PWManager.group", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    PWMImpl* p = PrintableWindowManager::current()->pwmi_;
-    int i;
-    i = int(chkarg(1, 0, p->screen()->count() - 1));
-    ScreenItem* si = (ScreenItem*) p->screen()->component(i);
-    if (ifarg(2)) {
-        hoc_obj_unref(si->group_obj_);
-        si->group_obj_ = *hoc_objgetarg(2);
-        hoc_obj_ref(si->group_obj_);
-    }
-    return hoc_temp_objptr(si->group_obj_);
+        PWMImpl* p = PrintableWindowManager::current()->pwmi_;
+        int i;
+        i = int(chkarg(1, 0, p->screen()->count() - 1));
+        ScreenItem* si = (ScreenItem*) p->screen()->component(i);
+        if (ifarg(2)) {
+            hoc_obj_unref(si->group_obj_);
+            si->group_obj_ = *hoc_objgetarg(2);
+            hoc_obj_ref(si->group_obj_);
+        }
+        return hoc_temp_objptr(si->group_obj_);
     }
 #endif
     return hoc_temp_objptr(0);
@@ -642,12 +643,12 @@ static double pwman_snap(void* v) {
 #if HAVE_IV
     if (hoc_usegui) {
 #if SNAPSHOT
-    PWMImpl* p = PrintableWindowManager::current()->pwmi_;
-    if (!ifarg(1)) {
-        p->snapshot_control();
-    }
+        PWMImpl* p = PrintableWindowManager::current()->pwmi_;
+        if (!ifarg(1)) {
+            p->snapshot_control();
+        }
 #endif
-    return 1.;
+        return 1.;
     }
 #endif
     return 0;
@@ -658,7 +659,7 @@ static double scale_;
 static void pwman_scale1(void*) {
 #if HAVE_IV
     if (hoc_usegui) {
-    iv_display_scale(scale_);
+        iv_display_scale(scale_);
     }
 #endif
 }
@@ -671,13 +672,13 @@ static double pwman_scale(void* v) {
     if (hoc_usegui) {
 #if defined(WIN32)
 #ifdef MINGW
-    if (!nrn_is_gui_thread()) {
-        scale_ = scale;
-        nrn_gui_exec(pwman_scale1, (void*) ((intptr_t) 1));
-        return scale;
-    }
+        if (!nrn_is_gui_thread()) {
+            scale_ = scale;
+            nrn_gui_exec(pwman_scale1, (void*) ((intptr_t) 1));
+            return scale;
+        }
 #endif
-    iv_display_scale(scale);
+        iv_display_scale(scale);
 #endif
     }
 #endif
@@ -688,13 +689,13 @@ static double pwman_window_place(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.window_place", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    int i;
-    PWMImpl* p = PrintableWindowManager::current()->pwmi_;
-    i = int(chkarg(1, 0, p->screen()->count() - 1));
-    ScreenItem* si = (ScreenItem*) p->screen()->component(i);
-    if (si->window()) {
-        si->window()->xmove(int(*getarg(2)), int(*getarg(3)));
-    }
+        int i;
+        PWMImpl* p = PrintableWindowManager::current()->pwmi_;
+        i = int(chkarg(1, 0, p->screen()->count() - 1));
+        ScreenItem* si = (ScreenItem*) p->screen()->component(i);
+        if (si->window()) {
+            si->window()->xmove(int(*getarg(2)), int(*getarg(3)));
+        }
     }
 #endif
     return 1.;
@@ -704,22 +705,22 @@ static double pwman_paper_place(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.paper_place", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    // index, show=0 or 1
-    // index, x, y, scale where x and y in inches from left bottom
-    int i;
-    PWMImpl* p = PrintableWindowManager::current()->pwmi_;
-    i = int(chkarg(1, 0, p->screen()->count() - 1));
-    ScreenItem* si = (ScreenItem*) p->screen()->component(i);
-    p->append_paper(si);
-    PaperItem* pi = si->paper_item();
-    if (!ifarg(3)) {
-        if ((int(chkarg(2, 0, 1))) == 0) {
-            p->unshow_paper(pi);
+        // index, show=0 or 1
+        // index, x, y, scale where x and y in inches from left bottom
+        int i;
+        PWMImpl* p = PrintableWindowManager::current()->pwmi_;
+        i = int(chkarg(1, 0, p->screen()->count() - 1));
+        ScreenItem* si = (ScreenItem*) p->screen()->component(i);
+        p->append_paper(si);
+        PaperItem* pi = si->paper_item();
+        if (!ifarg(3)) {
+            if ((int(chkarg(2, 0, 1))) == 0) {
+                p->unshow_paper(pi);
+            }
+        } else {
+            pi->scale(chkarg(4, 1e-4, 1e4));
+            p->paper()->move(p->paper_index(pi), *getarg(2) / pr_scl, *getarg(3) / pr_scl);
         }
-    } else {
-        pi->scale(chkarg(4, 1e-4, 1e4));
-        p->paper()->move(p->paper_index(pi), *getarg(2) / pr_scl, *getarg(3) / pr_scl);
-    }
     }
 #endif
     return 1.;
@@ -729,26 +730,26 @@ static double pwman_printfile(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.printfile", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    // first arg is filename
-    // second arg is 0,1,2 refers to postscript, idraw, ascii mode
-    // third arg is 0,1 refers to selected, all
-    PWMImpl* p = PrintableWindowManager::current()->pwmi_;
-    bool ses_style = false;
-    if (ifarg(3)) {
-        ses_style = int(chkarg(3, 0, 1)) ? true : false;
-    }
-    char* fname = gargstr(1);
-    switch ((int) chkarg(2, 0, 2)) {
-    case 0:
-        p->ps_file_print(false, fname, p->is_landscape(), ses_style);
-        break;
-    case 1:
-        p->idraw_write(fname, ses_style);
-        break;
-    case 2:
-        p->ascii_write(fname, ses_style);
-        break;
-    }
+        // first arg is filename
+        // second arg is 0,1,2 refers to postscript, idraw, ascii mode
+        // third arg is 0,1 refers to selected, all
+        PWMImpl* p = PrintableWindowManager::current()->pwmi_;
+        bool ses_style = false;
+        if (ifarg(3)) {
+            ses_style = int(chkarg(3, 0, 1)) ? true : false;
+        }
+        char* fname = gargstr(1);
+        switch ((int) chkarg(2, 0, 2)) {
+        case 0:
+            p->ps_file_print(false, fname, p->is_landscape(), ses_style);
+            break;
+        case 1:
+            p->idraw_write(fname, ses_style);
+            break;
+        case 2:
+            p->ascii_write(fname, ses_style);
+            break;
+        }
     }
 #endif
     return 1.;
@@ -758,8 +759,8 @@ static double pwman_landscape(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.landscape", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    PWMImpl* p = PrintableWindowManager::current()->pwmi_;
-    p->landscape(int(chkarg(1, 0, 1)) ? true : false);
+        PWMImpl* p = PrintableWindowManager::current()->pwmi_;
+        p->landscape(int(chkarg(1, 0, 1)) ? true : false);
     }
 #endif
     return 1.;
@@ -769,8 +770,8 @@ static double pwman_deco(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.deco", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    PWMImpl* p = PrintableWindowManager::current()->pwmi_;
-    p->deco(int(chkarg(1, 0, 2)));
+        PWMImpl* p = PrintableWindowManager::current()->pwmi_;
+        p->deco(int(chkarg(1, 0, 2)));
     }
 #endif
     return 1.;
@@ -1334,11 +1335,11 @@ void hoc_pwman_place() {
     TRY_GUI_REDIRECT_DOUBLE("pwman_place", NULL);
 #if HAVE_IV
     if (hoc_usegui) {
-    int x, y;
-    x = int(*getarg(1));
-    y = int(*getarg(2));
-    bool m = (ifarg(3) && int(*getarg(3)) == 0) ? false : true;
-    PrintableWindowManager::current()->xplace(x, y, m);
+        int x, y;
+        x = int(*getarg(1));
+        y = int(*getarg(2));
+        bool m = (ifarg(3) && int(*getarg(3)) == 0) ? false : true;
+        PrintableWindowManager::current()->xplace(x, y, m);
     }
 #endif
     hoc_ret();
@@ -1349,9 +1350,9 @@ void hoc_save_session() {
     TRY_GUI_REDIRECT_DOUBLE("save_session", NULL);
 #if HAVE_IV
     if (hoc_usegui) {
-    if (pwm_impl) {
-        pwm_impl->save_session(2, gargstr(1), (ifarg(2) ? gargstr(2) : NULL));
-    }
+        if (pwm_impl) {
+            pwm_impl->save_session(2, gargstr(1), (ifarg(2) ? gargstr(2) : NULL));
+        }
     }
 #endif
     hoc_ret();
@@ -1368,16 +1369,16 @@ void hoc_print_session() {
     TRY_GUI_REDIRECT_DOUBLE("print_session", NULL);
 #if HAVE_IV
     if (hoc_usegui) {
-    if (pwm_impl) {
-        if (ifarg(3) && chkarg(3, 0, 1) == 1.) {
-            pwm_impl->do_print((int) chkarg(1, 0, 1), gargstr(2));
-        } else if (ifarg(2)) {
-            pwm_impl->do_print_session((int) chkarg(1, 0, 1), gargstr(2));
-        } else {
-            bool b = ifarg(1) ? (chkarg(1, 0, 1) == 1.) : true;
-            pwm_impl->do_print_session(b);
+        if (pwm_impl) {
+            if (ifarg(3) && chkarg(3, 0, 1) == 1.) {
+                pwm_impl->do_print((int) chkarg(1, 0, 1), gargstr(2));
+            } else if (ifarg(2)) {
+                pwm_impl->do_print_session((int) chkarg(1, 0, 1), gargstr(2));
+            } else {
+                bool b = ifarg(1) ? (chkarg(1, 0, 1) == 1.) : true;
+                pwm_impl->do_print_session(b);
+            }
         }
-    }
     }
 #endif
     hoc_ret();

--- a/src/ivoc/pwman.cpp
+++ b/src/ivoc/pwman.cpp
@@ -428,9 +428,9 @@ static void* pwman_cons(Object*) {
     TRY_GUI_REDIRECT_OBJ("PWManager", NULL);
     void* v = NULL;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     v = (void*) PrintableWindowManager::current();
-    ENDGUI
+    }
 #endif
     return v;
 }
@@ -443,10 +443,10 @@ static double pwman_count(void* v) {
     hoc_return_type_code = 1;  // integer
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.count", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     PWMImpl* p = PrintableWindowManager::current()->pwmi_;
     cnt = p->screen()->count();
-    ENDGUI
+    }
 #endif
     return double(cnt);
 }
@@ -454,49 +454,49 @@ static double pwman_is_mapped(void* v) {
     hoc_return_type_code = 2;  // boolean
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.is_mapped", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     PWMImpl* p = PrintableWindowManager::current()->pwmi_;
     int i = (int) chkarg(1, 0, p->screen()->count() - 1);
     ScreenItem* si = (ScreenItem*) p->screen()->component(i);
     if (si->window()) {
         return double(si->window()->is_mapped());
     }
-    ENDGUI
+    }
 #endif
     return 0.;
 }
 static double pwman_map(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.map", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     PWMImpl* p = PrintableWindowManager::current()->pwmi_;
     int i = (int) chkarg(1, 0, p->screen()->count() - 1);
     ScreenItem* si = (ScreenItem*) p->screen()->component(i);
     if (si->window()) {
         si->window()->map();
     }
-    ENDGUI
+    }
 #endif
     return 0.;
 }
 static double pwman_hide(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.hide", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     PWMImpl* p = PrintableWindowManager::current()->pwmi_;
     int i = (int) chkarg(1, 0, p->screen()->count() - 1);
     ScreenItem* si = (ScreenItem*) p->screen()->component(i);
     if (si->window()) {
         si->window()->hide();
     }
-    ENDGUI
+    }
 #endif
     return 0.;
 }
 static const char** pwman_name(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_STR("PWManager.name", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     PWMImpl* p = PrintableWindowManager::current()->pwmi_;
     int i = (int) chkarg(1, 0, p->screen()->count() - 1);
     ScreenItem* si = (ScreenItem*) p->screen()->component(i);
@@ -505,14 +505,14 @@ static const char** pwman_name(void* v) {
         *ps = (char*) si->window()->name();
     }
     return (const char**) ps;
-    ENDGUI
+    }
 #endif
     return 0;
 }
 static double pwman_close(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.close", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     PWMImpl* p = PrintableWindowManager::current()->pwmi_;
     int i = (int) chkarg(1, 0, p->screen()->count() - 1);
     ScreenItem* si = (ScreenItem*) p->screen()->component(i);
@@ -520,15 +520,15 @@ static double pwman_close(void* v) {
         p->window(NULL);
     }
     si->window()->dismiss();
-    ENDGUI
+    }
 #endif
     return 0.;
 }
 #ifdef MINGW
 static void pwman_iconify1(void* v) {
 #if HAVE_IV
-    IFGUI((PrintableWindow*) v)->dismiss();
-    ENDGUI
+    if (hoc_usegui) {((PrintableWindow*) v)->dismiss();
+    }
 #endif
 }
 #endif
@@ -536,7 +536,7 @@ static void pwman_iconify1(void* v) {
 static double pwman_iconify(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.iconify", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     PrintableWindow* pw = PrintableWindow::leader();
 #ifdef MINGW
     if (!nrn_is_gui_thread()) {
@@ -545,17 +545,17 @@ static double pwman_iconify(void* v) {
     }
 #endif
     pw->dismiss();
-    ENDGUI
+    }
 #endif
     return 0.;
 }
 static double pwman_deiconify(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.deiconify", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     PrintableWindow* pw = PrintableWindow::leader();
     pw->map();
-    ENDGUI
+    }
 #endif
     return 0.;
 }
@@ -563,7 +563,7 @@ static double pwman_leader(void* v) {
     hoc_return_type_code = 1;  // integer
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.leader", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     PWMImpl* p = PrintableWindowManager::current()->pwmi_;
     PrintableWindow* pw = PrintableWindow::leader();
     int i, cnt = p->screen()->count();
@@ -573,7 +573,7 @@ static double pwman_leader(void* v) {
             return double(i);
         }
     }
-    ENDGUI
+    }
 #endif
     return -1.;
 }
@@ -581,7 +581,7 @@ static double pwman_manager(void* v) {
     hoc_return_type_code = 1;  // integer
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.manager", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     PWMImpl* p = PrintableWindowManager::current()->pwmi_;
     PrintableWindow* pw = p->window();
     int i, cnt = p->screen()->count();
@@ -591,7 +591,7 @@ static double pwman_manager(void* v) {
             return double(i);
         }
     }
-    ENDGUI
+    }
 #endif
     return -1.;
 }
@@ -600,7 +600,7 @@ static double pwman_save(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.save", v);
     int n = 0;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     // if arg2 is an object then save all windows with that group_obj
     // if arg2 is 1 then save all windows.
     // if arg2 is 0 then save selected (on paper) windows.
@@ -613,7 +613,7 @@ static double pwman_save(void* v) {
             p->save_session((n ? 2 : 0), gargstr(1), (ifarg(3) ? gargstr(3) : NULL));
         }
     }
-    ENDGUI
+    }
 #endif
     return (double) n;
 }
@@ -621,7 +621,7 @@ static double pwman_save(void* v) {
 static Object** pwman_group(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_OBJ("PWManager.group", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     PWMImpl* p = PrintableWindowManager::current()->pwmi_;
     int i;
     i = int(chkarg(1, 0, p->screen()->count() - 1));
@@ -632,7 +632,7 @@ static Object** pwman_group(void* v) {
         hoc_obj_ref(si->group_obj_);
     }
     return hoc_temp_objptr(si->group_obj_);
-    ENDGUI
+    }
 #endif
     return hoc_temp_objptr(0);
 }
@@ -640,7 +640,7 @@ static Object** pwman_group(void* v) {
 static double pwman_snap(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.snap", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
 #if SNAPSHOT
     PWMImpl* p = PrintableWindowManager::current()->pwmi_;
     if (!ifarg(1)) {
@@ -648,7 +648,7 @@ static double pwman_snap(void* v) {
     }
 #endif
     return 1.;
-    ENDGUI
+    }
 #endif
     return 0;
 }
@@ -657,9 +657,9 @@ static double pwman_snap(void* v) {
 static double scale_;
 static void pwman_scale1(void*) {
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     iv_display_scale(scale_);
-    ENDGUI
+    }
 #endif
 }
 #endif
@@ -668,7 +668,7 @@ static double pwman_scale(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.scale", v);
     double scale = chkarg(1, .01, 100);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
 #if defined(WIN32)
 #ifdef MINGW
     if (!nrn_is_gui_thread()) {
@@ -679,7 +679,7 @@ static double pwman_scale(void* v) {
 #endif
     iv_display_scale(scale);
 #endif
-    ENDGUI
+    }
 #endif
     return scale;
 }
@@ -687,7 +687,7 @@ static double pwman_scale(void* v) {
 static double pwman_window_place(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.window_place", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     int i;
     PWMImpl* p = PrintableWindowManager::current()->pwmi_;
     i = int(chkarg(1, 0, p->screen()->count() - 1));
@@ -695,7 +695,7 @@ static double pwman_window_place(void* v) {
     if (si->window()) {
         si->window()->xmove(int(*getarg(2)), int(*getarg(3)));
     }
-    ENDGUI
+    }
 #endif
     return 1.;
 }
@@ -703,7 +703,7 @@ static double pwman_window_place(void* v) {
 static double pwman_paper_place(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.paper_place", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     // index, show=0 or 1
     // index, x, y, scale where x and y in inches from left bottom
     int i;
@@ -720,7 +720,7 @@ static double pwman_paper_place(void* v) {
         pi->scale(chkarg(4, 1e-4, 1e4));
         p->paper()->move(p->paper_index(pi), *getarg(2) / pr_scl, *getarg(3) / pr_scl);
     }
-    ENDGUI
+    }
 #endif
     return 1.;
 }
@@ -728,7 +728,7 @@ static double pwman_paper_place(void* v) {
 static double pwman_printfile(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.printfile", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     // first arg is filename
     // second arg is 0,1,2 refers to postscript, idraw, ascii mode
     // third arg is 0,1 refers to selected, all
@@ -749,7 +749,7 @@ static double pwman_printfile(void* v) {
         p->ascii_write(fname, ses_style);
         break;
     }
-    ENDGUI
+    }
 #endif
     return 1.;
 }
@@ -757,10 +757,10 @@ static double pwman_printfile(void* v) {
 static double pwman_landscape(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.landscape", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     PWMImpl* p = PrintableWindowManager::current()->pwmi_;
     p->landscape(int(chkarg(1, 0, 1)) ? true : false);
-    ENDGUI
+    }
 #endif
     return 1.;
 }
@@ -768,10 +768,10 @@ static double pwman_landscape(void* v) {
 static double pwman_deco(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PWManager.deco", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     PWMImpl* p = PrintableWindowManager::current()->pwmi_;
     p->deco(int(chkarg(1, 0, 2)));
-    ENDGUI
+    }
 #endif
     return 1.;
 }
@@ -1333,13 +1333,13 @@ PrintableWindowManager::~PrintableWindowManager() {
 void hoc_pwman_place() {
     TRY_GUI_REDIRECT_DOUBLE("pwman_place", NULL);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     int x, y;
     x = int(*getarg(1));
     y = int(*getarg(2));
     bool m = (ifarg(3) && int(*getarg(3)) == 0) ? false : true;
     PrintableWindowManager::current()->xplace(x, y, m);
-    ENDGUI
+    }
 #endif
     hoc_ret();
     hoc_pushx(0.);
@@ -1348,11 +1348,11 @@ void hoc_pwman_place() {
 void hoc_save_session() {
     TRY_GUI_REDIRECT_DOUBLE("save_session", NULL);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     if (pwm_impl) {
         pwm_impl->save_session(2, gargstr(1), (ifarg(2) ? gargstr(2) : NULL));
     }
-    ENDGUI
+    }
 #endif
     hoc_ret();
     hoc_pushx(0.);
@@ -1367,7 +1367,7 @@ const char* pwm_session_filename() {
 void hoc_print_session() {
     TRY_GUI_REDIRECT_DOUBLE("print_session", NULL);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     if (pwm_impl) {
         if (ifarg(3) && chkarg(3, 0, 1) == 1.) {
             pwm_impl->do_print((int) chkarg(1, 0, 1), gargstr(2));
@@ -1378,7 +1378,7 @@ void hoc_print_session() {
             pwm_impl->do_print_session(b);
         }
     }
-    ENDGUI
+    }
 #endif
     hoc_ret();
     hoc_pushx(0.);

--- a/src/ivoc/symchoos.cpp
+++ b/src/ivoc/symchoos.cpp
@@ -145,7 +145,7 @@ static void* scons(Object*) {
     TRY_GUI_REDIRECT_OBJ("SymChooser", NULL);
 #if HAVE_IV
     SymChooser* sc = NULL;
-    IFGUI
+    if (hoc_usegui) {
     const char* caption = "Choose a Variable Name or";
     if (ifarg(1)) {
         caption = gargstr(1);
@@ -163,7 +163,7 @@ static void* scons(Object*) {
         sc = new SymChooser(NULL, WidgetKit::instance(), style);
     }
     Resource::ref(sc);
-    ENDGUI
+    }
     return (void*) sc;
 #else
     return nullptr;
@@ -180,7 +180,7 @@ static double srun(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("SymChooser.run", v);
 #if HAVE_IV
     bool b = false;
-    IFGUI
+    if (hoc_usegui) {
     SymChooser* sc = (SymChooser*) v;
     Display* d = Session::instance()->default_display();
     Coord x, y;
@@ -189,7 +189,7 @@ static double srun(void* v) {
     } else {
         b = sc->post_at_aligned(d->width() / 2, d->height() / 2, .5, .5);
     }
-    ENDGUI
+    }
     return double(b);
 #else
     return 0.;
@@ -198,10 +198,10 @@ static double srun(void* v) {
 static double text(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("SymChooser.text", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     SymChooser* sc = (SymChooser*) v;
     hoc_assign_str(hoc_pgargstr(1), sc->selected().c_str());
-    ENDGUI
+    }
     return 0.;
 #else
     return 0.;

--- a/src/ivoc/symchoos.cpp
+++ b/src/ivoc/symchoos.cpp
@@ -146,23 +146,23 @@ static void* scons(Object*) {
 #if HAVE_IV
     SymChooser* sc = NULL;
     if (hoc_usegui) {
-    const char* caption = "Choose a Variable Name or";
-    if (ifarg(1)) {
-        caption = gargstr(1);
-    }
-    Style* style = new Style(Session::instance()->style());
-    style->attribute("caption", caption);
-    if (ifarg(2)) {
-        Symbol* sym = hoc_lookup(gargstr(2));
-        int type = RANGEVAR;
-        if (sym) {
-            type = sym->type;
+        const char* caption = "Choose a Variable Name or";
+        if (ifarg(1)) {
+            caption = gargstr(1);
         }
-        sc = new SymChooser(new SymDirectory(type), WidgetKit::instance(), style, NULL, 1);
-    } else {
-        sc = new SymChooser(NULL, WidgetKit::instance(), style);
-    }
-    Resource::ref(sc);
+        Style* style = new Style(Session::instance()->style());
+        style->attribute("caption", caption);
+        if (ifarg(2)) {
+            Symbol* sym = hoc_lookup(gargstr(2));
+            int type = RANGEVAR;
+            if (sym) {
+                type = sym->type;
+            }
+            sc = new SymChooser(new SymDirectory(type), WidgetKit::instance(), style, NULL, 1);
+        } else {
+            sc = new SymChooser(NULL, WidgetKit::instance(), style);
+        }
+        Resource::ref(sc);
     }
     return (void*) sc;
 #else
@@ -181,14 +181,14 @@ static double srun(void* v) {
 #if HAVE_IV
     bool b = false;
     if (hoc_usegui) {
-    SymChooser* sc = (SymChooser*) v;
-    Display* d = Session::instance()->default_display();
-    Coord x, y;
-    if (nrn_spec_dialog_pos(x, y)) {
-        b = sc->post_at_aligned(x, y, 0.0, 0.0);
-    } else {
-        b = sc->post_at_aligned(d->width() / 2, d->height() / 2, .5, .5);
-    }
+        SymChooser* sc = (SymChooser*) v;
+        Display* d = Session::instance()->default_display();
+        Coord x, y;
+        if (nrn_spec_dialog_pos(x, y)) {
+            b = sc->post_at_aligned(x, y, 0.0, 0.0);
+        } else {
+            b = sc->post_at_aligned(d->width() / 2, d->height() / 2, .5, .5);
+        }
     }
     return double(b);
 #else
@@ -199,8 +199,8 @@ static double text(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("SymChooser.text", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    SymChooser* sc = (SymChooser*) v;
-    hoc_assign_str(hoc_pgargstr(1), sc->selected().c_str());
+        SymChooser* sc = (SymChooser*) v;
+        hoc_assign_str(hoc_pgargstr(1), sc->selected().c_str());
     }
     return 0.;
 #else

--- a/src/ivoc/utility.cpp
+++ b/src/ivoc/utility.cpp
@@ -288,11 +288,11 @@ void hoc_boolean_dialog() {
         return;
     }
     if (hoc_usegui) {
-    if (ifarg(3)) {
-        b = boolean_dialog(gargstr(1), gargstr(2), gargstr(3));
-    } else {
-        b = boolean_dialog(gargstr(1), "Yes", "No");
-    }
+        if (ifarg(3)) {
+            b = boolean_dialog(gargstr(1), gargstr(2), gargstr(3));
+        } else {
+            b = boolean_dialog(gargstr(1), "Yes", "No");
+        }
     }
     hoc_ret();
     hoc_pushx(double(b));
@@ -300,7 +300,7 @@ void hoc_boolean_dialog() {
 void hoc_continue_dialog() {
     TRY_GUI_REDIRECT_DOUBLE("continue_dialog", NULL);
     if (hoc_usegui) {
-    continue_dialog(gargstr(1));
+        continue_dialog(gargstr(1));
     }
     hoc_ret();
     hoc_pushx(1.);
@@ -309,12 +309,12 @@ void hoc_string_dialog() {
     TRY_GUI_REDIRECT_DOUBLE_SEND_STRREF("string_dialog", NULL);
     bool b = false;
     if (hoc_usegui) {
-    char buf[256];
-    Sprintf(buf, "%s", gargstr(2));
-    b = str_chooser(gargstr(1), buf);
-    if (b) {
-        hoc_assign_str(hoc_pgargstr(2), buf);
-    }
+        char buf[256];
+        Sprintf(buf, "%s", gargstr(2));
+        b = str_chooser(gargstr(1), buf);
+        if (b) {
+            hoc_assign_str(hoc_pgargstr(2), buf);
+        }
     }
     hoc_ret();
     hoc_pushx(double(b));

--- a/src/ivoc/utility.cpp
+++ b/src/ivoc/utility.cpp
@@ -287,35 +287,35 @@ void hoc_boolean_dialog() {
         hoc_pushx(neuron::python::methods.object_to_double(*result));
         return;
     }
-    IFGUI
+    if (hoc_usegui) {
     if (ifarg(3)) {
         b = boolean_dialog(gargstr(1), gargstr(2), gargstr(3));
     } else {
         b = boolean_dialog(gargstr(1), "Yes", "No");
     }
-    ENDGUI
+    }
     hoc_ret();
     hoc_pushx(double(b));
 }
 void hoc_continue_dialog() {
     TRY_GUI_REDIRECT_DOUBLE("continue_dialog", NULL);
-    IFGUI
+    if (hoc_usegui) {
     continue_dialog(gargstr(1));
-    ENDGUI
+    }
     hoc_ret();
     hoc_pushx(1.);
 }
 void hoc_string_dialog() {
     TRY_GUI_REDIRECT_DOUBLE_SEND_STRREF("string_dialog", NULL);
     bool b = false;
-    IFGUI
+    if (hoc_usegui) {
     char buf[256];
     Sprintf(buf, "%s", gargstr(2));
     b = str_chooser(gargstr(1), buf);
     if (b) {
         hoc_assign_str(hoc_pgargstr(2), buf);
     }
-    ENDGUI
+    }
     hoc_ret();
     hoc_pushx(double(b));
 }

--- a/src/ivoc/xmenu.cpp
+++ b/src/ivoc/xmenu.cpp
@@ -167,26 +167,26 @@ void hoc_notify_value() {
 void hoc_xpanel() {
     TRY_GUI_REDIRECT_DOUBLE("xpanel", NULL);
     if (hoc_usegui) {
-    if (ifarg(1) && hoc_is_str_arg(1)) {  // begin spec
-        bool h = false;
-        if (ifarg(2)) {
-            h = (int) chkarg(2, 0, 1) ? true : false;
-        }
-        hoc_ivpanel(gargstr(1), h);
-    } else {              // map
-        int scroll = -1;  // leave up to panel_scroll attribute
-        if (ifarg(2)) {
-            if (ifarg(3)) {
-                scroll = (int) chkarg(3, -1, 1);
+        if (ifarg(1) && hoc_is_str_arg(1)) {  // begin spec
+            bool h = false;
+            if (ifarg(2)) {
+                h = (int) chkarg(2, 0, 1) ? true : false;
             }
-            hoc_ivpanelPlace((Coord) *getarg(1), (Coord) *getarg(2), scroll);
-        } else {
-            if (ifarg(1)) {
-                scroll = (int) chkarg(1, -1, 1);
+            hoc_ivpanel(gargstr(1), h);
+        } else {              // map
+            int scroll = -1;  // leave up to panel_scroll attribute
+            if (ifarg(2)) {
+                if (ifarg(3)) {
+                    scroll = (int) chkarg(3, -1, 1);
+                }
+                hoc_ivpanelPlace((Coord) *getarg(1), (Coord) *getarg(2), scroll);
+            } else {
+                if (ifarg(1)) {
+                    scroll = (int) chkarg(1, -1, 1);
+                }
+                hoc_ivpanelmap(scroll);
             }
-            hoc_ivpanelmap(scroll);
         }
-    }
     }
 
     hoc_ret();
@@ -196,31 +196,31 @@ void hoc_xpanel() {
 void hoc_xmenu() {
     TRY_GUI_REDIRECT_DOUBLE("xmenu", NULL);
     if (hoc_usegui) {
-    bool add2menubar = false;
-    char* mk = NULL;
-    Object* pyact = NULL;
-    int i = 2;
-    if (ifarg(i)) {
-        if (hoc_is_str_arg(i)) {
-            mk = gargstr(i);
-            ++i;
-        } else if (hoc_is_object_arg(i)) {
-            pyact = *hoc_objgetarg(i);
-            ++i;
-        }
+        bool add2menubar = false;
+        char* mk = NULL;
+        Object* pyact = NULL;
+        int i = 2;
         if (ifarg(i)) {
-            add2menubar = int(chkarg(i, 0, 1));
+            if (hoc_is_str_arg(i)) {
+                mk = gargstr(i);
+                ++i;
+            } else if (hoc_is_object_arg(i)) {
+                pyact = *hoc_objgetarg(i);
+                ++i;
+            }
+            if (ifarg(i)) {
+                add2menubar = int(chkarg(i, 0, 1));
+            }
         }
-    }
-    if (ifarg(1)) {
-        if (mk || pyact) {
-            hoc_ivvarmenu(gargstr(1), mk, add2menubar, pyact);
+        if (ifarg(1)) {
+            if (mk || pyact) {
+                hoc_ivvarmenu(gargstr(1), mk, add2menubar, pyact);
+            } else {
+                hoc_ivmenu(gargstr(1), add2menubar);
+            }
         } else {
-            hoc_ivmenu(gargstr(1), add2menubar);
+            hoc_ivmenu((char*) 0);
         }
-    } else {
-        hoc_ivmenu((char*) 0);
-    }
     }
     hoc_ret();
     hoc_pushx(0.);
@@ -230,17 +230,17 @@ void hoc_xbutton() {
     TRY_GUI_REDIRECT_DOUBLE("xbutton", NULL);
 
     if (hoc_usegui) {
-    char* s1;
-    s1 = gargstr(1);
-    if (ifarg(2)) {
-        if (hoc_is_object_arg(2)) {
-            hoc_ivbutton(s1, NULL, *hoc_objgetarg(2));
+        char* s1;
+        s1 = gargstr(1);
+        if (ifarg(2)) {
+            if (hoc_is_object_arg(2)) {
+                hoc_ivbutton(s1, NULL, *hoc_objgetarg(2));
+            } else {
+                hoc_ivbutton(s1, gargstr(2));
+            }
         } else {
-            hoc_ivbutton(s1, gargstr(2));
+            hoc_ivbutton(s1, s1);
         }
-    } else {
-        hoc_ivbutton(s1, s1);
-    }
     }
     hoc_ret();
     hoc_pushx(0.);
@@ -255,24 +255,24 @@ xstatebutton("prompt",&var [,"action"])
 void hoc_xstatebutton() {
     TRY_GUI_REDIRECT_DOUBLE("xstatebutton", NULL);
     if (hoc_usegui) {
-    char *s1, *s2 = (char*) 0;
+        char *s1, *s2 = (char*) 0;
 
-    s1 = gargstr(1);
+        s1 = gargstr(1);
 
-    if (hoc_is_object_arg(2)) {
-        neuron::container::data_handle<double> ptr1{};
-        hoc_ivstatebutton(ptr1,
-                          s1,
-                          NULL,
-                          HocStateButton::PALETTE,
-                          *hoc_objgetarg(2),
-                          ifarg(3) ? *hoc_objgetarg(3) : NULL);
-    } else {
-        if (ifarg(3)) {
-            s2 = gargstr(3);
+        if (hoc_is_object_arg(2)) {
+            neuron::container::data_handle<double> ptr1{};
+            hoc_ivstatebutton(ptr1,
+                              s1,
+                              NULL,
+                              HocStateButton::PALETTE,
+                              *hoc_objgetarg(2),
+                              ifarg(3) ? *hoc_objgetarg(3) : NULL);
+        } else {
+            if (ifarg(3)) {
+                s2 = gargstr(3);
+            }
+            hoc_ivstatebutton(hoc_hgetarg<double>(2), s1, s2, HocStateButton::PALETTE);
         }
-        hoc_ivstatebutton(hoc_hgetarg<double>(2), s1, s2, HocStateButton::PALETTE);
-    }
     }
     hoc_ret();
     hoc_pushx(0.);
@@ -288,25 +288,24 @@ xcheckbox("prompt",&var [,"action"])
 void hoc_xcheckbox() {
     TRY_GUI_REDIRECT_DOUBLE("xcheckbox", NULL);
     if (hoc_usegui) {
+        char *s1, *s2 = (char*) 0;
 
-    char *s1, *s2 = (char*) 0;
+        s1 = gargstr(1);
 
-    s1 = gargstr(1);
-
-    if (hoc_is_object_arg(2)) {
-        neuron::container::data_handle<double> ptr1{};
-        hoc_ivstatebutton(ptr1,
-                          s1,
-                          NULL,
-                          HocStateButton::CHECKBOX,
-                          *hoc_objgetarg(2),
-                          ifarg(3) ? *hoc_objgetarg(3) : 0);
-    } else {
-        if (ifarg(3)) {
-            s2 = gargstr(3);
+        if (hoc_is_object_arg(2)) {
+            neuron::container::data_handle<double> ptr1{};
+            hoc_ivstatebutton(ptr1,
+                              s1,
+                              NULL,
+                              HocStateButton::CHECKBOX,
+                              *hoc_objgetarg(2),
+                              ifarg(3) ? *hoc_objgetarg(3) : 0);
+        } else {
+            if (ifarg(3)) {
+                s2 = gargstr(3);
+            }
+            hoc_ivstatebutton(hoc_hgetarg<double>(2), s1, s2, HocStateButton::CHECKBOX);
         }
-        hoc_ivstatebutton(hoc_hgetarg<double>(2), s1, s2, HocStateButton::CHECKBOX);
-    }
     }
     hoc_ret();
     hoc_pushx(0.);
@@ -316,27 +315,27 @@ void hoc_xradiobutton() {
     TRY_GUI_REDIRECT_DOUBLE("xradiobutton", NULL);
 
     if (hoc_usegui) {
-    char *s1, *s2 = (char*) 0;
-    Object* po = NULL;
-    bool activate = false;
-    s1 = gargstr(1);
-    if (ifarg(2)) {
-        if (hoc_is_object_arg(2)) {
-            po = *hoc_objgetarg(2);
+        char *s1, *s2 = (char*) 0;
+        Object* po = NULL;
+        bool activate = false;
+        s1 = gargstr(1);
+        if (ifarg(2)) {
+            if (hoc_is_object_arg(2)) {
+                po = *hoc_objgetarg(2);
+            } else {
+                s2 = gargstr(2);
+            }
+            if (ifarg(3)) {
+                activate = (chkarg(3, 0, 1) != 0.);
+            }
         } else {
-            s2 = gargstr(2);
+            s2 = s1;
         }
-        if (ifarg(3)) {
-            activate = (chkarg(3, 0, 1) != 0.);
+        if (po) {
+            hoc_ivradiobutton(s1, NULL, activate, po);
+        } else {
+            hoc_ivradiobutton(s1, s2, activate);
         }
-    } else {
-        s2 = s1;
-    }
-    if (po) {
-        hoc_ivradiobutton(s1, NULL, activate, po);
-    } else {
-        hoc_ivradiobutton(s1, s2, activate);
-    }
     }
     hoc_ret();
     hoc_pushx(0.);
@@ -344,53 +343,51 @@ void hoc_xradiobutton() {
 
 static void hoc_xvalue_helper() {
     if (hoc_usegui) {  // prompt, variable, deflt,action,canrun,usepointer
-        char *s1,
-        *s2, *s3;
-    // allow variable arg2 to be data_handle
-    neuron::container::data_handle<double> ptr2{};
-    Object* pyvar = NULL;
-    Object* pyact = NULL;
-    s2 = s3 = NULL;
-    s1 = gargstr(1);
-    if (ifarg(2)) {
-        if (hoc_is_object_arg(2)) {
-            pyvar = *hoc_objgetarg(2);
-        } else if (hoc_is_pdouble_arg(2)) {
-            ptr2 = hoc_hgetarg<double>(2);
-        } else {
-            s2 = gargstr(2);
-        }
-    } else {
-        s2 = s1;
-    }
-    bool deflt = false;
-    if (ifarg(3) && *getarg(3)) {
-        if (*getarg(3) == 2.) {
-            if (pyvar) {
-                hoc_ivvalue_keep_updated(s1, NULL, pyvar);
+        char *s1, *s2, *s3;
+        // allow variable arg2 to be data_handle
+        neuron::container::data_handle<double> ptr2{};
+        Object* pyvar = NULL;
+        Object* pyact = NULL;
+        s2 = s3 = NULL;
+        s1 = gargstr(1);
+        if (ifarg(2)) {
+            if (hoc_is_object_arg(2)) {
+                pyvar = *hoc_objgetarg(2);
+            } else if (hoc_is_pdouble_arg(2)) {
+                ptr2 = hoc_hgetarg<double>(2);
             } else {
-                hoc_ivvalue_keep_updated(s1, s2);
+                s2 = gargstr(2);
             }
-            return;
-        }
-        deflt = true;
-    }
-    bool canRun = false, usepointer = false;
-    if (ifarg(4)) {
-        if (hoc_is_object_arg(4)) {
-            pyact = *hoc_objgetarg(4);
         } else {
-            s3 = gargstr(4);
+            s2 = s1;
         }
-        if (ifarg(5) && *getarg(5)) {
-            canRun = true;
+        bool deflt = false;
+        if (ifarg(3) && *getarg(3)) {
+            if (*getarg(3) == 2.) {
+                if (pyvar) {
+                    hoc_ivvalue_keep_updated(s1, NULL, pyvar);
+                } else {
+                    hoc_ivvalue_keep_updated(s1, s2);
+                }
+                return;
+            }
+            deflt = true;
         }
-        if (ifarg(6) && *getarg(6)) {
-            usepointer = true;
+        bool canRun = false, usepointer = false;
+        if (ifarg(4)) {
+            if (hoc_is_object_arg(4)) {
+                pyact = *hoc_objgetarg(4);
+            } else {
+                s3 = gargstr(4);
+            }
+            if (ifarg(5) && *getarg(5)) {
+                canRun = true;
+            }
+            if (ifarg(6) && *getarg(6)) {
+                usepointer = true;
+            }
         }
-    }
-    hoc_ivvaluerun_ex(s1, s2, ptr2, pyvar, s3, pyact, deflt, canRun, usepointer);
-
+        hoc_ivvaluerun_ex(s1, s2, ptr2, pyvar, s3, pyact, deflt, canRun, usepointer);
     }
 }
 
@@ -398,24 +395,22 @@ void hoc_xfixedvalue() {
     TRY_GUI_REDIRECT_DOUBLE("xfixedvalue", NULL);
 
     if (hoc_usegui) {  // prompt, variable, deflt,action,canrun,usepointer
-        char *s1,
-        *s2;
-    s1 = gargstr(1);
-    if (ifarg(2)) {
-        s2 = gargstr(2);
-    } else {
-        s2 = s1;
-    }
-    bool deflt = false;
-    if (ifarg(3) && *getarg(3)) {
-        deflt = true;
-    }
-    bool usepointer = false;
-    if (ifarg(4) && *getarg(4)) {
-        usepointer = true;
-    }
-    hoc_ivfixedvalue(s1, s2, deflt, usepointer);
-
+        char *s1, *s2;
+        s1 = gargstr(1);
+        if (ifarg(2)) {
+            s2 = gargstr(2);
+        } else {
+            s2 = s1;
+        }
+        bool deflt = false;
+        if (ifarg(3) && *getarg(3)) {
+            deflt = true;
+        }
+        bool usepointer = false;
+        if (ifarg(4) && *getarg(4)) {
+            usepointer = true;
+        }
+        hoc_ivfixedvalue(s1, s2, deflt, usepointer);
     }
     hoc_ret();
     hoc_pushx(0.);
@@ -423,36 +418,35 @@ void hoc_xfixedvalue() {
 
 static void hoc_xpvalue_helper() {
     if (hoc_usegui) {  // prompt,variable,deflt,action,canrun
-        char *s1,
-        *s3;
-    neuron::container::data_handle<double> pd{};
-    HocSymExtension* extra = NULL;
-    Symbol* sym;
-    s1 = gargstr(1);
-    if (ifarg(2)) {
-        pd = hoc_hgetarg<double>(2);
-        sym = hoc_get_last_pointer_symbol();
-    } else {
-        pd = hoc_val_handle(s1);
-        sym = hoc_get_symbol(s1);
-    }
-    if (sym) {
-        extra = sym->extra;
-    }
-    bool deflt = false;
-    if (ifarg(3) && *getarg(3)) {
-        deflt = true;
-    }
-    if (ifarg(4)) {
-        s3 = gargstr(4);
-        bool canRun = false;
-        if (ifarg(5) && *getarg(5)) {
-            canRun = true;
+        char *s1, *s3;
+        neuron::container::data_handle<double> pd{};
+        HocSymExtension* extra = NULL;
+        Symbol* sym;
+        s1 = gargstr(1);
+        if (ifarg(2)) {
+            pd = hoc_hgetarg<double>(2);
+            sym = hoc_get_last_pointer_symbol();
+        } else {
+            pd = hoc_val_handle(s1);
+            sym = hoc_get_symbol(s1);
         }
-        hoc_ivpvaluerun(s1, pd, s3, deflt, canRun, extra);
-    } else {
-        hoc_ivpvalue(s1, pd, deflt, extra);
-    }
+        if (sym) {
+            extra = sym->extra;
+        }
+        bool deflt = false;
+        if (ifarg(3) && *getarg(3)) {
+            deflt = true;
+        }
+        if (ifarg(4)) {
+            s3 = gargstr(4);
+            bool canRun = false;
+            if (ifarg(5) && *getarg(5)) {
+                canRun = true;
+            }
+            hoc_ivpvaluerun(s1, pd, s3, deflt, canRun, extra);
+        } else {
+            hoc_ivpvalue(s1, pd, deflt, extra);
+        }
     }
 }
 
@@ -474,9 +468,9 @@ void hoc_xpvalue() {
 void hoc_xlabel() {
     TRY_GUI_REDIRECT_DOUBLE("xlabel", NULL);
     if (hoc_usegui) {
-    char* s1;
-    s1 = gargstr(1);
-    hoc_ivlabel(s1);
+        char* s1;
+        s1 = gargstr(1);
+        hoc_ivlabel(s1);
     }
     hoc_ret();
     hoc_pushx(0.);
@@ -485,11 +479,11 @@ void hoc_xlabel() {
 void hoc_xvarlabel() {
     TRY_GUI_REDIRECT_DOUBLE_SEND_STRREF("xvarlabel", NULL);
     if (hoc_usegui) {
-    if (hoc_is_object_arg(1)) {
-        hoc_ivvarlabel(NULL, *hoc_objgetarg(1));
-    } else {
-        hoc_ivvarlabel(hoc_pgargstr(1));
-    }
+        if (hoc_is_object_arg(1)) {
+            hoc_ivvarlabel(NULL, *hoc_objgetarg(1));
+        } else {
+            hoc_ivvarlabel(hoc_pgargstr(1));
+        }
     }
     hoc_ret();
     hoc_pushx(0.);
@@ -499,42 +493,42 @@ void hoc_xvarlabel() {
 void hoc_xslider() {
     TRY_GUI_REDIRECT_DOUBLE("xslider", NULL);
     if (hoc_usegui) {
-    float low = 0, high = 100;
-    float resolution = 1;
-    int nsteps = 10;
-    char* send = NULL;
-    Object* pysend = NULL;
-    neuron::container::data_handle<double> pval{};
-    Object* pyvar = NULL;
-    bool vert = 0;
-    if (ifarg(3)) {
-        low = *getarg(2);
-        high = *getarg(3);
-        resolution = (high - low) / 100.;
-    }
-    int iarg = 4;
-    if (ifarg(iarg)) {
-        if (hoc_is_str_arg(iarg)) {
-            send = gargstr(4);
-            ++iarg;
-        } else if (hoc_is_object_arg(iarg)) {
-            pysend = *hoc_objgetarg(iarg);
-            ++iarg;
+        float low = 0, high = 100;
+        float resolution = 1;
+        int nsteps = 10;
+        char* send = NULL;
+        Object* pysend = NULL;
+        neuron::container::data_handle<double> pval{};
+        Object* pyvar = NULL;
+        bool vert = 0;
+        if (ifarg(3)) {
+            low = *getarg(2);
+            high = *getarg(3);
+            resolution = (high - low) / 100.;
         }
-    }
-    if (ifarg(iarg)) {
-        vert = int(chkarg(iarg, 0, 1));
-    }
-    bool slow = false;
-    if (ifarg(++iarg)) {
-        slow = int(chkarg(iarg, 0, 1));
-    }
-    if (hoc_is_object_arg(1)) {
-        pyvar = *hoc_objgetarg(1);
-    } else {
-        pval = hoc_hgetarg<double>(1);
-    }
-    hoc_ivslider(pval, low, high, resolution, nsteps, send, vert, slow, pyvar, pysend);
+        int iarg = 4;
+        if (ifarg(iarg)) {
+            if (hoc_is_str_arg(iarg)) {
+                send = gargstr(4);
+                ++iarg;
+            } else if (hoc_is_object_arg(iarg)) {
+                pysend = *hoc_objgetarg(iarg);
+                ++iarg;
+            }
+        }
+        if (ifarg(iarg)) {
+            vert = int(chkarg(iarg, 0, 1));
+        }
+        bool slow = false;
+        if (ifarg(++iarg)) {
+            slow = int(chkarg(iarg, 0, 1));
+        }
+        if (hoc_is_object_arg(1)) {
+            pyvar = *hoc_objgetarg(1);
+        } else {
+            pval = hoc_hgetarg<double>(1);
+        }
+        hoc_ivslider(pval, low, high, resolution, nsteps, send, vert, slow, pyvar, pysend);
     }
     hoc_ret();
     hoc_pushx(0.);
@@ -3097,14 +3091,14 @@ static void* vfe_cons(Object*) {
     TRY_GUI_REDIRECT_OBJ("ValueFieldEditor", NULL);
 #if HAVE_IV
     if (hoc_usegui) {
-    if (!ifarg(2) || hoc_is_str_arg(2)) {
-        hoc_xvalue_helper();
-    } else {
-        hoc_xpvalue_helper();
-    }
-    HocValEditor* fe = last_fe_constructed_;
-    Resource::ref(fe);
-    return (void*) fe;
+        if (!ifarg(2) || hoc_is_str_arg(2)) {
+            hoc_xvalue_helper();
+        } else {
+            hoc_xpvalue_helper();
+        }
+        HocValEditor* fe = last_fe_constructed_;
+        Resource::ref(fe);
+        return (void*) fe;
     }
 #endif
     return 0;
@@ -3113,8 +3107,8 @@ static void vfe_destruct(void* v) {
     TRY_GUI_REDIRECT_NO_RETURN("~ValueFieldEditor", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    HocValEditor* fe = (HocValEditor*) v;
-    Resource::unref(fe);
+        HocValEditor* fe = (HocValEditor*) v;
+        Resource::unref(fe);
     }
 #endif
 }
@@ -3123,10 +3117,10 @@ static double vfe_default(void* v) {
     double x = 0.;
 #if HAVE_IV
     if (hoc_usegui) {
-    if (((HocValEditor*) v)->hoc_default_val_editor()) {
-        HocDefaultValEditor* dfe = (HocDefaultValEditor*) v;
-        dfe->deflt(x = dfe->get_val());
-    }
+        if (((HocValEditor*) v)->hoc_default_val_editor()) {
+            HocDefaultValEditor* dfe = (HocDefaultValEditor*) v;
+            dfe->deflt(x = dfe->get_val());
+        }
     }
 #endif
     return x;

--- a/src/ivoc/xmenu.cpp
+++ b/src/ivoc/xmenu.cpp
@@ -166,7 +166,7 @@ void hoc_notify_value() {
 
 void hoc_xpanel() {
     TRY_GUI_REDIRECT_DOUBLE("xpanel", NULL);
-    IFGUI
+    if (hoc_usegui) {
     if (ifarg(1) && hoc_is_str_arg(1)) {  // begin spec
         bool h = false;
         if (ifarg(2)) {
@@ -187,7 +187,7 @@ void hoc_xpanel() {
             hoc_ivpanelmap(scroll);
         }
     }
-    ENDGUI
+    }
 
     hoc_ret();
     hoc_pushx(0.);
@@ -195,7 +195,7 @@ void hoc_xpanel() {
 
 void hoc_xmenu() {
     TRY_GUI_REDIRECT_DOUBLE("xmenu", NULL);
-    IFGUI
+    if (hoc_usegui) {
     bool add2menubar = false;
     char* mk = NULL;
     Object* pyact = NULL;
@@ -221,7 +221,7 @@ void hoc_xmenu() {
     } else {
         hoc_ivmenu((char*) 0);
     }
-    ENDGUI
+    }
     hoc_ret();
     hoc_pushx(0.);
 }
@@ -229,7 +229,7 @@ void hoc_xmenu() {
 void hoc_xbutton() {
     TRY_GUI_REDIRECT_DOUBLE("xbutton", NULL);
 
-    IFGUI
+    if (hoc_usegui) {
     char* s1;
     s1 = gargstr(1);
     if (ifarg(2)) {
@@ -241,7 +241,7 @@ void hoc_xbutton() {
     } else {
         hoc_ivbutton(s1, s1);
     }
-    ENDGUI
+    }
     hoc_ret();
     hoc_pushx(0.);
 }
@@ -254,7 +254,7 @@ xstatebutton("prompt",&var [,"action"])
 
 void hoc_xstatebutton() {
     TRY_GUI_REDIRECT_DOUBLE("xstatebutton", NULL);
-    IFGUI
+    if (hoc_usegui) {
     char *s1, *s2 = (char*) 0;
 
     s1 = gargstr(1);
@@ -273,7 +273,7 @@ void hoc_xstatebutton() {
         }
         hoc_ivstatebutton(hoc_hgetarg<double>(2), s1, s2, HocStateButton::PALETTE);
     }
-    ENDGUI
+    }
     hoc_ret();
     hoc_pushx(0.);
 }
@@ -287,7 +287,7 @@ xcheckbox("prompt",&var [,"action"])
 
 void hoc_xcheckbox() {
     TRY_GUI_REDIRECT_DOUBLE("xcheckbox", NULL);
-    IFGUI
+    if (hoc_usegui) {
 
     char *s1, *s2 = (char*) 0;
 
@@ -307,7 +307,7 @@ void hoc_xcheckbox() {
         }
         hoc_ivstatebutton(hoc_hgetarg<double>(2), s1, s2, HocStateButton::CHECKBOX);
     }
-    ENDGUI
+    }
     hoc_ret();
     hoc_pushx(0.);
 }
@@ -315,7 +315,7 @@ void hoc_xcheckbox() {
 void hoc_xradiobutton() {
     TRY_GUI_REDIRECT_DOUBLE("xradiobutton", NULL);
 
-    IFGUI
+    if (hoc_usegui) {
     char *s1, *s2 = (char*) 0;
     Object* po = NULL;
     bool activate = false;
@@ -337,13 +337,13 @@ void hoc_xradiobutton() {
     } else {
         hoc_ivradiobutton(s1, s2, activate);
     }
-    ENDGUI
+    }
     hoc_ret();
     hoc_pushx(0.);
 }
 
 static void hoc_xvalue_helper() {
-    IFGUI  // prompt, variable, deflt,action,canrun,usepointer
+    if (hoc_usegui) {  // prompt, variable, deflt,action,canrun,usepointer
         char *s1,
         *s2, *s3;
     // allow variable arg2 to be data_handle
@@ -391,13 +391,13 @@ static void hoc_xvalue_helper() {
     }
     hoc_ivvaluerun_ex(s1, s2, ptr2, pyvar, s3, pyact, deflt, canRun, usepointer);
 
-    ENDGUI
+    }
 }
 
 void hoc_xfixedvalue() {
     TRY_GUI_REDIRECT_DOUBLE("xfixedvalue", NULL);
 
-    IFGUI  // prompt, variable, deflt,action,canrun,usepointer
+    if (hoc_usegui) {  // prompt, variable, deflt,action,canrun,usepointer
         char *s1,
         *s2;
     s1 = gargstr(1);
@@ -416,13 +416,13 @@ void hoc_xfixedvalue() {
     }
     hoc_ivfixedvalue(s1, s2, deflt, usepointer);
 
-    ENDGUI
+    }
     hoc_ret();
     hoc_pushx(0.);
 }
 
 static void hoc_xpvalue_helper() {
-    IFGUI  // prompt,variable,deflt,action,canrun
+    if (hoc_usegui) {  // prompt,variable,deflt,action,canrun
         char *s1,
         *s3;
     neuron::container::data_handle<double> pd{};
@@ -453,7 +453,7 @@ static void hoc_xpvalue_helper() {
     } else {
         hoc_ivpvalue(s1, pd, deflt, extra);
     }
-    ENDGUI
+    }
 }
 
 void hoc_xvalue() {
@@ -473,24 +473,24 @@ void hoc_xpvalue() {
 
 void hoc_xlabel() {
     TRY_GUI_REDIRECT_DOUBLE("xlabel", NULL);
-    IFGUI
+    if (hoc_usegui) {
     char* s1;
     s1 = gargstr(1);
     hoc_ivlabel(s1);
-    ENDGUI
+    }
     hoc_ret();
     hoc_pushx(0.);
 }
 
 void hoc_xvarlabel() {
     TRY_GUI_REDIRECT_DOUBLE_SEND_STRREF("xvarlabel", NULL);
-    IFGUI
+    if (hoc_usegui) {
     if (hoc_is_object_arg(1)) {
         hoc_ivvarlabel(NULL, *hoc_objgetarg(1));
     } else {
         hoc_ivvarlabel(hoc_pgargstr(1));
     }
-    ENDGUI
+    }
     hoc_ret();
     hoc_pushx(0.);
 }
@@ -498,7 +498,7 @@ void hoc_xvarlabel() {
 // ZFM modified to add vertical vs. horizontal
 void hoc_xslider() {
     TRY_GUI_REDIRECT_DOUBLE("xslider", NULL);
-    IFGUI
+    if (hoc_usegui) {
     float low = 0, high = 100;
     float resolution = 1;
     int nsteps = 10;
@@ -535,7 +535,7 @@ void hoc_xslider() {
         pval = hoc_hgetarg<double>(1);
     }
     hoc_ivslider(pval, low, high, resolution, nsteps, send, vert, slow, pyvar, pysend);
-    ENDGUI
+    }
     hoc_ret();
     hoc_pushx(0.);
 }
@@ -3096,7 +3096,7 @@ void HocStateMenuItem::write(std::ostream& o) {
 static void* vfe_cons(Object*) {
     TRY_GUI_REDIRECT_OBJ("ValueFieldEditor", NULL);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     if (!ifarg(2) || hoc_is_str_arg(2)) {
         hoc_xvalue_helper();
     } else {
@@ -3105,29 +3105,29 @@ static void* vfe_cons(Object*) {
     HocValEditor* fe = last_fe_constructed_;
     Resource::ref(fe);
     return (void*) fe;
-    ENDGUI
+    }
 #endif
     return 0;
 }
 static void vfe_destruct(void* v) {
     TRY_GUI_REDIRECT_NO_RETURN("~ValueFieldEditor", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     HocValEditor* fe = (HocValEditor*) v;
     Resource::unref(fe);
-    ENDGUI
+    }
 #endif
 }
 static double vfe_default(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("ValueFieldEditor.default", v);
     double x = 0.;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     if (((HocValEditor*) v)->hoc_default_val_editor()) {
         HocDefaultValEditor* dfe = (HocDefaultValEditor*) v;
         dfe->deflt(x = dfe->get_val());
     }
-    ENDGUI
+    }
 #endif
     return x;
 }

--- a/src/nrncvode/netcvode.cpp
+++ b/src/nrncvode/netcvode.cpp
@@ -2020,14 +2020,14 @@ int NetCvode::solve(double tout) {
                 }
 #if HAVE_IV
                 if (hoc_usegui) {
-                if (rt < time(nullptr)) {
-                    //				if (++cnt > 10000) {
-                    //					cnt = 0;
-                    Oc oc;
-                    oc.notify();
-                    single_event_run();
-                    rt = time(nullptr);
-                }
+                    if (rt < time(nullptr)) {
+                        //				if (++cnt > 10000) {
+                        //					cnt = 0;
+                        Oc oc;
+                        oc.notify();
+                        single_event_run();
+                        rt = time(nullptr);
+                    }
                 }
 #endif
             }

--- a/src/nrncvode/netcvode.cpp
+++ b/src/nrncvode/netcvode.cpp
@@ -2019,7 +2019,7 @@ int NetCvode::solve(double tout) {
                     return err;
                 }
 #if HAVE_IV
-                IFGUI
+                if (hoc_usegui) {
                 if (rt < time(nullptr)) {
                     //				if (++cnt > 10000) {
                     //					cnt = 0;
@@ -2028,7 +2028,7 @@ int NetCvode::solve(double tout) {
                     single_event_run();
                     rt = time(nullptr);
                 }
-                ENDGUI
+                }
 #endif
             }
             int n = p[0].nlcv_;

--- a/src/nrniv/nrnmenu.cpp
+++ b/src/nrniv/nrnmenu.cpp
@@ -50,9 +50,9 @@ void nrnallsectionmenu() {
     TRY_GUI_REDIRECT_DOUBLE("nrnallsectionmenu", NULL);
 
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     SectionBrowser::make_section_browser();
-    ENDGUI
+    }
 #endif
 
     hoc_retpushx(1.);
@@ -61,7 +61,7 @@ void nrnallsectionmenu() {
 void nrnsecmenu() {
     TRY_GUI_REDIRECT_DOUBLE("nrnsecmenu", NULL);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     double x;
     Section* sec = NULL;
     if (hoc_is_object_arg(1)) {  // x = -1 not allowed
@@ -74,7 +74,7 @@ void nrnsecmenu() {
     if (sec) {
         nrn_popsec();
     }
-    ENDGUI
+    }
 #endif
     hoc_retpushx(1.);
 }
@@ -94,7 +94,7 @@ static bool has_globals(const char* name) {
 void nrnglobalmechmenu() {
     TRY_GUI_REDIRECT_DOUBLE("nrnglobalmechmenu", NULL);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Symbol* sp;
     char* s;
     char buf[200];
@@ -146,7 +146,7 @@ void nrnglobalmechmenu() {
         }
     }
     hoc_ivpanelmap();
-    ENDGUI
+    }
 #endif
     hoc_retpushx(1.);
 }
@@ -345,7 +345,7 @@ static void mech_menu(Prop* p1, double x, int type, const char* path, MechSelect
 void nrnallpointmenu() {
     TRY_GUI_REDIRECT_DOUBLE("nrnallpointmenu", NULL);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     int i;
     double x = n_memb_func - 1;
     Symbol *sp, *psym;
@@ -403,7 +403,7 @@ void nrnallpointmenu() {
         }
         hoc_ivpanelmap();
     }
-    ENDGUI
+    }
 #endif
     hoc_retpushx(1.);
 }
@@ -411,7 +411,7 @@ void nrnallpointmenu() {
 void nrnpointmenu() {
     TRY_GUI_REDIRECT_DOUBLE("nrnpointmenu", NULL);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Object* ob;
     if (hoc_is_object_arg(1)) {
         ob = *hoc_objgetarg(1);
@@ -427,7 +427,7 @@ void nrnpointmenu() {
         make_label = int(chkarg(2, -1., 1.));
     }
     point_menu(ob, make_label);
-    ENDGUI
+    }
 #endif
     hoc_retpushx(1.);
 }
@@ -512,13 +512,13 @@ static Symbol* ms_class_sym_;
 static double ms_panel(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_DOUBLE("MechanismStandard.panel", ms_class_sym_, v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     char* label = NULL;
     if (ifarg(1)) {
         label = gargstr(1);
     }
     ((MechanismStandard*) v)->panel(label);
-    ENDGUI
+    }
 #endif
     return 0.;
 }
@@ -1022,10 +1022,10 @@ static double mt_count(void* v) {
 static double mt_menu(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_DOUBLE("MechanismType.menu", mt_class_sym_, v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     MechanismType* mt = (MechanismType*) v;
     mt->menu();
-    ENDGUI
+    }
 #endif
     return 0.;
 }

--- a/src/nrniv/nrnmenu.cpp
+++ b/src/nrniv/nrnmenu.cpp
@@ -51,7 +51,7 @@ void nrnallsectionmenu() {
 
 #if HAVE_IV
     if (hoc_usegui) {
-    SectionBrowser::make_section_browser();
+        SectionBrowser::make_section_browser();
     }
 #endif
 
@@ -62,18 +62,18 @@ void nrnsecmenu() {
     TRY_GUI_REDIRECT_DOUBLE("nrnsecmenu", NULL);
 #if HAVE_IV
     if (hoc_usegui) {
-    double x;
-    Section* sec = NULL;
-    if (hoc_is_object_arg(1)) {  // x = -1 not allowed
-        nrn_seg_or_x_arg(1, &sec, &x);
-        nrn_pushsec(sec);
-    } else {
-        x = chkarg(1, -1., 1.);
-    }
-    section_menu(x, (int) chkarg(2, 1., 3.));
-    if (sec) {
-        nrn_popsec();
-    }
+        double x;
+        Section* sec = NULL;
+        if (hoc_is_object_arg(1)) {  // x = -1 not allowed
+            nrn_seg_or_x_arg(1, &sec, &x);
+            nrn_pushsec(sec);
+        } else {
+            x = chkarg(1, -1., 1.);
+        }
+        section_menu(x, (int) chkarg(2, 1., 3.));
+        if (sec) {
+            nrn_popsec();
+        }
     }
 #endif
     hoc_retpushx(1.);
@@ -95,57 +95,57 @@ void nrnglobalmechmenu() {
     TRY_GUI_REDIRECT_DOUBLE("nrnglobalmechmenu", NULL);
 #if HAVE_IV
     if (hoc_usegui) {
-    Symbol* sp;
-    char* s;
-    char buf[200];
-    char suffix[100];
-    if (!ifarg(1)) {
-        hoc_ivmenu("Mechanisms (Globals)");
-        for (sp = hoc_built_in_symlist->first; sp; sp = sp->next) {
-            if (sp->type == MECHANISM && sp->subtype != MORPHOLOGY && has_globals(sp->name)) {
-                Sprintf(buf, "nrnglobalmechmenu(\"%s\")", sp->name);
-                hoc_ivbutton(sp->name, buf);
+        Symbol* sp;
+        char* s;
+        char buf[200];
+        char suffix[100];
+        if (!ifarg(1)) {
+            hoc_ivmenu("Mechanisms (Globals)");
+            for (sp = hoc_built_in_symlist->first; sp; sp = sp->next) {
+                if (sp->type == MECHANISM && sp->subtype != MORPHOLOGY && has_globals(sp->name)) {
+                    Sprintf(buf, "nrnglobalmechmenu(\"%s\")", sp->name);
+                    hoc_ivbutton(sp->name, buf);
+                }
             }
+            hoc_ivmenu(0);
+            hoc_retpushx(1.);
+            return;
         }
-        hoc_ivmenu(0);
-        hoc_retpushx(1.);
-        return;
-    }
-    char* name = gargstr(1);
-    Sprintf(suffix, "_%s", name);
-    if (ifarg(2) && *getarg(2) == 0.) {
-        int cnt = 0;
+        char* name = gargstr(1);
+        Sprintf(suffix, "_%s", name);
+        if (ifarg(2) && *getarg(2) == 0.) {
+            int cnt = 0;
+            for (sp = hoc_built_in_symlist->first; sp; sp = sp->next) {
+                if (sp->type == VAR && sp->subtype == USERDOUBLE &&
+                    (s = strstr(sp->name, suffix)) != 0 && s[strlen(suffix)] == '\0') {
+                    ++cnt;
+                }
+            }
+            hoc_retpushx(double(cnt));
+            return;
+        }
+        Sprintf(buf, "%s (Globals)", name);
+        hoc_ivpanel(buf);
         for (sp = hoc_built_in_symlist->first; sp; sp = sp->next) {
             if (sp->type == VAR && sp->subtype == USERDOUBLE &&
                 (s = strstr(sp->name, suffix)) != 0 && s[strlen(suffix)] == '\0') {
-                ++cnt;
-            }
-        }
-        hoc_retpushx(double(cnt));
-        return;
-    }
-    Sprintf(buf, "%s (Globals)", name);
-    hoc_ivpanel(buf);
-    for (sp = hoc_built_in_symlist->first; sp; sp = sp->next) {
-        if (sp->type == VAR && sp->subtype == USERDOUBLE && (s = strstr(sp->name, suffix)) != 0 &&
-            s[strlen(suffix)] == '\0') {
-            if (is_array(*sp)) {
-                char n[50];
-                int i;
-                Arrayinfo* a = sp->arayinfo;
-                for (i = 0; i < a->sub[0]; i++) {
-                    if (i > 5)
-                        break;
-                    Sprintf(buf, "%s[%d]", sp->name, i);
-                    Sprintf(n, "%s[%d]", sp->name, i);
-                    hoc_ivpvalue(n, hoc_val_handle(buf), false, sp->extra);
+                if (is_array(*sp)) {
+                    char n[50];
+                    int i;
+                    Arrayinfo* a = sp->arayinfo;
+                    for (i = 0; i < a->sub[0]; i++) {
+                        if (i > 5)
+                            break;
+                        Sprintf(buf, "%s[%d]", sp->name, i);
+                        Sprintf(n, "%s[%d]", sp->name, i);
+                        hoc_ivpvalue(n, hoc_val_handle(buf), false, sp->extra);
+                    }
+                } else {
+                    hoc_ivvalue(sp->name, sp->name, 1);
                 }
-            } else {
-                hoc_ivvalue(sp->name, sp->name, 1);
             }
         }
-    }
-    hoc_ivpanelmap();
+        hoc_ivpanelmap();
     }
 #endif
     hoc_retpushx(1.);
@@ -346,63 +346,64 @@ void nrnallpointmenu() {
     TRY_GUI_REDIRECT_DOUBLE("nrnallpointmenu", NULL);
 #if HAVE_IV
     if (hoc_usegui) {
-    int i;
-    double x = n_memb_func - 1;
-    Symbol *sp, *psym;
-    char buf[200];
-    hoc_Item* q;
+        int i;
+        double x = n_memb_func - 1;
+        Symbol *sp, *psym;
+        char buf[200];
+        hoc_Item* q;
 
-    if (!ifarg(1)) {
-        hoc_ivmenu("Point Processes");
-        for (i = 1; (sp = pointsym[i]) != (Symbol*) 0; i++) {
-            Sprintf(buf, "nrnallpointmenu(%d)", i);
-            hoc_ivbutton(sp->name, buf);
-        }
-        hoc_ivmenu(0);
-        hoc_retpushx(1.);
-        return;
-    }
-
-    i = (int) chkarg(1, 0., x);
-    if ((psym = pointsym[i]) != (Symbol*) 0) {
-        hoc_ivpanel(psym->name);
-        sp = hoc_table_lookup(psym->name, hoc_built_in_symlist);
-        assert(sp && sp->type == TEMPLATE);
-
-        bool locmenu = false;
-        ITERATE(q, sp->u.ctemplate->olist) {  // are there any
-            hoc_ivmenu("locations");
-            locmenu = true;
-            break;
+        if (!ifarg(1)) {
+            hoc_ivmenu("Point Processes");
+            for (i = 1; (sp = pointsym[i]) != (Symbol*) 0; i++) {
+                Sprintf(buf, "nrnallpointmenu(%d)", i);
+                hoc_ivbutton(sp->name, buf);
+            }
+            hoc_ivmenu(0);
+            hoc_retpushx(1.);
+            return;
         }
 
-        bool are_globals = false;
-        char suffix[100];
-        Sprintf(suffix, "_%s", sp->name);
-        for (Symbol* stmp = hoc_built_in_symlist->first; stmp; stmp = stmp->next) {
-            if (stmp->type == VAR && stmp->subtype == USERDOUBLE && strstr(stmp->name, suffix)) {
-                are_globals = true;
+        i = (int) chkarg(1, 0., x);
+        if ((psym = pointsym[i]) != (Symbol*) 0) {
+            hoc_ivpanel(psym->name);
+            sp = hoc_table_lookup(psym->name, hoc_built_in_symlist);
+            assert(sp && sp->type == TEMPLATE);
+
+            bool locmenu = false;
+            ITERATE(q, sp->u.ctemplate->olist) {  // are there any
+                hoc_ivmenu("locations");
+                locmenu = true;
                 break;
             }
-        }
 
-        ITERATE(q, sp->u.ctemplate->olist) {
-            Object* ob = OBJ(q);
-            Point_process* pp = ob2pntproc(ob);
-            if (pp->sec) {
-                Sprintf(buf, "nrnpointmenu(%p)", ob);
-                hoc_ivbutton(sec_and_position(pp->sec, pp->node), buf);
+            bool are_globals = false;
+            char suffix[100];
+            Sprintf(suffix, "_%s", sp->name);
+            for (Symbol* stmp = hoc_built_in_symlist->first; stmp; stmp = stmp->next) {
+                if (stmp->type == VAR && stmp->subtype == USERDOUBLE &&
+                    strstr(stmp->name, suffix)) {
+                    are_globals = true;
+                    break;
+                }
             }
+
+            ITERATE(q, sp->u.ctemplate->olist) {
+                Object* ob = OBJ(q);
+                Point_process* pp = ob2pntproc(ob);
+                if (pp->sec) {
+                    Sprintf(buf, "nrnpointmenu(%p)", ob);
+                    hoc_ivbutton(sec_and_position(pp->sec, pp->node), buf);
+                }
+            }
+            if (locmenu) {
+                hoc_ivmenu(0);
+            }
+            if (are_globals) {
+                Sprintf(buf, "nrnglobalmechmenu(\"%s\")", psym->name);
+                hoc_ivbutton("Globals", buf);
+            }
+            hoc_ivpanelmap();
         }
-        if (locmenu) {
-            hoc_ivmenu(0);
-        }
-        if (are_globals) {
-            Sprintf(buf, "nrnglobalmechmenu(\"%s\")", psym->name);
-            hoc_ivbutton("Globals", buf);
-        }
-        hoc_ivpanelmap();
-    }
     }
 #endif
     hoc_retpushx(1.);
@@ -412,21 +413,21 @@ void nrnpointmenu() {
     TRY_GUI_REDIRECT_DOUBLE("nrnpointmenu", NULL);
 #if HAVE_IV
     if (hoc_usegui) {
-    Object* ob;
-    if (hoc_is_object_arg(1)) {
-        ob = *hoc_objgetarg(1);
-    } else {
-        ob = (Object*) ((size_t) (*getarg(1)));
-    }
-    Symbol* sym = hoc_table_lookup(ob->ctemplate->sym->name, ob->ctemplate->symtable);
-    if (!sym || sym->type != MECHANISM || !memb_func[sym->subtype].is_point) {
-        hoc_execerror(ob->ctemplate->sym->name, "not a point process");
-    }
-    int make_label = 1;
-    if (ifarg(2)) {
-        make_label = int(chkarg(2, -1., 1.));
-    }
-    point_menu(ob, make_label);
+        Object* ob;
+        if (hoc_is_object_arg(1)) {
+            ob = *hoc_objgetarg(1);
+        } else {
+            ob = (Object*) ((size_t) (*getarg(1)));
+        }
+        Symbol* sym = hoc_table_lookup(ob->ctemplate->sym->name, ob->ctemplate->symtable);
+        if (!sym || sym->type != MECHANISM || !memb_func[sym->subtype].is_point) {
+            hoc_execerror(ob->ctemplate->sym->name, "not a point process");
+        }
+        int make_label = 1;
+        if (ifarg(2)) {
+            make_label = int(chkarg(2, -1., 1.));
+        }
+        point_menu(ob, make_label);
     }
 #endif
     hoc_retpushx(1.);
@@ -513,11 +514,11 @@ static double ms_panel(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_DOUBLE("MechanismStandard.panel", ms_class_sym_, v);
 #if HAVE_IV
     if (hoc_usegui) {
-    char* label = NULL;
-    if (ifarg(1)) {
-        label = gargstr(1);
-    }
-    ((MechanismStandard*) v)->panel(label);
+        char* label = NULL;
+        if (ifarg(1)) {
+            label = gargstr(1);
+        }
+        ((MechanismStandard*) v)->panel(label);
     }
 #endif
     return 0.;
@@ -1023,8 +1024,8 @@ static double mt_menu(void* v) {
     TRY_GUI_REDIRECT_METHOD_ACTUAL_DOUBLE("MechanismType.menu", mt_class_sym_, v);
 #if HAVE_IV
     if (hoc_usegui) {
-    MechanismType* mt = (MechanismType*) v;
-    mt->menu();
+        MechanismType* mt = (MechanismType*) v;
+        mt->menu();
     }
 #endif
     return 0.;

--- a/src/nrniv/ppshape.cpp
+++ b/src/nrniv/ppshape.cpp
@@ -14,10 +14,10 @@
 static double pp_append(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PPShape.append", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Object* ob = *hoc_objgetarg(1);
     ((PPShape*) v)->pp_append(ob);
-    ENDGUI
+    }
 #endif
     return 1.;
 }
@@ -30,7 +30,7 @@ static Member_func pp_members[] = {
 static void* pp_cons(Object* ho) {
     TRY_GUI_REDIRECT_OBJ("PPShape", NULL);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Object* ob = *hoc_objgetarg(1);
     check_obj_type(ob, "List");
     PPShape* p = new PPShape((OcList*) ob->u.this_pointer);
@@ -38,7 +38,7 @@ static void* pp_cons(Object* ho) {
     p->view(200);
     p->hoc_obj_ptr(ho);
     return (void*) p;
-    ENDGUI
+    }
 #endif
     return 0;
 }
@@ -46,9 +46,9 @@ static void* pp_cons(Object* ho) {
 static void pp_destruct(void* v) {
     TRY_GUI_REDIRECT_NO_RETURN("~PPShape", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Resource::unref((PPShape*) v);
-    ENDGUI
+    }
 #endif
 }
 

--- a/src/nrniv/ppshape.cpp
+++ b/src/nrniv/ppshape.cpp
@@ -15,8 +15,8 @@ static double pp_append(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PPShape.append", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Object* ob = *hoc_objgetarg(1);
-    ((PPShape*) v)->pp_append(ob);
+        Object* ob = *hoc_objgetarg(1);
+        ((PPShape*) v)->pp_append(ob);
     }
 #endif
     return 1.;
@@ -31,13 +31,13 @@ static void* pp_cons(Object* ho) {
     TRY_GUI_REDIRECT_OBJ("PPShape", NULL);
 #if HAVE_IV
     if (hoc_usegui) {
-    Object* ob = *hoc_objgetarg(1);
-    check_obj_type(ob, "List");
-    PPShape* p = new PPShape((OcList*) ob->u.this_pointer);
-    p->ref();
-    p->view(200);
-    p->hoc_obj_ptr(ho);
-    return (void*) p;
+        Object* ob = *hoc_objgetarg(1);
+        check_obj_type(ob, "List");
+        PPShape* p = new PPShape((OcList*) ob->u.this_pointer);
+        p->ref();
+        p->view(200);
+        p->hoc_obj_ptr(ho);
+        return (void*) p;
     }
 #endif
     return 0;
@@ -47,7 +47,7 @@ static void pp_destruct(void* v) {
     TRY_GUI_REDIRECT_NO_RETURN("~PPShape", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Resource::unref((PPShape*) v);
+        Resource::unref((PPShape*) v);
     }
 #endif
 }

--- a/src/nrniv/secbrows.cpp
+++ b/src/nrniv/secbrows.cpp
@@ -23,17 +23,17 @@
 static double sb_select(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("SectionBrowser.select", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Section* sec = chk_access();
     ((OcSectionBrowser*) v)->select_section(sec);
-    ENDGUI
+    }
 #endif
     return 1.;
 }
 static double sb_select_action(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("SectionBrowser.select_action", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     char* str_action = NULL;
     Object* obj_action = NULL;
     if (hoc_is_object_arg(1)) {
@@ -43,14 +43,14 @@ static double sb_select_action(void* v) {
     }
 
     ((OcSectionBrowser*) v)->set_select_action(str_action, obj_action);
-    ENDGUI
+    }
 #endif
     return 1.;
 }
 static double sb_accept_action(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("SectionBrowser.accept_action", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     char* str_action = NULL;
     Object* obj_action = NULL;
     if (hoc_is_object_arg(1)) {
@@ -60,7 +60,7 @@ static double sb_accept_action(void* v) {
     }
 
     ((OcSectionBrowser*) v)->set_accept_action(str_action, obj_action);
-    ENDGUI
+    }
 #endif
     return 1.;
 }
@@ -73,7 +73,7 @@ static void* sb_cons(Object*) {
     Object* ob;
 #if HAVE_IV
     OcSectionBrowser* b = NULL;
-    IFGUI
+    if (hoc_usegui) {
     if (ifarg(1)) {
         ob = *hoc_objgetarg(1);
         b = new OcSectionBrowser(ob);
@@ -83,7 +83,7 @@ static void* sb_cons(Object*) {
     b->ref();
     Window* w = new StandardWindow(b->standard_glyph());
     w->map();
-    ENDGUI
+    }
     return (void*) b;
 #else
     return 0;

--- a/src/nrniv/secbrows.cpp
+++ b/src/nrniv/secbrows.cpp
@@ -24,8 +24,8 @@ static double sb_select(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("SectionBrowser.select", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Section* sec = chk_access();
-    ((OcSectionBrowser*) v)->select_section(sec);
+        Section* sec = chk_access();
+        ((OcSectionBrowser*) v)->select_section(sec);
     }
 #endif
     return 1.;
@@ -34,15 +34,15 @@ static double sb_select_action(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("SectionBrowser.select_action", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    char* str_action = NULL;
-    Object* obj_action = NULL;
-    if (hoc_is_object_arg(1)) {
-        obj_action = *hoc_objgetarg(1);
-    } else {
-        str_action = gargstr(1);
-    }
+        char* str_action = NULL;
+        Object* obj_action = NULL;
+        if (hoc_is_object_arg(1)) {
+            obj_action = *hoc_objgetarg(1);
+        } else {
+            str_action = gargstr(1);
+        }
 
-    ((OcSectionBrowser*) v)->set_select_action(str_action, obj_action);
+        ((OcSectionBrowser*) v)->set_select_action(str_action, obj_action);
     }
 #endif
     return 1.;
@@ -51,15 +51,15 @@ static double sb_accept_action(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("SectionBrowser.accept_action", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    char* str_action = NULL;
-    Object* obj_action = NULL;
-    if (hoc_is_object_arg(1)) {
-        obj_action = *hoc_objgetarg(1);
-    } else {
-        str_action = gargstr(1);
-    }
+        char* str_action = NULL;
+        Object* obj_action = NULL;
+        if (hoc_is_object_arg(1)) {
+            obj_action = *hoc_objgetarg(1);
+        } else {
+            str_action = gargstr(1);
+        }
 
-    ((OcSectionBrowser*) v)->set_accept_action(str_action, obj_action);
+        ((OcSectionBrowser*) v)->set_accept_action(str_action, obj_action);
     }
 #endif
     return 1.;
@@ -74,15 +74,15 @@ static void* sb_cons(Object*) {
 #if HAVE_IV
     OcSectionBrowser* b = NULL;
     if (hoc_usegui) {
-    if (ifarg(1)) {
-        ob = *hoc_objgetarg(1);
-        b = new OcSectionBrowser(ob);
-    } else {
-        b = new OcSectionBrowser(NULL);
-    }
-    b->ref();
-    Window* w = new StandardWindow(b->standard_glyph());
-    w->map();
+        if (ifarg(1)) {
+            ob = *hoc_objgetarg(1);
+            b = new OcSectionBrowser(ob);
+        } else {
+            b = new OcSectionBrowser(NULL);
+        }
+        b->ref();
+        Window* w = new StandardWindow(b->standard_glyph());
+        w->map();
     }
     return (void*) b;
 #else

--- a/src/nrniv/shape.cpp
+++ b/src/nrniv/shape.cpp
@@ -184,7 +184,7 @@ bool OcShapeHandler::event(Event&) {
 static double sh_view(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.view", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcShape* sh = (OcShape*) v;
     if (ifarg(8)) {
         Coord x[8];
@@ -194,7 +194,7 @@ static double sh_view(void* v) {
         }
         sh->view(x);
     }
-    ENDGUI
+    }
 #endif
     return 1.;
 }
@@ -202,8 +202,8 @@ static double sh_view(void* v) {
 static double sh_flush(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.flush", v);
 #if HAVE_IV
-    IFGUI((ShapeScene*) v)->flush();
-    ENDGUI
+    if (hoc_usegui) {((ShapeScene*) v)->flush();
+    }
 #endif
     return 1.;
 }
@@ -216,8 +216,8 @@ static double sh_begin(void* v) {  // a noop. Exists only because graphs and
 static double sh_save_name(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.save_name", v);
 #if HAVE_IV
-    IFGUI((ShapeScene*) v)->name(gargstr(1));
-    ENDGUI
+    if (hoc_usegui) {((ShapeScene*) v)->name(gargstr(1));
+    }
 #endif
     return 1.;
 }
@@ -225,23 +225,23 @@ static double sh_save_name(void* v) {
 static double sh_select(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.select", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Section* sec = chk_access();
     ((OcShape*) v)->select_section(sec);
-    ENDGUI
+    }
 #endif
     return 1.;
 }
 static double sh_select_action(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.action", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     if (hoc_is_object_arg(1)) {
         ((OcShape*) v)->set_select_action(*hoc_objgetarg(1));
     } else {
         ((OcShape*) v)->set_select_action(gargstr(1));
     }
-    ENDGUI
+    }
 #endif
     return 1.;
 }
@@ -250,9 +250,9 @@ static double sh_view_count(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.view_count", v);
     int n = 0;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     n = ((ShapeScene*) v)->view_count();
-    ENDGUI
+    }
 #endif
     return double(n);
 }
@@ -261,9 +261,9 @@ double nrniv_sh_nearest(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.nearest", v);
     double d = 0.;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     d = ((ShapeScene*) v)->nearest(*getarg(1), *getarg(2));
-    ENDGUI
+    }
 #endif
     return d;
 }
@@ -272,14 +272,14 @@ double nrniv_sh_push(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.push_seleced", v);
     double d = -1.;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapeScene* ss = (ShapeScene*) v;
     ShapeSection* s = ss->selected();
     if (s && s->good()) {
         nrn_pushsec(s->section());
         d = ss->arc_selected();
     }
-    ENDGUI
+    }
 #endif
     return d;
 }
@@ -288,7 +288,7 @@ Object** nrniv_sh_nearest_seg(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_OBJ("Shape.nearest_seg", v);
     Object* obj = NULL;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapeScene* ss = (ShapeScene*) v;
     ShapeSection* ssec = NULL;
     double d = ss->nearest(*getarg(1), *getarg(2));
@@ -298,7 +298,7 @@ Object** nrniv_sh_nearest_seg(void* v) {
         obj = (*nrnpy_seg_from_sec_x)(ssec->section(), d);
     }
     --obj->refcount;
-    ENDGUI
+    }
 #endif
     return hoc_temp_objptr(obj);
 }
@@ -307,7 +307,7 @@ Object** nrniv_sh_selected_seg(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_OBJ("Shape.selected_seg", v);
     Object* obj = NULL;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapeScene* ss = (ShapeScene*) v;
     ShapeSection* ssec = NULL;
     ssec = ss->selected();
@@ -316,7 +316,7 @@ Object** nrniv_sh_selected_seg(void* v) {
         obj = (*nrnpy_seg_from_sec_x)(ssec->section(), d);
     }
     --obj->refcount;
-    ENDGUI
+    }
 #endif
     return hoc_temp_objptr(obj);
 }
@@ -324,7 +324,7 @@ Object** nrniv_sh_selected_seg(void* v) {
 double nrniv_sh_observe(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.observe", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapeScene* s = (ShapeScene*) v;
     SectionList* sl = NULL;
     if (ifarg(1)) {
@@ -337,7 +337,7 @@ double nrniv_sh_observe(void* v) {
     } else {
         s->observe(NULL);
     }
-    ENDGUI
+    }
 #endif
     return 0.;
 }
@@ -345,7 +345,7 @@ double nrniv_sh_observe(void* v) {
 double nrniv_sh_rotate(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.rotate", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapeScene* s = (ShapeScene*) v;
     if (!ifarg(1)) {
         // identity
@@ -355,7 +355,7 @@ double nrniv_sh_rotate(void* v) {
         // (relative to the current coord system)
         s->rotate(*getarg(1), *getarg(2), *getarg(3), *getarg(4), *getarg(5), *getarg(6));
     }
-    ENDGUI
+    }
 #endif
     return 0.;
 }
@@ -363,10 +363,10 @@ double nrniv_sh_rotate(void* v) {
 static double sh_unmap(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.unmap", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapeScene* s = (ShapeScene*) v;
     s->dismiss();
-    ENDGUI
+    }
 #endif
     return 0.;
 }
@@ -374,7 +374,7 @@ static double sh_unmap(void* v) {
 double nrniv_sh_color(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.color", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapeScene* s = (ShapeScene*) v;
     const Color* c = NULL;
     c = colors->color(int(*getarg(1)));
@@ -386,7 +386,7 @@ double nrniv_sh_color(void* v) {
     } else {
         s->color(chk_access(), c);
     }
-    ENDGUI
+    }
 #endif
     return 0.;
 }
@@ -394,12 +394,12 @@ double nrniv_sh_color(void* v) {
 double nrniv_sh_color_all(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.color_all", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapeScene* s = (ShapeScene*) v;
     const Color* c = NULL;
     c = colors->color(int(*getarg(1)));
     s->color(c);
-    ENDGUI
+    }
 #endif
     return 0.;
 }
@@ -407,12 +407,12 @@ double nrniv_sh_color_all(void* v) {
 double nrniv_sh_color_list(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.color_list", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapeScene* s = (ShapeScene*) v;
     const Color* c = NULL;
     c = colors->color(int(*getarg(2)));
     s->color(new SectionList(*hoc_objgetarg(1)), c);
-    ENDGUI
+    }
 #endif
     return 0.;
 }
@@ -420,7 +420,7 @@ double nrniv_sh_color_list(void* v) {
 static double sh_point_mark(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.point_mark", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     OcShape* s = (OcShape*) v;
     char style = 'O';
     float size = 8.;
@@ -439,7 +439,7 @@ static double sh_point_mark(void* v) {
     } else {
         s->point_mark(chk_access(), chkarg(1, 0., 1.), colors->color(int(*getarg(2))));
     }
-    ENDGUI
+    }
 #endif
     return 0.;
 }
@@ -447,14 +447,14 @@ static double sh_point_mark(void* v) {
 static double sh_point_mark_remove(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.point_mark_remove", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     Object* o = NULL;
     OcShape* s = (OcShape*) v;
     if (ifarg(1)) {
         o = *hoc_objgetarg(1);
     }
     s->point_mark_remove(o);
-    ENDGUI
+    }
 #endif
     return 0.;
 }
@@ -462,10 +462,10 @@ static double sh_point_mark_remove(void* v) {
 static double sh_printfile(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.printfile", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapeScene* s = (ShapeScene*) v;
     s->printfile(gargstr(1));
-    ENDGUI
+    }
 #endif
     return 1.;
 }
@@ -473,10 +473,10 @@ static double sh_printfile(void* v) {
 static double sh_show(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.show", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapeScene* s = (ShapeScene*) v;
     s->shape_type(int(chkarg(1, 0., 2.)));
-    ENDGUI
+    }
 #endif
     return 1.;
 }
@@ -487,8 +487,8 @@ extern double ivoc_gr_menu_action(void* v);
 static double exec_menu(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.exec_menu", v);
 #if HAVE_IV
-    IFGUI((Scene*) v)->picker()->exec_item(gargstr(1));
-    ENDGUI
+    if (hoc_usegui) {((Scene*) v)->picker()->exec_item(gargstr(1));
+    }
 #endif
     return 0.;
 }
@@ -496,7 +496,7 @@ static double exec_menu(void* v) {
 double nrniv_len_scale(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.len_scale", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapeScene* scene = (ShapeScene*) v;
     ShapeSection* ss = scene->shape_section(chk_access());
     if (ss) {
@@ -506,7 +506,7 @@ double nrniv_len_scale(void* v) {
         }
         return ss->scale();
     }
-    ENDGUI
+    }
 #endif
     return 0.;
 }
@@ -564,7 +564,7 @@ static void* sh_cons(Object* ho) {
     TRY_GUI_REDIRECT_OBJ("Shape", NULL);
 #if HAVE_IV
     OcShape* sh = NULL;
-    IFGUI
+    if (hoc_usegui) {
     int i = 1;
     int iarg = 1;
     SectionList* sl = NULL;
@@ -586,7 +586,7 @@ static void* sh_cons(Object* ho) {
     if (i) {
         sh->view(200);
     }
-    ENDGUI
+    }
     return (void*) sh;
 #endif
     return 0;
@@ -594,9 +594,9 @@ static void* sh_cons(Object* ho) {
 static void sh_destruct(void* v) {
     TRY_GUI_REDIRECT_NO_RETURN("~Shape", v);
 #if HAVE_IV
-    IFGUI((ShapeScene*) v)->dismiss();
+    if (hoc_usegui) {((ShapeScene*) v)->dismiss();
     Resource::unref((OcShape*) v);
-    ENDGUI
+    }
 #endif
 }
 void Shape_reg() {

--- a/src/nrniv/shape.cpp
+++ b/src/nrniv/shape.cpp
@@ -185,15 +185,15 @@ static double sh_view(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.view", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcShape* sh = (OcShape*) v;
-    if (ifarg(8)) {
-        Coord x[8];
-        int i;
-        for (i = 0; i < 8; ++i) {
-            x[i] = *getarg(i + 1);
+        OcShape* sh = (OcShape*) v;
+        if (ifarg(8)) {
+            Coord x[8];
+            int i;
+            for (i = 0; i < 8; ++i) {
+                x[i] = *getarg(i + 1);
+            }
+            sh->view(x);
         }
-        sh->view(x);
-    }
     }
 #endif
     return 1.;
@@ -202,7 +202,8 @@ static double sh_view(void* v) {
 static double sh_flush(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.flush", v);
 #if HAVE_IV
-    if (hoc_usegui) {((ShapeScene*) v)->flush();
+    if (hoc_usegui) {
+        ((ShapeScene*) v)->flush();
     }
 #endif
     return 1.;
@@ -216,7 +217,8 @@ static double sh_begin(void* v) {  // a noop. Exists only because graphs and
 static double sh_save_name(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.save_name", v);
 #if HAVE_IV
-    if (hoc_usegui) {((ShapeScene*) v)->name(gargstr(1));
+    if (hoc_usegui) {
+        ((ShapeScene*) v)->name(gargstr(1));
     }
 #endif
     return 1.;
@@ -226,8 +228,8 @@ static double sh_select(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.select", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Section* sec = chk_access();
-    ((OcShape*) v)->select_section(sec);
+        Section* sec = chk_access();
+        ((OcShape*) v)->select_section(sec);
     }
 #endif
     return 1.;
@@ -236,11 +238,11 @@ static double sh_select_action(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.action", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    if (hoc_is_object_arg(1)) {
-        ((OcShape*) v)->set_select_action(*hoc_objgetarg(1));
-    } else {
-        ((OcShape*) v)->set_select_action(gargstr(1));
-    }
+        if (hoc_is_object_arg(1)) {
+            ((OcShape*) v)->set_select_action(*hoc_objgetarg(1));
+        } else {
+            ((OcShape*) v)->set_select_action(gargstr(1));
+        }
     }
 #endif
     return 1.;
@@ -251,7 +253,7 @@ static double sh_view_count(void* v) {
     int n = 0;
 #if HAVE_IV
     if (hoc_usegui) {
-    n = ((ShapeScene*) v)->view_count();
+        n = ((ShapeScene*) v)->view_count();
     }
 #endif
     return double(n);
@@ -262,7 +264,7 @@ double nrniv_sh_nearest(void* v) {
     double d = 0.;
 #if HAVE_IV
     if (hoc_usegui) {
-    d = ((ShapeScene*) v)->nearest(*getarg(1), *getarg(2));
+        d = ((ShapeScene*) v)->nearest(*getarg(1), *getarg(2));
     }
 #endif
     return d;
@@ -273,12 +275,12 @@ double nrniv_sh_push(void* v) {
     double d = -1.;
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapeScene* ss = (ShapeScene*) v;
-    ShapeSection* s = ss->selected();
-    if (s && s->good()) {
-        nrn_pushsec(s->section());
-        d = ss->arc_selected();
-    }
+        ShapeScene* ss = (ShapeScene*) v;
+        ShapeSection* s = ss->selected();
+        if (s && s->good()) {
+            nrn_pushsec(s->section());
+            d = ss->arc_selected();
+        }
     }
 #endif
     return d;
@@ -289,15 +291,15 @@ Object** nrniv_sh_nearest_seg(void* v) {
     Object* obj = NULL;
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapeScene* ss = (ShapeScene*) v;
-    ShapeSection* ssec = NULL;
-    double d = ss->nearest(*getarg(1), *getarg(2));
-    ssec = ss->selected();
-    if (d < 1e15 && nrnpy_seg_from_sec_x && ssec) {
-        d = ss->arc_selected();
-        obj = (*nrnpy_seg_from_sec_x)(ssec->section(), d);
-    }
-    --obj->refcount;
+        ShapeScene* ss = (ShapeScene*) v;
+        ShapeSection* ssec = NULL;
+        double d = ss->nearest(*getarg(1), *getarg(2));
+        ssec = ss->selected();
+        if (d < 1e15 && nrnpy_seg_from_sec_x && ssec) {
+            d = ss->arc_selected();
+            obj = (*nrnpy_seg_from_sec_x)(ssec->section(), d);
+        }
+        --obj->refcount;
     }
 #endif
     return hoc_temp_objptr(obj);
@@ -308,14 +310,14 @@ Object** nrniv_sh_selected_seg(void* v) {
     Object* obj = NULL;
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapeScene* ss = (ShapeScene*) v;
-    ShapeSection* ssec = NULL;
-    ssec = ss->selected();
-    if (nrnpy_seg_from_sec_x && ssec) {
-        double d = ss->arc_selected();
-        obj = (*nrnpy_seg_from_sec_x)(ssec->section(), d);
-    }
-    --obj->refcount;
+        ShapeScene* ss = (ShapeScene*) v;
+        ShapeSection* ssec = NULL;
+        ssec = ss->selected();
+        if (nrnpy_seg_from_sec_x && ssec) {
+            double d = ss->arc_selected();
+            obj = (*nrnpy_seg_from_sec_x)(ssec->section(), d);
+        }
+        --obj->refcount;
     }
 #endif
     return hoc_temp_objptr(obj);
@@ -325,18 +327,18 @@ double nrniv_sh_observe(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.observe", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapeScene* s = (ShapeScene*) v;
-    SectionList* sl = NULL;
-    if (ifarg(1)) {
-        Object* o = *hoc_objgetarg(1);
-        check_obj_type(o, "SectionList");
-        sl = new SectionList(o);
-        sl->ref();
-        s->observe(sl);
-        sl->unref();
-    } else {
-        s->observe(NULL);
-    }
+        ShapeScene* s = (ShapeScene*) v;
+        SectionList* sl = NULL;
+        if (ifarg(1)) {
+            Object* o = *hoc_objgetarg(1);
+            check_obj_type(o, "SectionList");
+            sl = new SectionList(o);
+            sl->ref();
+            s->observe(sl);
+            sl->unref();
+        } else {
+            s->observe(NULL);
+        }
     }
 #endif
     return 0.;
@@ -346,15 +348,15 @@ double nrniv_sh_rotate(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.rotate", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapeScene* s = (ShapeScene*) v;
-    if (!ifarg(1)) {
-        // identity
-        s->rotate();
-    } else {
-        // defines origin (absolute) and rotation
-        // (relative to the current coord system)
-        s->rotate(*getarg(1), *getarg(2), *getarg(3), *getarg(4), *getarg(5), *getarg(6));
-    }
+        ShapeScene* s = (ShapeScene*) v;
+        if (!ifarg(1)) {
+            // identity
+            s->rotate();
+        } else {
+            // defines origin (absolute) and rotation
+            // (relative to the current coord system)
+            s->rotate(*getarg(1), *getarg(2), *getarg(3), *getarg(4), *getarg(5), *getarg(6));
+        }
     }
 #endif
     return 0.;
@@ -364,8 +366,8 @@ static double sh_unmap(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.unmap", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapeScene* s = (ShapeScene*) v;
-    s->dismiss();
+        ShapeScene* s = (ShapeScene*) v;
+        s->dismiss();
     }
 #endif
     return 0.;
@@ -375,17 +377,17 @@ double nrniv_sh_color(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.color", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapeScene* s = (ShapeScene*) v;
-    const Color* c = NULL;
-    c = colors->color(int(*getarg(1)));
-    if (ifarg(2)) {
-        Section* sec;
-        double x;
-        nrn_seg_or_x_arg(2, &sec, &x);
-        s->colorseg(sec, x, c);
-    } else {
-        s->color(chk_access(), c);
-    }
+        ShapeScene* s = (ShapeScene*) v;
+        const Color* c = NULL;
+        c = colors->color(int(*getarg(1)));
+        if (ifarg(2)) {
+            Section* sec;
+            double x;
+            nrn_seg_or_x_arg(2, &sec, &x);
+            s->colorseg(sec, x, c);
+        } else {
+            s->color(chk_access(), c);
+        }
     }
 #endif
     return 0.;
@@ -395,10 +397,10 @@ double nrniv_sh_color_all(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.color_all", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapeScene* s = (ShapeScene*) v;
-    const Color* c = NULL;
-    c = colors->color(int(*getarg(1)));
-    s->color(c);
+        ShapeScene* s = (ShapeScene*) v;
+        const Color* c = NULL;
+        c = colors->color(int(*getarg(1)));
+        s->color(c);
     }
 #endif
     return 0.;
@@ -408,10 +410,10 @@ double nrniv_sh_color_list(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.color_list", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapeScene* s = (ShapeScene*) v;
-    const Color* c = NULL;
-    c = colors->color(int(*getarg(2)));
-    s->color(new SectionList(*hoc_objgetarg(1)), c);
+        ShapeScene* s = (ShapeScene*) v;
+        const Color* c = NULL;
+        c = colors->color(int(*getarg(2)));
+        s->color(new SectionList(*hoc_objgetarg(1)), c);
     }
 #endif
     return 0.;
@@ -421,24 +423,24 @@ static double sh_point_mark(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.point_mark", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    OcShape* s = (OcShape*) v;
-    char style = 'O';
-    float size = 8.;
-    if (hoc_is_object_arg(1)) {
-        if (ifarg(3)) {
-            if (hoc_is_str_arg(3)) {
-                style = *gargstr(3);
-            } else {
-                style = char(chkarg(3, 0, 127));
+        OcShape* s = (OcShape*) v;
+        char style = 'O';
+        float size = 8.;
+        if (hoc_is_object_arg(1)) {
+            if (ifarg(3)) {
+                if (hoc_is_str_arg(3)) {
+                    style = *gargstr(3);
+                } else {
+                    style = char(chkarg(3, 0, 127));
+                }
             }
+            if (ifarg(4)) {
+                size = float(chkarg(4, 1e-9, 1e9));
+            }
+            s->point_mark(*hoc_objgetarg(1), colors->color(int(*getarg(2))), style, size);
+        } else {
+            s->point_mark(chk_access(), chkarg(1, 0., 1.), colors->color(int(*getarg(2))));
         }
-        if (ifarg(4)) {
-            size = float(chkarg(4, 1e-9, 1e9));
-        }
-        s->point_mark(*hoc_objgetarg(1), colors->color(int(*getarg(2))), style, size);
-    } else {
-        s->point_mark(chk_access(), chkarg(1, 0., 1.), colors->color(int(*getarg(2))));
-    }
     }
 #endif
     return 0.;
@@ -448,12 +450,12 @@ static double sh_point_mark_remove(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.point_mark_remove", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    Object* o = NULL;
-    OcShape* s = (OcShape*) v;
-    if (ifarg(1)) {
-        o = *hoc_objgetarg(1);
-    }
-    s->point_mark_remove(o);
+        Object* o = NULL;
+        OcShape* s = (OcShape*) v;
+        if (ifarg(1)) {
+            o = *hoc_objgetarg(1);
+        }
+        s->point_mark_remove(o);
     }
 #endif
     return 0.;
@@ -463,8 +465,8 @@ static double sh_printfile(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.printfile", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapeScene* s = (ShapeScene*) v;
-    s->printfile(gargstr(1));
+        ShapeScene* s = (ShapeScene*) v;
+        s->printfile(gargstr(1));
     }
 #endif
     return 1.;
@@ -474,8 +476,8 @@ static double sh_show(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.show", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapeScene* s = (ShapeScene*) v;
-    s->shape_type(int(chkarg(1, 0., 2.)));
+        ShapeScene* s = (ShapeScene*) v;
+        s->shape_type(int(chkarg(1, 0., 2.)));
     }
 #endif
     return 1.;
@@ -487,7 +489,8 @@ extern double ivoc_gr_menu_action(void* v);
 static double exec_menu(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.exec_menu", v);
 #if HAVE_IV
-    if (hoc_usegui) {((Scene*) v)->picker()->exec_item(gargstr(1));
+    if (hoc_usegui) {
+        ((Scene*) v)->picker()->exec_item(gargstr(1));
     }
 #endif
     return 0.;
@@ -497,15 +500,15 @@ double nrniv_len_scale(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("Shape.len_scale", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapeScene* scene = (ShapeScene*) v;
-    ShapeSection* ss = scene->shape_section(chk_access());
-    if (ss) {
-        if (ifarg(1)) {
-            ss->scale(chkarg(1, 1e-9, 1e9));
-            scene->force();
+        ShapeScene* scene = (ShapeScene*) v;
+        ShapeSection* ss = scene->shape_section(chk_access());
+        if (ss) {
+            if (ifarg(1)) {
+                ss->scale(chkarg(1, 1e-9, 1e9));
+                scene->force();
+            }
+            return ss->scale();
         }
-        return ss->scale();
-    }
     }
 #endif
     return 0.;
@@ -565,27 +568,27 @@ static void* sh_cons(Object* ho) {
 #if HAVE_IV
     OcShape* sh = NULL;
     if (hoc_usegui) {
-    int i = 1;
-    int iarg = 1;
-    SectionList* sl = NULL;
-    // first arg may be an object.
-    if (ifarg(iarg)) {
-        if (hoc_is_object_arg(iarg)) {
-            sl = new SectionList(*hoc_objgetarg(iarg));
-            sl->ref();
-            ++iarg;
+        int i = 1;
+        int iarg = 1;
+        SectionList* sl = NULL;
+        // first arg may be an object.
+        if (ifarg(iarg)) {
+            if (hoc_is_object_arg(iarg)) {
+                sl = new SectionList(*hoc_objgetarg(iarg));
+                sl->ref();
+                ++iarg;
+            }
         }
-    }
-    if (ifarg(iarg)) {
-        i = int(chkarg(iarg, 0, 1));
-    }
-    sh = new OcShape(sl);
-    Resource::unref(sl);
-    sh->ref();
-    sh->hoc_obj_ptr(ho);
-    if (i) {
-        sh->view(200);
-    }
+        if (ifarg(iarg)) {
+            i = int(chkarg(iarg, 0, 1));
+        }
+        sh = new OcShape(sl);
+        Resource::unref(sl);
+        sh->ref();
+        sh->hoc_obj_ptr(ho);
+        if (i) {
+            sh->view(200);
+        }
     }
     return (void*) sh;
 #endif
@@ -594,8 +597,9 @@ static void* sh_cons(Object* ho) {
 static void sh_destruct(void* v) {
     TRY_GUI_REDIRECT_NO_RETURN("~Shape", v);
 #if HAVE_IV
-    if (hoc_usegui) {((ShapeScene*) v)->dismiss();
-    Resource::unref((OcShape*) v);
+    if (hoc_usegui) {
+        ((ShapeScene*) v)->dismiss();
+        Resource::unref((OcShape*) v);
     }
 #endif
 }

--- a/src/nrniv/shapeplt.cpp
+++ b/src/nrniv/shapeplt.cpp
@@ -50,8 +50,8 @@ void (*nrnpy_decref)(void* pyobj) = 0;
 static double sh_flush(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.flush", v);
 #if HAVE_IV
-    IFGUI((ShapePlot*) v)->flush();
-    ENDGUI
+    if (hoc_usegui) {((ShapePlot*) v)->flush();
+    }
 #endif
     return 1.;
 }
@@ -59,8 +59,8 @@ static double sh_flush(void* v) {
 static double fast_flush(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.fast_flush", v);
 #if HAVE_IV
-    IFGUI((ShapePlot*) v)->fast_flush();
-    ENDGUI
+    if (hoc_usegui) {((ShapePlot*) v)->fast_flush();
+    }
 #endif
     return 1.;
 }
@@ -73,11 +73,11 @@ static double sh_begin(void* v) {  // a noop. Exists only because graphs and
 static double sh_scale(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.scale", v);
 #if HAVE_IV
-    IFGUI((ShapePlot*) v)->scale(float(*getarg(1)), float(*getarg(2)));
+    if (hoc_usegui) {((ShapePlot*) v)->scale(float(*getarg(1)), float(*getarg(2)));
 }
 else {
     ((ShapePlotData*) v)->scale(float(*getarg(1)), float(*getarg(2)));
-    ENDGUI
+    }
 #else
     ((ShapePlotData*) v)->scale(float(*getarg(1)), float(*getarg(2)));
 #endif
@@ -93,7 +93,7 @@ void ShapePlot::has_iv_view(bool value) {
 static double sh_view(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.view", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapePlot* sh = (ShapePlot*) v;
     sh->has_iv_view(true);
     if (sh->varobj()) {
@@ -107,7 +107,7 @@ static double sh_view(void* v) {
         }
         sh->view(x);
     }
-    ENDGUI
+    }
 #endif
     return 1.;
 }
@@ -126,7 +126,7 @@ static double sh_variable(void* v) {
             hoc_execerror("variable must be either a string or Python object", NULL);
         }
 #if HAVE_IV
-        IFGUI
+        if (hoc_usegui) {
         if (sh->has_iv_view()) {
             nrnpy_decref(py_var_);
             hoc_execerror("InterViews only supports string variables.", NULL);
@@ -134,7 +134,7 @@ static double sh_variable(void* v) {
         nrnpy_decref(sh->varobj());
         sh->varobj(py_var_);
         return 1;
-        ENDGUI
+        }
 #endif
         nrnpy_decref(spd->varobj());
         spd->varobj(py_var_);
@@ -144,7 +144,7 @@ static double sh_variable(void* v) {
     s = hoc_table_lookup(gargstr(1), hoc_built_in_symlist);
     if (s) {
 #if HAVE_IV
-        IFGUI
+        if (hoc_usegui) {
         if (nrnpy_decref) {
             nrnpy_decref(sh->varobj());
         }
@@ -157,7 +157,7 @@ static double sh_variable(void* v) {
         }
         spd->varobj(NULL);
         spd->variable(s);
-        ENDGUI
+        }
 #else
         if (nrnpy_decref) {
             nrnpy_decref(spd->varobj());
@@ -173,9 +173,9 @@ static double sh_view_count(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.view_count", v);
     int n = 0;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     n = ((ShapeScene*) v)->view_count();
-    ENDGUI
+    }
 #endif
     return double(n);
 }
@@ -183,8 +183,8 @@ static double sh_view_count(void* v) {
 static double sh_save_name(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.save_name", v);
 #if HAVE_IV
-    IFGUI((ShapeScene*) v)->name(gargstr(1));
-    ENDGUI
+    if (hoc_usegui) {((ShapeScene*) v)->name(gargstr(1));
+    }
 #endif
     return 1.;
 }
@@ -192,10 +192,10 @@ static double sh_save_name(void* v) {
 static double sh_unmap(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.unmap", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapeScene* s = (ShapeScene*) v;
     s->dismiss();
-    ENDGUI
+    }
 #endif
     return 0.;
 }
@@ -203,10 +203,10 @@ static double sh_unmap(void* v) {
 static double sh_printfile(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.printfile", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapeScene* s = (ShapeScene*) v;
     s->printfile(gargstr(1));
-    ENDGUI
+    }
 #endif
     return 1.;
 }
@@ -215,7 +215,7 @@ static double sh_show(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.show", v);
     hoc_return_type_code = 1;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapeScene* s = (ShapeScene*) v;
     if (ifarg(1)) {
         s->shape_type(int(chkarg(1, 0., 2.)));
@@ -229,7 +229,7 @@ else {
     } else {
         return ((ShapePlotData*) v)->get_mode();
     }
-    ENDGUI
+    }
 #else
     if (ifarg(1)) {
         ((ShapePlotData*) v)->set_mode(int(chkarg(1, 0., 2.)));
@@ -245,7 +245,7 @@ extern double ivoc_gr_menu_action(void* v);
 static double s_colormap(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.colormap", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapePlot* s = (ShapePlot*) v;
     if (ifarg(4)) {
         s->color_value()->colormap(int(chkarg(1, 0, 255)),
@@ -259,7 +259,7 @@ static double s_colormap(void* v) {
         }
         s->color_value()->colormap(int(chkarg(1, 0, 1000)), b);
     }
-    ENDGUI
+    }
 #endif
     return 1.;
 }
@@ -267,7 +267,7 @@ static double s_colormap(void* v) {
 static double sh_hinton(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.hinton", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapeScene* ss = (ShapeScene*) v;
     neuron::container::data_handle<double> pd = hoc_hgetarg<double>(1);
     double xsize = chkarg(4, 1e-9, 1e9);
@@ -278,7 +278,7 @@ static double sh_hinton(void* v) {
     Hinton* h = new Hinton(pd, xsize, ysize, ss);
     ss->append(new FastGraphItem(h));
     ss->move(ss->count() - 1, *getarg(2), *getarg(3));
-    ENDGUI
+    }
 #endif
     return 1.;
 }
@@ -286,8 +286,8 @@ static double sh_hinton(void* v) {
 static double exec_menu(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.exec_menu", v);
 #if HAVE_IV
-    IFGUI((Scene*) v)->picker()->exec_item(gargstr(1));
-    ENDGUI
+    if (hoc_usegui) {((Scene*) v)->picker()->exec_item(gargstr(1));
+    }
 #endif
     return 0.;
 }
@@ -362,10 +362,10 @@ static void* sh_cons(Object* ho) {
             ob = *hoc_objgetarg(iarg);
             check_obj_type(ob, "SectionList");
 #if HAVE_IV
-            IFGUI
+            if (hoc_usegui) {
             sl = new SectionList(ob);
             sl->ref();
-            ENDGUI
+            }
 #endif
             ++iarg;
         }
@@ -374,7 +374,7 @@ static void* sh_cons(Object* ho) {
         i = int(chkarg(iarg, 0, 1));
     }
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     ShapePlot* sh = NULL;
     sh = new ShapePlot(NULL, sl);
     sh->has_iv_view(i ? true : false);
@@ -390,7 +390,7 @@ static void* sh_cons(Object* ho) {
 else {
     ShapePlotData* spd = new ShapePlotData(NULL, ob);
     return (void*) spd;
-    ENDGUI
+    }
 #else
     ShapePlotData* sh = new ShapePlotData(NULL, ob);
     return (void*) sh;
@@ -400,7 +400,7 @@ else {
 static void sh_destruct(void* v) {
     TRY_GUI_REDIRECT_NO_RETURN("~PlotShape", v);
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     if (nrnpy_decref) {
         ShapePlot* sp = (ShapePlot*) v;
         nrnpy_decref(sp->varobj());
@@ -413,7 +413,7 @@ else {
         ShapePlotData* sp = (ShapePlotData*) v;
         nrnpy_decref(sp->varobj());
     }
-    ENDGUI
+    }
     Resource::unref((ShapeScene*) v);
 #else
     if (nrnpy_decref) {

--- a/src/nrniv/shapeplt.cpp
+++ b/src/nrniv/shapeplt.cpp
@@ -50,7 +50,8 @@ void (*nrnpy_decref)(void* pyobj) = 0;
 static double sh_flush(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.flush", v);
 #if HAVE_IV
-    if (hoc_usegui) {((ShapePlot*) v)->flush();
+    if (hoc_usegui) {
+        ((ShapePlot*) v)->flush();
     }
 #endif
     return 1.;
@@ -59,7 +60,8 @@ static double sh_flush(void* v) {
 static double fast_flush(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.fast_flush", v);
 #if HAVE_IV
-    if (hoc_usegui) {((ShapePlot*) v)->fast_flush();
+    if (hoc_usegui) {
+        ((ShapePlot*) v)->fast_flush();
     }
 #endif
     return 1.;
@@ -73,10 +75,10 @@ static double sh_begin(void* v) {  // a noop. Exists only because graphs and
 static double sh_scale(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.scale", v);
 #if HAVE_IV
-    if (hoc_usegui) {((ShapePlot*) v)->scale(float(*getarg(1)), float(*getarg(2)));
-}
-else {
-    ((ShapePlotData*) v)->scale(float(*getarg(1)), float(*getarg(2)));
+    if (hoc_usegui) {
+        ((ShapePlot*) v)->scale(float(*getarg(1)), float(*getarg(2)));
+    } else {
+        ((ShapePlotData*) v)->scale(float(*getarg(1)), float(*getarg(2)));
     }
 #else
     ((ShapePlotData*) v)->scale(float(*getarg(1)), float(*getarg(2)));
@@ -94,19 +96,19 @@ static double sh_view(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.view", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapePlot* sh = (ShapePlot*) v;
-    sh->has_iv_view(true);
-    if (sh->varobj()) {
-        hoc_execerror("InterViews only supports string variables.", NULL);
-    }
-    if (ifarg(8)) {
-        Coord x[8];
-        int i;
-        for (i = 0; i < 8; ++i) {
-            x[i] = *getarg(i + 1);
+        ShapePlot* sh = (ShapePlot*) v;
+        sh->has_iv_view(true);
+        if (sh->varobj()) {
+            hoc_execerror("InterViews only supports string variables.", NULL);
         }
-        sh->view(x);
-    }
+        if (ifarg(8)) {
+            Coord x[8];
+            int i;
+            for (i = 0; i < 8; ++i) {
+                x[i] = *getarg(i + 1);
+            }
+            sh->view(x);
+        }
     }
 #endif
     return 1.;
@@ -127,13 +129,13 @@ static double sh_variable(void* v) {
         }
 #if HAVE_IV
         if (hoc_usegui) {
-        if (sh->has_iv_view()) {
-            nrnpy_decref(py_var_);
-            hoc_execerror("InterViews only supports string variables.", NULL);
-        }
-        nrnpy_decref(sh->varobj());
-        sh->varobj(py_var_);
-        return 1;
+            if (sh->has_iv_view()) {
+                nrnpy_decref(py_var_);
+                hoc_execerror("InterViews only supports string variables.", NULL);
+            }
+            nrnpy_decref(sh->varobj());
+            sh->varobj(py_var_);
+            return 1;
         }
 #endif
         nrnpy_decref(spd->varobj());
@@ -145,18 +147,18 @@ static double sh_variable(void* v) {
     if (s) {
 #if HAVE_IV
         if (hoc_usegui) {
-        if (nrnpy_decref) {
-            nrnpy_decref(sh->varobj());
-        }
+            if (nrnpy_decref) {
+                nrnpy_decref(sh->varobj());
+            }
 
-        sh->varobj(NULL);
-        sh->variable(s);
-    } else {
-        if (nrnpy_decref) {
-            nrnpy_decref(spd->varobj());
-        }
-        spd->varobj(NULL);
-        spd->variable(s);
+            sh->varobj(NULL);
+            sh->variable(s);
+        } else {
+            if (nrnpy_decref) {
+                nrnpy_decref(spd->varobj());
+            }
+            spd->varobj(NULL);
+            spd->variable(s);
         }
 #else
         if (nrnpy_decref) {
@@ -174,7 +176,7 @@ static double sh_view_count(void* v) {
     int n = 0;
 #if HAVE_IV
     if (hoc_usegui) {
-    n = ((ShapeScene*) v)->view_count();
+        n = ((ShapeScene*) v)->view_count();
     }
 #endif
     return double(n);
@@ -183,7 +185,8 @@ static double sh_view_count(void* v) {
 static double sh_save_name(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.save_name", v);
 #if HAVE_IV
-    if (hoc_usegui) {((ShapeScene*) v)->name(gargstr(1));
+    if (hoc_usegui) {
+        ((ShapeScene*) v)->name(gargstr(1));
     }
 #endif
     return 1.;
@@ -193,8 +196,8 @@ static double sh_unmap(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.unmap", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapeScene* s = (ShapeScene*) v;
-    s->dismiss();
+        ShapeScene* s = (ShapeScene*) v;
+        s->dismiss();
     }
 #endif
     return 0.;
@@ -204,8 +207,8 @@ static double sh_printfile(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.printfile", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapeScene* s = (ShapeScene*) v;
-    s->printfile(gargstr(1));
+        ShapeScene* s = (ShapeScene*) v;
+        s->printfile(gargstr(1));
     }
 #endif
     return 1.;
@@ -216,19 +219,18 @@ static double sh_show(void* v) {
     hoc_return_type_code = 1;
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapeScene* s = (ShapeScene*) v;
-    if (ifarg(1)) {
-        s->shape_type(int(chkarg(1, 0., 2.)));
+        ShapeScene* s = (ShapeScene*) v;
+        if (ifarg(1)) {
+            s->shape_type(int(chkarg(1, 0., 2.)));
+        } else {
+            return s->shape_type();
+        }
     } else {
-        return s->shape_type();
-    }
-}
-else {
-    if (ifarg(1)) {
-        ((ShapePlotData*) v)->set_mode(int(chkarg(1, 0., 2.)));
-    } else {
-        return ((ShapePlotData*) v)->get_mode();
-    }
+        if (ifarg(1)) {
+            ((ShapePlotData*) v)->set_mode(int(chkarg(1, 0., 2.)));
+        } else {
+            return ((ShapePlotData*) v)->get_mode();
+        }
     }
 #else
     if (ifarg(1)) {
@@ -246,19 +248,19 @@ static double s_colormap(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.colormap", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapePlot* s = (ShapePlot*) v;
-    if (ifarg(4)) {
-        s->color_value()->colormap(int(chkarg(1, 0, 255)),
-                                   int(chkarg(2, 0, 255)),
-                                   int(chkarg(3, 0, 255)),
-                                   int(chkarg(4, 0, 255)));
-    } else {
-        bool b = false;
-        if (ifarg(2)) {
-            b = (bool) chkarg(2, 0, 1);
+        ShapePlot* s = (ShapePlot*) v;
+        if (ifarg(4)) {
+            s->color_value()->colormap(int(chkarg(1, 0, 255)),
+                                       int(chkarg(2, 0, 255)),
+                                       int(chkarg(3, 0, 255)),
+                                       int(chkarg(4, 0, 255)));
+        } else {
+            bool b = false;
+            if (ifarg(2)) {
+                b = (bool) chkarg(2, 0, 1);
+            }
+            s->color_value()->colormap(int(chkarg(1, 0, 1000)), b);
         }
-        s->color_value()->colormap(int(chkarg(1, 0, 1000)), b);
-    }
     }
 #endif
     return 1.;
@@ -268,16 +270,16 @@ static double sh_hinton(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.hinton", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapeScene* ss = (ShapeScene*) v;
-    neuron::container::data_handle<double> pd = hoc_hgetarg<double>(1);
-    double xsize = chkarg(4, 1e-9, 1e9);
-    double ysize = xsize;
-    if (ifarg(5)) {
-        ysize = chkarg(5, 1e-9, 1e9);
-    }
-    Hinton* h = new Hinton(pd, xsize, ysize, ss);
-    ss->append(new FastGraphItem(h));
-    ss->move(ss->count() - 1, *getarg(2), *getarg(3));
+        ShapeScene* ss = (ShapeScene*) v;
+        neuron::container::data_handle<double> pd = hoc_hgetarg<double>(1);
+        double xsize = chkarg(4, 1e-9, 1e9);
+        double ysize = xsize;
+        if (ifarg(5)) {
+            ysize = chkarg(5, 1e-9, 1e9);
+        }
+        Hinton* h = new Hinton(pd, xsize, ysize, ss);
+        ss->append(new FastGraphItem(h));
+        ss->move(ss->count() - 1, *getarg(2), *getarg(3));
     }
 #endif
     return 1.;
@@ -286,7 +288,8 @@ static double sh_hinton(void* v) {
 static double exec_menu(void* v) {
     TRY_GUI_REDIRECT_ACTUAL_DOUBLE("PlotShape.exec_menu", v);
 #if HAVE_IV
-    if (hoc_usegui) {((Scene*) v)->picker()->exec_item(gargstr(1));
+    if (hoc_usegui) {
+        ((Scene*) v)->picker()->exec_item(gargstr(1));
     }
 #endif
     return 0.;
@@ -363,8 +366,8 @@ static void* sh_cons(Object* ho) {
             check_obj_type(ob, "SectionList");
 #if HAVE_IV
             if (hoc_usegui) {
-            sl = new SectionList(ob);
-            sl->ref();
+                sl = new SectionList(ob);
+                sl->ref();
             }
 #endif
             ++iarg;
@@ -375,21 +378,20 @@ static void* sh_cons(Object* ho) {
     }
 #if HAVE_IV
     if (hoc_usegui) {
-    ShapePlot* sh = NULL;
-    sh = new ShapePlot(NULL, sl);
-    sh->has_iv_view(i ? true : false);
-    sh->varobj(NULL);
-    Resource::unref(sl);
-    sh->ref();
-    sh->hoc_obj_ptr(ho);
-    if (i) {
-        sh->view(200);
-    }
-    return (void*) sh;
-}
-else {
-    ShapePlotData* spd = new ShapePlotData(NULL, ob);
-    return (void*) spd;
+        ShapePlot* sh = NULL;
+        sh = new ShapePlot(NULL, sl);
+        sh->has_iv_view(i ? true : false);
+        sh->varobj(NULL);
+        Resource::unref(sl);
+        sh->ref();
+        sh->hoc_obj_ptr(ho);
+        if (i) {
+            sh->view(200);
+        }
+        return (void*) sh;
+    } else {
+        ShapePlotData* spd = new ShapePlotData(NULL, ob);
+        return (void*) spd;
     }
 #else
     ShapePlotData* sh = new ShapePlotData(NULL, ob);
@@ -401,18 +403,17 @@ static void sh_destruct(void* v) {
     TRY_GUI_REDIRECT_NO_RETURN("~PlotShape", v);
 #if HAVE_IV
     if (hoc_usegui) {
-    if (nrnpy_decref) {
-        ShapePlot* sp = (ShapePlot*) v;
-        nrnpy_decref(sp->varobj());
-    }
+        if (nrnpy_decref) {
+            ShapePlot* sp = (ShapePlot*) v;
+            nrnpy_decref(sp->varobj());
+        }
 
-    ((ShapeScene*) v)->dismiss();
-}
-else {
-    if (nrnpy_decref) {
-        ShapePlotData* sp = (ShapePlotData*) v;
-        nrnpy_decref(sp->varobj());
-    }
+        ((ShapeScene*) v)->dismiss();
+    } else {
+        if (nrnpy_decref) {
+            ShapePlotData* sp = (ShapePlotData*) v;
+            nrnpy_decref(sp->varobj());
+        }
     }
     Resource::unref((ShapeScene*) v);
 #else

--- a/src/nrniv/spaceplt.cpp
+++ b/src/nrniv/spaceplt.cpp
@@ -350,7 +350,7 @@ void RangeVarPlot::set_color(int new_color) {
     color_ = new_color;
 #if HAVE_IV
     if (hoc_usegui) {
-    color(colors->color(color_));
+        color(colors->color(color_));
     }
 #endif
 }

--- a/src/nrniv/spaceplt.cpp
+++ b/src/nrniv/spaceplt.cpp
@@ -349,9 +349,9 @@ int RangeVarPlot::get_color(void) {
 void RangeVarPlot::set_color(int new_color) {
     color_ = new_color;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
     color(colors->color(color_));
-    ENDGUI
+    }
 #endif
 }
 

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -2863,11 +2863,11 @@ extern "C" NRN_EXPORT PyObject* get_plotshape_data(PyObject* sp) {
     }
     void* that = pho->ho_->u.this_pointer;
 #if HAVE_IV
-    IFGUI
+    if (hoc_usegui) {
         spi = ((ShapePlot*) that);
     } else {
         spi = ((ShapePlotData*) that);
-    ENDGUI
+    }
 #else
     spi = ((ShapePlotData*) that);
 #endif

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -1651,12 +1651,12 @@ int hoc_get_line(void) { /* supports re-entry. fill cbuf with next line */
 #if INTERVIEWS
 #ifdef MINGW
             if (hoc_usegui) {
-            if (hoc_interviews && !hoc_in_yyparse) {
-                rl_getc_function = getc_hook;
-                hoc_notify_value();
-            } else {
-                rl_getc_function = rl_getc;
-            }
+                if (hoc_interviews && !hoc_in_yyparse) {
+                    rl_getc_function = getc_hook;
+                    hoc_notify_value();
+                } else {
+                    rl_getc_function = rl_getc;
+                }
             }
 #else /* not MINGW */
 #if defined(use_rl_getc_function)
@@ -1743,7 +1743,7 @@ void hoc_help(void) {
 #endif
     {
         if (hoc_usegui) {
-        hoc_warning("Help only available from version with ivoc library", 0);
+            hoc_warning("Help only available from version with ivoc library", 0);
         }
     }
     ctp = cbuf + strlen(cbuf) - 1;

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -1650,14 +1650,14 @@ int hoc_get_line(void) { /* supports re-entry. fill cbuf with next line */
             int n;
 #if INTERVIEWS
 #ifdef MINGW
-            IFGUI
+            if (hoc_usegui) {
             if (hoc_interviews && !hoc_in_yyparse) {
                 rl_getc_function = getc_hook;
                 hoc_notify_value();
             } else {
                 rl_getc_function = rl_getc;
             }
-            ENDGUI
+            }
 #else /* not MINGW */
 #if defined(use_rl_getc_function)
             if (hoc_interviews && !hoc_in_yyparse) {
@@ -1742,9 +1742,9 @@ void hoc_help(void) {
     } else
 #endif
     {
-        IFGUI
+        if (hoc_usegui) {
         hoc_warning("Help only available from version with ivoc library", 0);
-        ENDGUI
+        }
     }
     ctp = cbuf + strlen(cbuf) - 1;
 }

--- a/src/oc/hocdec.h
+++ b/src/oc/hocdec.h
@@ -282,8 +282,9 @@ using neuron::Sprintf;
 
 #define ERRCHK(c1) c1
 
-#define IFGUI  if (hoc_usegui) {
-#define ENDGUI }
+// No longer used because of clang format difficulty
+// #define IFGUI  if (hoc_usegui) {
+// #define ENDGUI }
 
 extern int hoc_usegui; /* when 0 does not make interviews calls */
 extern int nrn_istty_;


### PR DESCRIPTION
This replaces all the IFGUI, ENDGUI macros with their expansion
```
if (hoc_usegui) {
```
and
```
}
```
respectively.
The consequence is a lot of clang-format changes because there is now block indentation.