### PR TITLE
Improve wheel-building experience on multi-arch MacOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -148,8 +148,8 @@ stages:
           export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
           export NRN_BUILD_FOR_UPLOAD=1
-          sudo mkdir /opt/nrnwheel
-          sudo tar -zxf $(readlineSF.secureFilePath) --directory /opt/nrnwheel/
+          sudo mkdir -p /opt/nrnwheel/$(uname -m)
+          sudo tar -zxf $(readlineSF.secureFilePath) --directory /opt/nrnwheel/$(uname -m)
           packaging/python/build_wheels.bash osx $(python.version) coreneuron
         displayName: 'Build MacOS Wheel'
 

--- a/packaging/python/build_static_readline_osx.bash
+++ b/packaging/python/build_static_readline_osx.bash
@@ -8,22 +8,20 @@ set -xe
 #  - C/C++ compiler
 #  - /opt/nrnwheel folder created with access rights (this specific path is kept for consistency wrt `build_wheels.bash`)
 
-set -e
-
-if [[ `uname -s` != 'Darwin' ]]; then
+if [[ "$(uname -s)" != 'Darwin' ]]; then
     echo "Error: this script is for macOS only. readline is already built statically in the linux Docker images"
     exit 1
 fi
 
-NRNWHEEL_DIR=/opt/nrnwheel
+NRNWHEEL_DIR="${1:-/opt/nrnwheel/$(uname -m)}"
 if [[ ! -d "$NRNWHEEL_DIR" || ! -x "$NRNWHEEL_DIR" ]]; then
-    echo "Error: /opt/nrnwheel must exist and be accessible, i.e: sudo mkdir -p /opt/nrnwheel && sudo chown -R $USER /opt/nrnwheel"
+    echo "Error: ${NRNWHEEL_DIR} must exist and be accessible, i.e: sudo mkdir -p ${NRNWHEEL_DIR} && sudo chown -R ${USER} ${NRNWHEEL_DIR}"
     exit 1
 fi
 
 # Set MACOSX_DEPLOYMENT_TARGET based on wheel arch.
 # For upcoming `universal2` wheels we will consider leveling everything to 11.0.
-if [[ `uname -m` == 'arm64' ]]; then
+if [[ "$(uname -m)" == 'arm64' ]]; then
 	export MACOSX_DEPLOYMENT_TARGET=11.0  # for arm64 we need 11.0
 else
 	export MACOSX_DEPLOYMENT_TARGET=10.9  # for x86_64
@@ -32,16 +30,16 @@ fi
 (wget http://ftpmirror.gnu.org/ncurses/ncurses-6.4.tar.gz \
     && tar -xvzf ncurses-6.4.tar.gz \
     && cd ncurses-6.4  \
-    && ./configure --prefix=/opt/nrnwheel/ncurses --without-shared CFLAGS="-fPIC" \
+    && ./configure --prefix="${NRNWHEEL_DIR}/ncurses" --without-shared CFLAGS="-fPIC" \
     && make -j install)
 
 (curl -L -o readline-7.0.tar.gz https://ftp.gnu.org/gnu/readline/readline-7.0.tar.gz \
     && tar -xvzf readline-7.0.tar.gz \
     && cd readline-7.0  \
-    && ./configure --prefix=/opt/nrnwheel/readline --disable-shared CFLAGS="-fPIC" \
+    && ./configure --prefix="${NRNWHEEL_DIR}/readline" --disable-shared CFLAGS="-fPIC" \
     && make -j install)
 
