### PR TITLE
Fix upload path for nightly wheels

### DIFF
--- a/.github/workflows/pypi-upload-template.yml
+++ b/.github/workflows/pypi-upload-template.yml
@@ -22,6 +22,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wheels
-          path: wheelhouse/
+          path: dist/
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The upload workflow failed: https://github.com/neuronsimulator/nrn/actions/runs/14919393733/job/41912056826
One issue is that the default directory should be `dist`, not `wheelhouse` (which this PR fixes), while the other was that the name of the workflow file was wrong (already fixed on PyPI side).