### PR TITLE
Remove deprecated test methods

### DIFF
--- a/share/lib/python/neuron/tests/test_neuron.py
+++ b/share/lib/python/neuron/tests/test_neuron.py
@@ -294,8 +294,7 @@ def suite():
         ]
     except:
         pass
-    suite = unittest.makeSuite(NeuronTestCase, "test")
-    return suite
+    return unittest.defaultTestLoader.loadTestsFromTestCase(NeuronTestCase)
 
 
 if __name__ == "__main__":

--- a/share/lib/python/neuron/tests/test_rxd.py
+++ b/share/lib/python/neuron/tests/test_rxd.py
@@ -798,8 +798,7 @@ class RxDTestCase(unittest.TestCase):
 
 
 def suite():
-    suite = unittest.makeSuite(RxDTestCase, "test")
-    return suite
+    return unittest.defaultTestLoader.loadTestsFromTestCase(RxDTestCase)
 
 
 def test():

--- a/share/lib/python/neuron/tests/test_vector.py
+++ b/share/lib/python/neuron/tests/test_vector.py
@@ -156,8 +156,7 @@ class VectorTestCase(unittest.TestCase):
 
 
 def suite():
-    suite = unittest.makeSuite(VectorTestCase, "test")
-    return suite
+    return unittest.defaultTestLoader.loadTestsFromTestCase(VectorTestCase)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In Python 3.13, some of the methods from `unittest` were removed.