### PR TITLE
Synchronize PyPI nightly uploads in GitHub CI

### DIFF
--- a/.github/workflows/wheels-nightly.yml
+++ b/.github/workflows/wheels-nightly.yml
@@ -3,20 +3,68 @@ name: Build NEURON Python wheels for nightly upload
 on:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs:
+      upload:
+        description: "Upload wheels to PyPI"
+        required: false
+        default: "false"
+        type: boolean
+      os:
+        description: "Comma-separated list of OSes"
+        required: false
+        default: "macos-14,ubuntu-22.04-arm"
+      python_versions:
+        description: "Comma-separated list of Python versions"
+        required: false
+        default: "3.9,3.10,3.11,3.12,3.13"
+      commit:
+        description: The commit of NEURON for which to build the wheel
+        required: false
+        default: "master"
+
 jobs:
+  fetch-latest-commit:
+    runs-on: ubuntu-latest
+    outputs:
+      commit: ${{ steps.save-commit.outputs.commit }}
+    steps:
+      - name: Save commit ref
+        id: save-commit
+        run: |
+          commit="${{ github.event.inputs.commit }}"
+          if [[ -n "${commit}" ]]; then
+            echo "commit=${commit}" >> "$GITHUB_OUTPUT"
+          else
+            git ls-remote origin refs/heads/master | cut -f1 | xargs -I{} echo "commit={}" >> "$GITHUB_OUTPUT"
+          fi
+
+  generate-matrix:
+    name: Generate platform and Python matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          OS_INPUT="${{ github.event.inputs.os || 'macos-14,ubuntu-22.04-arm' }}"
+          PY_INPUT="${{ github.event.inputs.python_versions || '3.9,3.10,3.11,3.12,3.13' }}"
+          OS_JSON=$(echo "$OS_INPUT" | jq -R 'split(",")')
+          PY_JSON=$(echo "$PY_INPUT" | jq -R 'split(",")')
+          echo "matrix=$(jq -c -n --argjson os "$OS_JSON" --argjson py "$PY_JSON" '{os: $os, python_version: $py}')" >> "$GITHUB_OUTPUT"
+
   build-test:
     name: Build and test for nightly
+    needs: [fetch-latest-commit, generate-matrix]
     uses: ./.github/workflows/wheels-template.yml
     with:
       platform: ${{ matrix.os }}
       python_version: ${{ matrix.python_version }}
       optimize_rxd: true
       clone_depth: '0'
-      commit: 'master'
+      commit: ${{ needs.fetch-latest-commit.outputs.commit }}
     strategy:
-      matrix:
-        os: ['macos-14', 'ubuntu-22.04-arm']
-        python_version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
 
   merge:
     name: Merge artifacts
@@ -33,6 +81,7 @@ jobs:
 
   pypi-publish:
     name: Upload wheels to PyPI
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload == 'true')
     needs: merge
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
Also add option to run workflow on-demand if something doesn't work or is missing as a workaround for #3427.