### PR TITLE
Fedora gcc-15 fixes for release/8.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ project(
 # =============================================================================
 # CMake common project settings
 # =============================================================================
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/bin/nrnivmodl_makefile_cmake.in
+++ b/bin/nrnivmodl_makefile_cmake.in
@@ -66,7 +66,7 @@ ifeq ($(origin CC), default)
     CC = @CMAKE_C_COMPILER@
     CXX = @CMAKE_CXX_COMPILER@
 endif
-CFLAGS = @BUILD_TYPE_C_FLAGS@ @CMAKE_C_FLAGS@
+CFLAGS = @BUILD_TYPE_C_FLAGS@ @CMAKE_C_FLAGS@ @C11_STANDARD_COMPILE_OPTION@
 CXXFLAGS = @BUILD_TYPE_CXX_FLAGS@ @CMAKE_CXX_FLAGS@ @CXX11_STANDARD_COMPILE_OPTION@
 
 COMPILE = $(CC) $(CFLAGS) @NRN_COMPILE_DEFS_STRING@ @NRN_COMPILE_FLAGS_STRING@
@@ -139,7 +139,7 @@ mech_lib_static: mod_func.o $(mod_objs) $(nrn_lib) build_always
 
 mod_func.o: mod_func.cpp
 	@printf " -> $(C_GREEN)Compiling$(C_RESET) $<\n"
-	$(COMPILE) $(INCLUDES) @CMAKE_CXX_COMPILE_OPTIONS_PIC@ -c $< -o $@
+	$(CXXCOMPILE) $(INCLUDES) @CMAKE_CXX_COMPILE_OPTIONS_PIC@ -c $< -o $@
 
 # Generic build c->o. Need PIC for shared lib
 $(OBJS_DIR)/%.o: $(MODC_DIR)/%.c | $(OBJS_DIR)

--- a/cmake/CMakeListsNrnMech.cmake
+++ b/cmake/CMakeListsNrnMech.cmake
@@ -68,6 +68,7 @@ endforeach()
 
 # PGI add --c++11;-A option for c++11 flag
 string(REPLACE ";" " " CXX11_STANDARD_COMPILE_OPTION "${CMAKE_CXX11_STANDARD_COMPILE_OPTION}")
+set(C11_STANDARD_COMPILE_OPTION "${CMAKE_C11_STANDARD_COMPILE_OPTION}")
 
 # Compiler flags depending on cmake build type from BUILD_TYPE_<LANG>_FLAGS
 string(TOUPPER "${CMAKE_BUILD_TYPE}" _BUILD_TYPE)


### PR DESCRIPTION
The primary requirement to build release/8.2  with gcc-15 is ```-std=c11``` for c files and ```-std=c++11``` for c++ files.

Note that the fedora build also needed:
```
module load mpi/openmpi-x86_64
sudo dnf install xorg-x11-fonts-100dpi # logout and log back in
```

This PR primarily tests CI. The substantive progress is embodied in the hints discussed in #3376 and #3380