### PR TITLE
Suppress excessive warnings on NVHPC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,6 +294,11 @@ cpp_cc_git_submodule(eigen)
 nrn_add_external_project(fmt)
 set_property(TARGET fmt PROPERTY POSITION_INDEPENDENT_CODE ON)
 
+# suppress warnings on NVHPC
+if(NRN_FMT_COMPILER_WARNING_SUPPRESSIONS)
+  target_compile_options(fmt PRIVATE ${NRN_FMT_COMPILER_WARNING_SUPPRESSIONS})
+endif()
+
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/external/Random123/include/Random123"
      DESTINATION "${CMAKE_BINARY_DIR}/include/")
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/external/eigen/Eigen"
@@ -567,6 +572,10 @@ if(NRN_ENABLE_NMODL
     # See above, same logic as fmt
     set_target_properties(spdlog PROPERTIES POSITION_INDEPENDENT_CODE ON)
   endif()
+
+  # suppress warnings on NVHPC
+  include(${PROJECT_SOURCE_DIR}/cmake/nmodl/CompilerHelper.cmake)
+  target_compile_options(spdlog PRIVATE "${NMODL_COMPILER_WARNING_SUPPRESSIONS}")
 
   set(NMODL_ENABLE_PYTHON_BINDINGS
       OFF

--- a/cmake/CompilerHelper.cmake
+++ b/cmake/CompilerHelper.cmake
@@ -41,9 +41,19 @@ if(CMAKE_C_COMPILER_ID MATCHES "PGI" OR CMAKE_C_COMPILER_ID MATCHES "NVHPC")
     # "src/nrnpython/rxdmath.cpp", warning #541-D: allowing all exceptions is incompatible with previous function
     # "src/nmodl/nocpout.cpp", warning #550-D: variable "sion" was set but never used
     # "src/gnu/neuron_gnu_builtin.h", warning #816-D: type qualifier on return type is meaningless"
+    # "external/fmt/include/fmt/format.h", warning #1626-D: warning: routine is both "inline" and "noinline" [inline_gnu_noinline_conflict]
     # "src/modlunit/consist.cpp", warning #2465-D: conversion from a string literal to "char *" is deprecated
     # ~~~
-    list(APPEND NRN_COMPILE_FLAGS --diag_suppress=1,47,111,128,170,174,177,186,541,550,816,2465)
+    list(APPEND NRN_COMPILE_FLAGS
+         --diag_suppress=1,47,111,128,170,174,177,186,541,550,816,1626,2465)
+    # ~~~
+    # "external/CLI11/include/CLI/TypeTools.hpp", warning #2362-D: invalid narrowing conversion from "int" to "double" [narrowing_conversion]
+    # ~~~
+    list(APPEND NRN_NOCMODL_COMPILER_WARNING_SUPPRESSIONS --diag_suppress=2362)
+    # ~~~
+    # "external/fmt/include/fmt/format.h", warning #1626-D: warning: routine is both "inline" and "noinline" [inline_gnu_noinline_conflict]
+    # ~~~
+    list(APPEND NRN_FMT_COMPILER_WARNING_SUPPRESSIONS --diag_suppress=1626)
   endif()
   list(APPEND NRN_COMPILE_FLAGS -noswitcherror)
   list(APPEND NRN_LINK_FLAGS -noswitcherror)

--- a/cmake/nmodl/CompilerHelper.cmake
+++ b/cmake/nmodl/CompilerHelper.cmake
@@ -30,6 +30,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "PGI" OR CMAKE_CXX_COMPILER_ID MATCHES "NVHPC")
     # "ext/spdlog/include/spdlog/fmt/bundled/format.h", warning #1098-D: unknown attribute "fallthrough"
     # "ext/pybind11/include/pybind11/detail/common.h", warning #1626-D: routine is both "inline" and "noinline"
     # "ext/spdlog/include/spdlog/fmt/bundled/core.h", warning #1676-D: unrecognized GCC pragma
+    # "external/CLI11/include/CLI/TypeTools.hpp", warning #2362-D: invalid narrowing conversion from "int" to "double" [narrowing_conversion]
     # ~~~
     # The following warnings do not seem to be suppressible with --diag_suppress:
     # ~~~
@@ -38,11 +39,15 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "PGI" OR CMAKE_CXX_COMPILER_ID MATCHES "NVHPC")
     # ~~~
     # The situation may be better once https://github.com/fmtlib/fmt/pull/2582 is included in a
     # release.
