### PR TITLE
Improvements to `win_build_cmake.sh` and Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,10 +67,24 @@ jobs:
       run: |
         rm.exe C:\WINDOWS\system32\bash.EXE
         %MSYS2_ROOT%\usr\bin\bash -lc "$BUILD_SOURCESDIRECTORY/ci/win_build_cmake.sh"
+        # create a manifest of the files in the build directory
+        %MSYS2_ROOT%\usr\bin\bash -lc "find ${BUILD_SOURCESDIRECTORY}/build > ${BUILD_SOURCESDIRECTORY}/build/build_files.txt 2>/dev/null"
       shell: cmd
       working-directory: ${{runner.workspace}}\nrn
       env:
         BUILD_SOURCESDIRECTORY: ${{runner.workspace}}\nrn
+
+    - name: Upload build files for diagnostics and debugging
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: build_files
+        path: |
+          ${{runner.workspace}}/nrn/build/CMakeCache.txt
+          ${{runner.workspace}}/nrn/build/build.ninja
+          ${{runner.workspace}}/nrn/build/cmake_install.cmake
+          ${{runner.workspace}}/nrn/build/install_manifest.txt
+          ${{runner.workspace}}/nrn/build/build_files.txt
 
     # This step will set up an SSH connection on tmate.io for live debugging.
     # To enable it, you have to:

--- a/ci/win_build_cmake.sh
+++ b/ci/win_build_cmake.sh
@@ -53,4 +53,4 @@ cd "${BUILD_BUILDDIRECTORY}" && ctest -VV || cd -
 ${CMAKE_COMMAND} --build "${BUILD_BUILDDIRECTORY}" --target setup_exe
 
 # copy installer with fixed name for nightly upload
-cp "${BUILD_BUILDDIRECTORY}/src/mswin/nrn*AMD64.exe" "${BUILD_SOURCESDIRECTORY}/nrn-nightly-AMD64.exe"
+cp "${BUILD_BUILDDIRECTORY}/src/mswin/"nrn*AMD64.exe "${BUILD_SOURCESDIRECTORY}/nrn-nightly-AMD64.exe"

--- a/ci/win_build_cmake.sh
+++ b/ci/win_build_cmake.sh
@@ -14,6 +14,13 @@ python3 -m pip install "cython<=3.0.12"
 
 # if BUILD_SOURCESDIRECTORY not available, use the root of the repo
 if [ -z "${BUILD_SOURCESDIRECTORY:-}" ]; then
+    # this exits with non-zero status code if we're not inside of a git work tree
+    if ! git rev-parse --is-inside-work-tree >& /dev/null; then
+        printf "Not inside of a git repository, and BUILD_SOURCESDIRECTORY is not set; "
+        printf "either change the current directory to be anywhere inside the NEURON directory, "
+        echo "or set the BUILD_SOURCESDIRECTORY environment variable to the top-level NEURON source directory"
+        exit 1
+    fi
     BUILD_SOURCESDIRECTORY="$(git rev-parse --show-toplevel)"
     export BUILD_SOURCESDIRECTORY
 fi

--- a/ci/win_build_cmake.sh
+++ b/ci/win_build_cmake.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -eux
 
 # standard env variables from ming2 shell
 export MSYSTEM_CHOST=x86_64-w64-mingw32
@@ -12,34 +12,38 @@ export PATH=/mingw64/bin:$PATH
 # have compatible cython3
 python3 -m pip install "cython<=3.0.12"
 
-# if BUILD_SOURCESDIRECTORY not available, use te root of the repo
-if [ -z "$BUILD_SOURCESDIRECTORY" ]; then
-	export BUILD_SOURCESDIRECTORY=$(git rev-parse --show-toplevel)
+# if BUILD_SOURCESDIRECTORY not available, use the root of the repo
+if [ -z "${BUILD_SOURCESDIRECTORY:-}" ]; then
+    BUILD_SOURCESDIRECTORY="$(git rev-parse --show-toplevel)"
+    export BUILD_SOURCESDIRECTORY
 fi
