### PR TITLE
Add `_cvode_abstol` to header

### DIFF
--- a/src/nrnoc/nrn_ansi.h
+++ b/src/nrnoc/nrn_ansi.h
@@ -23,6 +23,7 @@ extern void hoc_register_units(int, HocParmUnits*);
 extern void hoc_register_dparam_semantics(int, int, const char*);
 extern void add_nrn_fornetcons(int, int);
 extern void hoc_register_tolerance(int, HocStateTolerance*, Symbol***);
+extern void _cvode_abstol(Symbol**, double*, int);
 
 extern void oc_save_cabcode(int* a1, int* a2);
 extern void oc_restore_cabcode(int* a1, int* a2);


### PR DESCRIPTION
This is needed for NMODL-generated files, i.e. CVode codegen. Not sure if this is the correct header to place it though.