### PR TITLE
Changed nrn_symbol_table_iterator_next's return value to Symbol*

### DIFF
--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -26,7 +26,7 @@ struct SectionListIterator {
 
 struct SymbolTableIterator {
     explicit SymbolTableIterator(Symlist*);
-    char const* next(void);
+    Symbol* next(void);
     int done(void) const;
 
   private:
@@ -355,8 +355,8 @@ int SectionListIterator::done(void) const {
 SymbolTableIterator::SymbolTableIterator(Symlist* list)
     : current(list->first) {}
 
-char const* SymbolTableIterator::next(void) {
-    auto result = current->name;
+Symbol* SymbolTableIterator::next(void) {
+    Symbol* result = current;
     current = current->next;
     return result;
 }
@@ -394,7 +394,7 @@ void nrn_symbol_table_iterator_free(SymbolTableIterator* st) {
     delete st;
 }
 
-char const* nrn_symbol_table_iterator_next(SymbolTableIterator* st) {
+Symbol* nrn_symbol_table_iterator_next(SymbolTableIterator* st) {
     return st->next();
 }
 

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -96,7 +96,7 @@ Section* nrn_sectionlist_iterator_next(SectionListIterator* sl);
 int nrn_sectionlist_iterator_done(SectionListIterator* sl);
 SymbolTableIterator* nrn_symbol_table_iterator_new(Symlist* my_symbol_table);
 void nrn_symbol_table_iterator_free(SymbolTableIterator* st);
-char const* nrn_symbol_table_iterator_next(SymbolTableIterator* st);
+Symbol* nrn_symbol_table_iterator_next(SymbolTableIterator* st);
 int nrn_symbol_table_iterator_done(SymbolTableIterator* st);
 int nrn_vector_capacity(const Object* vec);
 double* nrn_vector_data(Object* vec);


### PR DESCRIPTION
Changed nrn_symbol_table_iterator_next's return value to Symbol* to avoid unnecessary overhead of name->symbol lookups