### PR TITLE
Fix CI failure on MacOS and Windows

### DIFF
--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -125,6 +125,8 @@ jobs:
             brew install cmake
             echo "$(brew --prefix)/opt/cmake/bin" >> $GITHUB_PATH
           fi
+          # workaround for fmt 11.1 (see https://github.com/gabime/spdlog/pull/3312)
+          brew unlink fmt
           echo "$(brew --prefix)/opt/flex/bin:$(brew --prefix)/opt/bison/bin" >> $GITHUB_PATH
           # Core https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
           if [[ "${{matrix.os}}" == "macOS-13" ]]; then

--- a/ci/win_install_deps.cmd
+++ b/ci/win_install_deps.cmd
@@ -66,10 +66,10 @@ mingw-w64-x86_64-cmake ^
 mingw-w64-x86_64-ninja ^
 mingw-w64-x86_64-ncurses ^
 mingw-w64-x86_64-readline ^
-mingw-w64-x86_64-python3 ^
+mingw-w64-x86_64-python ^
 mingw-w64-x86_64-python-setuptools ^
-mingw-w64-x86_64-python3-packaging ^
-mingw-w64-x86_64-python3-pip ^
+mingw-w64-x86_64-python-packaging ^
+mingw-w64-x86_64-python-pip ^
 mingw64/mingw-w64-x86_64-dlfcn ^
 mingw-w64-x86_64-toolchain || goto :error
 


### PR DESCRIPTION
The error in the CI is:

```plaintext
FAILED: external/nmodl/ext/spdlog/CMakeFiles/spdlog.dir/src/color_sinks.cpp.o 
ccache /usr/bin/g++  -DMPICH_SKIP_MPICXX=1 -DMPI_NO_CPPBIND=1 -DOMPI_SKIP_MPICXX=1 -DSPDLOG_COMPILED_LIB -DSPDLOG_FMT_EXTERNAL -I/usr/local/include -I/usr/X11R6/include -I/usr/local/opt/flex/include -I../external/nmodl/ext/spdlog/include -I../external/fmt/include -isystem ../external/iv/src/include -openmp-simd -g  -O2   -isysroot /Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk -mmacosx-version-min=13.7 -fPIC -fvisibility=hidden   -ferror-limit=1 -std=c++17 -MD -MT external/nmodl/ext/spdlog/CMakeFiles/spdlog.dir/src/color_sinks.cpp.o -MF external/nmodl/ext/spdlog/CMakeFiles/spdlog.dir/src/color_sinks.cpp.o.d -o external/nmodl/ext/spdlog/CMakeFiles/spdlog.dir/src/color_sinks.cpp.o -c ../external/nmodl/ext/spdlog/src/color_sinks.cpp
In file included from ../external/nmodl/ext/spdlog/src/color_sinks.cpp:10:
In file included from ../external/nmodl/ext/spdlog/include/spdlog/async.h:17:
In file included from ../external/nmodl/ext/spdlog/include/spdlog/async_logger.h:17:
In file included from ../external/nmodl/ext/spdlog/include/spdlog/logger.h:17:
../external/nmodl/ext/spdlog/include/spdlog/common.h:369:54: error: no template named 'basic_format_string' in namespace 'fmt'; did you mean 'basic_format_arg'?
inline fmt::basic_string_view<T> to_string_view(fmt::basic_format_string<T, Args...> fmt) {
                                                ~~~~~^~~~~~~~~~~~~~~~~~~
                                                     basic_format_arg
/usr/local/include/fmt/base.h:2442:35: note: 'basic_format_arg' declared here
template <typename Context> class basic_format_arg {
                                  ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
2 errors generated.
```

Key item is `-I/usr/local/include`, because a bit further up we see:

```plaintext
==> Fetching dependencies for ccache: blake3, fmt, hiredis and xxhash
==> Downloading https://ghcr.io/v2/homebrew/core/blake3/manifests/1.5.5
==> Fetching blake3
==> Downloading https://ghcr.io/v2/homebrew/core/blake3/blobs/sha256:f6f057edf60d9448debbe993061fe1ec0a19f706473a7f99a43cc122ec4ad95b
==> Downloading https://ghcr.io/v2/homebrew/core/fmt/manifests/11.1.1
==> Fetching fmt
```

The problem is, this new version of fmt broke spdlog (see https://github.com/gabime/spdlog/pull/3312).
Since homebrew only ships versions 11.1.1 and wherever `HEAD` currently is (see [the formula](https://formulae.brew.sh/api/formula/fmt.json)), the solution is to unlink the library.

Before unlinking:

```plaintext
$ file /usr/local/include/fmt
/usr/local/include/fmt: directory
```

after:


```plaintext
$ file /usr/local/include/fmt
/usr/local/include/fmt: cannot open `/usr/local/include/fmt' (No such file or directory)
```

**UPDATE**: Windows broke in the same way as #3252 so I applied fixes for that as well.