### PR TITLE
from neuron import n

### DIFF
--- a/docs/coreneuron/installation.rst
+++ b/docs/coreneuron/installation.rst
@@ -221,7 +221,7 @@ Now you should be able to import neuron module as
 
 .. code-block::
 
-   python -c "from neuron import h; from neuron import coreneuron"
+   python -c "from neuron import n; from neuron import coreneuron"
 
 If you get ``ImportError`` then make sure ``PYTHONPATH`` is set correctly, and that ``python`` is the same version that CMake was configured to use.
 You can use ``-DPYTHON_EXECUTABLE=/path/to/python`` to force CMake to use a particular version.

--- a/docs/coreneuron/running-a-simulation.rst
+++ b/docs/coreneuron/running-a-simulation.rst
@@ -58,8 +58,8 @@ Finally, use ``psolve`` to run the simulation after initialization:
 
 .. code-block:: python
 
-   h.stdinit()
-   pc.psolve(h.tstop)
+   n.stdinit()
+   pc.psolve(n.tstop)
 
 With the above steps, NEURON will build the model in memory and transfer it to CoreNEURON for simulation.
 At the end of the simulation CoreNEURON will, by default, transfer spikes, voltages, state variables, NetCon weights, all ``Vector.record``, and most GUI trajectories to NEURON.

--- a/docs/tutorials/ball-and-stick-1.ipynb
+++ b/docs/tutorials/ball-and-stick-1.ipynb
@@ -31,7 +31,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We of course begin by loading NEURON's main submodule <tt>h</tt>."
+    "We of course begin by loading NEURON's main submodule `n`."
    ]
   },
   {
@@ -40,7 +40,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from neuron import h"
+    "from neuron import n"
    ]
   },
   {
@@ -72,7 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.load_file(\"stdrun.hoc\")"
+    "n.load_file(\"stdrun.hoc\")"
    ]
   },
   {
@@ -138,8 +138,8 @@
    "source": [
     "class BallAndStick:\n",
     "    def __init__(self):\n",
-    "        self.soma = h.Section(name=\"soma\", cell=self)\n",
-    "        self.dend = h.Section(name=\"dend\", cell=self)"
+    "        self.soma = n.Section(\"soma\", self)\n",
+    "        self.dend = n.Section(\"dend\", self)"
    ]
   },
   {
@@ -164,7 +164,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.topology()"
+    "n.topology()"
    ]
   },
   {
@@ -198,7 +198,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.topology()"
+    "n.topology()"
    ]
   },
   {
@@ -218,8 +218,8 @@
    "source": [
     "class BallAndStick:\n",
     "    def __init__(self):\n",
-    "        self.soma = h.Section(name=\"soma\", cell=self)\n",
-    "        self.dend = h.Section(name=\"dend\", cell=self)\n",
+    "        self.soma = n.Section(\"soma\", self)\n",
+    "        self.dend = n.Section(\"dend\", self)\n",
     "\n",
     "    def __repr__(self):\n",
     "        return \"BallAndStick\""
@@ -231,7 +231,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.topology()"
+    "n.topology()"
    ]
   },
   {
@@ -263,7 +263,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.topology()"
+    "n.topology()"
    ]
   },
   {
@@ -297,7 +297,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.topology()"
+    "n.topology()"
    ]
   },
   {
@@ -316,8 +316,8 @@
     "class BallAndStick:\n",
     "    def __init__(self, gid):\n",
     "        self._gid = gid\n",
-    "        self.soma = h.Section(name=\"soma\", cell=self)\n",
-    "        self.dend = h.Section(name=\"dend\", cell=self)\n",
+    "        self.soma = n.Section(\"soma\", self)\n",
+    "        self.dend = n.Section(\"dend\", self)\n",
     "\n",
     "    def __repr__(self):\n",
     "        return \"BallAndStick[{}]\".format(self._gid)"
@@ -360,7 +360,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.topology()"
+    "n.topology()"
    ]
   },
   {
@@ -393,8 +393,8 @@
     "class BallAndStick:\n",
     "    def __init__(self, gid):\n",
     "        self._gid = gid\n",
-    "        self.soma = h.Section(name=\"soma\", cell=self)\n",
-    "        self.dend = h.Section(name=\"dend\", cell=self)\n",
+    "        self.soma = n.Section(\"soma\", self)\n",
+    "        self.dend = n.Section(\"dend\", self)\n",
     "        self.dend.connect(self.soma)\n",
     "\n",
     "    def __repr__(self):\n",
@@ -431,7 +431,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.topology()"
+    "n.topology()"
    ]
   },
   {
@@ -456,7 +456,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.topology()"
+    "n.topology()"
    ]
   },
   {
@@ -503,8 +503,8 @@
     "class BallAndStick:\n",
     "    def __init__(self, gid):\n",
     "        self._gid = gid\n",
-    "        self.soma = h.Section(name=\"soma\", cell=self)\n",
-    "        self.dend = h.Section(name=\"dend\", cell=self)\n",
+    "        self.soma = n.Section(\"soma\", self)\n",
+    "        self.dend = n.Section(\"dend\", self)\n",
     "        self.dend.connect(self.soma)\n",
     "        self.soma.L = self.soma.diam = 12.6157 * µm\n",
     "        self.dend.L = 200 * µm\n",
@@ -571,7 +571,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.topology()"
+    "n.topology()"
    ]
   },
   {
@@ -589,7 +589,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "h.PlotShape(False).plot(plt)"
+    "n.PlotShape(False).plot(plt)"
    ]
   },
   {
@@ -609,14 +609,14 @@
     "from neuron import gui\n",
     "\n",
     "# here: True means show using NEURON's GUI; False means do not do so, at least not at first\n",
-    "ps = h.PlotShape(True)"
+    "ps = n.PlotShape(True)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Either way, you will notice that this looks like a line instead of a ball and stick. Why? It's because NEURON by default does not display diameters. This behavior is useful when we need to see the structure of small dendrites, and in NEURON 7.7, it's the only supported option for Jupyter notebooks with h.PlotShape (although gui2.PlotShape provides similar functionality)... but when using NEURON's built-in graphics, we can use the <tt>show</tt> method to show diamters via:"
+    "Either way, you will notice that this looks like a line instead of a ball and stick. Why? It's because NEURON by default does not display diameters. This behavior is useful when we need to see the structure of small dendrites, and in NEURON 7.7, it's the only supported option for Jupyter notebooks with `n.PlotShape`... but when using NEURON's built-in graphics, we can use the <tt>show</tt> method to show diamters via:"
    ]
   },
   {
@@ -632,7 +632,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ps = h.PlotShape(True)\n",
+    "ps = n.PlotShape(True)\n",
     "ps.show(0)"
    ]
   },
@@ -647,7 +647,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(Note: If you want to build your own visualization tool using matplotlib, mayavi, etc, ensure 3D points exist with `h.define_shape()`, then loop over all the sections with `h.allsec()` and read the morphology using `sec.x3d(i)` etc and `sec.diam3d(i)` for `i` in 0, .., `sec.n3d() - 1`. Less efficiently, the (x, y, z; diam) values for a whole section may be read by `sec.psection()['morphology']['pt3d']`.)"
+    "(Note: If you want to build your own visualization tool using matplotlib, mayavi, etc, ensure 3D points exist with `n.define_shape()`, then loop over all the sections with `n.allsec()` and read the morphology using `sec.x3d(i)` etc and `sec.diam3d(i)` for `i` in 0, .., `sec.n3d() - 1`. Less efficiently, the (x, y, z; diam) values for a whole section may be read by `sec.psection()['morphology']['pt3d']`.)"
    ]
   },
   {
@@ -673,8 +673,8 @@
     "class BallAndStick:\n",
     "    def __init__(self, gid):\n",
     "        self._gid = gid\n",
-    "        self.soma = h.Section(name=\"soma\", cell=self)\n",
-    "        self.dend = h.Section(name=\"dend\", cell=self)\n",
+    "        self.soma = n.Section(\"soma\", self)\n",
+    "        self.dend = n.Section(\"dend\", self)\n",
     "        self.dend.connect(self.soma)\n",
     "        self.all = self.soma.wholetree()  # <-- NEW\n",
     "        self.soma.L = self.soma.diam = 12.6157 * µm\n",
@@ -718,8 +718,8 @@
     "        self._setup_biophysics()\n",
     "\n",
     "    def _setup_morphology(self):\n",
-    "        self.soma = h.Section(name=\"soma\", cell=self)\n",
-    "        self.dend = h.Section(name=\"dend\", cell=self)\n",
+    "        self.soma = n.Section(\"soma\", self)\n",
+    "        self.dend = n.Section(\"dend\", self)\n",
     "        self.all = [self.soma, self.dend]\n",
     "        self.dend.connect(self.soma)\n",
     "        self.soma.L = self.soma.diam = 12.6157 * µm\n",
@@ -765,8 +765,8 @@
     "        self._setup_biophysics()\n",
     "\n",
     "    def _setup_morphology(self):\n",
-    "        self.soma = h.Section(name=\"soma\", cell=self)\n",
-    "        self.dend = h.Section(name=\"dend\", cell=self)\n",
+    "        self.soma = n.Section(\"soma\", self)\n",
+    "        self.dend = n.Section(\"dend\", self)\n",
     "        self.dend.connect(self.soma)\n",
     "        self.all = self.soma.wholetree()\n",
     "        self.soma.L = self.soma.diam = 12.6157 * µm\n",
@@ -777,7 +777,7 @@
     "        for sec in self.all:\n",
     "            sec.Ra = 100  # Axial resistance in Ohm * cm\n",
     "            sec.cm = 1  # Membrane capacitance in micro Farads / cm^2\n",
-    "        self.soma.insert(\"hh\")  # <-- NEW\n",
+    "        self.soma.insert(n.hh)  # <-- NEW\n",
     "        for seg in self.soma:  # <-- NEW\n",
     "            seg.hh.gnabar = (\n",
     "                0.12  # Sodium conductance in S/cm2                  # <-- NEW\n",
@@ -824,8 +824,8 @@
     "        self._setup_biophysics()\n",
     "\n",
     "    def _setup_morphology(self):\n",
-    "        self.soma = h.Section(name=\"soma\", cell=self)\n",
-    "        self.dend = h.Section(name=\"dend\", cell=self)\n",
+    "        self.soma = n.Section(\"soma\", self)\n",
+    "        self.dend = n.Section(\"dend\", self)\n",
     "        self.dend.connect(self.soma)\n",
     "        self.all = self.soma.wholetree()\n",
     "        self.soma.L = self.soma.diam = 12.6157 * µm\n",
@@ -836,14 +836,14 @@
     "        for sec in self.all:\n",
     "            sec.Ra = 100  # Axial resistance in Ohm * cm\n",
     "            sec.cm = 1  # Membrane capacitance in micro Farads / cm^2\n",
-    "        self.soma.insert(\"hh\")\n",
+    "        self.soma.insert(n.hh)\n",
     "        for seg in self.soma:\n",
     "            seg.hh.gnabar = 0.12  # Sodium conductance in S/cm2\n",
     "            seg.hh.gkbar = 0.036  # Potassium conductance in S/cm2\n",
     "            seg.hh.gl = 0.0003  # Leak conductance in S/cm2\n",
     "            seg.hh.el = -54.3 * mV  # Reversal potential\n",
     "        # Insert passive current in the dendrite                       # <-- NEW\n",
-    "        self.dend.insert(\"pas\")  # <-- NEW\n",
+    "        self.dend.insert(n.pas)  # <-- NEW\n",
     "        for seg in self.dend:  # <-- NEW\n",
     "            seg.pas.g = 0.001  # Passive conductance in S/cm2        # <-- NEW\n",
     "            seg.pas.e = -65 * mV  # Leak reversal potential             # <-- NEW\n",
@@ -868,7 +868,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(h.units(\"gnabar_hh\"))"
+    "print(n.units(\"gnabar_hh\"))"
    ]
   },
   {
@@ -884,7 +884,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for sec in h.allsec():\n",
+    "for sec in n.allsec():\n",
     "    print(\"%s: %s\" % (sec, \", \".join(sec.psection()[\"density_mechs\"].keys())))"
    ]
   },
