### PR TITLE
CoreNrn: support for rebalanced files.dat

### DIFF
--- a/src/coreneuron/io/nrn_setup.cpp
+++ b/src/coreneuron/io/nrn_setup.cpp
@@ -216,8 +216,10 @@ void nrn_read_filesdat(int& ngrp, int*& grp, const char* filesdat) {
 
         nrn_assert(fscanf(fp, "%d\n", &iFile) == 1);
         if ((iNum % nrnmpi_numprocs) == nrnmpi_myid) {
+            // A "-1" entry means that this rank should not be assigned further gid groups.
+            // It is a way to create files.dat files which deterministically assign gid groups to
+            // ranks, particularly useful for very large simulations which required load balancing.
             if (iFile == -1) {
-                // Sentinel value, we are done for this rank
                 break;
             }
             grp[ngrp] = iFile;

--- a/src/coreneuron/io/nrn_setup.cpp
+++ b/src/coreneuron/io/nrn_setup.cpp
@@ -216,6 +216,10 @@ void nrn_read_filesdat(int& ngrp, int*& grp, const char* filesdat) {
 
         nrn_assert(fscanf(fp, "%d\n", &iFile) == 1);
         if ((iNum % nrnmpi_numprocs) == nrnmpi_myid) {
+            if (iFile == -1) {
+                // Sentinel value, we are done for this rank
+                break;
+            }
             grp[ngrp] = iFile;
             ngrp++;
         }


### PR DESCRIPTION
For MMB (BBPP134-917) we need to be able to load a set of .dat files distributed in given way.
However for the moment CoreNeuron only reads it in plain RoundRobin, which is not suitable to load ranks a different number of files.

#### This PR

We introduce a mark value (-1 in this case) indicating no-data so that, even with round-robin, we can define precisely which rank will load a given data file. All ranks will be able to jump strides of size N_RANKS (at their respective offset) and find entries targeted at them. Upon seeing a `-1` the rank knows it is done and can stop reading.

This is a minor addition which enabled us to load balance and run the MMB simulation