### PR TITLE
Fix WindowsInstaller ModuleNotFoundError: No module named 'readline'

### DIFF
--- a/ci/win_install_deps.cmd
+++ b/ci/win_install_deps.cmd
@@ -21,11 +21,11 @@ pwsh -command "(Get-Content C:\Python310\Lib\distutils\cygwinccompiler.py) -repl
 pwsh -command "(Get-Content C:\Python311\Lib\distutils\cygwinccompiler.py) -replace 'msvcr100', 'msvcrt' | Out-File C:\Python311\Lib\distutils\cygwinccompiler.py"
 
 :: install numpy
-C:\Python39\python.exe -m pip install  numpy==1.19.3 "cython<3" || goto :error
-C:\Python310\python.exe -m pip install numpy==1.21.3 "cython<3" || goto :error
-C:\Python311\python.exe -m pip install numpy==1.23.5 "cython<3" || goto :error
-C:\Python312\python.exe -m pip install numpy==1.26.3 "cython<3" || goto :error
-C:\Python313\python.exe -m pip install numpy cython || goto :error
+C:\Python39\python.exe -m pip install  "numpy<=2.2.3" "cython<=3.0.12" || goto :error
+C:\Python310\python.exe -m pip install "numpy<=2.2.3" "cython<=3.0.12" || goto :error
+C:\Python311\python.exe -m pip install "numpy<=2.2.3" "cython<=3.0.12" || goto :error
+C:\Python312\python.exe -m pip install "numpy<=2.2.3" "cython<=3.0.12" || goto :error
+C:\Python313\python.exe -m pip install "numpy<=2.2.3" "cython<=3.0.12" || goto :error
 :: setuptools 70.2 leads to an error
 C:\Python312\python.exe -m pip install setuptools==70.1.1 || goto :error
 C:\Python313\python.exe -m pip install setuptools==70.1.1 || goto :error

--- a/ci/win_test_installer.cmd
+++ b/ci/win_test_installer.cmd
@@ -53,9 +53,6 @@ python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
 :: test python and nrniv
 python -c "from neuron import h; s = h.Section(); s.insert('hh'); quit()" || set "errorfound=y"
 python -m pip install "pyreadline3<=3.5.4"
-python -c "import sys; print(sys.executable)"
-python -c "import sys; print(sys.path)"
-nrniv -python -c "import sys; print(sys.path)"
 nrniv -python -c "from neuron import h; s = h.Section(); s.insert('hh'); quit()" || set "errorfound=y"
 
 :: test mpi

--- a/ci/win_test_installer.cmd
+++ b/ci/win_test_installer.cmd
@@ -52,6 +52,10 @@ python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
 
 :: test python and nrniv
 python -c "from neuron import h; s = h.Section(); s.insert('hh'); quit()" || set "errorfound=y"
+python -m pip install "pyreadline3<=3.5.4"
+python -c "import sys; print(sys.executable)"
+python -c "import sys; print(sys.path)"
+nrniv -python -c "import sys; print(sys.path)"
 nrniv -python -c "from neuron import h; s = h.Section(); s.insert('hh'); quit()" || set "errorfound=y"
 
 :: test mpi

--- a/ci/win_test_installer.cmd
+++ b/ci/win_test_installer.cmd
@@ -16,6 +16,13 @@ echo %NEURONHOME%
 :: If so, try again to generate it. No wait required like previous strategies, we rely on testing entropy from this point on.
 if not exist association.hoc.out (start /wait /REALTIME %cd%\ci\association.hoc)
 
+:: make sure readline is available
+C:\Python39\python.exe -m pip install "pyreadline3<=3.5.4"  || goto :error
+C:\Python310\python.exe -m pip install "pyreadline3<=3.5.4" || goto :error
+C:\Python311\python.exe -m pip install "pyreadline3<=3.5.4" || goto :error
+C:\Python312\python.exe -m pip install "pyreadline3<=3.5.4" || goto :error
+C:\Python313\python.exe -m pip install "pyreadline3<=3.5.4" || goto :error
+
 :: test all pythons
 C:\Python39\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
 C:\Python310\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"

--- a/nrn_requirements.txt
+++ b/nrn_requirements.txt
@@ -11,3 +11,4 @@ pytest
 pytest-cov
 mpi4py
 numpy
+pyreadline3<=3.5.4; sys_platform == "win32"

--- a/setup.py
+++ b/setup.py
@@ -590,6 +590,7 @@ def setup_package():
             "packaging",
             "find_libpython",
             "setuptools",
+            'pyreadline3<=3.5.4; sys_platform == "win32"',
         ]
         + maybe_patchelf,
         tests_require=["flake8", "pytest"],


### PR DESCRIPTION
This was occurring during execution on github of master branch .github/workflows/release.yml
That was activated manually from #3367 
```
Create new release+tag on GitHub via release workflow. 
```
Ultimately we experienced a failure for WindowsInstaller
```
ModuleNotFoundError: No module named 'readline'
...
"Uninstalled NEURON"
ERROR : exiting with error code 1 ..
Error: Process completed with exit code 1.
```

Perhaps we should test this at the PR level and not have to try a manual release.