### PR TITLE
Add top level symlist access

### DIFF
--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -192,6 +192,10 @@ int nrn_symbol_type(Symbol const* sym) {
     return sym->type;
 }
 
+int nrn_symbol_subtype(Symbol const* sym) {
+    return sym->subtype;
+}
+
 void nrn_symbol_push(Symbol* sym) {
     hoc_pushpx(sym->u.pval);
 }

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -507,4 +507,8 @@ Symlist* nrn_symbol_table(Symbol* sym) {
 Symlist* nrn_global_symbol_table(void) {
     return hoc_built_in_symlist;
 }
+
+Symlist* nrn_top_level_symbol_table(void) {
+    return hoc_top_level_symlist;
+}
 }

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -109,6 +109,7 @@ void nrn_property_array_push(Object* obj, const char* name, int i);
 char const* nrn_symbol_name(const Symbol* sym);
 Symlist* nrn_symbol_table(Symbol* sym);
 Symlist* nrn_global_symbol_table(void);
+Symlist* nrn_top_level_symbol_table(void);
 // TODO: need shapeplot information extraction
 
 #ifdef __cplusplus

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -62,6 +62,7 @@ void nrn_rangevar_set(Symbol* sym, Section* sec, double x, double value);
 Symbol* nrn_symbol(const char* name);
 void nrn_symbol_push(Symbol* sym);
 int nrn_symbol_type(const Symbol* sym);
+int nrn_symbol_subtype(Symbol const* sym);
 void nrn_double_push(double val);
 double nrn_double_pop(void);
 void nrn_double_ptr_push(double* addr);


### PR DESCRIPTION
This pull request adds a new function to the NEURON API:
`nrn_top_level_symbol_table`: Exposes `hoc_top_level_symlist`, enabling external access to allow MATLAB sessions to retrieve both built-in and user-defined symbols from within MATLAB, and combine them into a unified list in the session.
It also includes the previously proposed `nrn_get_subtype function` (from the `add-symbol-subtype-function` branch), as the MATLAB interface depends on both functions to construct a complete and correct symbol list.