### PR TITLE
Make `hh.mod` configure-able at compile-time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ virtualenv
 docs/_build
 docs/_generated
 .vscode
+src/nrnoc/hh.mod

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -790,30 +790,6 @@ add_custom_target(
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 # =============================================================================
-# ~~~
-# Update hh.mod for CoreNEURON compatibility
-# - Replace GLOBAL variable by RANGE
-# - Comment out TABLE
-# ~~~
-# =============================================================================
-if(NRN_ENABLE_CORENEURON OR NRN_ENABLE_MOD_COMPATIBILITY)
-  set(GLOBAL_VAR_TOGGLE_COMMAND "'s/ GLOBAL minf/ RANGE minf/'")
-else()
-  set(GLOBAL_VAR_TOGGLE_COMMAND "'s/ RANGE minf/ GLOBAL minf/'")
-endif()
-separate_arguments(GLOBAL_VAR_TOGGLE_COMMAND UNIX_COMMAND "${GLOBAL_VAR_TOGGLE_COMMAND}")
-add_custom_target(
-  hh_update
-  COMMAND sed ${GLOBAL_VAR_TOGGLE_COMMAND} ${CMAKE_SOURCE_DIR}/src/nrnoc/hh.mod >
-          ${CMAKE_BINARY_DIR}/hh.mod.1
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/hh.mod.1
-          ${CMAKE_SOURCE_DIR}/src/nrnoc/hh.mod
-  COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_BINARY_DIR}/hh.mod.1
-  COMMENT "Update hh.mod for CoreNEURON compatibility"
-  VERBATIM)
-add_dependencies(nrniv_lib hh_update)
-
-# =============================================================================
 # Generate help_data.dat
 # =============================================================================
 if(NRN_ENABLE_PYTHON)

--- a/cmake/MacroHelper.cmake
+++ b/cmake/MacroHelper.cmake
@@ -153,6 +153,11 @@ macro(nocmodl_mod_to_cpp modfile_basename)
   if(CMAKE_VERSION VERSION_LESS "3.17")
     set(REMOVE_CMAKE_COMMAND "remove")
   endif()
+  set(MODFILE_CONFIG_FILE ${PROJECT_SOURCE_DIR}/${modfile_basename}.mod.in)
+  if(EXISTS ${MODFILE_CONFIG_FILE})
+    configure_file(${MODFILE_CONFIG_FILE} ${PROJECT_SOURCE_DIR}/${modfile_basename}.mod @ONLY)
+  endif()
+
   get_filename_component(modfile_output_dir ${PROJECT_SOURCE_DIR}/${modfile_basename}.mod DIRECTORY)
   add_custom_command(
     OUTPUT ${PROJECT_BINARY_DIR}/${modfile_basename}.cpp

--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -115,6 +115,17 @@ endif()
 # Translate all MOD files to C and mark them generated
 # =============================================================================
 foreach(modfile ${NRN_MODFILE_BASE_NAMES})
+  # =============================================================================
+  # ~~~
+  # Set the correct supported keyword for CoreNEURON compatibility
+  # - Replace GLOBAL variable by RANGE
+  # ~~~
+  # =============================================================================
+  if(NRN_ENABLE_CORENEURON OR NRN_ENABLE_MOD_COMPATIBILITY)
+    set(NRN_SUPPORTED_KEYWORD "RANGE")
+  else()
+    set(NRN_SUPPORTED_KEYWORD "GLOBAL")
+  endif()
   nocmodl_mod_to_cpp(${modfile})
   list(APPEND NRN_MODFILE_CPP ${PROJECT_BINARY_DIR}/${modfile}.cpp)
 endforeach()

--- a/src/nrnoc/hh.mod.in
+++ b/src/nrnoc/hh.mod.in
@@ -29,8 +29,8 @@ NEURON {
         USEION k READ ek WRITE ik REPRESENTS CHEBI:29103
         NONSPECIFIC_CURRENT il
         RANGE gnabar, gkbar, gl, el, gna, gk
-        : `GLOBAL minf` will be replaced with `RANGE minf` if CoreNEURON enabled
-        GLOBAL minf, hinf, ninf, mtau, htau, ntau
+        : set at compile-time to `GLOBAL` if using NEURON, `RANGE` if using CoreNEURON
+        @NRN_SUPPORTED_KEYWORD@ minf, hinf, ninf, mtau, htau, ntau
 	THREADSAFE : assigned GLOBALs will be per thread
 }
  


### PR DESCRIPTION
This is one way to fix #3000. It basically makes `hh.mod` `configure`-able by CMake, so we can decide at compile-time what to do with the file depending on whether or not we are using CoreNEURON.