### PR TITLE
Bump version of Ubuntu in CI, pin specific CMake version

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,6 +47,11 @@ jobs:
           sudo apt-get install xfonts-100dpi build-essential doxygen lcov libboost-all-dev libopenmpi-dev libmpich-dev libx11-dev libxcomposite-dev mpich openmpi-bin gpg ninja-build flex bison libfl-dev
         shell: bash
 
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version : '3.18'
+
       - name: Setup Caliper profiler
         run: |
           git clone https://github.com/LLNL/Caliper.git

--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -46,7 +46,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macOS-13, ubuntu-20.04]
+        os: [macOS-13, ubuntu-22.04]
         config:
           - { matrix_eval : "CC=gcc-9 CXX=g++-9",   build_mode: "setuptools"}
           - { matrix_eval : "CC=gcc-10 CXX=g++-10", build_mode: "cmake", music: ON}
@@ -145,10 +145,6 @@ jobs:
           sudo apt-get install build-essential ccache libopenmpi-dev \
             libmpich-dev libx11-dev libxcomposite-dev mpich ninja-build \
             openmpi-bin flex libfl-dev bison libreadline-dev
-          # The sanitizer builds use ubuntu 22.04
-          if [[ "${{matrix.os}}" == "ubuntu-20.04" ]]; then
-            sudo apt-get install g++-7 g++-8
-          fi
           # Core https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
           echo CMAKE_BUILD_PARALLEL_LEVEL=4 >> $GITHUB_ENV
           echo CTEST_PARALLEL_LEVEL=4 >> $GITHUB_ENV


### PR DESCRIPTION
Ubuntu 20.04 runner image be removed on 2025-04-15, so we need to move to at least 22.04.
Source: https://github.com/actions/runner-images/issues/11101

There's also an unrelated change with setting up a specific version of CMake in the code coverage CI due to this error:

```plaintext
CMake Error at external/backward/CMakeLists.txt:23 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```

This is (most likely) caused by the recent release of CMake 4.0.0, since, from the [release notes](https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features):

> Compatibility with versions of CMake older than 3.5 has been removed. Calls to [cmake_minimum_required()](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required) or [cmake_policy()](https://cmake.org/cmake/help/latest/command/cmake_policy.html#command:cmake_policy) that set the policy version to an older value now issue an error.

There's also an issue upstream: https://github.com/actions/runner-images/issues/11926