### PR TITLE
Fix passing env variables to cibuildwheel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -133,6 +133,14 @@ stages:
           brew install flex bison mpich
           brew unlink mpich && brew install openmpi
           cmake --version
+          # the version of bash used by Azure (which is the default one
+          # provided by Apple) is too old and does not support associative
+          # arrays. This is because newer versions of bash have switched their
+          # license from GNU GPL v2 to GNU GPL v3, and Apple refuses to add any
+          # GNU GPL v3-licenced software in their stack, so we need to install
+          # the homebrew one
+          brew install bash
+          bash --version
           # see https://github.com/BlueBrain/CoreNeuron/issues/817, uninstall libomp until we fix this
           # as we are building wheels, we shouldn't enable OpenMP here anyway
           brew uninstall --ignore-dependencies libomp || echo "libomp doesn't exist"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -164,7 +164,8 @@ stages:
           fi
           sudo mkdir -p /opt/nrnwheel/$(uname -m)
           sudo tar -zxf $(readlineSF.secureFilePath) --directory /opt/nrnwheel/$(uname -m)
-          packaging/python/build_wheels.bash osx $(python.nodot)
+          bash --version
+          bash packaging/python/build_wheels.bash osx $(python.nodot)
         displayName: 'Build MacOS Wheel'
 
       - template: ci/azure-wheel-test-upload.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,7 @@ stages:
       - script: |
           if [ "$BUILD_REASON" = "Manual" ] || [ "$BUILD_REASON" = "Schedule" ]; then
             export NRN_RX3D_OPT_LEVEL=1
-          endif
+          fi
           sudo mkdir -p /opt/nrnwheel/mpt
           sudo tar -zxf $(mpt_headersSF.secureFilePath) --directory /opt/nrnwheel/mpt
           packaging/python/build_wheels.bash linux $(python.nodot)
@@ -161,7 +161,7 @@ stages:
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
           if [ "$BUILD_REASON" = "Manual" ] || [ "$BUILD_REASON" = "Schedule" ]; then
             export NRN_RX3D_OPT_LEVEL=1
-          endif
+          fi
           sudo mkdir -p /opt/nrnwheel/$(uname -m)
           sudo tar -zxf $(readlineSF.secureFilePath) --directory /opt/nrnwheel/$(uname -m)
           packaging/python/build_wheels.bash osx $(python.nodot)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,8 +172,7 @@ stages:
           fi
           sudo mkdir -p /opt/nrnwheel/$(uname -m)
           sudo tar -zxf $(readlineSF.secureFilePath) --directory /opt/nrnwheel/$(uname -m)
-          bash --version
-          bash packaging/python/build_wheels.bash osx $(python.nodot)
+          packaging/python/build_wheels.bash osx $(python.nodot)
         displayName: 'Build MacOS Wheel'
 
       - template: ci/azure-wheel-test-upload.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -153,14 +153,12 @@ stages:
         condition: and(in(variables['Build.Reason'], 'Manual'), eq(variables['NRN_RELEASE_UPLOAD'], 'true'))
         displayName: 'Change name of package for release'
 
-      # 10.14 is required for full C++17 support according to
-      # https://cibuildwheel.readthedocs.io/en/stable/cpp_standards, but it
-      # seems that 10.15 is actually needed for std::filesystem::path.
       - script: |
-          export MACOSX_DEPLOYMENT_TARGET=10.15
           export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
-          export NRN_BUILD_FOR_UPLOAD=1
+          if [ "$BUILD_REASON" = "Manual" ] || [ "$BUILD_REASON" = "Schedule" ]; then
+            export NRN_RX3D_OPT_LEVEL=1
+          endif
           sudo mkdir -p /opt/nrnwheel/$(uname -m)
           sudo tar -zxf $(readlineSF.secureFilePath) --directory /opt/nrnwheel/$(uname -m)
           packaging/python/build_wheels.bash osx $(python.nodot)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,6 +70,9 @@ stages:
       # Note that mpt headers must be mounted in the docker imager under `/nrnwheel/mpt`
       # This path is checked by `packaging/python/build_wheels.bash` when run in the image.
       - script: |
+          if [ "$BUILD_REASON" = "Manual" ] || [ "$BUILD_REASON" = "Schedule" ]; then
+            export NRN_RX3D_OPT_LEVEL=1
+          endif
           sudo mkdir -p /opt/nrnwheel/mpt
           sudo tar -zxf $(mpt_headersSF.secureFilePath) --directory /opt/nrnwheel/mpt
           packaging/python/build_wheels.bash linux $(python.nodot)

--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -76,6 +76,53 @@ collect_dirs_macos() {
 }
 
 
