### PR TITLE
Fix leaks in `get_endian_character`.

### DIFF
--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -3189,19 +3189,19 @@ static PyObject* py_hocobj_div(PyObject* obj1, PyObject* obj2) {
 char get_endian_character() {
     char endian_character = 0;
 
-    PyObject* psys = PyImport_ImportModule("sys");
-    if (psys == NULL) {
+    auto psys = nb::steal(PyImport_ImportModule("sys"));
+    if (!psys) {
         PyErr_SetString(PyExc_ImportError, "Failed to import sys to determine system byteorder.");
         return 0;
     }
 
-    PyObject* pbo = PyObject_GetAttrString(psys, "byteorder");
-    if (pbo == NULL) {
+    auto pbo = nb::steal(PyObject_GetAttrString(psys.ptr(), "byteorder"));
+    if (!pbo) {
         PyErr_SetString(PyExc_AttributeError, "sys module does not have attribute 'byteorder'!");
         return 0;
     }
 
-    Py2NRNString byteorder(pbo);
+    Py2NRNString byteorder(pbo.ptr());
     if (byteorder.c_str() == NULL) {
         return 0;
     }


### PR DESCRIPTION
The facts are:
  * `PyImport_ImportModule` returns a new reference [1].
  * `PyObject_GetAttrString` returns a new referece [2].
  * `Py2NRNString::as_ascii` doesn't steal.

Therefore, in both cases, we create a new reference without ever calling DECREF.

[1]: https://docs.python.org/3.12/c-api/import.html#c.PyImport_ImportModule
[2]: https://docs.python.org/3/c-api/object.html#c.PyObject_GetAttrString