### PR TITLE
Launching nrniv -python with Python 3.13.0 does not allow use of gui.

### DIFF
--- a/src/nrnpython/nrnpython.cpp
+++ b/src/nrnpython/nrnpython.cpp
@@ -318,6 +318,13 @@ static int nrnpython_start(int b) {
         // del g
         // Also, NEURONMainMenu/File/Quit did not work. The solution to both
         // seems to be to just avoid gui threads if MINGW and launched nrniv
+
+        // Beginning with Python 3.13.0 it seems that the readline
+        // module has not been loaded yet. Since PyInit_readline sets
+        // PyOS_ReadlineFunctionPointer = call_readline; without checking,
+        // we need to import here.
+        PyRun_SimpleString("import readline as nrn_readline");
+
         PyOS_ReadlineFunctionPointer = nrnpython_getline;
 
         // Is there a -c "command" or file.py arg.


### PR DESCRIPTION
Closes #3237 
