### PR TITLE
Remove needrestart from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
       - run:
           name: Test manylinux AArch64 wheel
           command: |
+            sudo apt purge -y needrestart
             sudo apt update
             echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu jammy main" | sudo tee /etc/apt/sources.list.d/deadsnakes-ppa.list && sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F23C5A6CF475977595C89F51BA6932366A755776 && sudo apt update
             sudo apt update


### PR DESCRIPTION
For some reason it is installed in the CI, only causing headaches since it expects an interactive TTY.