### PR TITLE
Fix leak in `nrnpy_store_savestate_`.

### DIFF
--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -2616,20 +2616,18 @@ static void nrnpy_store_savestate_(char** save_data, uint64_t* save_data_size) {
     if (store_savestate_) {
         // call store_savestate_ with no arguments to get a byte array that we can write out
         PyObject* args = PyTuple_New(0);
-        PyObject* result = PyObject_CallObject(store_savestate_, args);
-        Py_INCREF(result);
+        auto result = nb::steal(PyObject_CallObject(store_savestate_, args));
         Py_DECREF(args);
-        if (result == NULL) {
+        if (!result) {
             hoc_execerror("SaveState:", "Data store failure.");
         }
         // free any old data and make a copy
         if (*save_data) {
             delete[](*save_data);
         }
-        *save_data_size = PyByteArray_Size(result);
+        *save_data_size = PyByteArray_Size(result.ptr());
         *save_data = new char[*save_data_size];
-        memcpy(*save_data, PyByteArray_AsString(result), *save_data_size);
-        Py_DECREF(result);
+        memcpy(*save_data, PyByteArray_AsString(result.ptr()), *save_data_size);
     } else {
         *save_data_size = 0;
     }


### PR DESCRIPTION
Facts:
  * `PyObject_CallObject` returns a new reference [1].
  * `PyByteArray_Size` doesn't steal the reference [2].
  * `PyByteArray_AsString` doesn't steal the reference [3].

This is a leak because:
  * `PyObject_CallObject` returns a new reference: `+1`.
  * `Py_INCREF` increases the local reference count to  `+2`.
  * `PyByteArray_Size` and `PyByteArray_AsString` don't steal the reference.
  * `Py_DECREF` reduces the local reference count to `+1`.

Therefore, there's 1 INCREF we can't pair up with a DECREF.

The revised version does:
  * Takes ownership of the new reference with `nb::steal`. Therefore, the local reference count is `+0`.
  * `PyByteArray_Size` and `PyByteArray_AsString` don't steal the reference.

Therefore, all INCREF can be paired with a DECREF.

[1]: https://docs.python.org/3/c-api/call.html#c.PyObject_CallObject
[2]: https://docs.python.org/3/c-api/bytearray.html#c.PyByteArray_Size
[3]: https://docs.python.org/3/c-api/bytearray.html#c.PyByteArray_AsString