### PR TITLE
Add `float_control(precise, on)` on Clang

### DIFF
--- a/src/ivoc/mymath.cpp
+++ b/src/ivoc/mymath.cpp
@@ -1,4 +1,7 @@
 #ifndef __INTEL_LLVM_COMPILER
+#ifdef __clang__
+#pragma float_control(precise, on)
+#endif
 #pragma STDC FENV_ACCESS ON
 #endif
 

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -1,4 +1,7 @@
 #ifndef __INTEL_LLVM_COMPILER
+#ifdef __clang__
+#pragma float_control(precise, on)
+#endif
 #pragma STDC FENV_ACCESS ON
 #endif
 

--- a/src/oc/math.cpp
+++ b/src/oc/math.cpp
@@ -1,5 +1,8 @@
 #include "oc_ansi.h"
 #ifndef __INTEL_LLVM_COMPILER
+#ifdef __clang__
+#pragma float_control(precise, on)
+#endif
 #pragma STDC FENV_ACCESS ON
 #endif
 


### PR DESCRIPTION
A possible fix for #3504.

Excerpt from [the docs](https://clang.llvm.org/docs/LanguageExtensions.html):

> The #pragma float_control pragma allows precise floating-point semantics and floating-point exception behavior to be specified for a section of the source code. This pragma can only appear at file or namespace scope, within a language linkage specification or at the start of a compound statement (excluding comments). When used within a compound statement, the pragma is active within the scope of the compound statement. This pragma is modeled after a Microsoft pragma with the same spelling and syntax. For pragmas specified at file or namespace scope, or within a language linkage specification, a stack is supported so that the pragma float_control settings can be pushed or popped.

> When pragma float_control(precise, on) is enabled, the section of code governed by the pragma uses precise floating point semantics, effectively -ffast-math is disabled and -ffp-contract=on (fused multiply add) is enabled. This pragma enables -fmath-errno.

Combined with the [error message](https://reviews.llvm.org/D72841#C1945711NL869):

```plaintext
def err_pragma_fenv_requires_precise : Error<
  "'#pragma STDC FENV_ACCESS ON' is illegal when precise is disabled">;
```

it seems we need to set `precise=on` to be able to manipulate the floating point env on Clang. Note that, as written in the excerpt above, this disables `-ffast-math`, which is a superset of `-funsafe-math-optimizations`.