### PR TITLE
fix: Add Git version check for --depth option in submodule update

### DIFF
--- a/cmake/ExternalProjectHelper.cmake
+++ b/cmake/ExternalProjectHelper.cmake
@@ -29,7 +29,11 @@ function(nrn_initialize_submodule path)
     list(APPEND UPDATE_OPTIONS --recursive)
   endif()
   if(opt_SHALLOW)
-    list(APPEND UPDATE_OPTIONS --depth 1)
+    # RHEL7-family distributions ship with an old git that does not support the --depth argument to
+    # git submodule update
+    if(GIT_VERSION_STRING VERSION_GREATER_EQUAL "1.8.4")
+      list(APPEND UPDATE_OPTIONS --depth 1)
+    endif()
   endif()
   if(NOT ${GIT_FOUND})
     message(


### PR DESCRIPTION
Took the fix from here:
https://github.com/BlueBrain/hpc-coding-conventions/blob/3d157f9c8ea94d196a825aaa7f523265e360dc4b/cpp/cmake/3rdparty.cmake#L24