### PR TITLE
CMake cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,7 +280,7 @@ if(NOT PYTHON_EXECUTABLE)
   message(STATUS "\tSetting PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}")
 endif()
 
-find_package(PythonInterp 3.7 REQUIRED)
+find_package(Python 3.9 REQUIRED)
 
 # Try and emit an intelligent warning if the version number currently set in the CMake project(...)
 # call is inconsistent with the output of git describe.

--- a/cmake/ConfigFileSetting.cmake
+++ b/cmake/ConfigFileSetting.cmake
@@ -138,15 +138,6 @@ nrn_check_symbol_exists("SIGBUS" "signal.h" HAVE_SIGBUS)
 nrn_check_symbol_exists("stty" "" HAVE_STTY)
 
 # =============================================================================
-# Check data types
-# =============================================================================
-nrn_check_type_exists(sys/types.h gid_t int gid_t)
-nrn_check_type_exists(sys/types.h off_t "long int" off_t)
-nrn_check_type_exists(sys/types.h pid_t int pid_t)
-nrn_check_type_exists(sys/types.h size_t "unsigned int" size_t)
-nrn_check_type_exists(sys/types.h uid_t int uid_t)
-
-# =============================================================================
 # Generate file from file.in template
 # =============================================================================
 set(version_strs ${NRN_PYTHON_VERSIONS})

--- a/cmake/MacroHelper.cmake
+++ b/cmake/MacroHelper.cmake
@@ -12,57 +12,6 @@ include(CMakeParseArguments)
 set(CMAKE_REQUIRED_QUIET TRUE)
 
 # =============================================================================
-# Check if directory related to DIR exists by compiling code
-# =============================================================================
-macro(nrn_check_dir_exists HEADER VARIABLE)
-  # code template to check existence of DIR
-  string(
-    CONCAT CONFTEST_DIR_TPL
-           "#include <sys/types.h>\n"
-           "#include <@dir_header@>\n"
-           "int main () {\n"
-           "  if ((DIR *) 0)\n"
-           "    return 0\;\n"
-           "  return 0\;\n"
-           "}\n")
-  # first get header file
-  check_include_files(${HEADER} HAVE_HEADER)
-  if(${HAVE_HEADER})
-    # if header is found, create a code from template
-    string(REPLACE "@dir_header@" ${HEADER} CONFTEST_DIR "${CONFTEST_DIR_TPL}")
-    file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/conftest.cpp" ${CONFTEST_DIR})
-    # try to compile
-    try_compile(${VARIABLE} "${CMAKE_CURRENT_SOURCE_DIR}"
-                "${CMAKE_CURRENT_SOURCE_DIR}/conftest.cpp")
-    file(REMOVE "${CMAKE_CURRENT_SOURCE_DIR}/conftest.cpp")
-  endif()
-endmacro()
-
-# =============================================================================
-# Check if given type exists by compiling code
-# =============================================================================
-macro(nrn_check_type_exists HEADER TYPE DEFAULT_TYPE VARIABLE)
-  # code template to check existence of specific type
-  string(
-    CONCAT CONFTEST_TYPE_TPL
-           "#include <@header@>\n"
-           "int main () {\n"
-           "  if (sizeof (@type@))\n"
-           "    return 0\;\n"
-           "  return 0\;\n"
-           "}\n")
-  string(REPLACE "@header@" ${HEADER} CONFTEST_TYPE "${CONFTEST_TYPE_TPL}")
-  string(REPLACE "@type@" ${TYPE} CONFTEST_TYPE "${CONFTEST_TYPE}")
-  file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/conftest.cpp ${CONFTEST_TYPE})
-
-  try_compile(MY_RESULT_VAR ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/conftest.cpp)
-  if(NOT ${MY_RESULT_VAR})
-    set(${VARIABLE} ${DEFAULT_TYPE})
-  endif()
-  file(REMOVE "conftest.cpp")
-endmacro()
-
-# =============================================================================
 # Perform check_include_files and add it to NRN_HEADERS_INCLUDE_LIST if exist Passing an optional
 # CXX will call check_include_files_cxx instead.
 # =============================================================================

--- a/cmake_nrnconf.h.in
+++ b/cmake_nrnconf.h.in
@@ -113,9 +113,6 @@
    `char[]'. */
 #cmakedefine YYTEXT_POINTER @YYTEXT_POINTER@
 
-/* Define to `int' if <sys/types.h> does not define. */
-#cmakedefine pid_t @pid_t@
-
 /* __cplusplus guard still needed because this header is included from C code in
  * mesch (and maybe others)
  */

--- a/src/ivoc/ivocwin.cpp
+++ b/src/ivoc/ivocwin.cpp
@@ -203,7 +203,6 @@ int IOHandler::exceptionRaised(int) {
     return 0;
 }
 void IOHandler::timerExpired(long, long) {}
-void IOHandler::childStatus(pid_t, int) {}
 #endif  // MINGW
 
 #ifdef MINGW


### PR DESCRIPTION
- `find_package(PythonInterp ...)` has been deprecated, use `find_package(Python ...)`
- `nrn_check_dir_exists` was not used anywhere so it's been removed
- only instance of `pid_t` was in `childStatus`, which does...nothing? So that was removed as well
- due to the above, `nrn_check_type_exists` was not doing anything useful anymore so it's gone (`gid_t`, `off_t`, `uid_t` are not used anywhere, while `size_t` has been in the C/C++ standard for decades)