### PR TITLE
remove dimension keyword argument from rxd.Region

### DIFF
--- a/docs/python/modelspec/programmatic/rxd.rst
+++ b/docs/python/modelspec/programmatic/rxd.rst
@@ -56,7 +56,7 @@ Intracellular regions and regions in Frankenhauser-Hodgkin space
         .. code::
             python
 
-            r = rxd.Region(secs=None, nrn_region=None, geometry=None, dimension=None, dx=None, name=None)
+            r = rxd.Region(secs=None, nrn_region=None, geometry=None, dx=None, name=None)
 
         In NEURON 7.4+, ``secs`` is optional at initial region declaration, but it
         must be specified before the reaction-diffusion model is instantiated.
@@ -67,7 +67,6 @@ Intracellular regions and regions in Frankenhauser-Hodgkin space
         * ``nrn_region`` specifies the classic NEURON region associated with this object and must be either ``"i"`` for the region just inside the plasma membrane, ``"o"`` for the region just outside the plasma membrane or ``None`` for none of the above.
         * ``name`` is the name of the region (e.g. ``cyt`` or ``er``); this has no effect on the simulation results but it is helpful for debugging
         * ``dx`` specifies the 3D voxel edge length. Models in NEURON 9.0+ allow multiple values of dx per model, as long as 3D sections with different ``dx`` values do not connect to each other. If this condition is not true, an exception is raised during simulation. (Prior to NEURON 9.0, behavior of models with multiple values of ``dx`` is undefined, and no error checking was provided.)
-        * ``dimension`` deprecated; do not use
 
     .. property:: rxd.Region.nrn_region
 

--- a/share/lib/python/neuron/rxd/region.py
+++ b/share/lib/python/neuron/rxd/region.py
@@ -610,8 +610,6 @@ class Region(object):
     """
 
     def __repr__(self):
-        # Note: this used to print out dimension, but that's now on a per-segment basis
-        # TODO: remove the note when that is fully true
         return "Region(..., nrn_region=%r, geometry=%r, dx=%r, name=%r)" % (
             self.nrn_region,
             self._geometry,
@@ -861,15 +859,12 @@ class Region(object):
         secs=None,
         nrn_region=None,
         geometry=None,
-        dimension=None,
         dx=None,
         name=None,
     ):
         """
         In NEURON 7.4+, secs is optional at initial region declaration, but it
         must be specified before the reaction-diffusion model is instantiated.
-
-        .. note:: dimension and dx will be deprecated in a future version
         """
         self._allow_setting = True
         if hasattr(secs, "__len__"):
@@ -892,13 +887,6 @@ class Region(object):
         self._name = name
         self.nrn_region = nrn_region
 
-        if dimension is not None:
-            warnings.warn(
-                "dimension argument was a development feature only; use set_solve_type instead... the current version sets all the sections to your requested dimension, but this will override any previous settings"
-            )
-            import neuron
-
-            neuron.rxd.set_solve_type(secs, dimension=dimension)
         if dx is not None:
             try:
                 dx = float(dx)


### PR DESCRIPTION
This has always raised a warning and 11 years ago it had a comment that it would be removed in the future.