### PR TITLE
 Add NMODL warning if a FUNCTION does not have a return statement 

### DIFF
--- a/src/nmodl/visitors/semantic_analysis_visitor.hpp
+++ b/src/nmodl/visitors/semantic_analysis_visitor.hpp
@@ -100,6 +100,9 @@ class SemanticAnalysisVisitor: public ConstAstVisitor {
 
     bool check_table_vars(const ast::Program& node);
 
+    /// Check functions have return statements, log warning otherwise
+    void check_functions_have_return_statements(const ast::Program& node);
+
   public:
     SemanticAnalysisVisitor(bool accel_backend = false)
         : accel_backend(accel_backend) {}

--- a/test/nmodl/transpiler/unit/utils/test_utils.cpp
+++ b/test/nmodl/transpiler/unit/utils/test_utils.cpp
@@ -6,10 +6,12 @@
  */
 
 #include "test_utils.hpp"
-#include "utils/logger.hpp"
+#include "nmodl/utils/logger.hpp"
 #include "utils/string_utils.hpp"
 
 #include <cassert>
+
+#include <spdlog/sinks/ostream_sink.h>
 
 namespace nmodl {
 namespace test_utils {
@@ -81,6 +83,24 @@ std::string reindent_text(const std::string& text, int indent_level) {
     }
     return indented_text;
 }
+
+LoggerCapture::LoggerCapture()
+    : original_logger(nmodl::logger) {
+    capture_stream = std::make_shared<std::ostringstream>();
+    auto capture_sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(*capture_stream);
+    auto test_logger = std::make_shared<spdlog::logger>("TEST_LOGGER", capture_sink);
+    test_logger->set_pattern("[%n] [%l] :: %v");
+    nmodl::logger = test_logger;
+}
+
+LoggerCapture::~LoggerCapture() {
+    nmodl::logger = original_logger;
+}
+
+std::string LoggerCapture::output() const {
+    return capture_stream->str();
+}
+
 
 }  // namespace test_utils
 }  // namespace nmodl

--- a/test/nmodl/transpiler/unit/utils/test_utils.hpp
+++ b/test/nmodl/transpiler/unit/utils/test_utils.hpp
@@ -9,10 +9,23 @@
 
 #include <string>
 
+#include "nmodl/utils/logger.hpp"
+
 namespace nmodl {
 namespace test_utils {
 
 std::string reindent_text(const std::string& text, int indent_level = 0);
 
+// RAII state guard for the actual log
+class LoggerCapture {
+  public:
+    LoggerCapture();
+    ~LoggerCapture();
+    std::string output() const;
+
+  private:
+    std::shared_ptr<std::ostringstream> capture_stream;
+    nmodl::logger_type original_logger;
+};
 }  // namespace test_utils
 }  // namespace nmodl

--- a/test/nmodl/transpiler/unit/visitor/semantic_analysis.cpp
+++ b/test/nmodl/transpiler/unit/visitor/semantic_analysis.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 
@@ -14,7 +13,6 @@
 #include "utils/test_utils.hpp"
 #include "visitors/semantic_analysis_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"
-#include "nmodl/utils/logger.hpp"
 
 
 using namespace nmodl;
@@ -33,7 +31,6 @@ bool run_semantic_analysis_visitor(const std::string& text) {
     SymtabVisitor().visit_program(*ast);
     return SemanticAnalysisVisitor{}.check(*ast);
 }
-
 
 SCENARIO("TABLE stmt", "[visitor][semantic_analysis]") {
     GIVEN("Procedure with more than one argument") {

--- a/test/nmodl/transpiler/unit/visitor/semantic_analysis.cpp
+++ b/test/nmodl/transpiler/unit/visitor/semantic_analysis.cpp
@@ -12,6 +12,7 @@
 #include "utils/test_utils.hpp"
 #include "visitors/semantic_analysis_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"
+#include "utils/logger.hpp"
 
 
 using namespace nmodl;
@@ -300,6 +301,19 @@ SCENARIO("RANGE and FUNCTION/PROCEDURE block", "[visitor][semantic_analysis]") {
         )";
         THEN("Semantic analysis should fail") {
             REQUIRE(run_semantic_analysis_visitor(nmodl_text));
+        }
+    }
+}
+
+SCENARIO("FUNCTION block that does not return anything must raise a warning",
+         "[visitor][semantic_analysis]") {
+    GIVEN("A mod file with a FUNCTION that does not return anything") {
+        std::string nmodl_text = R"(
+            FUNCTION asdf() {
+            }
+        )";
+        THEN("Semantic analysis should raise a warning") {
+            run_semantic_analysis_visitor(nmodl_text);
         }
     }
 }


### PR DESCRIPTION
This adds warnings when processing mod files with NMODL in two scenarios:

- if a FUNCTION with a missing return statement doesn't have a VERBATIM block,  then we can definitely say the function is missing a return statement
- if a FUNCTION with a missing return statement does have a VERBATIM block, then we still warn, since the user could have forgotten it there as well