### PR TITLE
Add specific NumPy version for aarch64 build

### DIFF
--- a/packaging/python/build_requirements.txt
+++ b/packaging/python/build_requirements.txt
@@ -2,7 +2,7 @@ cython<3
 packaging
 numpy==1.17.5;python_version=='3.8'
 numpy==1.19.3;python_version=='3.9' and platform_machine=='x86_64'
-numpy==1.21.3;python_version=='3.9' and platform_machine=='arm64'
+numpy==1.21.3;python_version=='3.9' and (platform_machine=='arm64' or platform_machine=='aarch64')
 numpy==1.21.3;python_version=='3.10'
 numpy==1.23.5;python_version=='3.11'
 numpy==1.26.0;python_version=='3.12'


### PR DESCRIPTION
A CircleCI job is failing with the complaint that NumPy is not installed: https://app.circleci.com/pipelines/github/neuronsimulator/nrn/8756/workflows/e1ae34a6-b797-4194-a845-b6ef786442bd/jobs/4361/parallel-runs/0/steps/0-102?invite=true#step-102-14398_81

As it happens, `platform.machine()` on MacOS M1/2/N returns `arm64`, but on Linux it returns `aarch64`, so no version of NumPy was installed when running the CircleCI job on Python 3.9. Looking over the versions on [PyPI](https://pypi.org/project/numpy/1.21.3/#files), I think the same one as the one we use for `arm64` should be compatible.