+# cibuildwheel does not pass any environmental variables to the container
+# unless explicitly specified. Unfortunately, some of them should be set
+# dynamically, so we can't put them in pyproject.toml, and hence we set them
+# here. All of them can be overridden using its corresponding environmental
+# variable. Note that on Linux the variables must also be present in
+# pyproject.toml's `[tool.cibuildwheel.linux.environment-pass]` section, or set
+# as the `CIBW_ENVIRONMENT_PASS_LINUX` env variable.
+set_cibw_environment() {
+    platform="${1}"
+    if [ "${platform}" = 'macos' ]; then
+        declare -A defaults=(
+            [CMAKE_PREFIX_PATH]="/opt/nrnwheel/$(uname -m)/ncurses;/opt/nrnwheel/$(uname -m)/readline;/usr/x11"
+            [NRN_ENABLE_MPI_DYNAMIC]="ON"
+            [NRN_MPI_DYNAMIC]="$(brew --prefix)/opt/openmpi/include;$(brew --prefix)/opt/mpich/include"
+            [NRN_WHEEL_STATIC_READLINE]="ON"
+            [NRN_ENABLE_CORENEURON]="ON"
+            [NRN_BINARY_DIST_BUILD]="ON"
+            [NRN_RX3D_OPT_LEVEL]="0"
+            # 10.14 is required for full C++17 support according to
+            # https://cibuildwheel.readthedocs.io/en/stable/cpp_standards, but it
+            # seems that 10.15 is actually needed for std::filesystem::path.
+            # 11.0 is required on ARM machines
+            [MACOSX_DEPLOYMENT_TARGET]="10.15"
+        )
+    elif [ "${platform}" = 'linux' ]; then
+        declare -A defaults=(
+            [CMAKE_PREFIX_PATH]="/nrnwheel/ncurses;/nrnwheel/readline"
+            [NRN_ENABLE_MPI_DYNAMIC]="ON"
+            [NRN_MPI_DYNAMIC]="/usr/include/openmpi-$(uname -m);/usr/include/mpich-$(uname -m)"
+            [NRN_WHEEL_STATIC_READLINE]="ON"
+            [NRN_ENABLE_CORENEURON]="ON"
+            [CORENRN_ENABLE_OPENMP]="ON"
+            [NRN_BINARY_DIST_BUILD]="ON"
+            [NRN_RX3D_OPT_LEVEL]="0"
+        )
+    fi
+
+    local env_string=""
+    for var in "${!defaults[@]}"; do
+        local val="${!var:-${defaults[$var]}}"
+        env_string+="${var}='${val}' "
+    done
+
+    export CIBW_ENVIRONMENT="${env_string}"
+}
+
+
 # for building portable wheels
 # if building a Linux portable wheel, docker or podman must be installed
 # the preferred container engine can be set using the env variable `CIBW_CONTAINER_ENGINE`
@@ -99,11 +146,13 @@ build_wheel_portable() {
         export NRN_MPI_DYNAMIC
     fi
 
-    if [ "${platform}" = 'macos' ] && [ "$(uname -m)" = 'x86_64' ]; then
-        export MACOSX_DEPLOYMENT_TARGET='10.15'
-    else
-        export MACOSX_DEPLOYMENT_TARGET='11.0'
+    if [ "${platform}" = 'macos' ]; then
+        if [ "$(uname -m)" = 'arm64' ]; then
+            export MACOSX_DEPLOYMENT_TARGET='11.0'
+        fi
     fi
+
+    set_cibw_environment "${platform}"
 
     CIBW_BUILD_VERBOSITY=1 python -m cibuildwheel --debug-traceback --platform "${platform}" --output-dir wheelhouse
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,24 +159,5 @@ environment-pass = [
 #             ships an extra copy of libnrniv.so and hence exclude it here.
 repair-wheel-command = "auditwheel -v repair -w {dest_dir} {wheel} --exclude 'libgomp.so.1' --exclude 'libnrniv.so'"
 
-[tool.cibuildwheel.linux.environment]
-# all of the below env variables need to be specified under `[tool.cibuildwheel.linux.environment-pass]`
-CMAKE_PREFIX_PATH = "/nrnwheel/ncurses;/nrnwheel/readline"
-NRN_ENABLE_MPI_DYNAMIC = "ON"
-NRN_WHEEL_STATIC_READLINE = "ON"
-NRN_ENABLE_CORENEURON = "ON"
-CORENRN_ENABLE_OPENMP = "ON"
-NRN_BINARY_DIST_BUILD = "ON"
-NRN_RX3D_OPT_LEVEL = "2"
-
 [tool.cibuildwheel.macos]
 repair-wheel-command = "delocate-listdeps {wheel} && delocate-wheel -v -w {dest_dir} {wheel}"
-
-[tool.cibuildwheel.macos.environment]
-CMAKE_PREFIX_PATH = "/opt/nrnwheel/$(uname -m)/ncurses;/opt/nrnwheel/$(uname -m)/readline;/usr/x11"
-NRN_ENABLE_MPI_DYNAMIC = "ON"
-NRN_MPI_DYNAMIC = "$(brew --prefix)/opt/openmpi/include;$(brew --prefix)/opt/mpich/include"
-NRN_WHEEL_STATIC_READLINE = "ON"
-NRN_ENABLE_CORENEURON = "ON"
-NRN_BINARY_DIST_BUILD = "ON"
-NRN_RX3D_OPT_LEVEL = "2"


### PR DESCRIPTION
At least on MacOS, cibuildwheel does not automatically pass any random variable to the build process, one needs to explicitly pass the key-value pair in `CIBW_ENVIRONMENT` (or `CIBW_ENVIRONMENT_MACOS`). To keep things in one place, the env variable defaults for both MacOS and Linux wheels are now in `build_wheels.bash` instead of `pyproject.toml`. The default of `NRN_RX3D_OPT_LEVEL=0` should speed up CI, while the nightly wheels are now built with opt level 1 as there is no performance impact between 1 and 2.