### PR TITLE
Mark RXD test as skip on Ubuntu 22+

### DIFF
--- a/test/rxd/3d/test_multi_gridding_mix.py
+++ b/test/rxd/3d/test_multi_gridding_mix.py
@@ -8,7 +8,7 @@ sys.path.append("..")
 from testutils import check_platform, compare_data, tol
 
 
-@pytest.mark.xfail(
+@pytest.mark.skip(
     check_platform(),
     reason="See https://github.com/neuronsimulator/nrn-build-ci/issues/66",
 )

--- a/test/rxd/3d/test_multi_gridding_mix.py
+++ b/test/rxd/3d/test_multi_gridding_mix.py
@@ -8,7 +8,7 @@ sys.path.append("..")
 from testutils import check_platform, compare_data, tol
 
 
-@pytest.mark.skip(
+@pytest.mark.skipif(
     check_platform(),
     reason="See https://github.com/neuronsimulator/nrn-build-ci/issues/66",
 )

--- a/test/rxd/3d/test_multi_gridding_mix.py
+++ b/test/rxd/3d/test_multi_gridding_mix.py
@@ -1,10 +1,15 @@
+import pytest
+
 from neuron.units import µm, mM, ms, mV
-import sys
 
 sys.path.append("..")
-from testutils import compare_data, tol
+from testutils import compare_data, tol, skip_platform
 
 
+@pytest.mark.skipif(
+    skip_platform(),
+    reason="See https://github.com/neuronsimulator/nrn-build-ci/issues/66",
+)
 def test_multi_gridding_mix(neuron_instance):
     h, rxd, data, save_path = neuron_instance
     axon = h.Section(name="axon")

--- a/test/rxd/3d/test_multi_gridding_mix.py
+++ b/test/rxd/3d/test_multi_gridding_mix.py
@@ -8,7 +8,7 @@ sys.path.append("..")
 from testutils import compare_data, tol, skip_platform
 
 
-@pytest.mark.skipif(
+@pytest.mark.xfail(
     skip_platform(),
     reason="See https://github.com/neuronsimulator/nrn-build-ci/issues/66",
 )

--- a/test/rxd/3d/test_multi_gridding_mix.py
+++ b/test/rxd/3d/test_multi_gridding_mix.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from neuron.units import µm, mM, ms, mV

--- a/test/rxd/3d/test_multi_gridding_mix.py
+++ b/test/rxd/3d/test_multi_gridding_mix.py
@@ -5,11 +5,11 @@ import pytest
 from neuron.units import µm, mM, ms, mV
 
 sys.path.append("..")
-from testutils import compare_data, tol, skip_platform
+from testutils import check_platform, compare_data, tol
 
 
 @pytest.mark.xfail(
-    skip_platform(),
+    check_platform(),
     reason="See https://github.com/neuronsimulator/nrn-build-ci/issues/66",
 )
 def test_multi_gridding_mix(neuron_instance):

--- a/test/rxd/testutils.py
+++ b/test/rxd/testutils.py
@@ -130,7 +130,7 @@ def compare_data(data):
     return max_err
 
 
-def skip_platform():
+def check_platform():
     """Check whether there is an issue with the test on the current platform"""
     try:
         test_platform = platform.freedesktop_os_release()

--- a/test/rxd/testutils.py
+++ b/test/rxd/testutils.py
@@ -1,6 +1,8 @@
 import inspect
 import itertools
 import os
+import platform
+from packaging.version import Version
 
 import numpy
 
@@ -126,3 +128,22 @@ def compare_data(data):
     )
     max_err = numpy.amax(abs(corr_vals.T - tst_dat[t2_0:t2_n, 1:]))
     return max_err
+
+
+def skip_platform():
+    """Check whether there is an issue with the test on the current platform"""
+    try:
+        test_platform = platform.freedesktop_os_release().get("VERSION_ID")
+
+        # not a Ubuntu variant
+        if not test_platform:
+            return False
+
+        # skip Ubuntu 22 and above
+        return Version(test_platform) > Version("22")
+
+    # not a Linux variant (or a supported one anyway)
+    except (AttributeError, OSError):
+        return False
+
+    return False

--- a/test/rxd/testutils.py
+++ b/test/rxd/testutils.py
@@ -133,14 +133,12 @@ def compare_data(data):
 def skip_platform():
     """Check whether there is an issue with the test on the current platform"""
     try:
-        test_platform = platform.freedesktop_os_release().get("VERSION_ID")
-
-        # not a Ubuntu variant
-        if not test_platform:
-            return False
+        test_platform = platform.freedesktop_os_release()
 
         # skip Ubuntu 22 and above
-        return Version(test_platform) > Version("22")
+        return test_platform.get("ID") == "ubuntu" and Version(
+            test_platform["VERSION_ID"]
+        ) > Version("22")
 
     # not a Linux variant (or a supported one anyway)
     except (AttributeError, OSError):

--- a/test/rxd/testutils.py
+++ b/test/rxd/testutils.py
@@ -141,7 +141,5 @@ def skip_platform():
         ) > Version("22")
 
     # not a Linux variant (or a supported one anyway)
-    except (AttributeError, OSError):
+    except Exception:
         return False
-
-    return False

--- a/test/rxd/testutils.py
+++ b/test/rxd/testutils.py
@@ -1,8 +1,6 @@
 import inspect
 import itertools
 import os
-import platform
-from packaging.version import Version
 
 import numpy
 
@@ -128,18 +126,3 @@ def compare_data(data):
     )
     max_err = numpy.amax(abs(corr_vals.T - tst_dat[t2_0:t2_n, 1:]))
     return max_err
-
-
-def check_platform():
-    """Check whether there is an issue with the test on the current platform"""
-    try:
-        test_platform = platform.freedesktop_os_release()
-
-        # skip Ubuntu 22 and above
-        return test_platform.get("ID") == "ubuntu" and Version(
-            test_platform["VERSION_ID"]
-        ) > Version("22")
-
-    # not a Linux variant (or a supported one anyway)
-    except Exception:
-        return False


### PR DESCRIPTION
This is a _workaround, not a fix_, for https://github.com/neuronsimulator/nrn-build-ci/issues/66.
To minimize headaches, it shouldn't have any impact on anything other than that one test being marked as `skip` on Ubuntu 22 and newer.
See for instance https://github.com/neuronsimulator/nrn-build-ci/actions/runs/10955119487/job/30418368871