### PR TITLE
NRN_COVERAGE_FILES compiled in other CMakeLists.txt not covered.

### DIFF
--- a/cmake/Coverage.cmake
+++ b/cmake/Coverage.cmake
@@ -46,6 +46,8 @@ if(NRN_ENABLE_COVERAGE)
     # they are compiled and linked in src/nrnpython/CMakeLists.txt.
     # I.e. successful with
     # -DNRN_COVERAGE_FILES="src/nrniv/partrans.cpp;src/nmodl/parsact.cpp;src/nrnpython/nrnpy_hoc.cpp"
+    # Used to work but now files compiled in other CMakeLists.txt need the
+    # coverage flags set there.
     # ~~~
     if(NRN_ADDED_COVERAGE_FLAGS)
       message(
@@ -75,6 +77,26 @@ else()
     )
   endif()
 endif()
+
+# Macro to apply coverage flags to source files Use this macro in any CMakeLists.txt file that might
+# compile a file mentioned in NRN_COVERAGE_FILES
+macro(nrn_enable_coverage_files)
+  if(NRN_COVERAGE_FILES)
+    foreach(f ${NRN_COVERAGE_FILES})
+      get_property(
+        current_flags
+        SOURCE ${PROJECT_SOURCE_DIR}/${f}
+        PROPERTY COMPILE_FLAGS)
+      string(FIND "${current_flags}" "${NRN_COVERAGE_FLAGS}" found_pos)
+      if(found_pos EQUAL -1) # -1 means not found
+        set_property(
+          SOURCE ${PROJECT_SOURCE_DIR}/${f}
+          APPEND
+          PROPERTY COMPILE_FLAGS ${NRN_COVERAGE_FLAGS})
+      endif()
+    endforeach()
+  endif()
+endmacro()
 
 if(NRN_ENABLE_COVERAGE)
   set(cover_clean_command find "${PROJECT_BINARY_DIR}" "-name" "*.gcda" "-type" "f" "-delete")

--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -394,14 +394,8 @@ if(NRN_ENABLE_MUSIC)
                               PROPERTIES INCLUDE_DIRECTORIES ${MUSIC_INCDIR})
 endif()
 
-if(NRN_COVERAGE_FILES)
-  foreach(f ${NRN_COVERAGE_FILES})
-    set_property(
-      SOURCE ${PROJECT_SOURCE_DIR}/${f}
-      APPEND
-      PROPERTY COMPILE_FLAGS ${NRN_COVERAGE_FLAGS})
-  endforeach()
-endif()
+# Maybe NRN_COVERAGE_FILES mentions a file compiled by this CMakeLists.txt
+nrn_enable_coverage_files()
 
 # =============================================================================
 # All source directories to include

--- a/src/nrnpython/CMakeLists.txt
+++ b/src/nrnpython/CMakeLists.txt
@@ -85,6 +85,9 @@ endif()
 configure_file(_config_params.py.in "${PROJECT_BINARY_DIR}/lib/python/neuron/_config_params.py"
                @ONLY)
 
+# Maybe NRN_COVERAGE_FILES mentions a file compiled by this CMakeLists.txt
+nrn_enable_coverage_files()
+
 # Install package files that were created in build (e.g. .py.in)
 install(
   DIRECTORY ${PROJECT_BINARY_DIR}/share/lib/python


### PR DESCRIPTION
The ```if(NRN_COVERAGE_FILES)...``` fragment in src/nrniv/CMakeLists.txt no longer works for files compiled by other CMakeLists.txt files. The macro ```nrn_enable_coverage_files()``` needs to be in each CMakeLists.txt file which compiles files that are mentioned in NRN_COVERAGE_FILES.
This has been tested with 
```
cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=install -DNRN_ENABLE_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DNRN_ENABLE_COVERAGE=ON -DNRN_COVERAGE_FILES="src/oc/fileio.cpp;src/nrnpython/nrnpy_hoc.cpp"
```
and the build.ninja FLAGS for fileio.cpp and nrnpy_hoc.cpp look like:
```
FLAGS = -fopenmp-simd -g  -O0 -fstack-protector  -std=c++17 -fPIC --coverage -fno-inline -fprofile-update=atomic
```

It probably makes sense to add the macro in the many src/nmodl... CMakeLists.txt files as well.
Many attempts at doing this just in the top level CMakeLists.txt files failed.