### PR TITLE
vector.apply works with numeric returns convertable to floats

### DIFF
--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -3476,22 +3476,19 @@ static double nrnpy_call_func_(Object* obj, double x) {
     }
     PyObject* func = nrnpy_hoc2pyobject(obj);
     if (!PyCallable_Check(func)) {
-        PyErr_SetString(PyExc_TypeError, "Object is not callable");
-        return 0.0;
+	hoc_execerror("Object is not callable", nullptr);
     }
     auto result = nb::steal(PyObject_CallFunction(func, "d", x));
     if (!result) {
-        // leave whatever error occurred set
-        return 0.0;
+        PyErr_Clear();
+	hoc_execerror("Python function call raised exception", nullptr);
     }
     if (!PyNumber_Check(result.ptr())) {
-        PyErr_SetString(PyExc_TypeError, "Expected a numeric result from Python function");
-        return 0.0;
+        hoc_execerror("Expected a numeric result from Python function", nullptr);
     }
     double value = PyFloat_AsDouble(result.ptr());
     if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_TypeError, "Failed to convert result to float");
-        return 0.0;
+	hoc_execerror("Failed to convert result to float", nullptr);
     }
     return value;
 }

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -3476,19 +3476,19 @@ static double nrnpy_call_func_(Object* obj, double x) {
     }
     PyObject* func = nrnpy_hoc2pyobject(obj);
     if (!PyCallable_Check(func)) {
-	    hoc_execerror("Object is not callable", nullptr);
+        hoc_execerror("Object is not callable", nullptr);
     }
     auto result = nb::steal(PyObject_CallFunction(func, "d", x));
     if (!result) {
         PyErr_Clear();
-	    hoc_execerror("Python function call raised exception", nullptr);
+        hoc_execerror("Python function call raised exception", nullptr);
     }
     if (!PyNumber_Check(result.ptr())) {
         hoc_execerror("Expected a numeric result from Python function", nullptr);
     }
     double value = PyFloat_AsDouble(result.ptr());
     if (PyErr_Occurred()) {
-	    hoc_execerror("Failed to convert result to float", nullptr);
+        hoc_execerror("Failed to convert result to float", nullptr);
     }
     return value;
 }

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -3484,10 +3484,14 @@ static double nrnpy_call_func_(Object* obj, double x) {
         // leave whatever error occurred set
         return 0.0;
     }
-    if (!PyFloat_Check(result.ptr())) {
-        PyErr_SetString(PyExc_TypeError, "Expected a float result from Python function");
+    if (!PyNumber_Check(result.ptr())) {
+        PyErr_SetString(PyExc_TypeError, "Expected a numeric result from Python function");
         return 0.0;
     }
     double value = PyFloat_AsDouble(result.ptr());
+    if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_TypeError, "Failed to convert result to float");
+        return 0.0;
+    }
     return value;
 }

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -3476,19 +3476,19 @@ static double nrnpy_call_func_(Object* obj, double x) {
     }
     PyObject* func = nrnpy_hoc2pyobject(obj);
     if (!PyCallable_Check(func)) {
-	hoc_execerror("Object is not callable", nullptr);
+	    hoc_execerror("Object is not callable", nullptr);
     }
     auto result = nb::steal(PyObject_CallFunction(func, "d", x));
     if (!result) {
         PyErr_Clear();
-	hoc_execerror("Python function call raised exception", nullptr);
+	    hoc_execerror("Python function call raised exception", nullptr);
     }
     if (!PyNumber_Check(result.ptr())) {
         hoc_execerror("Expected a numeric result from Python function", nullptr);
     }
     double value = PyFloat_AsDouble(result.ptr());
     if (PyErr_Occurred()) {
-	hoc_execerror("Failed to convert result to float", nullptr);
+	    hoc_execerror("Failed to convert result to float", nullptr);
     }
     return value;
 }

--- a/test/hoctests/tests/test_vector.py
+++ b/test/hoctests/tests/test_vector.py
@@ -33,3 +33,7 @@ def unusable_function(x):
 
 
 expect_err("vec.apply(unusable_function)")
+
+# check works with ints and not just floats
+vec.apply(int)
+assert list(vec) == [4.0, -1.0, 17.0]


### PR DESCRIPTION
Previously: needed something that was a float so int return values wouldn't work