### PR TITLE
Add NRN_PARALLEL_BUILDS to setup.py

### DIFF
--- a/docs/install/python_wheels.md
+++ b/docs/install/python_wheels.md
@@ -171,6 +171,8 @@ bash packaging/python/build_wheels.bash linux 3* coreneuron
 ```
 Where we are passing `3*` to build the wheels with `CoreNEURON` support for all python 3 versions.
 
+You can also control the level of parallelization used for the build using the `NRN_PARALLEL_BUILDS` env variable (default: 4).
+
 ### macOS
 As mentioned above, for macOS all dependencies have to be available on a system. You have to then clone NEURON repository and execute:
 

--- a/setup.py
+++ b/setup.py
@@ -247,7 +247,12 @@ class CMakeAugmentedBuilder(build_ext):
         if self.cmake_defs:
             cmake_args += ["-D" + opt for opt in self.cmake_defs.split(",")]
 
-        build_args = ["--config", cfg, "--", "-j4"]  # , 'VERBOSE=1']
+        build_args = [
+            "--config",
+            cfg,
+            "--",
+            f"-j{os.environ.get('NRN_PARALLEL_BUILDS', 4)}",
+        ]
 
         env = os.environ.copy()
         env["CXXFLAGS"] = "{} -DVERSION_INFO='{}'".format(


### PR DESCRIPTION
Allows us to control the sought level of parallelization for the build.
Useful when building wheels locally (for debugging purposes and whatnot).