### PR TITLE
fix the -Wall warnings for containers

### DIFF
--- a/src/coreneuron/utils/profile/profiler_interface.h
+++ b/src/coreneuron/utils/profile/profiler_interface.h
@@ -48,8 +48,10 @@ namespace detail {
  */
 template <class... TProfilerImpl>
 struct Instrumentor {
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-value"
+#endif  // __clang__
     /*! \fn phase_begin
      *  \brief Activate the collection of profiling data within a code region.
      *
@@ -147,7 +149,9 @@ struct Instrumentor {
     inline static void finalize_profile() {
         std::initializer_list<int>{(TProfilerImpl::finalize_profile(), 0)...};
     }
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif  // __clang__
 
   private:
     /*!

--- a/src/neuron/container/soa_container.hpp
+++ b/src/neuron/container/soa_container.hpp
@@ -463,7 +463,7 @@ struct field_data<Tag, FieldImplementation::RuntimeVariable> {
      */
     template <may_cause_reallocation might_reallocate, typename Callable>
     Callable for_each_vector(Callable callable) {
-        for (auto i = 0; i < m_storage.size(); ++i) {
+        for (std::size_t i = 0; i < m_storage.size(); ++i) {
             callable(m_tag, m_storage[i], i, m_array_dims[i]);
         }
         if constexpr (might_reallocate == may_cause_reallocation::Yes) {
@@ -480,7 +480,7 @@ struct field_data<Tag, FieldImplementation::RuntimeVariable> {
      */
     template <typename Callable>
     Callable for_each_vector(Callable callable) const {
-        for (auto i = 0; i < m_storage.size(); ++i) {
+        for (std::size_t i = 0; i < m_storage.size(); ++i) {
             callable(m_tag, m_storage[i], i, m_array_dims[i]);
         }
 

--- a/src/neuron/model_data.hpp
+++ b/src/neuron/model_data.hpp
@@ -35,7 +35,7 @@ struct Model {
      */
     template <typename Callable>
     void apply_to_mechanisms(Callable const& callable) {
-        for (auto type = 0; type < m_mech_data.size(); ++type) {
+        for (std::size_t type = 0; type < m_mech_data.size(); ++type) {
             if (!m_mech_data[type]) {
                 continue;
             }
@@ -45,7 +45,7 @@ struct Model {
 
     template <typename Callable>
     void apply_to_mechanisms(Callable const& callable) const {
-        for (auto type = 0; type < m_mech_data.size(); ++type) {
+        for (std::size_t type = 0; type < m_mech_data.size(); ++type) {
             if (!m_mech_data[type]) {
                 continue;
             }
@@ -77,10 +77,10 @@ struct Model {
     /** @brief Destroy the structure holding the data of a particular mechanism.
      */
     void delete_mechanism(int type) {
-        if (type >= m_mech_data.size() || !m_mech_data[type]) {
+        if (type < 0 || std::size_t(type) >= m_mech_data.size() || !m_mech_data[type]) {
             return;
         }
-        if (auto const size = m_mech_data[type]->size(); size > 0) {
+        if (std::size_t const size = m_mech_data[type]->size(); size > 0) {
             throw std::runtime_error("delete_mechanism(" + std::to_string(type) +
                                      "): refusing to delete storage that still hosts " +
                                      std::to_string(size) + " instances");
@@ -105,7 +105,7 @@ struct Model {
     }
 
     [[nodiscard]] bool is_valid_mechanism(int type) const {
-        return 0 <= type && type < mechanism_storage_size() && m_mech_data[type];
+        return 0 <= type && std::size_t(type) < mechanism_storage_size() && m_mech_data[type];
     }
 
     /**
@@ -124,7 +124,7 @@ struct Model {
 
   private:
     container::Mechanism::storage& mechanism_data_impl(int type) const {
-        if (type < 0 || type >= m_mech_data.size()) {
+        if (type < 0 || std::size_t(type) >= m_mech_data.size()) {
             throw std::runtime_error("mechanism_data(" + std::to_string(type) +
                                      "): type out of range");
         }

--- a/src/nrniv/netpar.cpp
+++ b/src/nrniv/netpar.cpp
@@ -314,7 +314,7 @@ void NetParEvent::savestate_restore(double tt, NetCvode* nc) {
     if (ithread_ == 0) {
         // npe_->pr("savestate_restore", tt, nc);
         for (int i = 0; i < nrn_nthread; ++i)
-            if (npe_ + i) {
+            if (i < n_npe_) {
                 nc->event(tt, npe_ + i, nrn_threads + i);
             }
     }


### PR DESCRIPTION
Starting out with -Wall free for netpar.cpp and cabcode.cpp. Including neuron container files generated some very long messages.

See #3069 