### PR TITLE
Lvardt cell CvMembList.ml.size() should be the number of contiguous regions of the fixed step thread Memb_list

### DIFF
--- a/src/nrncvode/cvodeobj.h
+++ b/src/nrncvode/cvodeobj.h
@@ -30,7 +30,8 @@ struct model_sorted_token;
  *   contiguous
  * - with ml.size() >= 1 and ml[i].nodecount == 1 when non-contiguous instances need to be processed
  *
- * generic configurations with ml.size() and ml[i].nodecount both larger than one are not supported.
+ * generic configurations with ml.size() and ml[i].nodecount both larger than one are only
+ * supported for the local variable time step method.
  */
 struct CvMembList {
     CvMembList(int type)

--- a/src/nrncvode/occvode.cpp
+++ b/src/nrncvode/occvode.cpp
@@ -209,7 +209,7 @@ printf("%d Cvode::init_eqn id=%d neq_v_=%d #nonvint=%d #nonvint_extra=%d nvsize=
             NODERHS(z.v_node_[i]) = 1.;
         }
         i = 0;
-        for (auto& ml: z.cmlcap_->ml) {
+        if (zneq_cap_v) for (auto& ml: z.cmlcap_->ml) {
             for (int j = 0; j < ml.nodecount; ++j) {
                 auto* const node = ml.nodelist[j];
                 z.pv_[i] = node->v_handle();

--- a/src/nrncvode/occvode.cpp
+++ b/src/nrncvode/occvode.cpp
@@ -209,15 +209,16 @@ printf("%d Cvode::init_eqn id=%d neq_v_=%d #nonvint=%d #nonvint_extra=%d nvsize=
             NODERHS(z.v_node_[i]) = 1.;
         }
         i = 0;
-        if (zneq_cap_v) for (auto& ml: z.cmlcap_->ml) {
-            for (int j = 0; j < ml.nodecount; ++j) {
-                auto* const node = ml.nodelist[j];
-                z.pv_[i] = node->v_handle();
-                z.pvdot_[i] = node->rhs_handle();
-                *z.pvdot_[i] = 0.;  // only ones = 1 are no_cap
-                ++i;
+        if (zneq_cap_v)
+            for (auto& ml: z.cmlcap_->ml) {
+                for (int j = 0; j < ml.nodecount; ++j) {
+                    auto* const node = ml.nodelist[j];
+                    z.pv_[i] = node->v_handle();
+                    z.pvdot_[i] = node->rhs_handle();
+                    *z.pvdot_[i] = 0.;  // only ones = 1 are no_cap
+                    ++i;
+                }
             }
-        }
 
         // the remainder are no_cap nodes
         if (z.no_cap_node_) {


### PR DESCRIPTION
There are serious performance problems with the local variable time step method in comparison with 8.2 This PR is a prerequisite for fixing one of them.

The 9.0  implementation for local variable time step (each cell is integrated by its own cvode instance) demanded that a cell's ```CvMembList.ml.size()``` could be either 1 or ```Memb_list .nodecount```.
Thus, if there were multiple cells in a thread, the ```ml.size() == nodecount```, and each ```Memb_list``` instance was limited to a single Node*.

A subsequent PR will default sort the fixed step nodes so that Nodes of each cell will be as contiguous as possible. Presently, the default is that only nodes in a Section are contiguous.