### PR TITLE
Add nrn_get_subtype function to access symbol subtypes via API calls

### DIFF
--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -192,6 +192,10 @@ int nrn_symbol_type(Symbol const* sym) {
     return sym->type;
 }
 
+int nrn_symbol_subtype(Symbol const* sym) {
+    return sym->subtype;
+}
+
 void nrn_symbol_push(Symbol* sym) {
     hoc_pushpx(sym->u.pval);
 }

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -62,6 +62,7 @@ void nrn_rangevar_set(Symbol* sym, Section* sec, double x, double value);
 Symbol* nrn_symbol(const char* name);
 void nrn_symbol_push(Symbol* sym);
 int nrn_symbol_type(const Symbol* sym);
+int nrn_symbol_subtype(Symbol const* sym);
 void nrn_double_push(double val);
 double nrn_double_pop(void);
 void nrn_double_ptr_push(double* addr);


### PR DESCRIPTION
**Add `nrn_get_subtype` function to NEURON API**
This PR adds a new function, `nrn_get_subtype`, to the API. The purpose of this addition is to expose the subtype field of Symbol objects through the external API, allowing clients (e.g., MATLAB sessions) to retrieve symbol subtypes. Similarly, there already exists a function `nrn_get_type`.