### PR TITLE
Python 3.13.1 broke [s for s in sl] where sl is a SectionList.

### DIFF
--- a/docs/python/modelspec/programmatic/topology/seclist.rst
+++ b/docs/python/modelspec/programmatic/topology/seclist.rst
@@ -31,6 +31,10 @@ SectionList
             for sec in python_iterable_of_sections:
                 sl.append(sec)
 
+        ``len(sl)`` returns the number of sections in the SectionList.
+
+        ``list(sl)`` and ``[s for s in sl]`` generate equivalent lists.
+
     .. seealso::
         :class:`SectionBrowser`, :class:`Shape`, :meth:`RangeVarPlot.list`
 

--- a/test/hoctests/tests/test_seclist.py
+++ b/test/hoctests/tests/test_seclist.py
@@ -1,0 +1,18 @@
+from neuron import h
+
+secs = [h.Section() for _ in range(10)]
+
+
+def test():
+    sl = h.SectionList()
+    sl.allroots()
+    assert len(sl) == len(list(sl))
+    b = [(s1, s2) for s1 in sl for s2 in sl]
+    n = len(sl)
+    for i in range(n):
+        for j in range(n):
+            assert b[i * n + j][0] == b[i + j * n][1]
+    return sl
+
+
+sl = test()


### PR DESCRIPTION
This PR fixes (works around?) the following Python-3.13.1 error:
```
$ python
Python 3.13.1 (main, Dec  6 2024, 07:50:24) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from neuron import h
>>> sl = h.SectionList()
>>> [s for s in sl]
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    [s for s in sl]
                ^^
TypeError: Not an iterable HocObject
>>> 
```
It also provides the len function, ie. given the above empty sl
```
>>> len(sl)
0
```
