### PR TITLE
Fix leak in `pysec_children` and `pysec_subtree`.

### DIFF
--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -1163,10 +1163,7 @@ static PyObject* pysec_subtree1(PyObject* const sl, Section* const sec) {
 }
 
 // Returns a new reference.
-static PyObject* pysec_subtree(NPySecObj* const self) {
-    Section* const sec = self->sec_;
-    CHECK_SEC_INVALID(sec);
-
+static PyObject* pysec_subtree_impl(Section* sec) {
     auto result = nb::steal(PyList_New(0));
     if (!result) {
         return nullptr;
@@ -1179,6 +1176,14 @@ static PyObject* pysec_subtree(NPySecObj* const self) {
     return result.release().ptr();
 }
 
+// Returns a new reference.
+static PyObject* pysec_subtree(NPySecObj* const self) {
+    Section* const sec = self->sec_;
+    CHECK_SEC_INVALID(sec);
+
+    return pysec_subtree_impl(sec);
+}
+
 static PyObject* pysec_subtree_safe(NPySecObj* const self) {
     return nrn::convert_cxx_exceptions(pysec_subtree, self);
 }
@@ -1188,19 +1193,10 @@ static PyObject* pysec_wholetree(NPySecObj* const self) {
     CHECK_SEC_INVALID(sec);
     Section* s;
 
-    nb::object result = nb::steal(PyList_New(0));
-    if (!result) {
-        return NULL;
-    }
-
     for (s = sec; s->parentsec; s = s->parentsec) {
     }
 
-    if(!pysec_subtree1(result.ptr(), s)) {
-        return nullptr;
-    }
-
-    return result.release().ptr();
+    return pysec_subtree_impl(s);
 }
 
 static PyObject* pysec_wholetree_safe(NPySecObj* const self) {

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -1188,15 +1188,18 @@ static PyObject* pysec_subtree_safe(NPySecObj* const self) {
     return nrn::convert_cxx_exceptions(pysec_subtree, self);
 }
 
+static Section* find_root_section(Section* sec) {
+    for (; sec->parentsec; sec = sec->parentsec) {
+    }
+
+    return sec;
+}
+
 static PyObject* pysec_wholetree(NPySecObj* const self) {
     Section* sec = self->sec_;
     CHECK_SEC_INVALID(sec);
-    Section* s;
 
-    for (s = sec; s->parentsec; s = s->parentsec) {
-    }
-
-    return pysec_subtree_impl(s);
+    return pysec_subtree_impl(find_root_section(sec));
 }
 
 static PyObject* pysec_wholetree_safe(NPySecObj* const self) {

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -1169,7 +1169,7 @@ static PyObject* pysec_subtree_impl(Section* sec) {
         return nullptr;
     }
 
-    if(!pysec_subtree1(result.ptr(), sec)) {
+    if (!pysec_subtree1(result.ptr(), sec)) {
         return nullptr;
     }
 

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -1126,49 +1126,57 @@ static bool lappendsec(PyObject* const sl, Section* const s) {
     return true;
 }
 
-static PyObject* pysec_children1(PyObject* const sl, Section* const sec) {
-    for (Section* s = sec->child; s; s = s->sibling) {
-        if (!lappendsec(sl, s)) {
-            return NULL;
-        }
-    }
-    return sl;
-}
 
+// Returns a new reference.
 static PyObject* pysec_children(NPySecObj* const self) {
     Section* const sec = self->sec_;
     CHECK_SEC_INVALID(sec);
-    PyObject* const result = PyList_New(0);
+
+    nb::object result = nb::steal(PyList_New(0));
     if (!result) {
-        return NULL;
+        return nullptr;
     }
-    return pysec_children1(result, sec);
+
+    for (Section* s = sec->child; s; s = s->sibling) {
+        if (!lappendsec(result.ptr(), s)) {
+            return nullptr;
+        }
+    }
+    return result.release().ptr();
 }
 
 static PyObject* pysec_children_safe(NPySecObj* const self) {
     return nrn::convert_cxx_exceptions(pysec_children, self);
 }
 
+// Returns a borrowed reference (to `sl`).
 static PyObject* pysec_subtree1(PyObject* const sl, Section* const sec) {
     if (!lappendsec(sl, sec)) {
-        return NULL;
+        return nullptr;
     }
     for (Section* s = sec->child; s; s = s->sibling) {
         if (!pysec_subtree1(sl, s)) {
-            return NULL;
+            return nullptr;
         }
     }
     return sl;
 }
 
+// Returns a new reference.
 static PyObject* pysec_subtree(NPySecObj* const self) {
     Section* const sec = self->sec_;
     CHECK_SEC_INVALID(sec);
-    PyObject* const result = PyList_New(0);
+
+    auto result = nb::steal(PyList_New(0));
     if (!result) {
-        return NULL;
+        return nullptr;
     }
-    return pysec_subtree1(result, sec);
+
+    if(!pysec_subtree1(result.ptr(), sec)) {
+        return nullptr;
+    }
+
+    return result.release().ptr();
 }
 
 static PyObject* pysec_subtree_safe(NPySecObj* const self) {
@@ -1179,13 +1187,20 @@ static PyObject* pysec_wholetree(NPySecObj* const self) {
     Section* sec = self->sec_;
     CHECK_SEC_INVALID(sec);
     Section* s;
-    PyObject* result = PyList_New(0);
+
+    nb::object result = nb::steal(PyList_New(0));
     if (!result) {
         return NULL;
     }
+
     for (s = sec; s->parentsec; s = s->parentsec) {
     }
-    return pysec_subtree1(result, s);
+
+    if(!pysec_subtree1(result.ptr(), s)) {
+        return nullptr;
+    }
+
+    return result.release().ptr();
 }
 
 static PyObject* pysec_wholetree_safe(NPySecObj* const self) {


### PR DESCRIPTION
The leak happens when an error occurs in the `*1` helper functions. In
that case the `sl` (created in the top-level function under the name `result`)
isn't DECREFed, and also not returned. Therefore, it's leaked.

In the first case this is fixed by inlining the helper function.

In the second case, we check if the helper returns a `nullptr` and if not
we return the new reference to the newly created list (by using
`release().ptr()`). Note, that on the error path the `sl` will be
cleaned up due to RAII semantics.