### PR TITLE
Fix commenting when PR originates from a fork

### DIFF
--- a/.github/workflows/wheels-ci.yml
+++ b/.github/workflows/wheels-ci.yml
@@ -35,7 +35,7 @@ jobs:
           pattern: wheels-*
 
       - name: Create comment with URL to artifact
-        if: github.event.pull_request
+        if: github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Due to
https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#restrictions-on-repository-forks when making a PR from a fork of NEURON, the commenting to the link with wheels created by GitHub Actions will fail, so we disable the commenting altogether when a PR is from a fork.