### PR TITLE
Remove `ERRCHK` macro

### DIFF
--- a/src/oc/fileio.cpp
+++ b/src/oc/fileio.cpp
@@ -91,14 +91,16 @@ void wopen(void) /* open file for writing */
     else
         fname = "";
     d = 1.;
-    if (fout != stdout)
-        ERRCHK(IGNORE(fclose(fout));)
+    if (fout != stdout) {
+        IGNORE(fclose(fout));
+    }
     fout = stdout;
-    if (fname[0] != 0)
-        ERRCHK(if ((fout = fopen(expand_env_var(fname), "w")) == (FILE*) 0) {
+    if (fname[0] != 0) {
+        if ((fout = fopen(expand_env_var(fname), "w")) == nullptr) {
             d = 0.;
             fout = stdout;
-        })
+        }
+    }
     errno = 0;
     ret();
     pushx(d);

--- a/src/oc/hocdec.h
+++ b/src/oc/hocdec.h
@@ -276,8 +276,6 @@ int ilint;
 #endif
 using neuron::Sprintf;
 
-#define ERRCHK(c1) c1
-
 // No longer used because of clang format difficulty
 // #define IFGUI  if (hoc_usegui) {
 // #define ENDGUI }


### PR DESCRIPTION
It doesn't do anything really, i.e. it's the identity map.