### PR TITLE
Fix various CI issues

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           python3 -m venv music-venv
           source music-venv/bin/activate
-          python3 -m pip install mpi4py "cython<3" 'numpy<2' setuptools
+          python3 -m pip install 'mpi4py<4' "cython<3" 'numpy<2' setuptools
           sudo mkdir -p $MUSIC_INSTALL_DIR
           sudo chown -R $USER $MUSIC_INSTALL_DIR
           curl -L -o MUSIC.zip https://github.com/INCF/MUSIC/archive/refs/tags/${MUSIC_VERSION}.zip

--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -207,7 +207,7 @@ jobs:
         run: |
           python3 -m venv music-venv
           source music-venv/bin/activate
-          python3 -m pip install mpi4py "cython<3" 'numpy<2' setuptools
+          python3 -m pip install 'mpi4py<4' "cython<3" 'numpy<2' setuptools
           sudo mkdir -p $MUSIC_INSTALL_DIR
           sudo chown -R $USER $MUSIC_INSTALL_DIR
           curl -L -o MUSIC.zip https://github.com/INCF/MUSIC/archive/refs/tags/${MUSIC_VERSION}.zip

--- a/nrn_requirements.txt
+++ b/nrn_requirements.txt
@@ -10,6 +10,6 @@ cython<3
 packaging
 pytest<=8.1.1 # potential bug from 8.2.0 due to parallelism?
 pytest-cov
-mpi4py
+mpi4py<4 # MUSIC not compatible with MPI 4
 numpy<2
 find_libpython

--- a/packaging/python/build_requirements.txt
+++ b/packaging/python/build_requirements.txt
@@ -1,8 +1,8 @@
 cython<3
 packaging
 numpy==1.17.5;python_version=='3.8'
-numpy==1.19.3;python_version=='3.9' and platform_machine=='x86_64'
+numpy==1.19.3;python_version=='3.9' and platform_machine!='arm64'
 numpy==1.21.3;python_version=='3.9' and platform_machine=='arm64'
-numpy==1.21.3;python_version=='3.10'
+numpy==1.21.4;python_version=='3.10'
 numpy==1.23.5;python_version=='3.11'
 numpy==1.26.0;python_version=='3.12'


### PR DESCRIPTION
- NumPy 1.21.3 has the wrong tag on MacOS with Python 3.10, so `pip check` started failing
- NumPy was not being installed on Python 3.9 on aarch64 due to missing arch spec
- mpi4py version 4 does not appear to be compatible with MUSIC, so we pin it to <4 everywhere