### PR TITLE
bldnrnmacpkg.sh is the new name and updated for python3.13

### DIFF
--- a/bldnrnmacpkg.sh
+++ b/bldnrnmacpkg.sh
@@ -153,22 +153,29 @@ for i in $args ; do
   chk $i
 done
 
-#/Applications/Packages.app from
-# http://s.sudre.free.fr/Software/Packages/about.html
-# For mac to do a productsign, need my developerID_installer.cer
-# and Neurondev.p12 file. To add to the keychain, double click each
-# of those files. By default, I added my certificates to the login keychain.
-ninja macpkg # will sign the binaries, construct below
-            # mentioned PACKAGE_FILE_NAME, request notarization from
-            # Apple, and staple the package.
-
-# Copy the package to $HOME/$PACKAGE_FULL_NAME
-# You should then manually upload that to github.
 describe="`sh $NRN_SRC/nrnversion.sh describe`"
 macos=macos${MACOSX_DEPLOYMENT_TARGET}
 PACKAGE_FULL_NAME=nrn-${describe}-${mac_platform}-${PYVS}.pkg
 PACKAGE_FILE_NAME=$NRN_BLD/src/mac/build/NEURON.pkg
 
+#/Applications/Packages.app from
+# http://s.sudre.free.fr/Software/Packages/about.html
+# For mac to do a productsign, need my developerID_installer.cer
+# and Neurondev.p12 file. To add to the keychain, double click each
+# of those files. By default, I added my certificates to the login keychain.
+
+# Will sign the binaries, construct above
+# mentioned PACKAGE_FILE_NAME, request notarization from
+# Apple, and staple the package.
+if ! ninja macpkg ; then 
+  echo "ninja macpkg failed. (because of notification failure?)"
+  echo "Not creating $PACKAGE_FULL_NAME"
+  echo "  from $PACKAGE_FILE_NAME"
+  exit 1
+fi
+
+# Copy the package to $HOME/$PACKAGE_FULL_NAME
+# You should then manually upload that to github.
 cp $PACKAGE_FILE_NAME $HOME/$PACKAGE_FULL_NAME
 
 echo "

--- a/bldnrnmacpkg.sh
+++ b/bldnrnmacpkg.sh
@@ -6,10 +6,12 @@ default_pythons="python3.9 python3.10 python3.11 python3.12 python3.13"
 # bash bldnrnmacpkgcmake.sh
 # without args, default are the pythons above.
 
+if test "$RX3D_OPT" = "" ; then
+  RX3D_OPT=1 # a value of 2 takes much longer to build
+fi
+
 # If all the pythons are universal, then so is NEURON.
 # Otherwise $CPU
-# All pythons must have the same macos version and that will become
-# the MACOSX_DEPLOYMENT_TARGET
 
 # Now obsolete...
 # On my machine, to build nrn-x.x.x-macosx-10.9-universal2-py-38-39-310-311.pkg
@@ -24,10 +26,6 @@ default_pythons="python3.9 python3.10 python3.11 python3.12 python3.13"
 READLINE_LIST="/opt/nrnwheel/arm64/readline;/opt/nrnwheel/arm64/ncurses"
 
 CPU=`uname -m`
-
-if test "$RX3D_OPT" = "" ; then
-  RX3D_OPT=1 # a value of 2 takes much longer to build
-fi
 
 universal="yes" # changes to "no" if any python not universal
 

--- a/src/mac/nrn_productsign.sh
+++ b/src/mac/nrn_productsign.sh
@@ -13,4 +13,5 @@ rm -f $1.signed
 productsign --sign "Developer ID Installer: Michael Hines (8APKV34642)" \
   $1 $1.signed
 
+echo "mv $1.signed $1"
 mv $1.signed $1

--- a/src/mac/nrn_productsign.sh
+++ b/src/mac/nrn_productsign.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -ex
 
 # Signing the package with an identified developer certificate means the
 # installer does not have to lower the security settings on their machine.
@@ -13,5 +14,4 @@ rm -f $1.signed
 productsign --sign "Developer ID Installer: Michael Hines (8APKV34642)" \
   $1 $1.signed
 
-echo "mv $1.signed $1"
 mv $1.signed $1


### PR DESCRIPTION
bldnrnmacpkgcmake.sh renamed to bldnrnmacpkg.sh
Updated to default build for python3.9 - python3.13, ompi and mpich.
Minimum macosx is MACOSX_DEPLOYMENT_TARGET=10.15
universal2. (arm64;x86_64)
statically links readline and ncurses into libnrniv.dylib
An example of an installer name is
```
nrn-9.0a-464-g108ed37ee-macosx-10.15-universal2-py-39-310-311-312-313.pkg
```