### PR TITLE
nrn_symbol_dataptr function

### DIFF
--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -196,6 +196,10 @@ int nrn_symbol_subtype(Symbol const* sym) {
     return sym->subtype;
 }
 
+double* nrn_symbol_dataptr(Symbol* sym) {
+    return sym->u.pval;
+}
+
 void nrn_symbol_push(Symbol* sym) {
     hoc_pushpx(sym->u.pval);
 }

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -63,6 +63,7 @@ Symbol* nrn_symbol(const char* name);
 void nrn_symbol_push(Symbol* sym);
 int nrn_symbol_type(const Symbol* sym);
 int nrn_symbol_subtype(Symbol const* sym);
+double* nrn_symbol_dataptr(Symbol* sym);
 void nrn_double_push(double val);
 double nrn_double_pop(void);
 void nrn_double_ptr_push(double* addr);


### PR DESCRIPTION
Function to get pval for NEURON functionality in Matlab (ref, get_prop) -> needed to get and set Neuron properties