### PR TITLE
Don't prepend datpath to filesdat when user had it set

### DIFF
--- a/src/coreneuron/apps/corenrn_parameters.hpp
+++ b/src/coreneuron/apps/corenrn_parameters.hpp
@@ -45,6 +45,7 @@ struct corenrn_parameters_data {
     };
 
     static constexpr int report_buff_size_default = 4;
+    static constexpr char* default_dat_filename = "files.dat";
 
     unsigned spikebuf = 100'000;           /// Internal buffer used on every rank for spikes
     int prcellgid = -1;                    /// Gid of cell for prcellstate
@@ -86,7 +87,7 @@ struct corenrn_parameters_data {
     std::string patternstim;             /// Apply patternstim using the specified spike file.
     std::string datpath = ".";           /// Directory path where .dat files
     std::string outpath = ".";           /// Directory where spikes will be written
-    std::string filesdat = "files.dat";  /// Name of file containing list of gids dat files read in
+    std::string filesdat{};              /// Name of file containing list of gids dat files read in
     std::string restorepath;             /// Restore simulation from provided checkpoint directory.
     std::string reportfilepath;          /// Reports configuration file.
     std::string checkpointpath;  /// Enable checkpoint and specify directory to store related files.

--- a/src/coreneuron/apps/main1.cpp
+++ b/src/coreneuron/apps/main1.cpp
@@ -195,8 +195,10 @@ void nrn_init_and_load_data(int argc,
     }
 #endif
 
-    // full path of files.dat file
-    std::string filesdat(corenrn_param.datpath + "/" + corenrn_param.filesdat);
+    // Default path of files.dat is relative to datpath
+    if (corenrn_param.filesdat.empty()) {
+        corenrn_param.filesdat = corenrn_param.datpath + "/" + corenrn_param.default_dat_filename;
+    }
 
     // read the global variable names and set their values from globals.dat
     set_globals(corenrn_param.datpath.c_str(), (corenrn_param.seed >= 0), corenrn_param.seed);
@@ -257,7 +259,7 @@ void nrn_init_and_load_data(int argc,
     use_phase2_ = (corenrn_param.ms_phases == 2) ? 1 : 0;
 
     // reading *.dat files and setting up the data structures, setting mindelay
-    nrn_setup(filesdat.c_str(),
+    nrn_setup(corenrn_param.filesdat.c_str(),
               is_mapping_needed,
               checkPoints,
               run_setup_cleanup,


### PR DESCRIPTION
### Context

At the moment `-f, --filesdat` option is basically unusable since it tries to validate if the given file exists and then prepends something to it.

This is a fix for the problem. Only when not defined we do the prepend logic