### PR TITLE
Move from deprecated PyWeakref_GetObject

### DIFF
--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -1240,8 +1240,12 @@ static PyObject* pysec2cell(NPySecObj* self) {
     if (self->cell_weakref_) {
 #if PY_VERSION_HEX >= 0x030D0000
         PyObject* cell = nullptr;
-        PyWeakref_GetRef(self->cell_weakref_, &cell);
-        result = nb::steal(cell);
+        int ret = PyWeakref_GetRef(self->cell_weakref_, &cell);
+        if (ret > 0) {
+            result = nb::steal(cell);
+        } else {
+            result = nb::none();
+        }
 #else
         result = nb::borrow(PyWeakref_GetObject(self->cell_weakref_));
 #endif

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -186,16 +186,18 @@ static Object* pysec_cell(Section* sec) {
             } else if (err == 0) {
                 return nullptr;
             }
+            auto ret = nrnpy_po2ho(cell);
+            Py_DECREF(cell);
+            return ret;
 #else
             PyObject* cell = PyWeakref_GetObject(cell_weakref);
             if (!cell) {
                 PyErr_Print();
                 hoc_execerror("Error getting cell for", secname(sec));
-            } else if (cell == Py_None) {
-                return nullptr;
+            } else if (cell != Py_None) {
+                return nrnpy_po2ho(cell);
             }
 #endif
-            return nrnpy_po2ho(cell);
         }
     }
     return NULL;
@@ -234,14 +236,17 @@ static int pysec_cell_equals(Section* sec, Object* obj) {
                 PyErr_Print();
                 hoc_execerror("Error getting cell for", secname(sec));
             }
+            auto ret = nrnpy_ho_eq_po(obj, cell);
+            Py_DECREF(cell);
+            return ret;
 #else
             PyObject* cell = PyWeakref_GetObject(cell_weakref);
             if (!cell) {
                 PyErr_Print();
                 hoc_execerror("Error getting cell for", secname(sec));
             }
-#endif
             return nrnpy_ho_eq_po(obj, cell);
+#endif
         }
         return nrnpy_ho_eq_po(obj, Py_None);
     }


### PR DESCRIPTION
`PyWeakref_GetObject` is deprecated from python 3.13 and will be remove for python 3.15