### PR TITLE
Simplify `synpre.mod`.

### DIFF
--- a/share/examples/nrniv/nmodl/synpre.mod
+++ b/share/examples/nrniv/nmodl/synpre.mod
@@ -63,7 +63,7 @@ INITIAL {
 }
 
 BREAKPOINT {
-	SOLVE getonset
+	getonset()
 	g = gmax * alpha( (t - onset)/tau )
 	i = g*(v - e)
 }
@@ -82,8 +82,4 @@ PROCEDURE getonset() {
 	if (vpre > vprethresh && t > onset + deadtime) {
 		onset = t
 	}
-
-	VERBATIM
-	return 0;
-	ENDVERBATIM
 }

--- a/share/examples/nrniv/nmodl/synpre.mod
+++ b/share/examples/nrniv/nmodl/synpre.mod
@@ -1,13 +1,13 @@
 COMMENT
 
 A synaptic current with alpha function conductance defined by
-        i = g * (v - e)      i(nanoamps), g(micromhos);
-        where
-         g = 0 for t < onset and
-         g = gmax * (t - onset)/tau * exp(-(t - onset - tau)/tau)
-          for t > onset
-this has the property that the maximum value is gmax and occurs at
- t = onset + tau.
+    i = g * (v - e)      i(nanoamps), g(micromhos);
+where
+    g = 0 for t < onset and
+    g = gmax * (t - onset)/tau * exp(-(t - onset - tau)/tau)
+
+for t > onset this has the property that the maximum value is gmax and occurs
+at t = onset + tau.
 
 The synaptic onset time has been modified to occur when the presynaptic
 voltage, vpre, rises above threshold, vprethresh.
@@ -15,17 +15,18 @@ Another event is not allowed to occur for, deadtime, milliseconds after
 vpre rises above threshold.
 
 The user specifies the presynaptic location in hoc via the statement
-	connect vpre_syn[i] = v.section(x)
+    connect vpre_syn[i] = v.section(x)
 
 where x is the arc length (0 - 1) along the presynaptic section (the currently
 specified section), and i is the synapse number (Which is located at the
 postsynaptic location in the usual way via
-	postsynaptic_section {loc_syn(i, x)}
+    postsynaptic_section {loc_syn(i, x)}
+
 Notice that loc_syn() must be executed first since that function also
 allocates space for the synapse.
 
 ENDCOMMENT
-					       
+
 NEURON {
 	POINT_PROCESS synp
 	POINTER vpre
@@ -40,7 +41,7 @@ UNITS {
 
 PARAMETER {
 	tau=.1 (ms)
-	gmax=0 	(umho)
+	gmax=0	(umho)
 	e=0	(mV)
 	v	(mV)
 	vprethresh (mV)


### PR DESCRIPTION
Makes the following changes:
* Calls instead of SOLVEs the `getonset`.
* Remove unnecessary VERBATIM code.
* Some whitespace changes.