### PR TITLE
Allow parallel test coverage (e.g. ctest -j 8 )

### DIFF
--- a/cmake/Coverage.cmake
+++ b/cmake/Coverage.cmake
@@ -34,7 +34,7 @@ if(NRN_ENABLE_COVERAGE)
   if(NOT BUILD_TYPE_UPPER STREQUAL "DEBUG")
     message(WARNING "Using CMAKE_BUILD_TYPE=Debug is recommended with NRN_ENABLE_COVERAGE")
   endif()
-  set(NRN_COVERAGE_FLAGS_UNQUOTED --coverage -fno-inline)
+  set(NRN_COVERAGE_FLAGS_UNQUOTED --coverage -fno-inline -fprofile-update=atomic)
   string(JOIN " " NRN_COVERAGE_FLAGS ${NRN_COVERAGE_FLAGS_UNQUOTED})
   set(NRN_COVERAGE_LINK_FLAGS --coverage)
 


### PR DESCRIPTION
```ctest``` on my machine takes 5.7 minutes  Parallel testing with, e.g. ```ctest -j 8``` takes less that 1.5 minutes. (it would be faster but a few of the test times are 69, 64, 40s). Anyway, this PR allows use of parallel ctest when coverage is enabled.

Example:
```
cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=install -DCMAKE_BUILD_TYPE=Debug -DNRN_ENABLE_TESTS=ON -DNRN_ENABLE_PERFORMANCE_TESTS=OFF -DNRN_ENABLE_COVERAGE=ON -DNRN_COVERAGE_FILES="src/nrncvode/cvodeobj.cpp;src/nrncvode/netcvode.cpp;src/nrncvode/nrndaspk.cpp;src/nrnmpi/mpispike.cpp"

ninja install
ninja cover_begin
ctest -j 8
ninja cover_html
```