-(cd /opt/nrnwheel/readline/lib \
+(cd "${NRNWHEEL_DIR}/readline/lib" \
     && ar -x libreadline.a \
     && ar -x ../../ncurses/lib/libncurses.a \
     && ar cq libreadline.a *.o \
@@ -50,8 +48,7 @@ fi
 RDL_MINOS=`otool -l /opt/nrnwheel/readline/lib/libreadline.a | grep -e "minos \|version " | uniq | awk '{print $2}'`
 
 if [ "$RDL_MINOS" != "$MACOSX_DEPLOYMENT_TARGET" ]; then 
-	echo "Error: /opt/nrnwheel/readline/lib/libreadline.a doesn't match MACOSX_DEPLOYMENT_TARGET ($MACOSX_DEPLOYMENT_TARGET)"
+	echo "Error: ${NRNWHEEL_DIR}/readline/lib/libreadline.a doesn't match MACOSX_DEPLOYMENT_TARGET ($MACOSX_DEPLOYMENT_TARGET)"
 	exit 1
 fi
-
 echo "Done." 

--- a/packaging/python/build_static_readline_osx.bash
+++ b/packaging/python/build_static_readline_osx.bash
@@ -27,7 +27,7 @@ else
 	export MACOSX_DEPLOYMENT_TARGET=10.9  # for x86_64
 fi
 
-(wget http://ftpmirror.gnu.org/ncurses/ncurses-6.4.tar.gz \
+(curl -L -o ncurses-6.4.tar.gz http://ftpmirror.gnu.org/ncurses/ncurses-6.4.tar.gz \
     && tar -xvzf ncurses-6.4.tar.gz \
     && cd ncurses-6.4  \
     && ./configure --prefix="${NRNWHEEL_DIR}/ncurses" --without-shared CFLAGS="-fPIC" \
@@ -45,7 +45,7 @@ fi
     && ar cq libreadline.a *.o \
     && rm *.o)
 
-RDL_MINOS=`otool -l /opt/nrnwheel/readline/lib/libreadline.a | grep -e "minos \|version " | uniq | awk '{print $2}'`
+RDL_MINOS="$(otool -l /opt/nrnwheel/readline/lib/libreadline.a | grep -e "minos \|version " | uniq | awk '{print $2}')"
 
 if [ "$RDL_MINOS" != "$MACOSX_DEPLOYMENT_TARGET" ]; then 
 	echo "Error: ${NRNWHEEL_DIR}/readline/lib/libreadline.a doesn't match MACOSX_DEPLOYMENT_TARGET ($MACOSX_DEPLOYMENT_TARGET)"

--- a/packaging/python/build_static_readline_osx.bash
+++ b/packaging/python/build_static_readline_osx.bash
@@ -5,14 +5,16 @@ set -eux
 # PREREQUESITES:
 #  - curl
 #  - C/C++ compiler
-#  - /opt/nrnwheel folder created with access rights (this specific path is kept for consistency wrt `build_wheels.bash`)
+#  - /opt/nrnwheel/[ARCH] folder created with access rights (this specific path is kept for consistency wrt `build_wheels.bash`)
 
 if [[ "$(uname -s)" != 'Darwin' ]]; then
     echo "Error: this script is for macOS only. readline is already built statically in the linux Docker images"
     exit 1
 fi
 
-NRNWHEEL_DIR="${1:-/opt/nrnwheel/$(uname -m)}"
+ARCH="$(uname -m)"
+
+NRNWHEEL_DIR="${1:-/opt/nrnwheel/${ARCH}}"
 if [[ ! -d "$NRNWHEEL_DIR" || ! -x "$NRNWHEEL_DIR" ]]; then
     echo "Error: ${NRNWHEEL_DIR} must exist and be accessible, i.e: sudo mkdir -p ${NRNWHEEL_DIR} && sudo chown -R ${USER} ${NRNWHEEL_DIR}"
     exit 1
@@ -20,7 +22,7 @@ fi
 
 # Set MACOSX_DEPLOYMENT_TARGET based on wheel arch.
 # For upcoming `universal2` wheels we will consider leveling everything to 11.0.
-if [[ "$(uname -m)" == 'arm64' ]]; then
+if [[ "${ARCH}" == 'arm64' ]]; then
 	export MACOSX_DEPLOYMENT_TARGET=11.0  # for arm64 we need 11.0
 else
 	export MACOSX_DEPLOYMENT_TARGET=10.9  # for x86_64

--- a/packaging/python/build_static_readline_osx.bash
+++ b/packaging/python/build_static_readline_osx.bash
@@ -4,7 +4,6 @@ set -xe
 #
 # PREREQUESITES:
 #  - curl
-#  - wget
 #  - C/C++ compiler
 #  - /opt/nrnwheel folder created with access rights (this specific path is kept for consistency wrt `build_wheels.bash`)
 
@@ -45,7 +44,7 @@ fi
     && ar cq libreadline.a *.o \
     && rm *.o)
 
-RDL_MINOS="$(otool -l /opt/nrnwheel/readline/lib/libreadline.a | grep -e "minos \|version " | uniq | awk '{print $2}')"
+RDL_MINOS="$(otool -l "${NRNWHEEL_DIR}/readline/lib/libreadline.a" | grep -e "minos \|version " | uniq | awk '{print $2}')"
 
 if [ "$RDL_MINOS" != "$MACOSX_DEPLOYMENT_TARGET" ]; then 
 	echo "Error: ${NRNWHEEL_DIR}/readline/lib/libreadline.a doesn't match MACOSX_DEPLOYMENT_TARGET ($MACOSX_DEPLOYMENT_TARGET)"

--- a/packaging/python/build_static_readline_osx.bash
+++ b/packaging/python/build_static_readline_osx.bash
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -xe
+set -eux
 # A script to build a static readline library for osx
 #
 # PREREQUESITES:

--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -160,7 +160,7 @@ build_wheel_osx() {
       fi
     fi
 
-    python setup.py build_ext --cmake-prefix="/opt/nrnwheel/ncurses;/opt/nrnwheel/readline;/usr/x11" --cmake-defs="$CMAKE_DEFS" $setup_args bdist_wheel
+    python setup.py build_ext --cmake-prefix="/opt/nrnwheel/$(uname -m)/ncurses;/opt/nrnwheel/$(uname -m)/readline;/usr/x11" --cmake-defs="$CMAKE_DEFS" $setup_args bdist_wheel
 
     echo " - Calling delocate-listdeps"
     delocate-listdeps dist/*.whl


### PR DESCRIPTION
The `build_static_readline_osx.bash` script is a bit inflexible and cumbersome to use if trying to perform NEURON builds on both arm64 and x86_64; for instance, it installs everything to `/opt/nrnwheel`, which means that it doesn't really differentiate between arches, so if one wants to build a wheel, one has to remember to (re)install the readline library for the correct arch, otherwise we end up with many warnings about incompatible archs, and eventually the linker complaining about missing symbols.
This PR basically improves this by moving the install location to `/opt/nrnwheel/[ARCH]`, where `[ARCH]` is detected the usual way. This means we can use `build_static_readline_osx.bash` on either arch, and it won't clobber any existing install of the other arch. One can also specify a custom install location by passing a single argument to `build_static_readline_osx.bash`.

Note that Linux builds should not be affected by any of these changes.