### PR TITLE
Fix race condition in CMake code.

### DIFF
--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -44,8 +44,11 @@ add_custom_target(generated_source_files true)
 add_custom_target(modlunit_generated_files DEPENDS "${NRN_MODLUNIT_GEN}/lex.cpp"
                                                    "${NRN_MODLUNIT_GEN}/parse1.cpp")
 add_dependencies(generated_source_files modlunit_generated_files)
+
 add_executable(modlunit ${NRN_MODLUNIT_SRC_FILES} "${NRN_MODLUNIT_GEN}/lex.cpp"
                         "${NRN_MODLUNIT_GEN}/parse1.cpp")
+add_dependencies(modlunit modlunit_generated_files)
+
 target_compile_definitions(modlunit PRIVATE NRNUNIT=1)
 cpp_cc_configure_sanitizers(TARGET modlunit)
 # Generated .cpp needs to find source-directory .hpp and vice versa.
@@ -82,7 +85,7 @@ add_custom_command(
   COMMAND "${BISON_EXECUTABLE}" ARGS "--defines=${NRN_NOCMODL_GEN_REL}/diffeq.hpp" -o
           "${NRN_NOCMODL_GEN_REL}/diffeq.cpp" "${NRN_NOCMODL_SRC_REL}/diffeq.ypp"
   DEPENDS "${NRN_NOCMODL_SRC_DIR}/diffeq.ypp"
-  COMMENT "[BISON][nocmodlparser] Building parser with bison ${BISON_VERSION}")
+  COMMENT "[BISON][nocmodlparser] Building diffeq with bison ${BISON_VERSION}")
 
 add_custom_target(
   nocmodl_generated_files
@@ -90,9 +93,11 @@ add_custom_target(
           "${NRN_NOCMODL_GEN}/parse1.cpp" "${NRN_NOCMODL_GEN}/diffeq.hpp"
           "${NRN_NOCMODL_GEN}/diffeq.cpp")
 add_dependencies(generated_source_files nocmodl_generated_files)
+
 add_executable(nocmodl ${NRN_NOCMODL_SRC_FILES} "${NRN_NOCMODL_GEN}/lex.cpp"
                        "${NRN_NOCMODL_GEN}/parse1.cpp" "${NRN_NOCMODL_GEN}/diffeq.cpp")
 cpp_cc_configure_sanitizers(TARGET nocmodl)
+add_dependencies(nocmodl nocmodl_generated_files)
 target_compile_definitions(nocmodl PRIVATE COMPILE_DEFINITIONS NMODL=1 CVODE=1)
 # Otherwise the generated code in the binary directory does not find headers in the modlunit source
 # directory and the source files in the source directory do not find generated headers in the binary
@@ -401,6 +406,7 @@ include_directories(${NRN_INCLUDE_DIRS})
 # All source directories to include
 # =============================================================================
 add_library(nrniv_lib ${NRN_LIBRARY_TYPE} ${NRN_NRNIV_LIB_SRC_FILES})
+add_dependencies(nrniv_lib generated_source_files)
 target_link_libraries(nrniv_lib nrngnu)
 target_link_libraries(nrniv_lib sparse13)
 target_link_libraries(nrniv_lib fmt::fmt)


### PR DESCRIPTION
There's a race condition to create `parse1.cpp` (and other files). One way we can see there's an issue is by looking that the output of `cmake --build ... --parallel` (reordered):
```
[  0%] [BISON][modlunitparser] Building parser with bison 3.8.2
[  3%] [BISON][modlunitparser] Building parser with bison 3.8.2

[  1%] [FLEX][modlunitlexer] Building scanner with flex 2.6.4
[  3%] [FLEX][modlunitlexer] Building scanner with flex 2.6.4

[  0%] [BISON][nocmodlparser] Building parser with bison 3.8.2
[  1%] [BISON][nocmodlparser] Building parser with bison 3.8.2
[  3%] [BISON][nocmodlparser] Building parser with bison 3.8.2
[  3%] [BISON][nocmodlparser] Building parser with bison 3.8.2

[  1%] [FLEX][nocmodllexer] Building scanner with flex 2.6.4
[  3%] [BISON][ocparser] Building parser with bison 3.8.2
```
what we see is that `[nocmodlparser] Building parser` happens 4 times. Each file should only be generated once. The situation is slightly misleading, because there's 2 `add_custom_command`s that use the same description string. Therefore, we'd expect to see two such lines, but not 4.

Similarly, `[modlunitparser] Building parser` should only happen once.

The other way we can see the issue is by compiling repeatedly until we get a:
```
src/nrniv/nocmodl_generated/parse1.cpp:209:32: error: expected identifier at end of input
src/nrniv/nocmodl_generated/parse1.cpp:209:32: error: expected ‘}’ at end of input
src/nrniv/nocmodl_generated/parse1.cpp:163:1: note: to match this ‘{’
src/nrniv/nocmodl_generated/parse1.cpp:209:32: error: expected unqualified-id at end of input
```

After the changes I ran:
```
$ cat detect_race.sh
set -e
for i in $(seq 20)
do
  rm build-integrate -r; cmake -DCMAKE_INSTALL_PREFIX=build-integrate/install -DNRN_ENABLE_PYTHON=ON -DNRN_ENABLE_TESTS=ON -DNRN_ENABLE_DOCS=OFF -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_INTERVIEWS=OFF -DNRN_ENABLE_BACKTRACE=ON -DNRN_ENABLE_RX3D=OFF -DNRN_ENABLE_MPI_DYNAMIC=OFF -DCMAKE_BUILD_TYPE=Debug -DNRN_ENABLE_NMODL=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=On -B build-integrate . && cmake --build build-integrate --parallel --target=install
done
```
(which used to error on the first iteration.) The log contains (sorted to match the above):
```
[  3%] [BISON][modlunitparser] Building parser with bison 3.8.2

[  2%] [FLEX][modlunitlexer] Building scanner with flex 2.6.4

[  3%] [BISON][nocmodlparser] Building parser with bison 3.8.2
[  5%] [BISON][nocmodlparser] Building diffeq with bison 3.8.2

[  4%] [FLEX][nocmodllexer] Building scanner with flex 2.6.4
[  5%] [BISON][ocparser] Building parser with bison 3.8.2
```