### PR TITLE
Fix reference counts in `nrnexec`.

### DIFF
--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -205,8 +205,11 @@ static PyObject* nrnexec(PyObject* self, PyObject* args) {
     if (!PyArg_ParseTuple(args, "s", &cmd)) {
         return NULL;
     }
-    bool b = hoc_valid_stmt(cmd, 0);
-    return b ? Py_True : Py_False;
+    if(hoc_valid_stmt(cmd, 0)) {
+       Py_RETURN_TRUE;
+    } else {
+       Py_RETURN_FALSE;
+    }
 }
 
 static PyObject* nrnexec_safe(PyObject* self, PyObject* args) {


### PR DESCRIPTION
The function `nrnexec` is wrapped and then registered via `PyMethodDef`. Therefore is must satisfy the requirements: https://docs.python.org/3.12/c-api/structures.html#c.PyCFunction

Meaning it must return a new reference. Hence, it must the `Py_RETURN_{TRUE,FALSE}` macros.