### PR TITLE
Fix leak in `object_to_double_`.

### DIFF
--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -2652,10 +2652,8 @@ extern "C" NRN_EXPORT int nrnpy_set_gui_callback(PyObject* new_gui_callback) {
 }
 
 static double object_to_double_(Object* obj) {
-    PyObject* const pyobj = nrnpy_ho2po(obj);
-    Py_INCREF(pyobj);
-    const double result = PyFloat_AsDouble(pyobj);
-    Py_DECREF(pyobj);
+    auto pyobj = nb::steal(nrnpy_ho2po(obj));
+    const double result = PyFloat_AsDouble(pyobj.ptr());
     return result;
 }
 


### PR DESCRIPTION
The fact:
  * `nrnpy_ho2po` seems to return a "new reference".
  * `PyFloat_AsDouble` doesn't steal [1].

Therefore, the previous version had:
  * A local reference count of `+1` after `ho2po`.
  * A local reference count of `+2` after `INCREF`.
  * The `PyFloat_AsDouble` doesn't change the reference count.
  * A local reference count of `+1` after `DECREF`.

Leaving one INCREF that we can't pair up with a DECREF.

The proposed version immediately takes ownership of the new reference returned by `nrnpy_ho2po`.

[1]: https://docs.python.org/3/c-api/float.html#c.PyFloat_AsDouble