### PR TITLE
CheckGitDescribeCompatibility.cmake is PEP 440 compliant.

### DIFF
--- a/cmake/CheckGitDescribeCompatibility.cmake
+++ b/cmake/CheckGitDescribeCompatibility.cmake
@@ -1,39 +1,58 @@
 # CheckGitDescribeCompatibility.cmake
 #
 # Validates that git describe output is compatible with PEP 440 versioning. Normalizes the version
-# string to a PEP 440-compliant format for validation purposes. Used to check user-chosen tags, not
-# to set PyPI package versions.
+# string to a PEP 440-compliant format for validation purposes. Skips validation gracefully if tags
+# are unavailable (e.g., in shallow clones). Used to check user-chosen tags, not to set PyPI package
+# versions.
 
-find_package(Git)
+find_package(Git QUIET)
 if(NOT GIT_FOUND)
-  message(FATAL_ERROR "Git not found. Please ensure Git is installed and accessible.")
+  message(WARNING "Git not found. Skipping version validation.")
+  set(PROJECT_VERSION
+      "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
+      CACHE STRING "Project version")
+  message(STATUS "PROJECT_VERSION ${PROJECT_VERSION}")
+  return()
 endif()
 
 # Execute git describe to get the version string
 execute_process(
   COMMAND ${GIT_EXECUTABLE} describe --tags
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   OUTPUT_VARIABLE GIT_DESCRIBE_OUTPUT
   OUTPUT_STRIP_TRAILING_WHITESPACE
-  RESULT_VARIABLE GIT_DESCRIBE_RESULT)
+  RESULT_VARIABLE GIT_EXIT_CODE
+  ERROR_QUIET)
 
-if(NOT GIT_DESCRIBE_RESULT EQUAL 0)
-  message(FATAL_ERROR "git describe failed: ${GIT_DESCRIBE_OUTPUT}")
+if(NOT GIT_EXIT_CODE EQUAL 0)
+  message(WARNING "git describe failed (exit code: ${GIT_EXIT_CODE}). Skipping version validation.")
+  set(PROJECT_VERSION
+      "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
+      CACHE STRING "Project version")
+  message(STATUS "PROJECT_VERSION ${PROJECT_VERSION}")
+  return()
 endif()
 
 # Function to normalize version string to PEP 440
-function(normalize_pep440_version input_version output_version)
+function(normalize_pep440_version input_version output_version expected_project_version)
   # Remove leading 'v'
   string(REGEX REPLACE "^v" "" clean_version "${input_version}")
 
-  # Match version patterns: X.Y, X.Y.Z, X.Ya, X.Y.ZaN, X.Y.ZrcN, X.Y.Z-N-gHASH
+  # Match version patterns: X.Y, X.Y.Z, X.Y(a|b|rcN), X.Y.Z(a|b|rcN), X.Y.Z-N-gHASH
   string(REGEX MATCH "^([0-9]+\\.[0-9]+(\\.[0-9]+)?)(a|b|rc)?([0-9]+)?(-([0-9]+)-g[0-9a-f]+)?$"
                version_match "${clean_version}")
   if(NOT version_match)
     message(
-      FATAL_ERROR
-        "Version '${clean_version}' does not match expected format (e.g., 1.2, 1.2.3, 1.2a, 1.2.3aN, 1.2.3rcN, or 1.2.3-N-gabc123)"
+      WARNING
+        "Version '${clean_version}' does not match expected format (e.g., 1.2, 1.2.3, 1.2a, 1.2.3rc1, 1.2.3-N-gabc123)."
     )
+    set(${output_version}
+        ""
+        PARENT_SCOPE)
+    set(${expected_project_version}
+        ""
+        PARENT_SCOPE)
+    return()
   endif()
 
   # Extract components
@@ -43,7 +62,7 @@ function(normalize_pep440_version input_version output_version)
   set(pre_num "${CMAKE_MATCH_4}")
   set(post_part "${CMAKE_MATCH_6}")
 
-  # Normalize base version
+  # Normalize to PEP 440
   if(NOT third_digit)
     set(normalized_version "${main_version}.0")
   else()
@@ -51,10 +70,12 @@ function(normalize_pep440_version input_version output_version)
   endif()
 
   # Normalize pre-release (a, b, rc)
-  if(pre_type AND pre_num)
-    set(normalized_version "${normalized_version}.${pre_type}${pre_num}")
-  elseif(pre_type)
-    set(normalized_version "${normalized_version}.${pre_type}0")
+  if(pre_type)
+    if(pre_num)
+      set(normalized_version "${normalized_version}.${pre_type}${pre_num}")
+    else()
+      set(normalized_version "${normalized_version}.${pre_type}0")
+    endif()
   endif()
 
   # Normalize post-release
