### PR TITLE
fixed typo that caused backticks to appear in documentation

### DIFF
--- a/docs/dev/how-do-i/how-do-i.rst
+++ b/docs/dev/how-do-i/how-do-i.rst
@@ -78,7 +78,7 @@ Note: NEURON argument indices are always numbered from 1.
 Check for the existence of an argument
 --------------------------------------
 
-Use ``ifarg(n)`` to check to see if there is an ``n``th argument (the arguments are numbered from 1).
+Use ``ifarg(n)`` to check to see if there is an ``n``\ th argument (the arguments are numbered from 1).
 
 Many existing functions and methods currently do not check for too many arguments, however doing
 so is recommended as it indicates a probable user error.


### PR DESCRIPTION
A \ followed by whitespace removes the whitespace. Here it allows the backticked quantity to end.