@@ -929,7 +929,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stim = h.IClamp(my_cell.dend(1))"
+    "stim = n.IClamp(my_cell.dend(1))"
    ]
   },
   {
@@ -1002,8 +1002,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "soma_v = h.Vector().record(my_cell.soma(0.5)._ref_v)\n",
-    "t = h.Vector().record(h._ref_t)"
+    "soma_v = n.Vector().record(my_cell.soma(0.5)._ref_v)\n",
+    "t = n.Vector().record(n._ref_t)"
    ]
   },
   {
@@ -1026,7 +1026,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.finitialize(-65 * mV)"
+    "n.finitialize(-65 * mV)"
    ]
   },
   {
@@ -1042,7 +1042,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.continuerun(25 * ms)"
+    "n.continuerun(25 * ms)"
    ]
   },
   {
@@ -1135,8 +1135,8 @@
     "colors = [\"green\", \"blue\", \"red\", \"black\"]\n",
     "for amp, color in zip(amps, colors):\n",
     "    stim.amp = amp\n",
-    "    h.finitialize(-65 * mV)\n",
-    "    h.continuerun(25 * ms)\n",
+    "    n.finitialize(-65 * mV)\n",
+    "    n.continuerun(25 * ms)\n",
     "    f.line(t, list(soma_v), line_width=2, legend_label=\"amp=%g\" % amp, color=color)\n",
     "plt.show(f)"
    ]
@@ -1168,7 +1168,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dend_v = h.Vector().record(my_cell.dend(0.5)._ref_v)"
+    "dend_v = n.Vector().record(my_cell.dend(0.5)._ref_v)"
    ]
   },
   {
@@ -1196,8 +1196,8 @@
     "colors = [\"green\", \"blue\", \"red\", \"black\"]\n",
     "for amp, color in zip(amps, colors):\n",
     "    stim.amp = amp\n",
-    "    h.finitialize(-65 * mV)\n",
-    "    h.continuerun(25 * ms)\n",
+    "    n.finitialize(-65 * mV)\n",
+    "    n.continuerun(25 * ms)\n",
     "    f.line(t, list(soma_v), line_width=2, legend_label=\"amp=%g\" % amp, color=color)\n",
     "    f.line(t, list(dend_v), line_width=2, line_dash=\"dashed\", color=color)\n",
     "\n",
@@ -1244,8 +1244,8 @@
     "for amp, color in zip(amps, colors):\n",
     "    stim.amp = amp\n",
     "    for my_cell.dend.nseg, width in [(1, 2), (101, 1)]:\n",
-    "        h.finitialize(-65)\n",
-    "        h.continuerun(25)\n",
+    "        n.finitialize(-65)\n",
+    "        n.continuerun(25)\n",
     "        f.line(\n",
     "            t,\n",
     "            list(soma_v),\n",
@@ -1293,13 +1293,6 @@
    "source": [
     "Calculate the approximate absolute error for your low `nseg` solution that graphically overlaps the high `nseg` solution. Compare this to the error for the `nseg=1` case. (Since the true solution is unknown, approximate it with the high `nseg` solution.)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/tutorials/ball-and-stick-2.ipynb
+++ b/docs/tutorials/ball-and-stick-2.ipynb
@@ -37,7 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from neuron import h, gui\n",
+    "from neuron import n, gui\n",
     "from neuron.units import ms, mV"
    ]
   },
@@ -54,7 +54,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.load_file(\"stdrun.hoc\")"
+    "n.load_file(\"stdrun.hoc\")"
    ]
   },
   {
@@ -98,8 +98,8 @@
     "    name = \"BallAndStick\"\n",
     "\n",
     "    def _setup_morphology(self):\n",
-    "        self.soma = h.Section(name=\"soma\", cell=self)\n",
-    "        self.dend = h.Section(name=\"dend\", cell=self)\n",
+    "        self.soma = n.Section(\"soma\", self)\n",
+    "        self.dend = n.Section(\"dend\", self)\n",
     "        self.dend.connect(self.soma)\n",
     "        self.soma.L = self.soma.diam = 12.6157\n",
     "        self.dend.L = 200\n",
@@ -109,14 +109,14 @@
     "        for sec in self.all:\n",
     "            sec.Ra = 100  # Axial resistance in Ohm * cm\n",
     "            sec.cm = 1  # Membrane capacitance in micro Farads / cm^2\n",
-    "        self.soma.insert(\"hh\")\n",
+    "        self.soma.insert(n.hh)\n",
     "        for seg in self.soma:\n",
     "            seg.hh.gnabar = 0.12  # Sodium conductance in S/cm2\n",
     "            seg.hh.gkbar = 0.036  # Potassium conductance in S/cm2\n",
     "            seg.hh.gl = 0.0003  # Leak conductance in S/cm2\n",
     "            seg.hh.el = -54.3  # Reversal potential in mV\n",
     "        # Insert passive current in the dendrite\n",
-    "        self.dend.insert(\"pas\")\n",
+    "        self.dend.insert(n.pas)\n",
     "        for seg in self.dend:\n",
     "            seg.pas.g = 0.001  # Passive conductance in S/cm2\n",
     "            seg.pas.e = -65  # Leak reversal potential mV"
@@ -156,7 +156,7 @@
     "        self.all = self.soma.wholetree()\n",
     "        self._setup_biophysics()\n",
     "        self.x = self.y = self.z = 0  # <-- NEW\n",
-    "        h.define_shape()\n",
+    "        n.define_shape()\n",
     "        self._rotate_z(theta)  # <-- NEW\n",
     "        self._set_position(x, y, z)  # <-- NEW\n",
     "\n",
@@ -183,8 +183,8 @@
     "            for i in range(sec.n3d()):\n",
     "                x = sec.x3d(i)\n",
     "                y = sec.y3d(i)\n",
-    "                c = h.cos(theta)\n",
-    "                s = h.sin(theta)\n",
+    "                c = n.cos(theta)\n",
+    "                s = n.sin(theta)\n",
     "                xprime = x * c - y * s\n",
     "                yprime = x * s + y * c\n",
     "                sec.pt3dchange(i, xprime, yprime, sec.z3d(i), sec.diam3d(i))"
@@ -208,8 +208,8 @@
     "    name = \"BallAndStick\"\n",
     "\n",
     "    def _setup_morphology(self):\n",
-    "        self.soma = h.Section(name=\"soma\", cell=self)\n",
-    "        self.dend = h.Section(name=\"dend\", cell=self)\n",
+    "        self.soma = n.Section(\"soma\", self)\n",
+    "        self.dend = n.Section(\"dend\", self)\n",
     "        self.dend.connect(self.soma)\n",
     "        self.soma.L = self.soma.diam = 12.6157\n",
     "        self.dend.L = 200\n",
@@ -219,14 +219,14 @@
     "        for sec in self.all:\n",
     "            sec.Ra = 100  # Axial resistance in Ohm * cm\n",
     "            sec.cm = 1  # Membrane capacitance in micro Farads / cm^2\n",
-    "        self.soma.insert(\"hh\")\n",
+    "        self.soma.insert(n.hh)\n",
     "        for seg in self.soma:\n",
     "            seg.hh.gnabar = 0.12  # Sodium conductance in S/cm2\n",
     "            seg.hh.gkbar = 0.036  # Potassium conductance in S/cm2\n",
     "            seg.hh.gl = 0.0003  # Leak conductance in S/cm2\n",
     "            seg.hh.el = -54.3  # Reversal potential in mV\n",
     "        # Insert passive current in the dendrite\n",
-    "        self.dend.insert(\"pas\")\n",
+    "        self.dend.insert(n.pas)\n",
     "        for seg in self.dend:\n",
     "            seg.pas.g = 0.001  # Passive conductance in S/cm2\n",
     "            seg.pas.e = -65  # Leak reversal potential mV"
@@ -291,12 +291,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def create_n_BallAndStick(n, r):\n",
-    "    \"\"\"n = number of cells; r = radius of circle\"\"\"\n",
+    "def create_n_BallAndStick(num, r):\n",
+    "    \"\"\"num = number of cells; r = radius of circle\"\"\"\n",
     "    cells = []\n",
-    "    for i in range(n):\n",
-    "        theta = i * 2 * h.PI / n\n",
-    "        cells.append(BallAndStick(i, h.cos(theta) * r, h.sin(theta) * r, 0, theta))\n",
+    "    for i in range(num):\n",
+    "        theta = i * 2 * n.PI / num\n",
+    "        cells.append(BallAndStick(i, n.cos(theta) * r, n.sin(theta) * r, 0, theta))\n",
     "    return cells"
    ]
   },
