### PR TITLE
Copy mod files out-of-source when testing wheels

### DIFF
--- a/packaging/python/test_wheels.sh
+++ b/packaging/python/test_wheels.sh
@@ -74,9 +74,14 @@ run_mpi_test () {
   # coreneuron execution via neuron
   if [[ "$has_coreneuron" == "true" ]]; then
     rm -rf $ARCH_DIR
+    TEMP_DIR="${TMPDIR:-/tmp}/test/coreneuron/mod files/"
+    if [ ! -d "${TEMP_DIR}" ]; then
+        mkdir -p "${TEMP_DIR}"
+    fi
+    cp "test/coreneuron/mod files/"* "${TEMP_DIR}/"
     # also copy one MOD file containing sparse solver
-    cp share/examples/nrniv/nmodl/capmp.mod "test/coreneuron/mod files/"
-    nrnivmodl -coreneuron "test/coreneuron/mod files/"
+    cp share/examples/nrniv/nmodl/capmp.mod "${TEMP_DIR}"
+    nrnivmodl -coreneuron "${TEMP_DIR}"
 
     $mpi_launcher -n 1 $python_exe test/coreneuron/test_direct.py
 


### PR DESCRIPTION
After running `test_wheels.sh`, `capmp.mod` ends up in`test/coreneuron/mod files/`, which is in the source tree. Instead, respect `TMPDIR` and dump the mod files there before compilation.