### PR TITLE
Update version of Python package `packaging`

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1432,9 +1432,9 @@ overrides==7.7.0 \
     --hash=sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a \
     --hash=sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49
     # via jupyter-server
-packaging==21.3 \
-    --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
-    --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
+packaging==24.2 \
+    --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759 \
+    --hash=sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f
     # via
     #   -r docs/docs_requirements.txt
     #   -r nrn_requirements.txt
@@ -1704,9 +1704,7 @@ pygments==2.19.1 \
 pyparsing==3.2.3 \
     --hash=sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf \
     --hash=sha256:b9c13f1ab8b3b542f72e28f634bad4de758ab3ce4546e4301970ad6fa77c38be
-    # via
-    #   matplotlib
-    #   packaging
+    # via matplotlib
 pytest==8.1.1 \
     --hash=sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7 \
     --hash=sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044

--- a/ci/win_install_deps.cmd
+++ b/ci/win_install_deps.cmd
@@ -26,9 +26,8 @@ C:\Python310\python.exe -m pip install "numpy<=2.2.3" "cython<=3.0.12" || goto :
 C:\Python311\python.exe -m pip install "numpy<=2.2.3" "cython<=3.0.12" || goto :error
 C:\Python312\python.exe -m pip install "numpy<=2.2.3" "cython<=3.0.12" || goto :error
 C:\Python313\python.exe -m pip install "numpy<=2.2.3" "cython<=3.0.12" || goto :error
-:: setuptools 70.2 leads to an error
-C:\Python312\python.exe -m pip install setuptools==70.1.1 || goto :error
-C:\Python313\python.exe -m pip install setuptools==70.1.1 || goto :error
+C:\Python312\python.exe -m pip install "setuptools<=80.8.0" || goto :error
+C:\Python313\python.exe -m pip install "setuptools<=80.8.0" || goto :error
 
 :: install nsis
 nsis-3.05-setup.exe /S || goto :error

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -15,6 +15,6 @@ nbsphinx
 jinja2
 sphinx-design
 sphinx-inline-tabs
-packaging==21.3
+packaging<=24.2,>=22.0
 tenacity<8.4
 anywidget

--- a/nrn_requirements.txt
+++ b/nrn_requirements.txt
@@ -2,8 +2,8 @@ matplotlib<=3.10.0
 ipython<=8.32.0
 mpi4py<=4.0.3
 find_libpython<=0.4.0
-packaging<=24.2.0
-setuptools<=70.3
+packaging<=24.2.0,>=22.0
+setuptools<=80.8.0
 -r packaging/python/build_requirements.txt
 -r packaging/python/test_requirements.txt
 -r nmodl_requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,8 @@ dynamic = [ "version" ]
 dependencies = [
   "find-libpython<=0.4",
   "numpy>=1.9.3,<=2.2.3",
-  "packaging<=24.2",
-  "setuptools<=70.3",
+  "packaging<=24.2,>=22.0",
+  "setuptools<=80.8.0",
   "sympy>=1.3,<=1.13.3",
 ]
 


### PR DESCRIPTION
As per
https://github.com/pypa/setuptools/issues/4483#issuecomment-2236339726 setuptools version 71 and above is not compatible with packaging version 22 and below. In #2706 we pinned packaging to 21.3, but since merging #3370 this should no longer be required as we do not use it anymore when building the docs. This allows us to install a more recent version of setuptools (which is not used for building NEURON, but only for detecting the compiler version in binwrapper.py at run-time).