@@ -329,7 +329,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ps = h.PlotShape(True)\n",
+    "ps = n.PlotShape(True)\n",
     "ps.show(0)"
    ]
   },
@@ -382,16 +382,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stim = h.NetStim()  # Make a new stimulator\n",
+    "stim = n.NetStim()  # Make a new stimulator\n",
     "\n",
     "## Attach it to a synapse in the middle of the dendrite\n",
     "## of the first cell in the network. (Named 'syn_' to avoid\n",
     "## being overwritten with the 'syn' var assigned later.)\n",
-    "syn_ = h.ExpSyn(my_cells[0].dend(0.5))\n",
+    "syn_ = n.ExpSyn(my_cells[0].dend(0.5))\n",
     "\n",
     "stim.number = 1\n",
     "stim.start = 9\n",
-    "ncstim = h.NetCon(stim, syn_)\n",
+    "ncstim = n.NetCon(stim, syn_)\n",
     "ncstim.delay = 1 * ms\n",
     "ncstim.weight[0] = 0.04  # NetCon weight is a vector."
    ]
@@ -456,9 +456,9 @@
    "outputs": [],
    "source": [
     "recording_cell = my_cells[0]\n",
-    "soma_v = h.Vector().record(recording_cell.soma(0.5)._ref_v)\n",
-    "dend_v = h.Vector().record(recording_cell.dend(0.5)._ref_v)\n",
-    "t = h.Vector().record(h._ref_t)"
+    "soma_v = n.Vector().record(recording_cell.soma(0.5)._ref_v)\n",
+    "dend_v = n.Vector().record(recording_cell.dend(0.5)._ref_v)\n",
+    "t = n.Vector().record(n._ref_t)"
    ]
   },
   {
@@ -474,8 +474,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.finitialize(-65 * mV)\n",
-    "h.continuerun(25 * ms)"
+    "n.finitialize(-65 * mV)\n",
+    "n.continuerun(25 * ms)"
    ]
   },
   {
@@ -535,7 +535,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "syn_i = h.Vector().record(syn_._ref_i)"
+    "syn_i = n.Vector().record(syn_._ref_i)"
    ]
   },
   {
@@ -551,8 +551,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.finitialize(-65 * mV)\n",
-    "h.continuerun(25 * ms)"
+    "n.finitialize(-65 * mV)\n",
+    "n.continuerun(25 * ms)"
    ]
   },
   {
@@ -582,7 +582,7 @@
     "ax2 = fig.add_subplot(2, 1, 2)\n",
     "syn_plot = ax2.plot(t, syn_i, color=\"blue\", label=\"synaptic current\")\n",
     "ax2.legend()\n",
-    "ax2.set_ylabel(h.units(\"ExpSyn.i\"))\n",
+    "ax2.set_ylabel(n.units(\"ExpSyn.i\"))\n",
     "ax2.set_xlabel(\"time (ms)\")\n",
     "plt.show()"
    ]
@@ -618,8 +618,8 @@
     "syns = []\n",
     "netcons = []\n",
     "for source, target in zip(my_cells, my_cells[1:] + [my_cells[0]]):\n",
-    "    syn = h.ExpSyn(target.dend(0.5))\n",
-    "    nc = h.NetCon(source.soma(0.5)._ref_v, syn, sec=source.soma)\n",
+    "    syn = n.ExpSyn(target.dend(0.5))\n",
+    "    nc = n.NetCon(source.soma(0.5)._ref_v, syn, sec=source.soma)\n",
     "    nc.weight[0] = 0.05\n",
     "    nc.delay = 5\n",
     "    netcons.append(nc)\n",
@@ -646,8 +646,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.finitialize(-65 * mV)\n",
-    "h.continuerun(100 * ms)\n",
+    "n.finitialize(-65 * mV)\n",
+    "n.continuerun(100 * ms)\n",
     "plt.plot(t, soma_v, label=\"soma(0.5)\")\n",
     "plt.plot(t, dend_v, label=\"dend(0.5)\")\n",
     "plt.legend()\n",
@@ -676,7 +676,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spike_times = [h.Vector() for nc in netcons]\n",
+    "spike_times = [n.Vector() for nc in netcons]\n",
     "for nc, spike_times_vec in zip(netcons, spike_times):\n",
     "    nc.record(spike_times_vec)"
    ]
@@ -694,8 +694,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.finitialize(-65 * mV)\n",
-    "h.continuerun(100 * ms)"
+    "n.finitialize(-65 * mV)\n",
+    "n.continuerun(100 * ms)"
    ]
   },
   {

--- a/docs/tutorials/ball-and-stick-3.ipynb
+++ b/docs/tutorials/ball-and-stick-3.ipynb
@@ -34,10 +34,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from neuron import h, gui\n",
+    "from neuron import n, gui\n",
     "from neuron.units import ms, mV\n",
     "\n",
-    "h.load_file(\"stdrun.hoc\")"
+    "n.load_file(\"stdrun.hoc\")"
    ]
   },
   {
@@ -67,18 +67,18 @@
     "        self.all = self.soma.wholetree()\n",
     "        self._setup_biophysics()\n",
     "        self.x = self.y = self.z = 0\n",
-    "        h.define_shape()\n",
+    "        n.define_shape()\n",
     "        self._rotate_z(theta)\n",
     "        self._set_position(x, y, z)\n",
     "\n",
     "        # everything below here in this method is NEW\n",
-    "        self._spike_detector = h.NetCon(self.soma(0.5)._ref_v, None, sec=self.soma)\n",
-    "        self.spike_times = h.Vector()\n",
+    "        self._spike_detector = n.NetCon(self.soma(0.5)._ref_v, None, sec=self.soma)\n",
+    "        self.spike_times = n.Vector()\n",
     "        self._spike_detector.record(self.spike_times)\n",
     "\n",
     "        self._ncs = []\n",
     "\n",
-    "        self.soma_v = h.Vector().record(self.soma(0.5)._ref_v)\n",
+    "        self.soma_v = n.Vector().record(self.soma(0.5)._ref_v)\n",
     "\n",
     "    def __repr__(self):\n",
     "        return \"{}[{}]\".format(self.name, self._gid)\n",
@@ -101,8 +101,8 @@
     "            for i in range(sec.n3d()):\n",
     "                x = sec.x3d(i)\n",
     "                y = sec.y3d(i)\n",
-    "                c = h.cos(theta)\n",
-    "                s = h.sin(theta)\n",
+    "                c = n.cos(theta)\n",
+    "                s = n.sin(theta)\n",
     "                xprime = x * c - y * s\n",
     "                yprime = x * s + y * c\n",
     "                sec.pt3dchange(i, xprime, yprime, sec.z3d(i), sec.diam3d(i))"
@@ -125,8 +125,8 @@
     "    name = \"BallAndStick\"\n",
     "\n",
     "    def _setup_morphology(self):\n",
-    "        self.soma = h.Section(name=\"soma\", cell=self)\n",
-    "        self.dend = h.Section(name=\"dend\", cell=self)\n",
+    "        self.soma = n.Section(\"soma\", self)\n",
+    "        self.dend = n.Section(\"dend\", self)\n",
     "        self.dend.connect(self.soma)\n",
     "        self.soma.L = self.soma.diam = 12.6157\n",
     "        self.dend.L = 200\n",
@@ -136,20 +136,20 @@
     "        for sec in self.all:\n",
     "            sec.Ra = 100  # Axial resistance in Ohm * cm\n",
     "            sec.cm = 1  # Membrane capacitance in micro Farads / cm^2\n",
-    "        self.soma.insert(\"hh\")\n",
+    "        self.soma.insert(n.hh)\n",
     "        for seg in self.soma:\n",
     "            seg.hh.gnabar = 0.12  # Sodium conductance in S/cm2\n",
     "            seg.hh.gkbar = 0.036  # Potassium conductance in S/cm2\n",
     "            seg.hh.gl = 0.0003  # Leak conductance in S/cm2\n",
     "            seg.hh.el = -54.3  # Reversal potential in mV\n",
     "        # Insert passive current in the dendrite\n",
-    "        self.dend.insert(\"pas\")\n",
+    "        self.dend.insert(n.pas)\n",
     "        for seg in self.dend:\n",
     "            seg.pas.g = 0.001  # Passive conductance in S/cm2\n",
     "            seg.pas.e = -65  # Leak reversal potential mV\n",
     "\n",
     "        # NEW: the synapse\n",
-    "        self.syn = h.ExpSyn(self.dend(0.5))\n",
+    "        self.syn = n.ExpSyn(self.dend(0.5))\n",
     "        self.syn.tau = 2 * ms"
    ]
   },
@@ -157,7 +157,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Due to the nature of `h.ExpSyn` decay, there is mathematically no difference between having two ExpSyn objects at the same point or one synapse where multiple inputs add linearly, so it suffices to have just the one as long as we're happy with all inputs going into `dend(0.5)`."
+    "Due to the nature of `n.ExpSyn` decay, there is mathematically no difference between having two ExpSyn objects at the same point or one synapse where multiple inputs add linearly, so it suffices to have just the one as long as we're happy with all inputs going into `dend(0.5)`."
    ]
   },
   {
@@ -203,24 +203,24 @@
     "        self._create_cells(N, r)\n",
     "        self._connect_cells()\n",
     "        # add stimulus\n",
-    "        self._netstim = h.NetStim()\n",
+    "        self._netstim = n.NetStim()\n",
     "        self._netstim.number = 1\n",
     "        self._netstim.start = stim_t\n",
-    "        self._nc = h.NetCon(self._netstim, self.cells[0].syn)\n",
+    "        self._nc = n.NetCon(self._netstim, self.cells[0].syn)\n",
     "        self._nc.delay = stim_delay\n",
     "        self._nc.weight[0] = stim_w\n",
     "\n",
     "    def _create_cells(self, N, r):\n",
     "        self.cells = []\n",
     "        for i in range(N):\n",
-    "            theta = i * 2 * h.PI / N\n",
+    "            theta = i * 2 * n.PI / N\n",
     "            self.cells.append(\n",
-    "                BallAndStick(i, h.cos(theta) * r, h.sin(theta) * r, 0, theta)\n",
+    "                BallAndStick(i, n.cos(theta) * r, n.sin(theta) * r, 0, theta)\n",
     "            )\n",
     "\n",
     "    def _connect_cells(self):\n",
     "        for source, target in zip(self.cells, self.cells[1:] + [self.cells[0]]):\n",
-    "            nc = h.NetCon(source.soma(0.5)._ref_v, target.syn, sec=source.soma)\n",
+    "            nc = n.NetCon(source.soma(0.5)._ref_v, target.syn, sec=source.soma)\n",
     "            nc.weight[0] = self._syn_w\n",
     "            nc.delay = self._syn_delay\n",
     "            source._ncs.append(nc)"
@@ -269,7 +269,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "shape_window = h.PlotShape(True)\n",
+    "shape_window = n.PlotShape(True)\n",
     "shape_window.show(0)"
    ]
   },
