### PR TITLE
Fix handling of `hh.mod` when using coreNEURON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -790,30 +790,6 @@ add_custom_target(
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 # =============================================================================
-# ~~~
-# Update hh.mod for CoreNEURON compatibility
-# - Replace GLOBAL variable by RANGE
-# - Comment out TABLE
-# ~~~
-# =============================================================================
-if(NRN_ENABLE_CORENEURON OR NRN_ENABLE_MOD_COMPATIBILITY)
-  set(GLOBAL_VAR_TOGGLE_COMMAND "'s/ GLOBAL minf/ RANGE minf/'")
-else()
-  set(GLOBAL_VAR_TOGGLE_COMMAND "'s/ RANGE minf/ GLOBAL minf/'")
-endif()
-separate_arguments(GLOBAL_VAR_TOGGLE_COMMAND UNIX_COMMAND "${GLOBAL_VAR_TOGGLE_COMMAND}")
-add_custom_target(
-  hh_update
-  COMMAND sed ${GLOBAL_VAR_TOGGLE_COMMAND} ${CMAKE_SOURCE_DIR}/src/nrnoc/hh.mod >
-          ${CMAKE_BINARY_DIR}/hh.mod.1
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/hh.mod.1
-          ${CMAKE_SOURCE_DIR}/src/nrnoc/hh.mod
-  COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_BINARY_DIR}/hh.mod.1
-  COMMENT "Update hh.mod for CoreNEURON compatibility"
-  VERBATIM)
-add_dependencies(nrniv_lib hh_update)
-
-# =============================================================================
 # Generate help_data.dat
 # =============================================================================
 if(NRN_ENABLE_PYTHON)

--- a/cmake/MacroHelper.cmake
+++ b/cmake/MacroHelper.cmake
@@ -144,29 +144,40 @@ endmacro()
 # =============================================================================
 # Run nocmodl to convert NMODL to C
 # =============================================================================
-macro(nocmodl_mod_to_cpp modfile_basename)
+macro(nocmodl_mod_to_cpp modfile_basename modfile_compat)
   set(NOCMODL_SED_EXPR "s/_reg()/_reg_()/")
   if(NOT MSVC)
     set(NOCMODL_SED_EXPR "'${NOCMODL_SED_EXPR}'")
   endif()
-  set(REMOVE_CMAKE_COMMAND "rm")
-  if(CMAKE_VERSION VERSION_LESS "3.17")
-    set(REMOVE_CMAKE_COMMAND "remove")
+  set(MODFILE_INPUT_PATH "${PROJECT_SOURCE_DIR}/${modfile_basename}.mod")
+  set(MODFILE_OUTPUT_PATH "${PROJECT_BINARY_DIR}/${modfile_basename}.mod")
+
+  # for coreNEURON only
+  if(modfile_compat)
+    file(READ "${MODFILE_INPUT_PATH}" FILE_CONTENT)
+    string(REGEX REPLACE " GLOBAL minf" " RANGE minf" FILE_CONTENT "${FILE_CONTENT}")
+    file(WRITE "${MODFILE_OUTPUT_PATH}" "${FILE_CONTENT}")
+  else()
+    configure_file("${MODFILE_INPUT_PATH}" "${MODFILE_OUTPUT_PATH}" COPYONLY)
   endif()
-  get_filename_component(modfile_output_dir ${PROJECT_SOURCE_DIR}/${modfile_basename}.mod DIRECTORY)
+
+  get_filename_component(modfile_output_dir "${MODFILE_OUTPUT_PATH}" DIRECTORY)
+  get_filename_component(modfile_name "${MODFILE_OUTPUT_PATH}" NAME_WE)
+  set(CPPFILE_OUTPUT_PATH "${modfile_output_dir}/${modfile_name}.cpp")
+
   add_custom_command(
-    OUTPUT ${PROJECT_BINARY_DIR}/${modfile_basename}.cpp
+    OUTPUT ${CPPFILE_OUTPUT_PATH}
     COMMAND
       ${CMAKE_COMMAND} -E env "MODLUNIT=${PROJECT_BINARY_DIR}/share/nrn/lib/nrnunits.lib"
       ${NRN_NOCMODL_SANITIZER_ENVIRONMENT} $<TARGET_FILE:${NRN_CODEGENERATOR_TARGET}>
-      ${PROJECT_SOURCE_DIR}/${modfile_basename}.mod ${NRN_NMODL_--neuron} -o ${modfile_output_dir}
-    COMMAND sed ${NOCMODL_SED_EXPR} ${PROJECT_SOURCE_DIR}/${modfile_basename}.cpp >
-            ${PROJECT_BINARY_DIR}/${modfile_basename}.cpp
-    COMMAND ${CMAKE_COMMAND} -E ${REMOVE_CMAKE_COMMAND}
-            ${PROJECT_SOURCE_DIR}/${modfile_basename}.cpp
-    DEPENDS ${NRN_CODEGENERATOR_TARGET} ${PROJECT_SOURCE_DIR}/${modfile_basename}.mod
+      ${MODFILE_OUTPUT_PATH} ${NRN_NMODL_--neuron} -o ${modfile_output_dir}
+    COMMAND sed ${NOCMODL_SED_EXPR} ${CPPFILE_OUTPUT_PATH} > ${CPPFILE_OUTPUT_PATH}.tmp
+    COMMAND ${CMAKE_COMMAND} -E copy ${CPPFILE_OUTPUT_PATH}.tmp ${CPPFILE_OUTPUT_PATH}
+    COMMAND ${CMAKE_COMMAND} -E remove ${CPPFILE_OUTPUT_PATH}.tmp
+    DEPENDS ${NRN_CODEGENERATOR_TARGET} ${MODFILE_INPUT_PATH}
             ${PROJECT_BINARY_DIR}/share/nrn/lib/nrnunits.lib
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src/nrniv)
+
 endmacro()
 
 # =============================================================================

--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -115,7 +115,11 @@ endif()
 # Translate all MOD files to C and mark them generated
 # =============================================================================
 foreach(modfile ${NRN_MODFILE_BASE_NAMES})
-  nocmodl_mod_to_cpp(${modfile})
+  set(modfile_compat OFF)
+  if((NRN_ENABLE_CORENEURON OR NRN_ENABLE_MOD_COMPATIBILITY) AND modfile MATCHES "hh$")
+    set(modfile_compat ON)
+  endif()
+  nocmodl_mod_to_cpp(${modfile} ${modfile_compat})
   list(APPEND NRN_MODFILE_CPP ${PROJECT_BINARY_DIR}/${modfile}.cpp)
 endforeach()
 set_property(


### PR DESCRIPTION
Fixes #3000.
All mod files are first copied to the build dir (unless it's `hh.mod` in coreNEURON mode, in which case we modify the file) at configure time, then at build-time those files are actually converted to `cpp` files and compiled.

Unfortunately, one cannot use `file` at _build-time_, so we need to use `add_custom_command` with an external util (like `sed`) for replacing `_reg()` with `_reg_()` in the generated cpp files (since those are actually generated only at build-time). I also opted for using `cmake -E copy` etc. for modifying the file because 1) `sed '[pattern]' [input] > [output]` does not work, and 2) the default MacOS `sed` has some idiosyncrasies compared to GNU `sed` that I wanted to avoid.