### PR TITLE
Update syn.mod

### DIFF
--- a/src/nrnoc/syn.mod
+++ b/src/nrnoc/syn.mod
@@ -3,7 +3,7 @@ a synaptic current with alpha function conductance defined by
         i = g * (v - e)      i(nanoamps), g(microsiemens);
         where
          g = 0 for t < onset and
-         g = gmax * (t - onset)/tau * exp(-(t - onset - tau)/tau)
+         g = gmax * (t - onset)/tau * exp((t - onset)/tau)
           for t > onset
 this has the property that the maximum value is gmax and occurs at
  t = delay + tau.


### PR DESCRIPTION
COMMENT previously said "g = gmax * (t - onset)/tau * exp(-(t - onset - tau)/tau)" which is doubly incorrect.