-    set(NMODL_COMPILER_WARNING_SUPPRESSIONS --diag_suppress=1,111,128,185,186,998,1098,1626,1676)
+    set(NMODL_COMPILER_WARNING_SUPPRESSIONS
+        --diag_suppress=1,111,128,185,186,998,1098,1626,1676,2362)
     # There are a few more warnings produced by the unit test infrastructure.
     # ~~~
+    # "external/eigen/Eigen/src/Core/arch/AVX/PacketMath.h", warning #68-D: integer conversion resulted in a change of sign [integer_sign_change]
     # "test/unit/visitor/constant_folder.cpp", warning #177-D: variable "..." was declared but never referenced
+    # "src/ast/all.hpp", warning #998-D: function "..." is hidden by "..." -- virtual function override intended?
+    # "external/fmt/include/fmt/format.h", warning #1626-D: routine is both "inline" and "noinline"
     # ~~~
-    set(NMODL_TESTS_COMPILER_WARNING_SUPPRESSIONS --diag_suppress=177)
+    set(NMODL_TESTS_COMPILER_WARNING_SUPPRESSIONS --diag_suppress=68,177,998,1626)
   endif()
 endif()

--- a/src/nmodl/CMakeLists.txt
+++ b/src/nmodl/CMakeLists.txt
@@ -1,4 +1,5 @@
 include(${PROJECT_SOURCE_DIR}/cmake/nmodl/FlexHelper.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/nmodl/CompilerHelper.cmake)
 include_directories(${NMODL_PROJECT_PLATLIB_SOURCE_DIR} ${NMODL_PROJECT_PLATLIB_BINARY_DIR})
 
 list(APPEND NMODL_EXTRA_CXX_FLAGS ${NRN_SANITIZER_COMPILER_FLAGS})
@@ -76,6 +77,9 @@ add_custom_target(pyastgen DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/ast/ast.cpp)
 # Add extra compile flags to NMODL sources
 # =============================================================================
 add_compile_options(${NMODL_EXTRA_CXX_FLAGS})
+if(NMODL_COMPILER_WARNING_SUPPRESSIONS)
+  add_compile_options(${NMODL_COMPILER_WARNING_SUPPRESSIONS})
+endif()
 add_link_options(${NMODL_EXTRA_CXX_FLAGS})
 
 add_subdirectory(codegen)

--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -111,6 +111,11 @@ if(NRN_NOCMODL_CXX_FLAGS)
   target_compile_options(nocmodl PRIVATE ${NRN_NOCMODL_CXX_FLAGS})
 endif()
 
+# CLI11-included headers have some warnings on NVHPC
+if(NRN_NOCMODL_COMPILER_WARNING_SUPPRESSIONS)
+  target_compile_options(nocmodl PRIVATE ${NRN_NOCMODL_COMPILER_WARNING_SUPPRESSIONS})
+endif()
+
 # =============================================================================
 # Translate all MOD files to C and mark them generated
 # =============================================================================

--- a/test/nmodl/transpiler/unit/CMakeLists.txt
+++ b/test/nmodl/transpiler/unit/CMakeLists.txt
@@ -4,7 +4,9 @@
 include(${PROJECT_SOURCE_DIR}/cmake/nmodl/FlexHelper.cmake)
 add_compile_options(${NMODL_EXTRA_CXX_FLAGS})
 add_link_options(${NMODL_EXTRA_CXX_FLAGS})
-add_compile_options(${NMODL_TESTS_COMPILER_WARNING_SUPPRESSIONS})
+if(NMODL_TESTS_COMPILER_WARNING_SUPPRESSIONS)
+  add_compile_options(${NMODL_TESTS_COMPILER_WARNING_SUPPRESSIONS})
+endif()
 
 add_library(nmodl_test_flags INTERFACE)
 


### PR DESCRIPTION
The build log becomes way too large to comfortably navigate otherwise. Use `--display_error_number` (taken from [the docs](https://docs.nvidia.com/hpc-sdk/archive/24.3/compilers/hpc-compilers-ref-guide/index.html#display-error-number)) to obtain the actual number of the warning. The diagnostic name of the warning can be used as well (e.g. `inline_gnu_noinline_conflict` instead of `1626`), but I don't know how backwards-compatible the non-numbered errors are.