-mkdir -p $BUILD_SOURCESDIRECTORY/build
-cd $BUILD_SOURCESDIRECTORY/build
+
+export BUILD_BUILDDIRECTORY="${BUILD_SOURCESDIRECTORY}/build"
+export CMAKE_COMMAND=/mingw64/bin/cmake
 
 # build and create installer
-/mingw64/bin/cmake .. \
-	-G Ninja  \
-	-DNRN_ENABLE_MPI_DYNAMIC=ON  \
-	-DNRN_ENABLE_MPI=ON  \
-	-DCMAKE_PREFIX_PATH='/c/msmpi'  \
-	-DNRN_ENABLE_INTERVIEWS=ON  \
-	-DNRN_ENABLE_PYTHON=ON  \
-	-DNRN_ENABLE_RX3D=ON  \
-	-DNRN_RX3D_OPT_LEVEL=2 \
-	-DNRN_BINARY_DIST_BUILD=ON \
-	-DPYTHON_EXECUTABLE=/c/Python39/python.exe \
-	-DNRN_ENABLE_PYTHON_DYNAMIC=ON  \
-	-DNRN_PYTHON_DYNAMIC='c:/Python39/python.exe;c:/Python310/python.exe;c:/Python311/python.exe;c:/Python312/python.exe;c:/Python313/python.exe'  \
-	-DCMAKE_INSTALL_PREFIX='/c/nrn-install' \
-	-DMPI_CXX_LIB_NAMES:STRING=msmpi \
-	-DMPI_C_LIB_NAMES:STRING=msmpi \
-	-DMPI_msmpi_LIBRARY:FILEPATH=c:/msmpi/lib/x64/msmpi.lib
-ninja install
-ctest -VV
-ninja setup_exe
+${CMAKE_COMMAND} \
+    -S "${BUILD_SOURCESDIRECTORY}" \
+    -B "${BUILD_BUILDDIRECTORY}" \
+    -G Ninja  \
+    -DNRN_ENABLE_MPI_DYNAMIC=ON  \
+    -DNRN_ENABLE_MPI=ON  \
+    -DCMAKE_PREFIX_PATH='/c/msmpi'  \
+    -DNRN_ENABLE_INTERVIEWS=ON  \
+    -DNRN_ENABLE_PYTHON=ON  \
+    -DNRN_ENABLE_RX3D=ON  \
+    -DNRN_RX3D_OPT_LEVEL=2 \
+    -DNRN_BINARY_DIST_BUILD=ON \
+    -DPYTHON_EXECUTABLE=/c/Python39/python.exe \
+    -DNRN_ENABLE_PYTHON_DYNAMIC=ON  \
+    -DNRN_PYTHON_DYNAMIC='c:/Python39/python.exe;c:/Python310/python.exe;c:/Python311/python.exe;c:/Python312/python.exe;c:/Python313/python.exe'  \
+    -DCMAKE_INSTALL_PREFIX='/c/nrn-install' \
+    -DMPI_CXX_LIB_NAMES:STRING=msmpi \
+    -DMPI_C_LIB_NAMES:STRING=msmpi \
+    -DMPI_msmpi_LIBRARY:FILEPATH=c:/msmpi/lib/x64/msmpi.lib
+${CMAKE_COMMAND} --build "${BUILD_BUILDDIRECTORY}" --target install
+cd "${BUILD_BUILDDIRECTORY}" && ctest -VV || cd -
+${CMAKE_COMMAND} --build "${BUILD_BUILDDIRECTORY}" --target setup_exe
 
 # copy installer with fixed name for nightly upload
-cp src/mswin/nrn*AMD64.exe $BUILD_SOURCESDIRECTORY/nrn-nightly-AMD64.exe
+cp "${BUILD_BUILDDIRECTORY}/src/mswin/nrn*AMD64.exe" "${BUILD_SOURCESDIRECTORY}/nrn-nightly-AMD64.exe"


### PR DESCRIPTION
This should make it easier (and mostly directory-agnostic) to build and debug NEURON on Windows (also applies to the CI).

After the build completes in the CI, it uploads the following files (regardless of success/failure):
- CMakeFiles.txt (how CMakeLists.txt was parsed)
- build.ninja (list of build rules)
- install_manifest.txt (complete list of files in the install directory)
- build_files.txt (complete list of files in the build directory)