### PR TITLE
Reduce proliferation of requirements and remove temp files

### DIFF
--- a/nrn_requirements.txt
+++ b/nrn_requirements.txt
@@ -4,10 +4,8 @@ setuptools<=70.3.0
 scikit-build
 matplotlib
 ipython
-cython
-packaging
 pytest<=8.1.1 # potential bug from 8.2.0 due to parallelism?
 pytest-cov
 mpi4py<4 # MUSIC not compatible with MPI 4
-numpy
 find_libpython
+-r packaging/python/build_requirements.txt

--- a/nrn_requirements.txt
+++ b/nrn_requirements.txt
@@ -4,8 +4,7 @@ setuptools<=70.3.0
 scikit-build
 matplotlib
 ipython
-pytest<=8.1.1 # potential bug from 8.2.0 due to parallelism?
-pytest-cov
 mpi4py<4 # MUSIC not compatible with MPI 4
 find_libpython
 -r packaging/python/build_requirements.txt
+-r packaging/python/test_requirements.txt

--- a/packaging/python/test_requirements.txt
+++ b/packaging/python/test_requirements.txt
@@ -1,2 +1,5 @@
-pytest
-setuptools;python_version>='3.12' # From 3.12, no longer installed by default
+pytest<=8.1.1 # potential bug from 8.2.0 due to parallelism?
+# for coverage
+pytest-cov
+# for RXD test
+plotly


### PR DESCRIPTION
Two changes:

- we can use `-r /path/to/some_requirements.txt` to reference other requirements files, so as to reduce the repetition between the various requirements
- `my_requirements.txt` will no longer pollute the root directory, but will instead be cast into the void (a temp dir) where it belongs