### PR TITLE
Explicitly pin all Python dependencies to max versions

### DIFF
--- a/ci_requirements.txt
+++ b/ci_requirements.txt
@@ -1,4 +1,4 @@
-plotly
-ipywidgets>=7.0.0
+plotly<=6.0.0
+ipywidgets>=7.0.0,<=8.1.5
 tenacity<8.4 # needed until plotly fixes it upstream
-anywidget
+anywidget<=0.9.13

--- a/nrn_requirements.txt
+++ b/nrn_requirements.txt
@@ -1,10 +1,9 @@
-wheel
-setuptools_scm
+wheel<=0.45.1
+setuptools_scm<=8.1.0
 setuptools<=70.3.0
-scikit-build
-matplotlib
-ipython
-mpi4py
-find_libpython
+matplotlib<=3.10.0
+ipython<=8.32.0
+mpi4py<=4.0.3
+find_libpython<=0.4.0
 -r packaging/python/build_requirements.txt
 -r packaging/python/test_requirements.txt

--- a/packaging/python/build_requirements.txt
+++ b/packaging/python/build_requirements.txt
@@ -1,3 +1,3 @@
-cython
-packaging
-numpy
+cython<=3.0.12
+packaging<=24.2.0
+numpy<=2.2.3

--- a/packaging/python/test_requirements.txt
+++ b/packaging/python/test_requirements.txt
@@ -1,6 +1,6 @@
 pytest<=8.1.1 # potential bug from 8.2.0 due to parallelism?
 # for coverage
-pytest-cov
+pytest-cov<=6.0.0
 # for RXD test
-plotly
-anywidget
+plotly<=6.0.0
+anywidget<=0.9.13

--- a/setup.py
+++ b/setup.py
@@ -523,22 +523,22 @@ def setup_package():
         },
         cmdclass=dict(build_ext=CMakeAugmentedBuilder, docs=Docs),
         install_requires=[
-            "numpy>=1.9.3",
-            "packaging",
-            "find_libpython",
+            "numpy>=1.9.3,<=2.2.3",
+            "packaging<=24.2.0",
+            "find_libpython<=0.4.0",
             "setuptools<=70.3.0",
         ]
         + (
             [
-                "sympy>=1.3",
+                "sympy>=1.3,<=1.13.3",
                 "importlib_resources;python_version<'3.9'",
                 "importlib_metadata;python_version<'3.9'",
             ]
             if Components.CORENRN
             else []
         ),
-        tests_require=["flake8", "pytest"],
-        setup_requires=["wheel", "setuptools_scm"]
+        tests_require=["flake8<=7.1.2", "pytest<=8.1.1"],
+        setup_requires=["wheel<=0.45.1", "setuptools_scm<=8.1.0"]
         + maybe_docs
         + maybe_test_runner
         + maybe_rxd_reqs,


### PR DESCRIPTION
Since Python packages keep making breaking changes, even on minor releases, this PR basically pins all Python dependencies to their max working versions, using the `<=major.minor.patch` condition, where `major.minor.patch` is the latest version of a given Python package that is known to work with NEURON.

This solves 2 problems:
- the CI randomly breaking when any of the Python dependencies inevitably gets updated
- users complaining that NEURON doesn't build/run with their own set of Python dependencies