### PR TITLE
Expand scope of `NRN_AVOID_ABSOLUTE_PATHS`

### DIFF
--- a/src/nocmodl/io.cpp
+++ b/src/nocmodl/io.cpp
@@ -216,8 +216,15 @@ void unGets(char* buf)		/* all this because we don't have an ENDBLOCK
 char* current_line() { /* assumes we actually want the previous line */
     static char buf[NRN_BUFSIZE];
     char* p;
-    Sprintf(
-        buf, "at line %d in file %s:\\n%s", linenum - 1, finname, inlinebuf[whichbuf ? 0 : 1] + 30);
+    Sprintf(buf,
+            "at line %d in file %s:\\n%s",
+            linenum - 1,
+#if !defined(NRN_AVOID_ABSOLUTE_PATHS)
+            finname,
+#else
+            fs::absolute(finname).filename().c_str(),
+#endif
+            inlinebuf[whichbuf ? 0 : 1] + 30);
     for (p = buf; *p; ++p) {
         if (*p == '\n') {
             *p = '\0';

--- a/src/nocmodl/modl.cpp
+++ b/src/nocmodl/modl.cpp
@@ -152,7 +152,9 @@ int main(int argc, char** argv) {
 #if !defined(NRN_AVOID_ABSOLUTE_PATHS)
         fprintf(fcout, "    const char* nmodl_filename = \"%s\";\n", fs::absolute(finname).c_str());
 #else
-        fprintf(fcout, "    const char* nmodl_filename = \"%s\";\n", finname);
+        fprintf(fcout,
+                "    const char* nmodl_filename = \"%s\";\n",
+                fs::path(finname).filename().c_str());
 #endif
         fprintf(fcout, "    const char* nmodl_file_text = \n");
         ITERATE(q, filetxtlist) {

--- a/src/nocmodl/nocpout.cpp
+++ b/src/nocmodl/nocpout.cpp
@@ -1427,7 +1427,10 @@ if (auto* const _extnode = _nrn_mechanism_access_extnode(_nd); _extnode) {\n\
                 mechname,
                 fs::absolute(finname).c_str());
 #else
-        Sprintf(buf1, "\tivoc_help(\"help ?1 %s %s\\n\");\n", mechname, finname);
+        Sprintf(buf1,
+                "\tivoc_help(\"help ?1 %s %s\\n\");\n",
+                mechname,
+                fs::path(finname).filename().c_str());
 #endif
         Lappendstr(defs_list, buf1);
     }


### PR DESCRIPTION
Part 1 towards #3309.
If `NRN_AVOID_ABSOLUTE_PATHS=ON`, only the filename is now inserted in the generated mod files (some parts were missing before).
Note that this is not the default setting so it has no effect on releases.