### PR TITLE
PEP440 regex too complicated for cmake 3.22.1 . Use Python.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,23 @@ endif()
 set(allowableBuildTypes Custom Debug Release RelWithDebInfo Fast FastDebug)
 include(ReleaseDebugAutoFlags)
 
+# ~~~
+# Figure out early what Python to use as a build helper for cmake.
+# Since PythonInterp module prefers system-wide python, if PYTHON_EXECUTABLE
+# is not set, look it up in the PATH exclusively.
+# ~~~
+if(NOT PYTHON_EXECUTABLE)
+  message(
+    STATUS "-DPYTHON_EXECUTABLE not specified. Looking for `python3` in the PATH exclusively...")
+  find_program(
+    PYTHON_EXECUTABLE python3
+    PATHS ENV PATH
+    NO_DEFAULT_PATH)
+  message(STATUS "\tSetting PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}")
+endif()
+
+find_package(PythonInterp 3.7 REQUIRED)
+
 # Try and emit an intelligent warning if the version number currently set in the CMake project(...)
 # call is inconsistent with the output of git describe.
 include(cmake/CheckGitDescribeCompatibility.cmake)

--- a/cmake/check_pep440_version.py
+++ b/cmake/check_pep440_version.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import re
+import sys
+
+
+def is_pep440_canonical_version(version):
+    # Regex matching your simplified version (no epoch, as per your latest attempt)
+    regex = r"^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$"
+    return bool(re.match(regex, version))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: check_pep440_version.py <version>", file=sys.stderr)
+        sys.exit(1)
+    version = sys.argv[1]
+    result = is_pep440_canonical_version(version)
+    print("TRUE" if result else "FALSE")
+    sys.exit(0)


### PR DESCRIPTION
Cherry picks the fix from hines/827-fixes