### PR TITLE
For issue https://github.com/neuronsimulator/nrn/issues/3330 (#1)

### DIFF
--- a/src/nmodl/codegen/codegen_cpp_visitor.cpp
+++ b/src/nmodl/codegen/codegen_cpp_visitor.cpp
@@ -1759,15 +1759,17 @@ std::tuple<bool, int> CodegenCppVisitor::check_if_var_is_array(const std::string
 void CodegenCppVisitor::print_rename_state_vars() const {
     for (const auto& state: info.state_vars) {
         auto state_name = state->get_name();
-        auto lhs = get_variable_name(state_name);
-        auto rhs = get_variable_name(state_name + "0");
+        if (!info.is_ionic_conc(state_name)) {
+            auto lhs = get_variable_name(state_name);
+            auto rhs = get_variable_name(state_name + "0");
 
-        if (state->is_array()) {
-            for (int i = 0; i < state->get_length(); ++i) {
-                printer->fmt_line("{}[{}] = {};", lhs, i, rhs);
+            if (state->is_array()) {
+                for (int i = 0; i < state->get_length(); ++i) {
+                    printer->fmt_line("{}[{}] = {};", lhs, i, rhs);
+                }
+            } else {
+                printer->fmt_line("{} = {};", lhs, rhs);
             }
-        } else {
-            printer->fmt_line("{} = {};", lhs, rhs);
         }
     }
 }


### PR DESCRIPTION
Restore check for ionic concentration var types when initializing STATE variable This will avoid re-initializing these vars when loading coreneuron data from files

JGK