### PR TITLE
Fix build with NRN_ENABLE_INTERVIEWS=OFF and IV_ENABLE_X11_DYNAMIC=ON

### DIFF
--- a/src/ivoc/ivocmain.cpp
+++ b/src/ivoc/ivocmain.cpp
@@ -41,7 +41,7 @@ void iv_display_scale(float);
 #include "nrnmpi.h"
 #include "nrnpy.h"
 
-#if defined(IVX11_DYNAM)
+#if defined(HAVE_IV) && defined(IVX11_DYNAM)
 #include <IV-X11/ivx11_dynam.h>
 #endif
 
@@ -448,7 +448,7 @@ nrniv [options] [fileargs]
 
 #endif
 
-#if defined(IVX11_DYNAM)
+#if defined(HAVE_IV) && defined(IVX11_DYNAM)
     if (hoc_usegui && ivx11_dyload()) {
         hoc_usegui = 0;
         hoc_print_first_instance = 0;


### PR DESCRIPTION
NEURON fails to compile when `NRN_ENABLE_INTERVIEWS=OFF` and `IV_ENABLE_X11_DYNAMIC=ON` due to not checking the `HAVE_IV` variable as well as `IVX11_DYNAM`. Having the latter defined without checking the former first gives an invalid configuration anyway (we want X11, but, without building IV, using X11 makes no sense).