### PR TITLE
Use `PyBool_FromLong` instead of macros

### DIFF
--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -2386,10 +2386,7 @@ PyObject* nrn_ptr_richcmp(void* self_ptr, void* other_ptr, int op) {
         result = self_ptr >= other_ptr;
         break;
     }
-    if (result) {
-        Py_RETURN_TRUE;
-    }
-    Py_RETURN_FALSE;
+    return PyBool_FromLong(result);
 }
 
 // TODO: unfortunately, this duplicates code from hocobj_same; consolidate?
@@ -2440,20 +2437,14 @@ static PyObject* hocobj_richcmp(PyHocObject* self, PyObject* other, int op) {
                     break;
                 }
                 if (self->nindex_ != pyhoc_other->nindex_ || self->sym_ != pyhoc_other->sym_) {
-                    if (op == Py_NE) {
-                        Py_RETURN_TRUE;
-                    }
-                    Py_RETURN_FALSE;
+                    return PyBool_FromLong(op == Py_NE);
                 }
                 for (int i = 0; i < self->nindex_; i++) {
                     if (self->indices_[i] != pyhoc_other->indices_[i]) {
                         are_equal = false;
                     }
                 }
-                if (are_equal == (op == Py_EQ)) {
-                    Py_RETURN_TRUE;
-                }
-                Py_RETURN_FALSE;
+                return PyBool_FromLong(are_equal == (op == Py_EQ));
             default:
                 other_ptr = pyhoc_other->ho_;
             }
@@ -2474,12 +2465,8 @@ static PyObject* hocobj_richcmp(PyHocObject* self, PyObject* other, int op) {
 static PyObject* hocobj_same(PyHocObject* pself, PyObject* args) {
     PyObject* po;
     if (PyArg_ParseTuple(args, "O", &po)) {
-        if (PyObject_TypeCheck(po, hocobject_type)) {
-            if (((PyHocObject*) po)->ho_ == pself->ho_) {
-                Py_RETURN_TRUE;
-            }
-        }
-        Py_RETURN_FALSE;
+        return PyBool_FromLong(PyObject_TypeCheck(po, hocobject_type) &&
+                               ((PyHocObject*) po)->ho_ == pself->ho_);
     }
     return NULL;
 }

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -206,7 +206,7 @@ static PyObject* nrnexec(PyObject* self, PyObject* args) {
         return NULL;
     }
     bool b = hoc_valid_stmt(cmd, 0);
-    return b ? Py_True : Py_False;
+    return PyBool_FromLong(b);
 }
 
 static PyObject* nrnexec_safe(PyObject* self, PyObject* args) {

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -859,11 +859,7 @@ static PyObject* NPySecObj_pt3dstyle(NPySecObj* self, PyObject* args) {
             return NULL;
         }
     }
-
-    if (sec->logical_connection) {
-        Py_RETURN_TRUE;
-    }
-    Py_RETURN_FALSE;
+    return PyBool_FromLong(sec->logical_connection != nullptr);
 }
 
 static PyObject* NPySecObj_pt3dstyle_safe(NPySecObj* self, PyObject* args) {
@@ -956,10 +952,7 @@ static PyObject* NPySecObj_spine3d(NPySecObj* self, PyObject* args) {
     if (pt3d == NULL) {
         return NULL;
     }
-    if (pt3d->d < 0) {
-        Py_RETURN_TRUE;
-    }
-    Py_RETURN_FALSE;
+    return PyBool_FromLong(pt3d->d < 0);
 }
 
 static PyObject* NPySecObj_spine3d_safe(NPySecObj* self, PyObject* args) {
@@ -1044,10 +1037,8 @@ static PyObject* NPySecObj_psection_safe(NPySecObj* self) {
 
 static PyObject* is_pysec(NPySecObj* self) {
     CHECK_SEC_INVALID(self->sec_);
-    if (self->sec_->prop && self->sec_->prop->dparam[PROP_PY_INDEX].get<void*>()) {
-        Py_RETURN_TRUE;
-    }
-    Py_RETURN_FALSE;
+    return PyBool_FromLong(self->sec_->prop &&
+                           self->sec_->prop->dparam[PROP_PY_INDEX].get<void*>());
 }
 
 static PyObject* is_pysec_safe(NPySecObj* self) {
@@ -1316,14 +1307,9 @@ static PyObject* pysec_richcmp_safe(NPySecObj* self, PyObject* other, int op) {
 
 static PyObject* pysec_same(NPySecObj* self, PyObject* args) {
     PyObject* pysec;
-    if (PyArg_ParseTuple(args, "O", &pysec)) {
-        if (PyObject_TypeCheck(pysec, psection_type)) {
-            if (((NPySecObj*) pysec)->sec_ == self->sec_) {
-                Py_RETURN_TRUE;
-            }
-        }
-    }
-    Py_RETURN_FALSE;
+    return PyBool_FromLong(PyArg_ParseTuple(args, "O", &pysec) &&
+                           PyObject_TypeCheck(pysec, psection_type) &&
+                           ((NPySecObj*) pysec)->sec_ == self->sec_);
 }
 
 static PyObject* pysec_same_safe(NPySecObj* self, PyObject* args) {
@@ -1391,10 +1377,7 @@ static PyObject* NPyMechFunc_call_safe(NPyMechFunc* self, PyObject* args) {
 
 static PyObject* NPyMechObj_is_ion(NPyMechObj* self) {
     CHECK_PROP_INVALID(self->prop_id_);
-    if (nrn_is_ion(self->type_)) {
-        Py_RETURN_TRUE;
-    }
-    Py_RETURN_FALSE;
+    return PyBool_FromLong(nrn_is_ion(self->type_));
 }
 
 static PyObject* NPyMechObj_is_ion_safe(NPyMechObj* self) {

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -1590,7 +1590,7 @@ static PyObject* NPySecObj_has_membrane(NPySecObj* self, PyObject* args) {
     if (!PyArg_ParseTuple(args, "s", &mechanism_name)) {
         return NULL;
     }
-    result = has_membrane(mechanism_name, self->sec_) ? Py_True : Py_False;
+    result = PyBool_FromLong(has_membrane(mechanism_name, self->sec_));
     Py_XINCREF(result);
     return result;
 }


### PR DESCRIPTION
* use `PyBool_FromLong` (part of stable ABI/limited API) instead of macros
* simplify some logic to use less branching

As an impl detail, the function is defined in cpython as:

```c
PyObject *PyBool_FromLong(long ok)
{
    return ok ? Py_True : Py_False;
}
```