### PR TITLE
Bump Ubuntu image in Azure CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ stages:
     - job: 'ManyLinuxWheels'
       timeoutInMinutes: 45
       pool:
-        vmImage: 'ubuntu-20.04'
+        vmImage: 'ubuntu-22.04'
       strategy:
         matrix:
           Python39:
@@ -161,7 +161,7 @@ stages:
     jobs:
       - job: AzureDropURL
         pool:
-          vmImage: 'ubuntu-20.04'
+          vmImage: 'ubuntu-22.04'
         condition: eq(variables['Build.Reason'], 'PullRequest')
         steps:
           - checkout: none


### PR DESCRIPTION
I noticed this message in Azure:

> The Ubuntu-20.04 image for the Microsoft-hosted "Azure Pipelines" pool is deprecated and will be retired April 1st. Please review [aka.ms/azdo-ubuntu-20.04](https://aka.ms/azdo-ubuntu-20.04) for brownout schedule and other image news.

so I guess it's time to move to Ubuntu 22.04.