### PR TITLE
Fix several test failures

### DIFF
--- a/cmake/MacroHelper.cmake
+++ b/cmake/MacroHelper.cmake
@@ -205,21 +205,22 @@ endmacro()
 # =============================================================================
 # ~~~
 macro(nrn_install_dir_symlink source_dir symlink_dir)
-  # Create variables for substitution
+  # Create variables for substitution (@arg@ not allowed for CONFIGURE)
   set(src_dir "${source_dir}")
   set(link_dir "${symlink_dir}")
-  # Get the parent directory of the symlink
   get_filename_component(parent_symlink_dir "${link_dir}" DIRECTORY)
 
+  # ~~~
   # Define CODE block with placeholders
+  # @name@ seems to be the only way to get names declared in this macro
+  # to get their proper value during install. ${name} ends up empty.
+  # ~~~
   set(code
       [[
-    # Create parent directory
     execute_process(
       COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_INSTALL_PREFIX}/@parent_symlink_dir@"
       COMMAND_ECHO STDOUT
     )
-    # Resolve source and symlink paths
     if(IS_ABSOLUTE "@src_dir@")
       set(abs_source_dir "@src_dir@")
     else()
@@ -233,14 +234,13 @@ macro(nrn_install_dir_symlink source_dir symlink_dir)
     # Compute relative path from symlink's parent to source
     get_filename_component(abs_parent_symlink_dir "${abs_symlink_dir}" DIRECTORY)
     file(RELATIVE_PATH rel_path "${abs_parent_symlink_dir}" "${abs_source_dir}")
-    # Create symlink
+
     execute_process(
       COMMAND ${CMAKE_COMMAND} -E create_symlink "${rel_path}" "${abs_symlink_dir}"
       COMMAND_ECHO STDOUT
     )
   ]])
 
-  # Substitute variables into the CODE block
   string(CONFIGURE "${code}" configured_code @ONLY)
   install(CODE "${configured_code}")
 endmacro()

--- a/cmake/MacroHelper.cmake
+++ b/cmake/MacroHelper.cmake
@@ -181,17 +181,69 @@ macro(nocmodl_mod_to_cpp modfile_basename modfile_compat)
 
 endmacro()
 
+# ~~~
 # =============================================================================
-# Create symbolic links
+# Create symbolic links during the install phase
+#
+# Usage: nrn_install_dir_symlink(source_dir symlink_dir)
+#
+# Creates a relative symbolic link at `CMAKE_INSTALL_PREFIX/symlink_dir` pointing
+# to `source_dir`, executed during `ninja install`. The link is relative to the
+# symlink's parent directory (e.g., `x86_64/bin -> ../bin`).
+#
+# Arguments:
+#   source_dir: Path to the target directory (absolute, e.g., `/home/user/bin`,
+#               or relative, e.g., `bin`, `neuron/.data/bin`).
+#   symlink_dir: Path where the symlink is created (absolute or relative, e.g.,
+#                `x86_64/bin`, `neuron/.data/x86_64/bin`).
+#
+# In NEURON, used to create `install/x86_64/bin -> ../bin` and `install/x86_64/lib -> ../lib`
+# for non-wheel builds, or `install/neuron/.data/x86_64/bin -> ../bin` for wheel builds.
+#
+# The macro ensures the symlink's parent directory (e.g., `install/x86_64`) exists
+# and computes the relative path from the symlink's parent to the source directory.
 # =============================================================================
+# ~~~
 macro(nrn_install_dir_symlink source_dir symlink_dir)
-  # make sure to have directory path exist upto parent dir
-  get_filename_component(parent_symlink_dir ${symlink_dir} DIRECTORY)
-  install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${parent_symlink_dir})")
-  # create symbolic link
-  install(
-    CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${source_dir} ${symlink_dir})")
-endmacro(nrn_install_dir_symlink)
+  # Create variables for substitution
+  set(src_dir "${source_dir}")
+  set(link_dir "${symlink_dir}")
+  # Get the parent directory of the symlink
+  get_filename_component(parent_symlink_dir "${link_dir}" DIRECTORY)
+
+  # Define CODE block with placeholders
+  set(code
+      [[
+    # Create parent directory
+    execute_process(
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_INSTALL_PREFIX}/@parent_symlink_dir@"
+      COMMAND_ECHO STDOUT
+    )
+    # Resolve source and symlink paths
+    if(IS_ABSOLUTE "@src_dir@")
+      set(abs_source_dir "@src_dir@")
+    else()
+      file(TO_CMAKE_PATH "${CMAKE_INSTALL_PREFIX}/@src_dir@" abs_source_dir)
+    endif()
+    if(IS_ABSOLUTE "@link_dir@")
+      set(abs_symlink_dir "@link_dir@")
+    else()
+      file(TO_CMAKE_PATH "${CMAKE_INSTALL_PREFIX}/@link_dir@" abs_symlink_dir)
+    endif()
+    # Compute relative path from symlink's parent to source
+    get_filename_component(abs_parent_symlink_dir "${abs_symlink_dir}" DIRECTORY)
+    file(RELATIVE_PATH rel_path "${abs_parent_symlink_dir}" "${abs_source_dir}")
+    # Create symlink
+    execute_process(
+      COMMAND ${CMAKE_COMMAND} -E create_symlink "${rel_path}" "${abs_symlink_dir}"
+      COMMAND_ECHO STDOUT
+    )
+  ]])
+
+  # Substitute variables into the CODE block
+  string(CONFIGURE "${code}" configured_code @ONLY)
+  install(CODE "${configured_code}")
+endmacro()
 
 # ========================================================================
 # There is an edge case to 'find_package(MPI REQUIRED)' in that we can still build a universal2

--- a/test/pytest_coreneuron/test_version_macros.py
+++ b/test/pytest_coreneuron/test_version_macros.py
@@ -1,5 +1,6 @@
 from neuron.tests.utils.strtobool import strtobool
 import os
+import re
 from neuron import coreneuron, h
 
 
@@ -11,7 +12,10 @@ def test_version_macros():
     # Get the CMake PACKAGE_VERSION variable, which should always be in
     # major.minor.patch format. This should be baked into C++ as part of the main
     # NEURON build, not as part of nrnivmodl.
-    ver = tuple(int(x) for x in h.nrnversion(0).split(".", 2))
+    # Note the PACKAGE_VERSION now is pep 440 compliant with respect to
+    # 'git describe' if possible. This results in '9.0a-1388-ga24757450' being
+    # transformed into '9.0.0a0.post1388'. So now we get the 9.0.0 from...
+    ver = tuple(int(x) for x in re.split(r"[^\d]+", h.nrnversion(0))[:3] if x)
 
     pc = h.ParallelContext()
     s = h.Section()


### PR DESCRIPTION
Fix a symbolic link issue for  ```rxdmod_tests::rxd_tests``` by having nrn_install_dir_symlink handle relative paths.
Fix how a test determines the version for ```pytest_coreneuron::basic_tests_py3.13``` (failure for test_version_macros.py).
