### PR TITLE
Fix RXD test

### DIFF
--- a/ci_requirements.txt
+++ b/ci_requirements.txt
@@ -1,3 +1,4 @@
 plotly
 ipywidgets>=7.0.0
 tenacity<8.4 # needed until plotly fixes it upstream
+anywidget

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -17,3 +17,4 @@ sphinx-design
 sphinx-inline-tabs
 packaging==21.3
 tenacity<8.4
+anywidget

--- a/packaging/python/test_requirements.txt
+++ b/packaging/python/test_requirements.txt
@@ -3,3 +3,4 @@ pytest<=8.1.1 # potential bug from 8.2.0 due to parallelism?
 pytest-cov
 # for RXD test
 plotly
+anywidget


### PR DESCRIPTION
Plotly 6 requires `anywidget`.