@@ -62,24 +83,61 @@ function(normalize_pep440_version input_version output_version)
     set(normalized_version "${normalized_version}.post${post_part}")
   endif()
 
+  # Derive expected project version (for CMakeLists.txt comparison)
+  if(pre_type)
+    set(expected_version "${main_version}.0")
+  else()
+    set(expected_version "${main_version}")
+    if(NOT third_digit)
+      set(expected_version "${expected_version}.0")
+    endif()
+  endif()
+
   # Validate PEP 440 compliance
-  if(NOT normalized_version MATCHES
-     "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)*(\\.a[0-9]+|\\.b[0-9]+|\\.rc[0-9]+)?(\\.post[0-9]+)?$")
-    message(FATAL_ERROR "Normalized version '${normalized_version}' is not PEP 440 compliant")
+  if(normalized_version
+     AND NOT
+         normalized_version
+         MATCHES
+         "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)*(\\.a[0-9]+|\\.b[0-9]+|\\.rc[0-9]+)?(\\.post[0-9]+)?$"
+  )
+    message(WARNING "Normalized version '${normalized_version}' is not PEP 440 compliant.")
+    set(${output_version}
+        ""
+        PARENT_SCOPE)
+    set(${expected_project_version}
+        ""
+        PARENT_SCOPE)
+    return()
   endif()
 
   set(${output_version}
       "${normalized_version}"
       PARENT_SCOPE)
+  set(${expected_project_version}
+      "${expected_version}"
+      PARENT_SCOPE)
 endfunction()
 
 # Normalize the git describe output
-normalize_pep440_version("${GIT_DESCRIBE_OUTPUT}" PEP440_VERSION)
+normalize_pep440_version("${GIT_DESCRIBE_OUTPUT}" PEP440_VERSION EXPECTED_PROJECT_VERSION)
 
