### PR TITLE
Skip existing nightly uploads

### DIFF
--- a/.github/workflows/wheels-nightly.yml
+++ b/.github/workflows/wheels-nightly.yml
@@ -97,3 +97,5 @@ jobs:
           path: dist/
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true


### PR DESCRIPTION
Fixes #3494. Since the wheels we upload from Azure and GitHub Actions do not overlap, it's safe to use `skip-existing: true` in the upload action.