### PR TITLE
Add CI action for uploading Docker image for wheels

### DIFF
--- a/.github/workflows/wheel_image.yml
+++ b/.github/workflows/wheel_image.yml
@@ -1,0 +1,46 @@
+name: Build custom Docker image for manylinux wheels
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_image:
+        description: 'The base Docker image to use'
+        default: 'manylinux2014'
+        type: choice
+        options:
+          - 'manylinux2014'
+          - 'manylinux_2_28'
+          - 'manylinux_2_34'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - platform: 'linux/amd64'
+            tag: 'x86_64'
+          - platform: 'linux/arm64'
+            tag: 'aarch64'
+
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: neuronsimulator/neuron_wheel:latest
+          build-args: |
+            MANYLINUX_IMAGE: ${{ github.event.inputs.base_image }}_${{ matrix.tag }}

--- a/.github/workflows/wheel_image.yml
+++ b/.github/workflows/wheel_image.yml
@@ -12,6 +12,12 @@ on:
           - 'manylinux_2_28'
           - 'manylinux_2_34'
 
+      upload:
+        description: 'Whether to upload (push) the image to DockerHub'
+        default: 'false'
+        required: true
+        type: 'boolean'
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -19,9 +25,9 @@ jobs:
       matrix:
         include:
           - platform: 'linux/amd64'
-            tag: 'x86_64'
+            arch: 'x86_64'
           - platform: 'linux/arm64'
-            tag: 'aarch64'
+            arch: 'aarch64'
 
     steps:
       - name: Login to Docker Hub
@@ -40,7 +46,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: ${{ matrix.platform }}
-          push: true
+          push: ${{ github.event.inputs.upload }}
           tags: neuronsimulator/neuron_wheel:latest
           build-args: |
-            MANYLINUX_IMAGE: ${{ github.event.inputs.base_image }}_${{ matrix.tag }}
+            MANYLINUX_IMAGE: ${{ github.event.inputs.base_image }}_${{ matrix.arch }}


### PR DESCRIPTION
The images on https://hub.docker.com/r/neuronsimulator/neuron_wheel/tags are a bit inconsistent; we should use one tag for all platforms (since Docker picks the right one when pulling, no naming conflict there). They are also a bit of a pain to update: someone (with push permissions!) needs to build the image on their own machine, for both x86_64 and aarch64, tag them correctly, and then upload them to DockerHub. This whole process is a bit error-prone and can take a while, which is what this CI solves.

Note that `DOCKERHUB_USERNAME` needs to be set as an env variable for this repo, and `DOCKERHUB_TOKEN` needs to be set as an env **secret** for pushing to work.

Once this is merged, and this action is ran at least once, I can make another PR which introduces the necessary changes to use a unified `neuronsimulator/neuron_wheel:latest` image everywhere.