### PR TITLE
Introduce `unique_cstr`.

### DIFF
--- a/src/neuron/unique_cstr.hpp
+++ b/src/neuron/unique_cstr.hpp
@@ -54,7 +54,7 @@ class unique_cstr {
 };
 
 inline std::ostream& operator<<(std::ostream& os, const unique_cstr& cstr) {
-    return os << cstr;
+    return os << cstr.c_str();
 }
 
 }  // namespace neuron

--- a/src/neuron/unique_cstr.hpp
+++ b/src/neuron/unique_cstr.hpp
@@ -20,8 +20,8 @@ class unique_cstr {
         *this = std::move(other);
     }
 
-    const unique_cstr& operator=(const unique_cstr&) = delete;
-    const unique_cstr& operator=(unique_cstr&& other) noexcept {
+    unique_cstr& operator=(const unique_cstr&) = delete;
+    unique_cstr& operator=(unique_cstr&& other) noexcept {
         std::free(this->str_);
         this->str_ = std::exchange(other.str_, nullptr);
         return *this;

--- a/src/neuron/unique_cstr.hpp
+++ b/src/neuron/unique_cstr.hpp
@@ -16,12 +16,12 @@ namespace neuron {
 class unique_cstr {
   public:
     unique_cstr(const unique_cstr&) = delete;
-    unique_cstr(unique_cstr&& other) {
+    unique_cstr(unique_cstr&& other) noexcept {
         *this = std::move(other);
     }
 
     const unique_cstr& operator=(const unique_cstr&) = delete;
-    const unique_cstr& operator=(unique_cstr&& other) {
+    const unique_cstr& operator=(unique_cstr&& other) noexcept {
         std::free(this->str_);
         this->str_ = std::exchange(other.str_, nullptr);
         return *this;

--- a/src/neuron/unique_cstr.hpp
+++ b/src/neuron/unique_cstr.hpp
@@ -53,8 +53,4 @@ class unique_cstr {
     char* str_ = nullptr;
 };
 
-inline std::ostream& operator<<(std::ostream& os, const unique_cstr& cstr) {
-    return os << cstr.c_str();
-}
-
 }  // namespace neuron

--- a/src/neuron/unique_cstr.hpp
+++ b/src/neuron/unique_cstr.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdlib>
 #include <utility>
+#include <ostream>
 
 namespace neuron {
 
@@ -50,5 +51,9 @@ class unique_cstr {
   private:
     char* str_ = nullptr;
 };
+
+inline std::ostream& operator<<(std::ostream& os, const unique_cstr& cstr) {
+  return os << cstr;
+}
 
 }  // namespace neuron

--- a/src/neuron/unique_cstr.hpp
+++ b/src/neuron/unique_cstr.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cstdlib>
+#include <utility>
+
+namespace neuron {
+
+/** A RAII wrapper for C-style strings.
+ *
+ *  The string must be null-terminated and allocated with `malloc`. The lifetime of the string is
+ * bound to the life time of the `unique_cstr`. Certain patterns in NRN require passing on
+ * ownership, this is achieved using `.release()`, which returns the contained C-string and makes
+ * this object invalid.
+ */
+class unique_cstr {
+  public:
+    unique_cstr(const unique_cstr&) = delete;
+    unique_cstr(unique_cstr&& other) {
+        *this = std::move(other);
+    }
+
+    const unique_cstr& operator=(const unique_cstr&) = delete;
+    const unique_cstr& operator=(unique_cstr&& other) {
+        this->str_ = std::exchange(other.str_, nullptr);
+        return *this;
+    }
+
+    explicit unique_cstr(char* cstr)
+        : str_(cstr) {}
+
+    ~unique_cstr() {
+        std::free((void*) str_);
+    }
+
+    /** Releases ownership of the string.
+     *
+     *  Returns the string and makes this object invalid.
+     */
+    [[nodiscard]] char* release() {
+        return std::exchange(str_, nullptr);
+    }
+
+    char* c_str() const {
+        return str_;
+    }
+    bool is_valid() const {
+        return str_ != nullptr;
+    }
+
+  private:
+    char* str_ = nullptr;
+};
+
+}  // namespace neuron

--- a/src/neuron/unique_cstr.hpp
+++ b/src/neuron/unique_cstr.hpp
@@ -54,7 +54,7 @@ class unique_cstr {
 };
 
 inline std::ostream& operator<<(std::ostream& os, const unique_cstr& cstr) {
-  return os << cstr;
+    return os << cstr;
 }
 
 }  // namespace neuron

--- a/src/neuron/unique_cstr.hpp
+++ b/src/neuron/unique_cstr.hpp
@@ -22,6 +22,7 @@ class unique_cstr {
 
     const unique_cstr& operator=(const unique_cstr&) = delete;
     const unique_cstr& operator=(unique_cstr&& other) {
+        std::free(this->str_);
         this->str_ = std::exchange(other.str_, nullptr);
         return *this;
     }

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -11,6 +11,7 @@
 #include "nrnpy.h"
 #include "nrnpy_utils.h"
 #include "convert_cxx_exceptions.hpp"
+#include "neuron/unique_cstr.hpp"
 
 #ifndef M_PI
 #define M_PI (3.14159265358979323846)
@@ -40,8 +41,7 @@ extern void nrn_pt3dstyle0(Section* sec);
 
 extern PyObject* nrn_ptr_richcmp(void* self_ptr, void* other_ptr, int op);
 // used to be static in nrnpy_hoc.cpp
-extern int hocobj_pushargs(PyObject*, std::vector<char*>&);
-extern void hocobj_pushargs_free_strings(std::vector<char*>&);
+extern int hocobj_pushargs(PyObject*, std::vector<neuron::unique_cstr>&);
 
 
 struct NPyAllSegOfSecIter {
@@ -1318,7 +1318,7 @@ static PyObject* NPyMechFunc_call(NPyMechFunc* self, PyObject* args) {
     // patterning after fcall
     Symbol sym{};  // in case of error, need the name.
     sym.name = (char*) self->f_->name;
-    std::vector<char*> strings_to_free;
+    std::vector<neuron::unique_cstr> strings_to_free;
     int narg = hocobj_pushargs(args, strings_to_free);
     hoc_push_frame(&sym, narg);  // get_argument uses the current frame
     try {
@@ -1330,7 +1330,6 @@ static PyObject* NPyMechFunc_call(NPyMechFunc* self, PyObject* args) {
         PyErr_SetString(PyExc_RuntimeError, oss.str().c_str());
     }
     hoc_pop_frame();
-    hocobj_pushargs_free_strings(strings_to_free);
 
     return result;
 }


### PR DESCRIPTION
This commit adds a RAII wrapper for C-strings, called `unique_cstr`. Several places in the NRN Python bindings use `char *` when owning a malloc allocated string.

This new class is then used to prevent leaking HOC strings on error paths, see https://github.com/neuronsimulator/nrn/pull/1437