### PR TITLE
Fix leak in `nrncore_arg`.

### DIFF
--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -3335,11 +3335,11 @@ static char* nrncore_arg(double tstop) {
     if (modules) {
         PyObject* module = PyDict_GetItemString(modules, "neuron.coreneuron");
         if (module) {
-            PyObject* callable = PyObject_GetAttrString(module, "nrncore_arg");
+            auto callable = nb::steal(PyObject_GetAttrString(module, "nrncore_arg"));
             if (callable) {
                 PyObject* ts = Py_BuildValue("(d)", tstop);
                 if (ts) {
-                    PyObject* arg = PyObject_CallObject(callable, ts);
+                    PyObject* arg = PyObject_CallObject(callable.ptr(), ts);
                     Py_DECREF(ts);
                     if (arg) {
                         Py2NRNString str(arg);


### PR DESCRIPTION
Because `PyObject_GetAttrString` returns a new reference [1], we're responsible for calling DECREF on the `callable`.

[1]: https://docs.python.org/3/c-api/object.html#c.PyObject_GetAttrString