### PR TITLE
On h.quit() terminal settings are same as when neuron.hoc was imported.

### DIFF
--- a/src/nrnpython/inithoc.cpp
+++ b/src/nrnpython/inithoc.cpp
@@ -207,7 +207,7 @@ static int have_opt(const char* arg) {
     return 0;
 }
 
-#if __linux__
+#if __linux__ || DARWIN
 
 /* we do this because thread sanitizer does not allow system calls.
    In particular
@@ -242,7 +242,7 @@ void nrnpython_finalize() {
 #endif
         Py_Finalize();
     }
-#if __linux__
+#if __linux__ || DARWIN
     restore_original_terminal_settings();
 #endif
 }
@@ -254,7 +254,7 @@ extern "C" NRN_EXPORT PyObject* PyInit_hoc() {
     main_thread_ = std::this_thread::get_id();
 #endif
 
-#if __linux__
+#if __linux__ || DARWIN
     save_original_terminal_settings();
 #endif  // __linux__
 

--- a/src/nrnpython/inithoc.cpp
+++ b/src/nrnpython/inithoc.cpp
@@ -207,7 +207,7 @@ static int have_opt(const char* arg) {
     return 0;
 }
 
-#if __linux__ || DARWIN
+#if defined(__linux__) || defined(DARWIN)
 
 /* we do this because thread sanitizer does not allow system calls.
    In particular
@@ -242,7 +242,7 @@ void nrnpython_finalize() {
 #endif
         Py_Finalize();
     }
-#if __linux__ || DARWIN
+#if defined(__linux__) || defined(DARWIN)
     restore_original_terminal_settings();
 #endif
 }
@@ -254,7 +254,7 @@ extern "C" NRN_EXPORT PyObject* PyInit_hoc() {
     main_thread_ = std::this_thread::get_id();
 #endif
 
-#if __linux__ || DARWIN
+#if defined(__linux__) || defined(DARWIN)
     save_original_terminal_settings();
 #endif  // __linux__
 

--- a/src/nrnpython/inithoc.cpp
+++ b/src/nrnpython/inithoc.cpp
@@ -222,13 +222,13 @@ static int have_opt(const char* arg) {
 static struct termios original_termios;
 
 static void save_original_terminal_settings() {
-    if (tcgetattr(STDIN_FILENO, &original_termios) == -1) {
+    if (tcgetattr(STDIN_FILENO, &original_termios) == -1 && isatty(STDIN_FILENO)) {
         std::cerr << "Error getting original terminal attributes\n";
     }
 }
 
 static void restore_original_terminal_settings() {
-    if (tcsetattr(STDIN_FILENO, TCSANOW, &original_termios) == -1) {
+    if (tcsetattr(STDIN_FILENO, TCSANOW, &original_termios) == -1 && isatty(STDIN_FILENO)) {
         std::cerr << "Error restoring terminal attributes\n";
     }
 }


### PR DESCRIPTION
On h.quit() ensure terminal settings are same as when neuron.hoc was imported. This is most important with
NEURONMainMenu/File/Quit which would leave terminal in raw readline state with no input echoing and no return before linefeed when newline was printed.  I.e. Consider the following when at the prompt, NEURONMainMenu/File/Quit is selected, and on exit, stty is typed at the terminal shell $ prompt (no echoing of stty)
```
$ python -i -c 'from neuron import h, gui'
>>> hines@hines-ThinkStation-P5:~/neuron/sane/bld$ 
speed 38400 baud; line = 0;
                           min = 1; time = 0;
                                             -imaxbel iutf8
                                                           -opost
                                                                 -icanon -iexten -echo
```
