### PR TITLE
Generate dynamic MPI headers out-of-source

### DIFF
--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -274,13 +274,13 @@ add_dependencies(generated_source_files generate_hocusr_header)
 
 # header for dynamic mpi
 if(NRN_ENABLE_MPI_DYNAMIC)
-  configure_file(${PROJECT_SOURCE_DIR}/src/nrnmpi/mkdynam.sh.in
-                 ${PROJECT_BINARY_DIR}/src/nrnmpi/mkdynam.sh @ONLY)
+  file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/src/nrnmpi")
   add_custom_command(
     OUTPUT ${NRNMPI_DYNAMIC_INCLUDE_FILE}
-    COMMAND sh mkdynam.sh
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src/nrnmpi
-    DEPENDS ${PROJECT_SOURCE_DIR}/src/nrnmpi/nrnmpidec.h)
+    COMMAND sh mkdynam.sh "${PROJECT_BINARY_DIR}/src/nrnmpi"
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src/nrnmpi
+    DEPENDS ${PROJECT_SOURCE_DIR}/src/nrnmpi/mkdynam.sh
+            ${PROJECT_SOURCE_DIR}/src/nrnmpi/nrnmpidec.h)
 endif()
 
 # =============================================================================

--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -208,6 +208,7 @@ set(NRN_INCLUDE_DIRS
     ${NRN_OC_SRC_DIR}
     ${PROJECT_BINARY_DIR}
     ${PROJECT_BINARY_DIR}/src/nrncvode
+    ${PROJECT_BINARY_DIR}/src/nrnmpi
     ${PROJECT_BINARY_DIR}/src/nrnoc
     ${PROJECT_BINARY_DIR}/src/nrnpython
     ${PROJECT_BINARY_DIR}/src/oc
@@ -273,12 +274,13 @@ add_dependencies(generated_source_files generate_hocusr_header)
 
 # header for dynamic mpi
 if(NRN_ENABLE_MPI_DYNAMIC)
+  configure_file(${PROJECT_SOURCE_DIR}/src/nrnmpi/mkdynam.sh.in
+                 ${PROJECT_BINARY_DIR}/src/nrnmpi/mkdynam.sh @ONLY)
   add_custom_command(
     OUTPUT ${NRNMPI_DYNAMIC_INCLUDE_FILE}
     COMMAND sh mkdynam.sh
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src/nrnmpi
-    DEPENDS ${PROJECT_SOURCE_DIR}/src/nrnmpi/mkdynam.sh
-            ${PROJECT_SOURCE_DIR}/src/nrnmpi/nrnmpidec.h)
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src/nrnmpi
+    DEPENDS ${PROJECT_SOURCE_DIR}/src/nrnmpi/nrnmpidec.h)
 endif()
 
 # =============================================================================

--- a/src/nrnmpi/mkdynam.sh.in
+++ b/src/nrnmpi/mkdynam.sh.in
@@ -2,15 +2,17 @@
 
 set -e
 
-names=`sed -n '
+NRNMPI_SOURCE='@PROJECT_SOURCE_DIR@/src/nrnmpi/nrnmpidec.h'
+
+names="$(sed -n '
 /extern /s/extern [a-z*]* \(nrnmpi_[a-zA-Z0-9_]*\)(.*);/\1/p
-' nrnmpidec.h`
+' "${NRNMPI_SOURCE}")"
 
 #generate nrnmpi_dynam_wrappers.inc
 sed -n '
 /extern void/s/extern \(void\) \(nrnmpi_[a-zA-Z0-9_]*\)\(.*\);/\1 \2\3 {@  (*p_\2)\3;@}/p
 /extern [^v]/s/extern \([a-z*]*\) \(nrnmpi_[a-zA-Z0-9_]*\)\(.*\);/\1 \2\3 {@  return (*p_\2)\3;@}/p
-' nrnmpidec.h | tr '@' '\n' | sed '
+' "${NRNMPI_SOURCE}" | tr '@' '\n' | sed '
 /p_nrnmpi/ {
 s/, const [a-zA-Z0-9_:*&]* /, /g
 s/)(const [a-zA-Z0-9_:*&]* /)(/
@@ -48,7 +50,7 @@ echo '
 
 sed -n '
 /extern/s/extern \([a-z*]*\) \(nrnmpi_[a-zA-Z0-9_]*\)\(.*\);/static \1 (*p_\2)\3;/p
-' nrnmpidec.h
+' "${NRNMPI_SOURCE}"
 echo '
 static struct {
 	const char* name;
@@ -61,4 +63,3 @@ echo '	0,0
 };
 '
 ) > nrnmpi_dynam_cinc
-


### PR DESCRIPTION
With this change, both `src` and `share` dirs no longer contain any build artifacts 🎉  (except `*.egg-info`, which is a bug in `setuptools`, see https://github.com/pypa/setuptools/issues/1347, though I hope to replace `setuptools` with `scikit-build-core` at some point in the future).