### PR TITLE
Add support for pytest 8.4.0

### DIFF
--- a/nmodl_requirements.txt
+++ b/nmodl_requirements.txt
@@ -6,7 +6,7 @@ pyyaml>=3.13,<=6.0.2
 find_libpython<=0.4.0
 sympy>=1.3,<=1.13.3
 # dependencies for test
-pytest<=8.1.1
+pytest<=8.4.0
 pytest-cov
 numpy>=1.9.3,<=2.2.3
 scipy

--- a/packaging/python/test_requirements.txt
+++ b/packaging/python/test_requirements.txt
@@ -1,4 +1,4 @@
-pytest<=8.1.1 # potential bug from 8.2.0 due to parallelism?
+pytest<=8.4.0
 # for coverage
 pytest-cov<=6.0.0
 # for RXD test

--- a/test/rxd/test_savestate_basic.py
+++ b/test/rxd/test_savestate_basic.py
@@ -215,7 +215,7 @@ def test_savestate_basic(neuron_nosave_instance):
         return vecs, vecs_std_save
 
     # run the test
-    return test_savestate_rxd()
+    test_savestate_rxd()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#3488, but only for `master`. Note that the CI does not use this version of pytest, but I can verify it works locally on Ubuntu 24.04 LTS at least.