### PR TITLE
Add workaround for `install_name_tool` issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 from collections import defaultdict
 import logging
+import platform
 
 logging.basicConfig(level=logging.INFO)
 from shutil import copytree, which
@@ -461,6 +462,8 @@ def setup_package():
                 + ["-Wl,-rpath,{}".format(REL_RPATH + "/../../.data/lib/")],
             )
         )
+        if platform.system() == "Darwin":
+            rxd_params["extra_link_args"] += ["-headerpad_max_install_names"]
 
         logging.info("RX3D compile flags %s" % str(rxd_params))
 


### PR DESCRIPTION
Hopefully fixes #3277.
According to the `ld` man page:

```plaintext
-headerpad_max_install_names
  Automatically adds space for future expansion of load commands such that all paths could expand
  to MAXPATHLEN.  Only useful if intend to run install_name_tool to alter the load commands later.
```

According to `man 2 statfs`:

```plaintext
     #define MAXPATHLEN      1024
```

which I'm guessing is the same `MAXPATHLEN` (haven't found references to any others), in which case we should be good for a while.