### PR TITLE
Do not run `xcrun` on non-Mac systems

### DIFF
--- a/bin/nrnivmodl_core_makefile.in
+++ b/bin/nrnivmodl_core_makefile.in
@@ -16,8 +16,10 @@ DESTDIR =
 TARGET_LIB_TYPE = $(BUILD_TYPE)
 
 # required for OSX to execute nrnivmodl-core
-ifeq ($(origin SDKROOT), undefined)
-  export SDKROOT := $(shell xcrun --sdk macosx --show-sdk-path)
+ifeq ($(OS_NAME), Darwin)
+  ifeq ($(origin SDKROOT), undefined)
+    export SDKROOT := $(shell xcrun --sdk macosx --show-sdk-path)
+  endif
 endif
 
 # CoreNEURON installation directories


### PR DESCRIPTION
Removes the annoying `xcrun: No such file or directory` message on Linux.