### PR TITLE
Function to register func/object (for nrnmatlab)

### DIFF
--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -511,4 +511,13 @@ Symlist* nrn_global_symbol_table(void) {
 Symlist* nrn_top_level_symbol_table(void) {
     return hoc_top_level_symlist;
 }
+
+// Function to register function/object in hoc
+void nrn_register_function(void (*proc)(), const char* func_name) {
+    Symbol* sym;
+    sym = hoc_install(func_name, FUNCTION, 0, &hoc_top_level_symlist);
+    sym->u.u_proc->defn.pf = proc;
+    sym->u.u_proc->nauto = 0;
+    sym->u.u_proc->nobjauto = 0;
+}
 }

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -110,7 +110,7 @@ char const* nrn_symbol_name(const Symbol* sym);
 Symlist* nrn_symbol_table(Symbol* sym);
 Symlist* nrn_global_symbol_table(void);
 Symlist* nrn_top_level_symbol_table(void);
-void nrn_register_function(void (*proc)(), const char* func_name)
+void nrn_register_function(void (*proc)(), const char* func_name);
 // TODO: need shapeplot information extraction
 
 #ifdef __cplusplus

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -110,6 +110,7 @@ char const* nrn_symbol_name(const Symbol* sym);
 Symlist* nrn_symbol_table(Symbol* sym);
 Symlist* nrn_global_symbol_table(void);
 Symlist* nrn_top_level_symbol_table(void);
+void nrn_register_function(void (*proc)(), const char* func_name)
 // TODO: need shapeplot information extraction
 
 #ifdef __cplusplus


### PR DESCRIPTION
Implemented reusable function to register func/object (e.g., used by both nrnmatlab and FInitializehandler to set up a valid MATLAB session) 