### PR TITLE
Fix build issues from pyproject migration

### DIFF
--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -93,7 +93,7 @@ build_wheel_portable() {
     if [ "${platform}" = 'linux' ]; then
         NRN_MPI_DYNAMIC="/usr/include/openmpi-$(uname -m);/usr/include/mpich-$(uname -m)"
         # if we are building on Azure, we can use the MPT headers as well
-        if [ -n "${TF_BUILD}" ]; then
+        if [ -n "${TF_BUILD:-}" ]; then
             NRN_MPI_DYNAMIC="${NRN_MPI_DYNAMIC};/host/opt/nrnwheel/mpt/include"
         fi
         export NRN_MPI_DYNAMIC
@@ -188,7 +188,8 @@ case "${platform}" in
     ;;
 
   CI)
-    if [[ "${CI_OS_NAME}" == "osx" || "${CI_OS_NAME}" == "${PLATFORM_MACOS}" ]]; then
+      CI_OS_NAME="${CI_OS_NAME:-$(uname -s)}"
+      if [[ "${CI_OS_NAME}" == "osx" || "${CI_OS_NAME}" == "${PLATFORM_MACOS}" ]]; then
         collect_dirs_macos
     else
         collect_dirs_linux

--- a/src/nrnpython/CMakeLists.txt
+++ b/src/nrnpython/CMakeLists.txt
@@ -155,7 +155,7 @@ else()
     # for nrnconf.h
     ${CMAKE_CURRENT_BINARY_DIR}
     ${PROJECT_BINARY_DIR}/nrnmpi
-    ${pyinc}
+    ${NRN_DEFAULT_PYTHON_INCLUDES}
     LIBRARIES
     nrniv_lib
     rxdmath


### PR DESCRIPTION
- running `bash packaging/python/build_wheels.bash CI $(command -v python3)` would throw an error if `CI_OS_NAME` was unset; now we define the default to `uname -s`
- the hoc Python module was not including the Python headers properly on some platforms