@@ -286,9 +286,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "t = h.Vector().record(h._ref_t)\n",
-    "h.finitialize(-65 * mV)\n",
-    "h.continuerun(100)"
+    "t = n.Vector().record(n._ref_t)\n",
+    "n.finitialize(-65 * mV)\n",
+    "n.continuerun(100)"
    ]
   },
   {
@@ -368,8 +368,8 @@
     "plt.figure()\n",
     "for syn_w, color in [(0.01, \"black\"), (0.005, \"red\")]:\n",
     "    ring = Ring(N=5, syn_w=syn_w)\n",
-    "    h.finitialize(-65 * mV)\n",
-    "    h.continuerun(100 * ms)\n",
+    "    n.finitialize(-65 * mV)\n",
+    "    n.continuerun(100 * ms)\n",
     "    for i, cell in enumerate(ring.cells):\n",
     "        plt.vlines(list(cell.spike_times), i + 0.5, i + 1.5, color=color)\n",
     "\n",

--- a/docs/tutorials/ball-and-stick-4.ipynb
+++ b/docs/tutorials/ball-and-stick-4.ipynb
@@ -92,11 +92,11 @@
    "outputs": [],
    "source": [
     "%%writefile testmpi.py\n",
-    "from neuron import h\n",
-    "h.nrnmpi_init()       # initialize MPI\n",
-    "pc = h.ParallelContext()\n",
+    "from neuron import n\n",
+    "n.nrnmpi_init()       # initialize MPI\n",
+    "pc = n.ParallelContext()\n",
     "print('I am {} of {}'.format(pc.id(), pc.nhost()))\n",
-    "h.quit()              # necessary to avoid a warning message on parallel exit on some systems"
+    "n.quit()              # necessary to avoid a warning message on parallel exit on some systems"
    ]
   },
   {
@@ -190,12 +190,12 @@
    "outputs": [],
    "source": [
     "%%writefile ring.py\n",
-    "from neuron import h\n",
+    "from neuron import n\n",
     "from ballandstick import BallAndStick\n",
     "\n",
     "### MPI must be initialized before we create a ParallelContext object\n",
-    "h.nrnmpi_init()\n",
-    "pc = h.ParallelContext()\n",
+    "n.nrnmpi_init()\n",
+    "pc = n.ParallelContext()\n",
     "\n",
     "class Ring:\n",
     "    \"\"\"A network of *N* ball-and-stick cells where cell n makes an\n",
@@ -220,10 +220,10 @@
     "        self._connect_cells()\n",
     "        ### the 0th cell only exists on one process... that's the only one that gets a netstim\n",
     "        if pc.gid_exists(0):\n",
-    "            self._netstim = h.NetStim()\n",
+    "            self._netstim = n.NetStim()\n",
     "            self._netstim.number = 1\n",
     "            self._netstim.start = stim_t\n",
-    "            self._nc = h.NetCon(self._netstim, pc.gid2cell(0).syn)   ### grab cell with gid==0 wherever it exists\n",
+    "            self._nc = n.NetCon(self._netstim, pc.gid2cell(0).syn)   ### grab cell with gid==0 wherever it exists\n",
     "            self._nc.delay = stim_delay\n",
     "            self._nc.weight[0] = stim_w\n",
     "    \n",
@@ -238,8 +238,8 @@
     "    def _create_cells(self, r):\n",
     "        self.cells = []\n",
     "        for i in self.gidlist:    ### only create the cells that exist on this host\n",
-    "            theta = i * 2 * h.PI / self._N\n",
-    "            self.cells.append(BallAndStick(i, h.cos(theta) * r, h.sin(theta) * r, 0, theta))\n",
+    "            theta = i * 2 * n.PI / self._N\n",
+    "            self.cells.append(BallAndStick(i, n.cos(theta) * r, n.sin(theta) * r, 0, theta))\n",
     "        ### associate the cell with this host and gid\n",
     "        for cell in self.cells:\n",
     "            pc.cell(cell._gid, cell._spike_detector)\n",
@@ -258,7 +258,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The call to `h.nrnmpi_init()` must happen before any use of the [ParallelContext](../python/modelspec/programmatic/network/parcon.html) class -- which forms a key part of any NEURON parallel simulation.\n",
+    "The call to `n.nrnmpi_init()` must happen before any use of the [ParallelContext](../python/modelspec/programmatic/network/parcon.html) class -- which forms a key part of any NEURON parallel simulation.\n",
     "\n",
     "The only conceptually new method here is the `set_gids` method where each process specifies which cells it will simulate. Here we use what is known as a round-robin approach, where the `pc.id()`th process starts at `pc.id()` and skips by however many processes are running (`pc.nhost`)."
    ]
@@ -291,7 +291,7 @@
    "outputs": [],
    "source": [
     "%%writefile test_ring1.py\n",
-    "from neuron import h\n",
+    "from neuron import n\n",
     "from neuron.units import ms, mV\n",
     "import matplotlib.pyplot as plt\n",
     "from ring import Ring\n",
@@ -300,11 +300,11 @@
     "\n",
     "ring = Ring()\n",
     "\n",
-    "pc = h.ParallelContext()\n",
+    "pc = n.ParallelContext()\n",
     "pc.set_maxstep(10 * ms)\n",
     "\n",
-    "t = h.Vector().record(h._ref_t)\n",
-    "h.finitialize(-65 * mV)\n",
+    "t = n.Vector().record(n._ref_t)\n",
+    "n.finitialize(-65 * mV)\n",
     "pc.psolve(100 * ms)\n",
     "\n",
     "if pc.gid_exists(cell_to_plot):\n",
@@ -317,7 +317,7 @@
     "\n",
     "pc.barrier()\n",
     "pc.done()\n",
-    "h.quit()"
+    "n.quit()"
    ]
   },
   {
@@ -334,7 +334,7 @@
     "The conceptually new pieces are:\n",
     "\n",
     "* [pc.set_maxstep(10 * ms)](../python/modelspec/programmatic/network/parcon.html#ParallelContext.set_maxstep) -- sets an upper bound on how far MPI can simulate without communicating, here a simulated 10 ms. This *must* be called before attempting a parallel simulation.\n",
-    "* [pc.psolve(100 * ms)](../python/modelspec/programmatic/network/parcon.html#ParallelContext.psolve) -- a parallel version of [h.continuerun](../python/simctrl/stdrun.html), but does not support updating NEURON graphics during the simulation.\n",
+    "* [pc.psolve(100 * ms)](../python/modelspec/programmatic/network/parcon.html#ParallelContext.psolve) -- a parallel version of [n.continuerun](../python/simctrl/stdrun.html), but does not support updating NEURON graphics during the simulation.\n",
     "* [pc.gid_exists](../python/modelspec/programmatic/network/parcon.html#ParallelContext.gid_exists)  -- only the process that owns the specified cell should make the plot.\n",
     "* [pc.gid2cell](../python/modelspec/programmatic/network/parcon.html#ParallelContext.gid2cell) -- lookup a cell by gid.\n",
     "* [pc.barrier()](../python/modelspec/programmatic/network/parcon.html#ParallelContext.barrier) -- wait until all processes reach this point; used to make sure processes don't shut down before the graph is closed."
@@ -429,18 +429,18 @@
    "outputs": [],
    "source": [
     "%%writefile test_ring2.py\n",
-    "from neuron import h\n",
+    "from neuron import n\n",
     "from neuron.units import ms, mV\n",
     "import matplotlib.pyplot as plt\n",
     "from ring import Ring\n",
     "\n",
     "ring = Ring()\n",
     "\n",
-    "pc = h.ParallelContext()\n",
+    "pc = n.ParallelContext()\n",
     "pc.set_maxstep(10 * ms)\n",
     "\n",
-    "t = h.Vector().record(h._ref_t)\n",
-    "h.finitialize(-65 * mV)\n",
+    "t = n.Vector().record(n._ref_t)\n",
+    "n.finitialize(-65 * mV)\n",
     "pc.psolve(100 * ms)\n",
     "\n",
     "# send all spike time data to rank 0\n",
@@ -463,7 +463,7 @@
     "\n",
     "pc.barrier()\n",
     "pc.done()\n",
-    "h.quit()"
+    "n.quit()"
    ]
   },
   {

--- a/docs/tutorials/ballandstick.py
+++ b/docs/tutorials/ballandstick.py
@@ -1,7 +1,7 @@
-from neuron import h, gui
+from neuron import n, gui
 from neuron.units import ms, mV
 
-h.load_file("stdrun.hoc")
+n.load_file("stdrun.hoc")
 
 
 class Cell:
@@ -11,18 +11,18 @@ class Cell:
         self.all = self.soma.wholetree()
         self._setup_biophysics()
         self.x = self.y = self.z = 0
-        h.define_shape()
+        n.define_shape()
         self._rotate_z(theta)
         self._set_position(x, y, z)
 
         # everything below here in this method is NEW
-        self._spike_detector = h.NetCon(self.soma(0.5)._ref_v, None, sec=self.soma)
-        self.spike_times = h.Vector()
+        self._spike_detector = n.NetCon(self.soma(0.5)._ref_v, None, sec=self.soma)
+        self.spike_times = n.Vector()
         self._spike_detector.record(self.spike_times)
 
         self._ncs = []
 
-        self.soma_v = h.Vector().record(self.soma(0.5)._ref_v)
+        self.soma_v = n.Vector().record(self.soma(0.5)._ref_v)
 
     def __repr__(self):
         return "{}[{}]".format(self.name, self._gid)
@@ -45,8 +45,8 @@ class Cell:
             for i in range(sec.n3d()):
                 x = sec.x3d(i)
                 y = sec.y3d(i)
-                c = h.cos(theta)
-                s = h.sin(theta)
+                c = n.cos(theta)
+                s = n.sin(theta)
                 xprime = x * c - y * s
                 yprime = x * s + y * c
                 sec.pt3dchange(i, xprime, yprime, sec.z3d(i), sec.diam3d(i))
@@ -56,8 +56,8 @@ class BallAndStick(Cell):
     name = "BallAndStick"
 
     def _setup_morphology(self):
-        self.soma = h.Section(name="soma", cell=self)
-        self.dend = h.Section(name="dend", cell=self)
+        self.soma = n.Section("soma", self)
+        self.dend = n.Section("dend", self)
         self.dend.connect(self.soma)
         self.soma.L = self.soma.diam = 12.6157
         self.dend.L = 200
@@ -67,7 +67,7 @@ class BallAndStick(Cell):
         for sec in self.all:
             sec.Ra = 100  # Axial resistance in Ohm * cm
             sec.cm = 1  # Membrane capacitance in micro Farads / cm^2
-        self.soma.insert("hh")
+        self.soma.insert(n.hh)
         for seg in self.soma:
             seg.hh.gnabar = 0.12  # Sodium conductance in S/cm2
             seg.hh.gkbar = 0.036  # Potassium conductance in S/cm2
@@ -80,5 +80,5 @@ class BallAndStick(Cell):
             seg.pas.e = -65  # Leak reversal potential mV
 
         # NEW: the synapse
-        self.syn = h.ExpSyn(self.dend(0.5))
+        self.syn = n.ExpSyn(self.dend(0.5))
         self.syn.tau = 2 * ms

--- a/docs/tutorials/scripting-neuron-basics.ipynb
+++ b/docs/tutorials/scripting-neuron-basics.ipynb
@@ -92,14 +92,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from neuron import h"
+    "from neuron import n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When using NEURON, you will always want the <tt>h</tt> submodule. You may or may not need to import the additional submodules mentioned above. If you do, they can be imported separately or loaded in one line with a comma separated list, as in:"
+    "When using NEURON, you will always want the <tt>n</tt> submodule. (With older code, you may have seen people use the <tt>h</tt> submodule. They are almost exactly equivalent, and <tt>h</tt> continues to work.) You may or may not need to import the additional submodules mentioned above. If you do, they can be imported separately or loaded in one line with a comma separated list, as in:"
    ]
   },
   {
@@ -108,14 +108,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from neuron import h, rxd"
+    "from neuron import n, rxd"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "NB: When importing <tt>h</tt>, etc like this, there is usually no need for importing <tt>neuron</tt> separately."
+    "NB: When importing <tt>n</tt>, etc like this, there is usually no need for importing <tt>neuron</tt> separately."
    ]
   },
   {
@@ -161,7 +161,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "soma = h.Section(name=\"soma\")"
+    "soma = n.Section(\"soma\")"
    ]
   },
   {
@@ -175,15 +175,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Aside 1: NEURON's <tt>h.topology</tt> function"
+    "### Aside 1: NEURON's `n.topology` function"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<p>NEURON's <tt>h.topology()</tt> function displays the topological structure of the entire model, indicating which sections are connected to which sections, where they are connected, and how many <i>segments</i> each section is divided into.</p>\n",
-    "<p>If you're following along with our example, there's not much to see yet since there is only one section, but it does demonstrate that the soma has been created and has one segment (one dash is shown):</p>"
+    "NEURON's `n.topology()` function displays the topological structure of the entire model, indicating which sections are connected to which sections, where they are connected, and how many *segments* each section is divided into.\n",
+    "\n",
+    "If you're following along with our example, there's not much to see yet since there is only one section, but it does demonstrate that the soma has been created and has one segment (one dash is shown):"
    ]
   },
   {
@@ -192,21 +193,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.topology()"
+    "n.topology()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The <tt>h.topology()</tt> function displays its data to screen and returns <tt>1.0</tt> indicating success (this function always succeeds). Note: This function is only for displaying data; other methods must be used to store the data in a variable for programmatic analysis."
+    "The `n.topology()` function displays its data to screen and returns `1.0` indicating success (this function always succeeds). Note: This function is only for displaying data; other methods must be used to store the data in a variable for programmatic analysis."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Aside 2: The <tt>psection</tt> method"
+    "### Aside 2: The `psection` method"
    ]
   },
   {
@@ -289,7 +290,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<b>Important:</b> You may have noticed that the default diameter is 500 μm, which is excessively large for mammalian neurons. It's the default because it's appropriate for the squid giant axons studied by Hodgkin and Huxley. NEURON also uses squid-relevant values for axial resistivity (<tt>soma.Ra</tt>) and temperature (<tt>h.celsius</tt>). These should all be adjusted for mammalian models."
+    "**Important:** You may have noticed that the default diameter is 500 μm, which is excessively large for mammalian neurons. It's the default because it's appropriate for the squid giant axons studied by Hodgkin and Huxley. NEURON also uses squid-relevant values for axial resistivity (`soma.Ra`) and temperature (`n.celsius`). These should all be adjusted for mammalian models."
    ]
   },
   {
@@ -327,7 +328,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Aside 3: Python's <tt>dir</tt> function"
+    "### Aside 3: Python's `dir` function"
    ]
   },
   {
@@ -350,7 +351,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This tells us all of the Python methods and variables associated with the object. Any methods with two leading and trailing underscores are reserved by Python. The other items in the list are additional members of soma that we can call. To see all of the functions, variables, etc available through NEURON's <tt>h</tt> submodule, try:"
+    "This tells us all of the Python methods and variables associated with the object. Any methods with two leading and trailing underscores are reserved by Python. The other items in the list are additional members of soma that we can call. To see all of the functions, variables, etc available through NEURON's `n` submodule, try:"
    ]
   },
   {
@@ -361,7 +362,7 @@
    "source": [
     "import textwrap\n",
     "\n",
-    "print(textwrap.fill(\", \".join(dir(h))))"
+    "print(textwrap.fill(\", \".join(dir(n))))"
    ]
   },
   {
@@ -474,7 +475,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A section's <tt>insert</tt> method is used to insert density mechanisms (i.e. anything where we don't want to specify every single instance separately). Let's insert Hodgkin-Huxley channels into the <tt>soma</tt>'s membrane. We do this by passing 'hh' as the mechanism type:"
+    "A section's `insert` method is used to insert density mechanisms (i.e. anything where we don't want to specify every single instance separately). Let's insert Hodgkin-Huxley channels into the `soma`'s membrane. We do this by passing `n.hh` as the mechanism type:"
    ]
   },
   {
@@ -483,7 +484,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "soma.insert(\"hh\")"
+    "soma.insert(n.hh)"
    ]
   },
   {
@@ -537,8 +538,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"type(soma) = {}\".format(type(soma)))\n",
-    "print(\"type(soma(0.5)) = {}\".format(type(soma(0.5))))"
+    "print(f\"type(soma) = {type(soma)}\")\n",
+    "print(f\"type(soma(0.5)) = {type(soma(0.5))}\")"
    ]
   },
   {
@@ -598,7 +599,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's insert a current clamp (an <a class=\"reference external\" href=\"https://neuron.yale.edu/neuron/static/py_doc/modelspec/programmatic/mechanisms/mech.html#IClamp\" title=\"(in NEURON v7.5)\"><code class=\"xref py py-class docutils literal\"><span class=\"pre\">IClamp</span></code></a> object) into the center of the soma to induce some membrane dynamics."
+    "Let's insert a current clamp (an <a class=\"reference external\" href=\"https://nrn.readthedocs.io/en/latest/python/modelspec/programmatic/mechanisms/mech.html#IClamp\"><code class=\"xref py py-class docutils literal\"><span class=\"pre\">IClamp</span></code></a> object) into the center of the soma to induce some membrane dynamics."
    ]
   },
   {
@@ -607,7 +608,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "iclamp = h.IClamp(soma(0.5))"
+    "iclamp = n.IClamp(soma(0.5))"
    ]
   },
   {
@@ -673,7 +674,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The cell should be configured to run a simulation. However, we need to indicate which variables we wish to record; these will be stored in a NEURON Vector (<tt>h.Vector</tt> object). For now, we will record the membrane potential, which is <tt>soma(0.5).v</tt> and the corresponding time points (<tt>h.t</tt>). References to variables are available by preceding the last part of the variable name with a `_ref_`"
+    "The cell should be configured to run a simulation. However, we need to indicate which variables we wish to record; these will be stored in a NEURON Vector (<tt>n.Vector</tt> object). For now, we will record the membrane potential, which is <tt>soma(0.5).v</tt> and the corresponding time points (<tt>n.t</tt>). References to variables are available by preceding the last part of the variable name with a `_ref_`"
    ]
   },
   {
@@ -682,8 +683,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "v = h.Vector().record(soma(0.5)._ref_v)  # Membrane potential vector\n",
-    "t = h.Vector().record(h._ref_t)  # Time stamp vector"
+    "v = n.Vector().record(soma(0.5)._ref_v)  # Membrane potential vector\n",
+    "t = n.Vector().record(n._ref_t)  # Time stamp vector"
    ]
   },
   {
@@ -706,7 +707,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.load_file(\"stdrun.hoc\")"
+    "n.load_file(\"stdrun.hoc\")"
    ]
   },
   {
@@ -722,7 +723,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.finitialize(-65 * mV)"
+    "n.finitialize(-65 * mV)"
    ]
   },
   {
@@ -738,7 +739,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.continuerun(40 * ms)"
+    "n.continuerun(40 * ms)"
    ]
   },
   {
@@ -1244,7 +1245,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is a minor distinction though, as we've already seen <tt>list(vec)</tt> copies a Vector <tt>vec</tt> into a new list. Using `h.Vector(old_list)` makes a NEURON Vector that is a copy of `old_list`."
+    "This is a minor distinction though, as we've already seen <tt>list(vec)</tt> copies a Vector <tt>vec</tt> into a new list. Using `n.Vector(old_list)` makes a NEURON Vector that is a copy of `old_list`."
    ]
   },
   {
@@ -1266,13 +1267,6 @@
     "plt.ylabel(\"v (mV)\")\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/share/lib/python/neuron/__init__.py
+++ b/share/lib/python/neuron/__init__.py
@@ -36,29 +36,30 @@ For help on these useful functions, see their docstrings:
   load_mechanisms
 
 
-neuron.h
+neuron.n
 
-   The top-level Hoc interpreter.
+   The top-level NEURON interface. Synonymous with neuron.h
+   except the type and __repr__ are different.
 
-   Execute Hoc commands by calling h with a string argument:
+   Execute Hoc commands by calling n with a string argument:
 
-   >>> h('objref myobj')
-   >>> h('myobj = new Vector(10)')
+   >>> n('objref myobj')
+   >>> n('myobj = new Vector(10)')
 
-   All Hoc defined variables are accessible by attribute access to h.
+   All Hoc defined variables are accessible by attribute access to n.
 
    Example:
 
-   >>> print h.myobj.x[9]
+   >>> print(n.myobj.x[9])
 
    Hoc Classes are also defined, for example:
 
-   >>> v = h.Vector([1,2,3])
-   >>> soma = h.Section()
+   >>> v = n.Vector([1,2,3])
+   >>> soma = n.Section("soma")
 
    More help is available for the respective class by looking in the object docstring:
 
-   >>> help(h.Vector)
+   >>> help(n.Vector)
 
 
 
@@ -155,8 +156,21 @@ from . import hoc
 import nrn
 import _neuron_section
 
+# we keep the old h as before with the old repr and type
 h = hoc.HocObject()
-version = h.nrnversion(5)
+
+
+class _NEURON_INTERFACE(hoc.HocObject):
+    def __repr__(self):
+        return "<TopLevelNEURONInterface>"
+
+    def __dir__(self):
+        return dir(h)
+
+
+n = _NEURON_INTERFACE()
+
+version = n.nrnversion(5)
 __version__ = version
 _userrxd = False
 
@@ -201,7 +215,7 @@ def _check_for_intel_openmp():
     # Try to load the CoreNEURON shared library so that the various NVIDIA
     # runtime libraries also get loaded, before we import numpy lower down this
     # file.
-    loaded_coreneuron = bool(h.coreneuron_handle())
+    loaded_coreneuron = bool(n.coreneuron_handle())
     if not loaded_coreneuron:
         warnings.warn(
             "Failed to pre-load CoreNEURON when importing NEURON. "
@@ -286,8 +300,8 @@ def test_rxd(exitOnError=True):
 
 
 # ------------------------------------------------------------------------------
-# class factory for subclassing h.anyclass
-# h.anyclass methods may be overridden. If so the base method can be called
+# class factory for subclassing n.anyclass
+# n.anyclass methods may be overridden. If so the base method can be called
 # using the idiom self.basemethod = self.baseattr('methodname')
 # ------------------------------------------------------------------------------
 
@@ -325,7 +339,7 @@ def load_mechanisms(path, warn_if_already_loaded=True):
     arch_list = [platform.machine(), "i686", "x86_64", "powerpc", "umac"]
 
     # windows loads nrnmech.dll
-    if h.unix_mac_pc() == 3:
+    if n.unix_mac_pc() == 3:
         libname = "nrnmech.dll"
         libsubdir = ""
         arch_list = [""]
@@ -333,7 +347,7 @@ def load_mechanisms(path, warn_if_already_loaded=True):
     for arch in arch_list:
         lib_path = os.path.join(path, arch, libsubdir, libname)
         if os.path.exists(lib_path):
-            h.nrn_load_dll(lib_path)
+            n.nrn_load_dll(lib_path)
             nrn_dll_loaded.append(path)
             return True
     print("NEURON mechanisms not found in %s." % path)
@@ -395,10 +409,10 @@ def new_point_process(name, doc=None):
         def __init__(self, section, position=0.5):
             assert 0 <= position <= 1
             section.push()
-            self.__dict__["hoc_obj"] = getattr(h, "new_%s" % name)(
+            self.__dict__["hoc_obj"] = getattr(n, "new_%s" % name)(
                 position
             )  # have to put directly in __dict__ to avoid infinite recursion with __getattr__
-            h.pop_section()
+            n.pop_section()
 
     someclass.__name__ = name
     return someclass
@@ -440,7 +454,7 @@ def xopen(*args, **kwargs):
 
 
     Description:
-        ``h.xopen()`` executes the commands in ``hocfile``.  This is a convenient way
+        ``n.xopen()`` executes the commands in ``hocfile``.  This is a convenient way
         to define user functions and procedures.
         An optional second argument is the RCS revision number in the form of a
         string. The RCS file with that revision number is checked out into a
@@ -448,14 +462,14 @@ def xopen(*args, **kwargs):
         of the same primary name is unaffected.
 
     This function is deprecated and will be removed in a future release.
-    Use ``h.xopen`` instead.
+    Use ``n.xopen`` instead.
     """
     warnings.warn(
-        "neuron.xopen is deprecated; use h.xopen instead",
+        "neuron.xopen is deprecated; use n.xopen instead",
         DeprecationWarning,
         stacklevel=2,
     )
-    return h.xopen(*args, **kwargs)
+    return n.xopen(*args, **kwargs)
 
 
 def quit(*args, **kwargs):
@@ -464,15 +478,15 @@ def quit(*args, **kwargs):
     are open you will be asked if you wish to save them before the final exit.
 
     This function is deprecated and will be removed in a future release.
-    Use ``h.quit()`` or ``sys.exit()`` instead. (Note: sys.exit will not prompt
+    Use ``n.quit()`` or ``sys.exit()`` instead. (Note: sys.exit will not prompt
     for saving edit buffers.)
     """
     warnings.warn(
-        "neuron.quit() is deprecated; use h.quit() or sys.exit() instead",
+        "neuron.quit() is deprecated; use n.quit() or sys.exit() instead",
         DeprecationWarning,
         stacklevel=2,
     )
-    return h.quit(*args, **kwargs)
+    return n.quit(*args, **kwargs)
 
 
 def psection(section):
@@ -497,7 +511,7 @@ def psection(section):
         DeprecationWarning,
         stacklevel=2,
     )
-    h.psection(sec=section)
+    n.psection(sec=section)
 
 
 def init():
@@ -508,30 +522,30 @@ def init():
 
     ** This function exists for historical purposes. Use in new code is not recommended. **
 
-    Use h.finitialize() instead, which allows you to specify the membrane potential
-    to initialize to; via e.g. h.finitialize(-65)
+    Use n.finitialize() instead, which allows you to specify the membrane potential
+    to initialize to; via e.g. n.finitialize(-65)
 
     This function is deprecated and will be removed in a future
     release.
 
-    By default, the units used by h.finitialize are in mV, but you can be explicit using
+    By default, the units used by n.finitialize are in mV, but you can be explicit using
     NEURON's unit's library, e.g.
 
     .. code-block:: python
 
         from neuron.units import mV
-        h.finitialize(-65 * mV)
+        n.finitialize(-65 * mV)
 
     https://nrn.readthedocs.io/en/latest/python/simctrl/programmatic.html#finitialize
 
     """
     warnings.warn(
-        "neuron.init() is deprecated; use h.init() instead",
+        "neuron.init() is deprecated; use n.init() instead",
         DeprecationWarning,
         stacklevel=2,
     )
 
-    h.finitialize()
+    n.finitialize()
 
 
 def run(tstop):
@@ -540,7 +554,7 @@ def run(tstop):
 
     Run the simulation (advance the solver) until tstop [ms]
 
-    `h.run()` and `h.continuerun(tstop)` are more powerful solutions defined in the `stdrun.hoc` library.
+    `n.run()` and `n.continuerun(tstop)` are more powerful solutions defined in the `stdrun.hoc` library.
 
     ** This function exists for historical purposes. Use in new code is not recommended. **
 
@@ -553,29 +567,29 @@ def run(tstop):
 
     .. code-block:: python
 
-        from neuron import h
+        from neuron import n
         from neuron.units import ms, mV
-        h.load_file('stdrun.hoc')
+        n.load_file('stdrun.hoc')
 
     Then when it is time to initialize and run the simulation:
 
     .. code-block:: python
 
-        h.finitialize(-65 * mV)
-        h.continuerun(100 * ms)
+        n.finitialize(-65 * mV)
+        n.continuerun(100 * ms)
 
     where the initial membrane potential and the simulation run time are adjusted as appropriate
     for your model.
 
     """
     warnings.warn(
-        "neuron.run(tstop) is deprecated; use h.stdinit() and h.continuerun(tstop) instead",
+        "neuron.run(tstop) is deprecated; use n.stdinit() and n.continuerun(tstop) instead",
         DeprecationWarning,
         stacklevel=2,
     )
 
-    h("tstop = %g" % tstop)
-    h("while (t < tstop) { fadvance() }")
+    n("tstop = %g" % tstop)
+    n("while (t < tstop) { fadvance() }")
     # what about pc.psolve(tstop)?
 
 
@@ -655,7 +669,7 @@ def nrn_dll_sym_nt(name, type):
 
     if len(nt_dlls) == 0:
         b = "bin"
-        path = os.path.join(h.neuronhome().replace("/", "\\"), b)
+        path = os.path.join(n.neuronhome().replace("/", "\\"), b)
         for dllname in [
             "libnrniv.dll",
             "libnrnpython{}.{}.dll".format(*sys.version_info[:2]),
@@ -719,7 +733,7 @@ def nrn_dll(printpath=False):
     except:
         pass
     # maybe old default module location
-    neuron_home = os.path.split(os.path.split(h.neuronhome())[0])[0]
+    neuron_home = os.path.split(os.path.split(n.neuronhome())[0])[0]
     base_path = os.path.join(neuron_home, "lib", "python", "neuron", p)
     for extension in ["", ".dll", ".so", ".dylib"]:
         dlls = glob.glob(base_path + "*" + extension)
@@ -788,7 +802,7 @@ def _create_sections_in_obj(obj, name, numsecs):
     setattr(
         obj,
         name,
-        [h.Section(name="%s[%d]" % (name, i), cell=obj) for i in range(int(numsecs))],
+        [n.Section(name="%s[%d]" % (name, i), cell=obj) for i in range(int(numsecs))],
     )
 
 
@@ -816,12 +830,12 @@ def _parse_import3d_name(name):
 def _pt3dstyle_in_obj(obj, name, x, y, z):
     # used by import3d
     array, i = _parse_import3d_name(name)
-    h.pt3dstyle(1, x, y, z, sec=getattr(obj, array)[i])
+    n.pt3dstyle(1, x, y, z, sec=getattr(obj, array)[i])
 
 
 def _pt3dadd_in_obj(obj, name, x, y, z, d):
     array, i = _parse_import3d_name(name)
-    h.pt3dadd(x, y, z, d, sec=getattr(obj, array)[i])
+    n.pt3dadd(x, y, z, d, sec=getattr(obj, array)[i])
 
 
 def numpy_from_pointer(cpointer, size):
@@ -876,14 +890,14 @@ class _RangeVarPlot(_WrapperPlot):
     .. code::
 
       from matplotlib import pyplot
-      from neuron import h, gui
+      from neuron import n, gui
       import bokeh.plotting as b
       import plotly
       import plotly.graph_objects as go
       import plotnine as p9
       import math
 
-      dend = h.Section(name='dend')
+      dend = n.Section(name='dend')
       dend.nseg = 55
       dend.L = 6.28
 
@@ -891,14 +905,14 @@ class _RangeVarPlot(_WrapperPlot):
       for seg in dend.allseg():
           seg.v = math.sin(dend.L * seg.x)
 
-      r = h.RangeVarPlot('v', dend(0), dend(1))
+      r = n.RangeVarPlot('v', dend(0), dend(1))
 
       # matplotlib
       graph = pyplot.gca()
       r.plot(graph, linewidth=10, color='r')
 
       # NEURON Interviews graph
-      g = h.Graph()
+      g = n.Graph()
       r.plot(g, 2, 3)
       g.exec_menu('View = plot')
 
@@ -925,8 +939,8 @@ class _RangeVarPlot(_WrapperPlot):
     """
 
     def __call__(self, graph, *args, **kwargs):
-        yvec = h.Vector()
-        xvec = h.Vector()
+        yvec = n.Vector()
+        xvec = n.Vector()
         self._data.to_vector(yvec, xvec)
         if isinstance(graph, hoc.HocObject):
             return yvec.line(graph, xvec, *args)
@@ -984,7 +998,7 @@ class _PlotShapePlot(_WrapperPlot):
     Currently only pyplot is supported, e.g.
 
     from matplotlib import pyplot
-    ps = h.PlotShape(False)
+    ps = n.PlotShape(False)
     ps.variable('v')
     ps.plot(pyplot)
     pyplot.show()
@@ -1046,7 +1060,7 @@ class _PlotShapePlot(_WrapperPlot):
                     """
                     Plots a 3D shapeplot
                     Args:
-                        sections = list of h.Section() objects to be plotted
+                        sections = list of n.Section() objects to be plotted
                         **kwargs passes on to matplotlib (e.g. linewidth=2 for thick lines)
                     Returns:
                         lines = list of line objects making up shapeplot
@@ -1057,9 +1071,9 @@ class _PlotShapePlot(_WrapperPlot):
 
                     # Default is to plot all sections.
                     if sections is None:
-                        sections = list(h.allsec())
+                        sections = list(n.allsec())
 
-                    h.define_shape()
+                    n.define_shape()
 
                     # Plot each segement as a line
                     lines = {}
@@ -1252,7 +1266,7 @@ class _PlotShapePlot(_WrapperPlot):
             if varobj is not None:
                 variable = varobj
             if secs is None:
-                secs = list(h.allsec())
+                secs = list(n.allsec())
 
             if variable is None and varobj is None:
                 kwargs.setdefault("color", "black")
@@ -1355,7 +1369,7 @@ class DensityMechanism:
         Takes the name of a range mechanism; call via e.g. neuron.DensityMechanism('hh')
         """
         self.__name = name
-        self.__mt = h.MechanismType(0)
+        self.__mt = n.MechanismType(0)
         self.__mt.select(-1)
         self.__mt.select(name)
         if self.__mt.selected() == -1:
@@ -1546,7 +1560,7 @@ try:
         return _RangeVarPlot(rvp)
 
     def _plotshape_plot(ps):
-        h.define_shape()
+        n.define_shape()
         return _PlotShapePlot(ps)
 
     _mech_classes = {}
@@ -1620,8 +1634,8 @@ def _has_scipy():
 
 
 def _pkl(arg):
-    # print 'neuron._pkl arg is ', arg
-    return h.Vector(0)
+    # print('neuron._pkl arg is ', arg)
+    return n.Vector(0)
 
 
 def format_exception(type, value, tb):
@@ -1654,7 +1668,7 @@ def nrnpy_pr(stdoe, s):
 
 # nrnpy_pr callback in place of hoc printf
 # ensures consistent with python stdout even with jupyter notebook.
-# nrnpy_pass callback used by h.doNotify() in MINGW when not called from
+# nrnpy_pass callback used by n.doNotify() in MINGW when not called from
 # gui thread in order to allow the gui thread to run.
 # When this was introduced in ef4da5dbf293580ee1bf86b3a94d3d2f80226f62 it was wrapped in a
 # try .. except .. pass block for reasons that are not obvious to olupton, who removed it.
@@ -1719,7 +1733,7 @@ def _nrnpy_rvp_pyobj_callback(f):
         return f
 
     # if we're here, f is an rxd variable, and we return a function that looks
-    # up the weighted average concentration given an x and h.cas()
+    # up the weighted average concentration given an x and n.cas()
     # this is not particularly efficient so it is probably better to use this for
     # fixed timepoints rather than displays that update mid-simulation
     fref = weakref.ref(f)
@@ -1730,8 +1744,8 @@ def _nrnpy_rvp_pyobj_callback(f):
         sp = fref()
         if sp:
             try:
-                # h.cas() will fail if there are no sections
-                nodes = sp.nodes(h.cas()(x))
+                # n.cas() will fail if there are no sections
+                nodes = sp.nodes(n.cas()(x))
             except:
                 return None
             if nodes:
@@ -1841,7 +1855,7 @@ try:
     from bokeh.core.serialization import Serializer
 
     Serializer.register(
-        h.Vector, lambda obj, serializer: [serializer.encode(item) for item in obj]
+        n.Vector, lambda obj, serializer: [serializer.encode(item) for item in obj]
     )
 except ImportError:
     pass

--- a/share/lib/python/neuron/tests/test_neuron.py
+++ b/share/lib/python/neuron/tests/test_neuron.py
@@ -7,7 +7,7 @@ $Id$
 
 import unittest
 import neuron
-from neuron import h
+from neuron import n
 
 
 class NeuronTestCase(unittest.TestCase):
@@ -26,23 +26,23 @@ class NeuronTestCase(unittest.TestCase):
         b.s = "two"
         assert a.s == "one"
         assert b.s == "two"
-        assert h.A[0].s == "one"
+        assert n.A[0].s == "one"
         assert a.p() == 7.0
         assert b.p() == 5.0
         a.a = 2
         b.a = 3
         assert a.a == 2
         assert b.a == 3
-        assert h.List("A").count() == 2
+        assert n.List("A").count() == 2
         a = 1
         b = 1
-        assert h.List("A").count() == 0
+        assert n.List("A").count() == 0
 
     @classmethod
     def psection(cls):
         """Test neuron.psection(Section)"""
 
-        s = h.Section(name="soma")
+        s = n.Section(name="soma")
         neuron.psection(s)
 
     def testpsection(self):
@@ -57,12 +57,12 @@ class NeuronTestCase(unittest.TestCase):
 
         # Py_nb_bool
         assert True if h else False
-        assert True if h.List else False
+        assert True if n.List else False
         # ensure creating a List doesn't change the truth value
-        l = h.List()
-        assert True if h.List else False
+        l = n.List()
+        assert True if n.List else False
         assert False if l else True
-        v = h.Vector(1)
+        v = n.Vector(1)
         l.append(v)
         assert True if l else False
 
@@ -77,8 +77,8 @@ class NeuronTestCase(unittest.TestCase):
     def testIterators(self):
         """Test section, segment, mechanism, rangevar iterators."""
         # setup model
-        sections = [h.Section(name="s%d" % i) for i in range(3)]
-        iclamps = [h.IClamp(sec(0.5)) for sec in sections]
+        sections = [n.Section(name="s%d" % i) for i in range(3)]
+        iclamps = [n.IClamp(sec(0.5)) for sec in sections]
         for i, sec in enumerate(sections):
             sec.nseg = 3
             sec.insert("pas")
@@ -87,7 +87,7 @@ class NeuronTestCase(unittest.TestCase):
         import hashlib
 
         sha = hashlib.sha256()
-        for sec in h.allsec():
+        for sec in n.allsec():
             for seg in sec:
                 for mech in seg:
                     for var in mech:
@@ -110,14 +110,14 @@ class NeuronTestCase(unittest.TestCase):
 
     def testSectionArgOrder(self):
         """First optional arg for Section is name (but name="name" is recommended)"""
-        soma = h.Section("soma")
+        soma = n.Section("soma")
         assert soma.name() == "soma"
 
     def testSectionCell(self):
         """Section.cell() internally referenced as weakref."""
         err = -1
         try:
-            soma = h.Section(cell="foo", name="soma")
+            soma = n.Section(cell="foo", name="soma")
             err = 1
         except:
             err = 0
@@ -128,7 +128,7 @@ class NeuronTestCase(unittest.TestCase):
                 return "hello"
 
         c = Cell()
-        soma = h.Section(cell=c, name="soma")
+        soma = n.Section(cell=c, name="soma")
         assert soma.name() == "hello.soma"
         assert soma.cell() == c
         del c
@@ -138,17 +138,17 @@ class NeuronTestCase(unittest.TestCase):
         """As of v8.0, iteration over a SectionList does not change the cas"""
         # See issue 509. SectionList iterator bug requires change to
         # longstanding behavior
-        soma = h.Section(name="soma")
+        soma = n.Section(name="soma")
         soma.push()
-        sections = [h.Section(name="s%d" % i) for i in range(3)]
-        assert len([s for s in h.allsec()]) == 4
-        sl = h.SectionList(sections)
+        sections = [n.Section(name="s%d" % i) for i in range(3)]
+        assert len([s for s in n.allsec()]) == 4
+        sl = n.SectionList(sections)
         # Iteration over s SectionList does not change the currently accessed section
         for s in sl:
-            assert 1 and h.cas() == soma
+            assert 1 and n.cas() == soma
         # If an iteration does not complete the section stack is still ok.
         assert sections[1] in sl
-        assert 2 and h.cas() == soma
+        assert 2 and n.cas() == soma
 
     @classmethod
     def ExtendedSection(cls):
@@ -218,8 +218,8 @@ class NeuronTestCase(unittest.TestCase):
     def test_newobj_err(self):
         """Test deletion of incompletely constructed objects"""
         print()  # Error message not on above line
-        h.load_file("stdlib.hoc")  # need hoc String
-        h(
+        n.load_file("stdlib.hoc")  # need hoc String
+        n(
             """
 begintemplate Foo
 endtemplate Foo
@@ -250,9 +250,9 @@ endtemplate NewObj
         # arg[0] - arg[1] + 1 should be successfully constructed
         # arg[1] should be partially constructed and destroyed.
         args = (4, 2)
-        a = h.NewObj(*args)
-        b = h.List("NewObj")
-        c = h.List("Foo")
+        a = n.NewObj(*args)
+        b = n.List("NewObj")
+        c = n.List("Foo")
         print("#NewObj and #Foo in existence", b.count(), c.count())
         z = args[0] - args[1] + 1
         assert b.count() == z
@@ -261,8 +261,8 @@ endtemplate NewObj
         del a
         del b
         del c
-        b = h.List("NewObj")
-        c = h.List("Foo")
+        b = n.List("NewObj")
+        c = n.List("Foo")
         print("after del a #NewObj and #Foo in existence", b.count(), c.count())
         assert b.count() == 0
         assert c.count() == 0
@@ -273,13 +273,13 @@ endtemplate NewObj
 def basicRxD3D():
     from neuron import h, rxd
 
-    s = h.Section(name="s")
+    s = n.Section(name="s")
     s.L = s.diam = 1
     cyt = rxd.Region([s])
     ca = rxd.Species(cyt)
     rxd.set_solve_type(dimension=3)
-    h.finitialize(-65)
-    h.fadvance()
+    n.finitialize(-65)
+    n.fadvance()
     return 1
 
 

--- a/share/lib/python/neuron/tests/test_rxd.py
+++ b/share/lib/python/neuron/tests/test_rxd.py
@@ -1,4 +1,4 @@
-from neuron import h
+from neuron import n
 import neuron
 import unittest
 import sys
@@ -22,19 +22,19 @@ test_data = json.load(open(os.path.join(fdir, "test_rxd.json"), "r"))
 def scalar_bistable(lock, path=None):
     from neuron import rxd
 
-    h.load_file("stdrun.hoc")
-    s = h.Section(name="s")
+    n.load_file("stdrun.hoc")
+    s = n.Section(name="s")
     s.nseg = 101
-    cyt = rxd.Region(h.allsec())
+    cyt = rxd.Region(n.allsec())
     c = rxd.Species(
         cyt, name="c", initial=lambda node: 1 if 0.4 < node.x < 0.6 else 0, d=1
     )
     r = rxd.Rate(c, -c * (1 - c) * (0.3 - c))
-    h.finitialize()
-    h.run()
+    n.finitialize()
+    n.run()
 
     # check the results
-    result = h.Vector(c.nodes.concentration)
+    result = n.Vector(c.nodes.concentration)
     if path is not None:
         lock.acquire()
         if os.path.exists(path):
@@ -45,7 +45,7 @@ def scalar_bistable(lock, path=None):
         json.dump(data, open(path, "w"), indent=4)
         lock.release()
     else:
-        cmpV = h.Vector(test_data["scalar_bistable_data"])
+        cmpV = n.Vector(test_data["scalar_bistable_data"])
         cmpV.sub(result)
         cmpV.abs()
         if cmpV.sum() >= 1e-6:
@@ -59,16 +59,16 @@ def trivial_ecs(scale, lock, path=None):
     import warnings
 
     warnings.simplefilter("ignore", UserWarning)
-    h.load_file("stdrun.hoc")
+    n.load_file("stdrun.hoc")
     tstop = 10
     if scale:  # variable step case
-        h.CVode().active(True)
-        h.CVode().event(tstop)
+        n.CVode().active(True)
+        n.CVode().event(tstop)
     else:  # fixed step case
-        h.CVode().active(False)
-        h.dt = 0.1
+        n.CVode().active(False)
+        n.dt = 0.1
 
-    sec = h.Section()  # NEURON requires at least 1 section
+    sec = n.Section()  # NEURON requires at least 1 section
 
     # enable extracellular RxD
     rxd.options.enable.extracellular = True
@@ -104,10 +104,10 @@ def trivial_ecs(scale, lock, path=None):
     )
 
     # record the concentration at (0,0,0)
-    ecs_vec = h.Vector()
+    ecs_vec = n.Vector()
     ecs_vec.record(k_rxd[extracellular].node_by_location(0, 0, 0)._ref_value)
-    h.finitialize()
-    h.continuerun(tstop)  # run the simulation
+    n.finitialize()
+    n.continuerun(tstop)  # run the simulation
 
     if path is not None:
         lock.acquire()
@@ -122,7 +122,7 @@ def trivial_ecs(scale, lock, path=None):
         lock.release()
     else:
         # compare with previous solution
-        ecs_vec.sub(h.Vector(test_data["trivial_ecs_data"][str(scale)]))
+        ecs_vec.sub(n.Vector(test_data["trivial_ecs_data"][str(scale)]))
         ecs_vec.abs()
         if ecs_vec.sum() > 1e-9:
             sys.exit(-1)

--- a/share/lib/python/neuron/tests/test_vector.py
+++ b/share/lib/python/neuron/tests/test_vector.py
@@ -5,7 +5,7 @@ $Id$
 """
 
 import unittest
-from neuron import h
+from neuron import n
 
 
 class Bench(object):
@@ -37,7 +37,7 @@ class VectorTestCase(unittest.TestCase):
         import sys
 
         sys_endian = endian_map[sys.byteorder]
-        v = h.Vector(10)
+        v = n.Vector(10)
         assert sys_endian == v.__array_interface__["typestr"][0]
 
     def testBytesize(self):
@@ -46,7 +46,7 @@ class VectorTestCase(unittest.TestCase):
         try:
             import numpy
 
-            v = h.Vector(10)
+            v = n.Vector(10)
             a = numpy.array([], dtype=float)
             assert a.__array_interface__["typestr"] == v.__array_interface__["typestr"]
         except:
@@ -61,19 +61,19 @@ class VectorTestCase(unittest.TestCase):
             bench = Bench(globals(), locals())
             print("\n")
             bench("l = range(1000000)")
-            bench("v = h.Vector(l)")
+            bench("v = n.Vector(l)")
             print("inplace:")
             bench("v.from_python(l)")
             bench("a = numpy.array(v)")
             print("inplace:")
             bench("v.to_python(a)")
-            bench("v2 = h.Vector(a)")
+            bench("v2 = n.Vector(a)")
             print("inplace:")
             bench("v2.from_python(a)")
             bench("l2 = list(v2)")
             print("inplace:")
             bench("v.to_python(l2)")
-            bench("v2 = h.Vector(a[::-1])")
+            bench("v2 = n.Vector(a[::-1])")
             bench("a2 = numpy.array(v2)")
         except:
             pass
@@ -87,10 +87,10 @@ class VectorTestCase(unittest.TestCase):
 
             a = numpy.random.normal(size=10000)
             # b = numpy.random.normal(size=10000)
-            v = h.Vector(a)
+            v = n.Vector(a)
             a1 = array(v)
             assert alltrue(a == a1), 'numpy array "a" not equal to array(Vector(a))'
-            v = h.Vector(a[::-1])
+            v = n.Vector(a[::-1])
             assert alltrue(
                 array(v)[::-1] == a
             ), "Vector(a) malfuctions when a is a sliced array"
@@ -103,7 +103,7 @@ class VectorTestCase(unittest.TestCase):
 
     def testNegativeIndex(self):
         l = [i for i in range(10)]
-        v = h.Vector(l)
+        v = n.Vector(l)
         assert v[-3] == l[-3], "v[-3] Failed"
         v[-3] = 42
         l[-3] = 42
@@ -111,7 +111,7 @@ class VectorTestCase(unittest.TestCase):
 
     def testSlicing(self):
         l = [i for i in range(10)]
-        v = h.Vector(l)
+        v = n.Vector(l)
         assert list(v[2:6]) == l[2:6], "v[2:6] Failed"
         assert list(v[-3:-1]) == l[-3:-1], "v[-3:-1] Failed"
         assert list(v[::2]) == l[::2], "v[::2] Failed"
@@ -125,7 +125,7 @@ class VectorTestCase(unittest.TestCase):
 
     def testAssignmentSlicing(self):
         l = [i for i in range(10)]
-        v = h.Vector(l)
+        v = n.Vector(l)
         v[2:4] = [12, 13]
         l[2:4] = [12, 13]
         assert list(v[2:4]) == l[2:4], "v[2:4] Failed"
@@ -141,13 +141,13 @@ class VectorTestCase(unittest.TestCase):
         v[3:6:2] = [-123, -456]
         l[3:6:2] = [-123, -456]
         assert list(v[3:6:2]) == l[3:6:2], "v[3:6] Failed"
-        v2 = h.Vector(x for x in range(10, 20))
+        v2 = n.Vector(x for x in range(10, 20))
         v[3:8] = v2[3:8]
         assert list(v[3:8]) == list(v2[3:8]), "v[3:8] = v2[3:8] Failed"
 
     def testErrorHandling(self):
         l = [i for i in range(10)]
-        v = h.Vector(l)
+        v = n.Vector(l)
         # Input that is too short or long should raise an IndexError
         with self.assertRaises(IndexError):
             v[0:3] = [55]


### PR DESCRIPTION
Works like `h` but different repr; returns the right dir.

The main rationale is to eliminate the need to explain why "h stands for NEURON", and more broadly to remove relics of NEURON's hoc past from its Python interface.

I updated the basic tutorials to use `n`, but have not changed the docs because (1) there's a large docs PR (#3358) and I don't want to create merge conflicts, and (2) because `h` still remains valid.