### PR TITLE
Fix Windows CI

### DIFF
--- a/ci/win_install_deps.cmd
+++ b/ci/win_install_deps.cmd
@@ -64,7 +64,7 @@ mingw-w64-x86_64-ninja ^
 mingw-w64-x86_64-ncurses ^
 mingw-w64-x86_64-readline ^
 mingw-w64-x86_64-python3 ^
-mingw-w64-x86_64-python3-setuptools ^
+mingw-w64-x86_64-python-setuptools ^
 mingw-w64-x86_64-python3-packaging ^
 mingw-w64-x86_64-python3-pip ^
 mingw64/mingw-w64-x86_64-dlfcn ^


### PR DESCRIPTION
For some reason, the (virtual) package `mingw-w64-x86_64-python3-setuptools` doesn't exist anymore (https://packages.msys2.org/packages/mingw-w64-x86_64-python3-setuptools is gone), but `mingw-w64-x86_64-python-setuptools` does exist (and was earlier providing the actual package for the former).

Could this happen to all of the `python3*` packages in the build script? Maybe, but they're not broken at the moment, so minimal fix it is.