### PR TITLE
Suppress unsigned-integer-overflow for fmt.

### DIFF
--- a/.sanitizers/undefined.supp
+++ b/.sanitizers/undefined.supp
@@ -31,6 +31,7 @@ unsigned-integer-overflow:_philox4x32bumpkey(r123array2x32)
 unsigned-integer-overflow:coreneuron::nrnran123_deletestream(coreneuron::nrnran123_State*, bool)
 unsigned-integer-overflow:coreneuron::nrnran123_newstream3(unsigned int, unsigned int, unsigned int, bool)
 unsigned-integer-overflow:Py_INCREF(_object*)
+unsigned-integer-overflow:fmt::*
 vptr:NetCon::disconnect(ivObservable*)
 vptr:ObjObservable::object()
 vptr:PreSyn::disconnect(ivObservable*)


### PR DESCRIPTION
Makes full use of unsigned integer math, including overflow behaviour. Hence, the sanitizer should ignore all unsigned integer overflows for anything fmt related.