-# Output the normalized version
-message(STATUS "PEP 440 compliant version: ${PEP440_VERSION}")
+if(PEP440_VERSION)
+  message(STATUS "PEP 440 compliant version: ${PEP440_VERSION}")
+  # Compare with PROJECT_VERSION
+  set(cmake_version "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
+  if(EXPECTED_PROJECT_VERSION AND NOT cmake_version STREQUAL EXPECTED_PROJECT_VERSION)
+    message(
+      WARNING
+        "Git tag suggests project version '${EXPECTED_PROJECT_VERSION}' but CMakeLists.txt specifies '${cmake_version}'. Consider updating CMakeLists.txt."
+    )
+  endif()
+else()
+  message(WARNING "Unable to validate git describe output.")
+  set(PEP440_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
+endif()
 
 # Set the version variable for use in the project
 set(PROJECT_VERSION
     "${PEP440_VERSION}"
-    CACHE STRING "Project version normalized to PEP 440")
+    CACHE STRING "Project version normalized to PEP 440" FORCE)
+message(STATUS "PROJECT_VERSION ${PROJECT_VERSION}")

--- a/cmake/CheckGitDescribeCompatibility.cmake
+++ b/cmake/CheckGitDescribeCompatibility.cmake
@@ -76,13 +76,14 @@ function(normalize_pep440_version input_version output_version expected_project_
   # Remove leading 'v'
   string(REGEX REPLACE "^v" "" clean_version "${input_version}")
 
-  # Match version patterns: X.Y(.Z)?(a|b|rc|dev)?(N)?(-N-gHASH)?
-  string(REGEX MATCH "^([0-9]+\\.[0-9]+(\\.[0-9]+)?)(a|b|rc|dev)?([0-9]+)?(-([0-9]+)-g[0-9a-f]+)?$"
+  # Match version patterns: X.Y(.Z)?(\.?(a|b|rc|dev))?(N)?(-N-gHASH)?
+  string(REGEX MATCH
+               "^([0-9]+\\.[0-9]+(\\.[0-9]+)?)(\\.?(a|b|rc|dev))?([0-9]+)?(-([0-9]+)-g[0-9a-f]+)?$"
                version_match "${clean_version}")
   if(NOT version_match)
     message(
       WARNING
-        "Version '${clean_version}' does not match expected format X.Y(.Z)?(a|b|rc|dev)?(N)?(-N-gHASH)?. Note '?' mean 0 or 1 of preceding group."
+        "Version '${clean_version}' does not match expected format X.Y(.Z)?(.?(a|b|rc|dev))?(N)?(-N-gHASH)?. Note '?' means 0 or 1 of preceding group."
     )
     set(${output_version}
         ""
@@ -96,9 +97,9 @@ function(normalize_pep440_version input_version output_version expected_project_
   # Extract components
   set(main_version "${CMAKE_MATCH_1}")
   set(third_digit "${CMAKE_MATCH_2}")
-  set(pre_type "${CMAKE_MATCH_3}")
-  set(pre_num "${CMAKE_MATCH_4}")
-  set(post_part "${CMAKE_MATCH_6}")
+  set(pre_type "${CMAKE_MATCH_4}")
+  set(pre_num "${CMAKE_MATCH_5}")
+  set(post_part "${CMAKE_MATCH_7}")
   message(STATUS "main_version ${main_version}")
   message(STATUS "third_digit ${third_digit}")
   message(STATUS "pre_type ${pre_type}")

--- a/cmake/CheckGitDescribeCompatibility.cmake
+++ b/cmake/CheckGitDescribeCompatibility.cmake
@@ -1,61 +1,85 @@
-find_package(Git QUIET)
-if(GIT_FOUND)
-  # --abbrev=0 just gives the parent tag without a suffix representing the number of commits since
-  # the tag and the current commit hash
-  execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe --abbrev=0
-    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-    RESULT_VARIABLE GIT_EXIT_CODE
-    OUTPUT_VARIABLE PARENT_GIT_TAG
-    ERROR_VARIABLE GIT_STDERR
-    OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE)
-  if(${GIT_EXIT_CODE} EQUAL 0)
-    if(NOT GIT_STDERR STREQUAL "")
-      message(FATAL_ERROR "git describe succeeded but had stderr: '${GIT_STDERR}'")
-    endif()
-    # ${PARENT_GIT_TAG} contains the name of the parent tag of the current commit. In a tagged
-    # release, this should be exactly the version number in semver-compatible MAJOR.MINOR.PATCH
-    # format. On a development or feature branch, this should be a tag that has been created just
-    # after the last release from that branch. For example, the master branch (and feature branches
-    # based on it) after the 8.1 release have a parent tag called 8.2.dev, so that git describe
-    # produces output compatible with the guidelines in the NEURON documentation:
-    # https://nrn.readthedocs.io/en/latest/scm/guide/SCMGuide.html#a-versioning-scheme-for-neuron.
-    # In a branch whose parent tag is 8.2.dev, the project(...) call should say that the version is
-    # 8.2.0. If and when an incompatible change is merged to the master branch then a 9.0.dev tag
-    # should be created and the project(...) version should be updated to 9.0.0. If changes are
-    # cherry-picked to a branch such as release/8.1 then a 8.1.1.dev tag should be created there and
-    # the project(...) version in that branch updated to 8.1.1. The three cases handled are:
-    #
-    # * if the parent tag is a MAJOR.MINOR.PATCH version then it should exactly match project(...)
-    # * if the parent tag is MAJOR.MINOR(a|b|rcN) then project(...) should contain MAJOR.MINOR.0
-    # * if the parent tag has a .dev suffix, the part before .dev is suffixed with .0 if needed to
-    #   make a full MAJOR.MINOR.PATCH version, which should exactly match project(...)
-    if(PARENT_GIT_TAG MATCHES "^([0-9]+\\.[0-9]+)\\.dev$")
-      # X.Y.dev CMAKE_MATCH_1 holds X.Y
-      set(expected_version "${CMAKE_MATCH_1}.0")
-    elseif(PARENT_GIT_TAG MATCHES "^([0-9]+\\.[0-9]+\\.[0-9]+)\\.dev$")
-      # X.Y.Z.dev, CMAKE_MATCH_1 holds X.Y.Z
-      set(expected_version "${CMAKE_MATCH_1}")
-    elseif(PARENT_GIT_TAG MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
-      # Release tag
-      set(expected_version "${PARENT_GIT_TAG}")
-    elseif(PARENT_GIT_TAG MATCHES "^([0-9]+\\.[0-9]+)(a|b|rc[0-9]+)$")
-      # Alpha, beta or release candidate (what about alpha/beta/rc of a patch release, i.e. 8.1.1a?
-      # This is not foreseen in the docs.)
-      set(expected_version "${CMAKE_MATCH_1}.0")
-    else()
-      message(FATAL_ERROR "Failed to parse Git tag: '${GIT_STDOUT}'")
-    endif()
-    if(NOT expected_version STREQUAL
-       "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
-      message(WARNING "Parent git tag is ${PARENT_GIT_TAG} but the CMake version is "
-                      "${PROJECT_VERSION}; you should probably update CMakeLists.txt "
-                      "to contain project(NEURON VERSION ${expected_version} ...)!")
-    endif()
-  else()
-    message(
-      STATUS "git describe failed "
-             "(stdout: '${PARENT_GIT_TAG}', stderr: '${GIT_STDERR}', code: ${GIT_EXIT_CODE}), "
-             "skipping the version check")
-  endif()
+# CheckGitDescribeCompatibility.cmake
+#
+# Validates that git describe output is compatible with PEP 440 versioning. Normalizes the version
+# string to a PEP 440-compliant format for validation purposes. Used to check user-chosen tags, not
+# to set PyPI package versions.
+
+find_package(Git)
+if(NOT GIT_FOUND)
+  message(FATAL_ERROR "Git not found. Please ensure Git is installed and accessible.")
 endif()
+
+# Execute git describe to get the version string
+execute_process(
+  COMMAND ${GIT_EXECUTABLE} describe --tags
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_DESCRIBE_OUTPUT
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE GIT_DESCRIBE_RESULT)
+
+if(NOT GIT_DESCRIBE_RESULT EQUAL 0)
+  message(FATAL_ERROR "git describe failed: ${GIT_DESCRIBE_OUTPUT}")
+endif()
+
+# Function to normalize version string to PEP 440
+function(normalize_pep440_version input_version output_version)
+  # Remove leading 'v'
+  string(REGEX REPLACE "^v" "" clean_version "${input_version}")
+
+  # Match version patterns: X.Y, X.Y.Z, X.Ya, X.Y.ZaN, X.Y.ZrcN, X.Y.Z-N-gHASH
+  string(REGEX MATCH "^([0-9]+\\.[0-9]+(\\.[0-9]+)?)(a|b|rc)?([0-9]+)?(-([0-9]+)-g[0-9a-f]+)?$"
+               version_match "${clean_version}")
+  if(NOT version_match)
+    message(
+      FATAL_ERROR
+        "Version '${clean_version}' does not match expected format (e.g., 1.2, 1.2.3, 1.2a, 1.2.3aN, 1.2.3rcN, or 1.2.3-N-gabc123)"
+    )
+  endif()
+
+  # Extract components
+  set(main_version "${CMAKE_MATCH_1}")
+  set(third_digit "${CMAKE_MATCH_2}")
+  set(pre_type "${CMAKE_MATCH_3}")
+  set(pre_num "${CMAKE_MATCH_4}")
+  set(post_part "${CMAKE_MATCH_6}")
+
+  # Normalize base version
+  if(NOT third_digit)
+    set(normalized_version "${main_version}.0")
+  else()
+    set(normalized_version "${main_version}")
+  endif()
+
+  # Normalize pre-release (a, b, rc)
+  if(pre_type AND pre_num)
+    set(normalized_version "${normalized_version}.${pre_type}${pre_num}")
+  elseif(pre_type)
+    set(normalized_version "${normalized_version}.${pre_type}0")
+  endif()
+
+  # Normalize post-release
+  if(post_part)
+    set(normalized_version "${normalized_version}.post${post_part}")
+  endif()
+
+  # Validate PEP 440 compliance
+  if(NOT normalized_version MATCHES
+     "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)*(\\.a[0-9]+|\\.b[0-9]+|\\.rc[0-9]+)?(\\.post[0-9]+)?$")
+    message(FATAL_ERROR "Normalized version '${normalized_version}' is not PEP 440 compliant")
+  endif()
+
+  set(${output_version}
+      "${normalized_version}"
+      PARENT_SCOPE)
+endfunction()
+
+# Normalize the git describe output
+normalize_pep440_version("${GIT_DESCRIBE_OUTPUT}" PEP440_VERSION)
+
+# Output the normalized version
+message(STATUS "PEP 440 compliant version: ${PEP440_VERSION}")
+
+# Set the version variable for use in the project
+set(PROJECT_VERSION
+    "${PEP440_VERSION}"
+    CACHE STRING "Project version normalized to PEP 440")


### PR DESCRIPTION
At the moment this does not have much of a substantive use since wheel names are chosen by setup.py call to setuptoosls_scm. However it does validate and normalize user chosen tags and git describe versions. E.g.
```
$ git describe
9.0a-1381-g18b87a10a

$ cmake ...
-- PEP 440 compliant version: 9.0.0.a0.post1381
```
The normalized version is in ${PROJECT_VERSION}