### PR TITLE
Pin setuptools to a known working version

### DIFF
--- a/nrn_requirements.txt
+++ b/nrn_requirements.txt
@@ -1,6 +1,6 @@
 wheel
-setuptools
 setuptools_scm
+setuptools<=70.3.0
 scikit-build
 matplotlib
 # bokeh 3 seems to break docs notebooks

--- a/setup.py
+++ b/setup.py
@@ -513,7 +513,7 @@ def setup_package():
             "numpy>=1.9.3,<2",
             "packaging",
             "find_libpython",
-            "setuptools",
+            "setuptools<=70.3.0",
         ]
         + (
             [


### PR DESCRIPTION
Same as #3006 but for master.
The problem happens when we build the docs (see for example [here](https://github.com/neuronsimulator/nrn/actions/runs/9987803705/job/27604344375)), with the strange stack trace:

```python
  File "/opt/hostedtoolcache/Python/3.12.4/x64/lib/python3.12/site-packages/setuptools/_core_metadata.py", line 284, in _distribution_fullname
    canonicalize_version(version, strip_trailing_zero=False),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'
```

I think the problem is [this setuptools commit](https://github.com/pypa/setuptools/commit/d4352b5d6653d44a6604532436c37fe1f62e7b02), in which they start using `from packaging.utils import canonicalize_version`, and since we install `packaging==21.2` (see https://github.com/neuronsimulator/nrn/pull/2706 for the explanation), which _doesn't_ have the argument `strip_trailing_zero`, we get the error above. Using an older version of setuptools fixes the issue.