### PR TITLE
Add missing cstdint include

### DIFF
--- a/src/coreneuron/io/phase2.hpp
+++ b/src/coreneuron/io/phase2.hpp
@@ -13,6 +13,7 @@
 #include "coreneuron/utils/ivocvect.hpp"
 
 #include <memory>
+#include <cstdint>
 
 namespace coreneuron {
 struct NrnThread;


### PR DESCRIPTION
Add compatibility with GCC 15 on Fedora 42.

Note that there are still some MPI-related test failures on Fedora 42 (see https://github.com/neuronsimulator/nrn-build-ci/actions/runs/15393546660/job/43311114770 for the full trace), not sure if this is related to using containers or not:

```plaintext
[f54bcf1e49bc:20099:0:20099] Caught signal 7 (Bus error: nonexistent physical address)
==== backtrace (tid:  20099) ====
 0  /lib64/libucs.so.0(ucs_handle_error+0x2e4) [0x7faf44871df4]
 1  /lib64/libucs.so.0(+0x17aed) [0x7faf44873aed]
 2  /lib64/libucs.so.0(+0x17c74) [0x7faf44873c74]
 3  /lib64/libc.so.6(+0x19c30) [0x7faf46609c30]
 4  /lib64/libc.so.6(+0x146e89) [0x7faf46736e89]
 5  /lib64/libfabric.so.1(+0x3fdae8) [0x7faf44d8bae8]
 6  /lib64/libfabric.so.1(+0x3dcdf2) [0x7faf44d6adf2]
 7  /lib64/libfabric.so.1(+0x3df50b) [0x7faf44d6d50b]
 8  /lib64/libfabric.so.1(+0x3b82e0) [0x7faf44d462e0]
 9  /lib64/libfabric.so.1(+0x3a74dd) [0x7faf44d354dd]
10  /usr/lib64/openmpi/lib/libmpi.so.40(+0x1934a1) [0x7faf456174a1]
11  /usr/lib64/openmpi/lib/libmpi.so.40(ompi_mtl_base_select+0x9a) [0x7faf4560edba]
12  /usr/lib64/openmpi/lib/libmpi.so.40(+0x229e50) [0x7faf456ade50]
13  /usr/lib64/openmpi/lib/libmpi.so.40(mca_pml_base_select+0x1e3) [0x7faf4568af73]
14  /usr/lib64/openmpi/lib/libmpi.so.40(+0x4b601) [0x7faf454cf601]
15  /usr/lib64/openmpi/lib/libmpi.so.40(ompi_mpi_instance_init+0x68) [0x7faf454d05d8]
16  /usr/lib64/openmpi/lib/libmpi.so.40(ompi_mpi_init+0x80) [0x7faf454c1dc0]
17  /usr/lib64/openmpi/lib/libmpi.so.40(PMPI_Init_thread+0x5b) [0x7faf45506ceb]
18  /__w/nrn-build-ci/nrn-build-ci/nrn/build/lib/libnrniv.so(nrnmpi_init+0xde) [0x7faf45b6e62e]
19  /__w/nrn-build-ci/nrn-build-ci/nrn/build/lib/python/neuron/hoc.cpython-313-x86_64-linux-gnu.so(PyInit_hoc+0x87e) [0x7faf4613818e]
20  /lib64/libpython3.13.so.1.0(+0x22b59f) [0x7faf46a0d59f]
21  /lib64/libpython3.13.so.1.0(+0x22b270) [0x7faf46a0d270]
22  /lib64/libpython3.13.so.1.0(+0x264272) [0x7faf46a46272]
23  /lib64/libpython3.13.so.1.0(+0x172ed7) [0x7faf46954ed7]
24  /lib64/libpython3.13.so.1.0(_PyEval_EvalFrameDefault+0x6276) [0x7faf46935096]
25  /lib64/libpython3.13.so.1.0(+0x1702ff) [0x7faf469522ff]
26  /lib64/libpython3.13.so.1.0(PyObject_CallMethodObjArgs+0xfd) [0x7faf4698c7cd]
27  /lib64/libpython3.13.so.1.0(PyImport_ImportModuleLevelObject+0xe2b) [0x7faf4698c4bb]
28  /lib64/libpython3.13.so.1.0(+0x1682ab) [0x7faf4694a2ab]
29  /lib64/libpython3.13.so.1.0(_PyEval_EvalFrameDefault+0x6276) [0x7faf46935096]
30  /lib64/libpython3.13.so.1.0(+0x1702ff) [0x7faf469522ff]
31  /lib64/libpython3.13.so.1.0(PyObject_CallMethodObjArgs+0xfd) [0x7faf4698c7cd]
32  /lib64/libpython3.13.so.1.0(PyImport_ImportModuleLevelObject+0x32b) [0x7faf4698b9bb]
33  /lib64/libpython3.13.so.1.0(_PyEval_EvalFrameDefault+0x87da) [0x7faf469375fa]
34  /lib64/libpython3.13.so.1.0(PyEval_EvalCode+0x9f) [0x7faf46a05d6f]
35  /lib64/libpython3.13.so.1.0(+0x23f1c3) [0x7faf46a211c3]
36  /lib64/libpython3.13.so.1.0(+0x1682ab) [0x7faf4694a2ab]
37  /lib64/libpython3.13.so.1.0(_PyEval_EvalFrameDefault+0x6276) [0x7faf46935096]
38  /lib64/libpython3.13.so.1.0(+0x1702ff) [0x7faf469522ff]
39  /lib64/libpython3.13.so.1.0(PyObject_CallMethodObjArgs+0xfd) [0x7faf4698c7cd]
40  /lib64/libpython3.13.so.1.0(PyImport_ImportModuleLevelObject+0xe2b) [0x7faf4698c4bb]
41  /lib64/libpython3.13.so.1.0(_PyEval_EvalFrameDefault+0x87da) [0x7faf469375fa]
42  /lib64/libpython3.13.so.1.0(PyEval_EvalCode+0x9f) [0x7faf46a05d6f]
43  /lib64/libpython3.13.so.1.0(+0x26323c) [0x7faf46a4523c]
44  /lib64/libpython3.13.so.1.0(+0x2605b3) [0x7faf46a425b3]
45  /lib64/libpython3.13.so.1.0(+0x25dc87) [0x7faf46a3fc87]
46  /lib64/libpython3.13.so.1.0(+0x25cf4f) [0x7faf46a3ef4f]
47  /lib64/libpython3.13.so.1.0(+0x25cca1) [0x7faf46a3eca1]
48  /lib64/libpython3.13.so.1.0(Py_RunMain+0x3f1) [0x7faf46a3c7e1]
49  /lib64/libpython3.13.so.1.0(Py_BytesMain+0x3b) [0x7faf469f33ab]
50  /lib64/libc.so.6(+0x35f5) [0x7faf465f35f5]
51  /lib64/libc.so.6(__libc_start_main+0x88) [0x7faf465f36a8]
52  /__w/nrn-build-ci/nrn-build-ci/nrn/nrn_venv/bin/python(_start+0x25) [0x5649948323d5]
=================================
--------------------------------------------------------------------------
prterun noticed that process rank 1 with PID 20099 on node f54bcf1e49bc exited on
signal 7 (Bus error).
--------------------------------------------------------------------------
```