### PR TITLE
block unsupported use of set_solve_type

### DIFF
--- a/share/lib/python/neuron/rxd/rxd.py
+++ b/share/lib/python/neuron/rxd/rxd.py
@@ -291,6 +291,10 @@ def set_solve_type(domain=None, dimension=None, dx=None, nsubseg=None, method=No
     domain -- a section or Python iterable of sections"""
 
     global _dimensions_default, _dimensions
+
+    if initializer.is_initialized():
+        raise RxDException("set_solve_type must be called before any access to nodes.")
+
     setting_default = False
     if domain is None:
         domain = h.allsec()


### PR DESCRIPTION
Partially solves #1718 in that it blocks attempts to use set_solve_type after nodes have been allocated, which did not work. A better solution (still needed) would be to allow reallocating e.g. 1D nodes to 3D or vice-versa.