### PR TITLE
Pytest experiments

### DIFF
--- a/share/examples/nrniv/nmodl/cagkftab.py
+++ b/share/examples/nrniv/nmodl/cagkftab.py
@@ -47,17 +47,12 @@ def test_empty():
     expect_err("print(h.alp_cagkftab(-50., 1e-2))")
 
 
-test_empty()
-
-
 def test_const():
     h.table_alp_cagkftab(5.1)
     h.table_tst_cagkftab(6.2)
     assert h.alp_cagkftab(-50.0, 1e-2) == 5.1
     assert h.tst1_cagkftab(3) == 6.2
 
-
-test_const()
 
 # HOC matrix and 2-d double memory order is irow*ncol + jcol
 def memorder():
@@ -76,9 +71,6 @@ def memorder():
         assert ra[i] == float(i)
 
 
-memorder()
-
-
 def vecrange(min, max, step):
     return h.Vector().indgen(min, max, step)
 
@@ -94,10 +86,7 @@ def test_errs():
     expect_err("h.table_tst_cagkftab(f._ref_x[0], len(x), x.x[len(x)-1], x.x[0])")
 
 
-test_errs()
-
-
-def test_1d_tst(f, domain):  # test_1d helper when different arg styles
+def _test_1d_tst(f, domain):  # test_1d helper when different arg styles
     assert h.tst_cagkftab(-1000.0) == f.x[0]
     assert h.tst_cagkftab(1000.0) == f.x[domain.size() - 1]
     for x in domain:  # exactly at the domain points
@@ -110,15 +99,11 @@ def test_1d():
     x = vecrange(-80, 50, 0.1)
     f = h.Vector([tst(v) for v in x])
     h.table_tst_cagkftab(f._ref_x[0], len(x), x.x[0], x.x[len(x) - 1])
-    test_1d_tst(f, x)
+    _test_1d_tst(f, x)
     h.table_tst_cagkftab(f._ref_x[0], len(x), x._ref_x[0])
-    test_1d_tst(f, x)
+    _test_1d_tst(f, x)
     h.table_tst_cagkftab(f, x)
-    test_1d_tst(f, x)
-    return f, x
-
-
-test_1d_vecs = test_1d()  # keep in existence in case of later use
+    _test_1d_tst(f, x)
 
 
 def assert_isclose(a, b, abs_tol):
@@ -162,9 +147,6 @@ def setup_tables():
     return malp, mbet, vsteps, casteps
 
 
-tabs = setup_tables()
-
-
 def cmp(v, lnca):
     print(v, lnca, h.alp_cagk(v, exp(lnca)), h.alp_cagkftab(v, lnca))
 
@@ -181,9 +163,6 @@ def compare_exact():
             )
 
 
-compare_exact()
-
-
 def compare():
     for cai in [1e-3, 1e-2, 1e-1]:
         for v in range(-80, 50):
@@ -192,9 +171,6 @@ def compare():
             h.rate_cagkftab(v, cai)
             oftab = h.oinf_cagkftab
             assert isclose(o, oftab, abs_tol=1e-4)
-
-
-compare()
 
 
 def ik_vs_t():
@@ -239,4 +215,16 @@ def ik_vs_t():
     return g, tvec, ikvecs
 
 
-p = ik_vs_t()
+if __name__ == "__main__":
+    test_empty()
+
+    test_const()
+
+    memorder()
+
+    test_errs()
+    test_1d_vecs = test_1d()  # keep in existence in case of later use
+    tabs = setup_tables()
+    compare_exact()
+    compare()
+    p = ik_vs_t()

--- a/share/examples/nrniv/nmodl/expsynspine.py
+++ b/share/examples/nrniv/nmodl/expsynspine.py
@@ -1,21 +1,23 @@
 from neuron import h, gui
 
-somas = [h.Section(name="soma" + str(i)) for i in range(2)]
-for sec in somas:
-    sec.L = 10
-    sec.diam = 10
-    sec.insert("pas")
-    sec.e_pas = -65
-    sec.g_pas = 0.0001
 
-syns = [h.ExpSynSpine(somas[0](0.5)), h.ExpSyn(somas[1](0.5))]
-syns[0].rsp = 0
+def test_expsynspine():
+    somas = [h.Section(name="soma" + str(i)) for i in range(2)]
+    for sec in somas:
+        sec.L = 10
+        sec.diam = 10
+        sec.insert("pas")
+        sec.e_pas = -65
+        sec.g_pas = 0.0001
 
-stim = h.NetStim()
-stim.interval = 1
-stim.number = 10
-stim.start = 1
+    syns = [h.ExpSynSpine(somas[0](0.5)), h.ExpSyn(somas[1](0.5))]
+    syns[0].rsp = 0
 
-netcons = [h.NetCon(stim, syn, 0, 1, 0.1) for syn in syns]
+    stim = h.NetStim()
+    stim.interval = 1
+    stim.number = 10
+    stim.start = 1
 
-h.load_file("expsynspine.ses")
+    netcons = [h.NetCon(stim, syn, 0, 1, 0.1) for syn in syns]
+
+    h.load_file("expsynspine.ses")

--- a/share/examples/nrniv/nmodl/nonlin.py
+++ b/share/examples/nrniv/nmodl/nonlin.py
@@ -3,17 +3,6 @@
 
 from neuron import h, gui
 
-pc = h.ParallelContext()
-
-ncell = 10000
-csize = 40.0
-
-cells = [h.NonLinTest() for i in range(ncell)]
-
-r = h.Random()
-r.Random123(1, 2, 3)
-r.uniform(-csize, csize)
-
 
 def dif(tol):
     for cell in cells:
@@ -39,9 +28,6 @@ def solve(a, b, c):
     dif(1e-13)
 
 
-solve(5, 10, 15)
-
-
 def rnd(x):
     return round(x, 10)
 
@@ -59,4 +45,18 @@ def distinct():
         print(i)
 
 
-distinct()
+def test_nonlin():
+    pc = h.ParallelContext()
+
+    ncell = 10000
+    csize = 40.0
+
+    cells = [h.NonLinTest() for i in range(ncell)]
+
+    r = h.Random()
+    r.Random123(1, 2, 3)
+    r.uniform(-csize, csize)
+
+    solve(5, 10, 15)
+
+    distinct()

--- a/share/examples/nrniv/nmodl/tstpnt1.py
+++ b/share/examples/nrniv/nmodl/tstpnt1.py
@@ -1,37 +1,39 @@
-from neuron import h
-
-a = h.Section()
-vec = h.Vector(10).indgen().add(100)
-tp = []
-for i in range(0, 10):
-    tp.append(h.t1(a(0.5)))
-
-
-a.v = 10
-
-tp[2].f1()
-
-# h.setpointer(a(.5)._ref_v, 'p1', tp[0])
-tp[0]._ref_p1 = a(0.5)._ref_v
-for i in range(1, 10):
-    # h.setpointer(vec._ref_x[i], 'p1', tp[i])
-    tp[i]._ref_p1 = vec._ref_x[i]
-
-for i in range(0, 10):
-    print(i, tp[i].p1, tp[i].f1())
-
-tp[2].p1 = 25
-print(vec[2], tp[2].p1)
-
-z = h.t1()
 import sys
 
-try:
-    h.setpointer(a(0.5)._ref_v, "p1", z)
-except:
-    print(sys.exc_info()[0], ": ", sys.exc_info()[1])
+from neuron import h
 
-try:
-    z._ref_p1 = a(0.5)._ref_v
-except:
-    print(sys.exc_info()[0], ": ", sys.exc_info()[1])
+
+def test_pointer1():
+    a = h.Section()
+    vec = h.Vector(10).indgen().add(100)
+    tp = []
+    for i in range(0, 10):
+        tp.append(h.t1(a(0.5)))
+
+    a.v = 10
+
+    tp[2].f1()
+
+    # h.setpointer(a(.5)._ref_v, 'p1', tp[0])
+    tp[0]._ref_p1 = a(0.5)._ref_v
+    for i in range(1, 10):
+        # h.setpointer(vec._ref_x[i], 'p1', tp[i])
+        tp[i]._ref_p1 = vec._ref_x[i]
+
+    for i in range(0, 10):
+        print(i, tp[i].p1, tp[i].f1())
+
+    tp[2].p1 = 25
+    print(vec[2], tp[2].p1)
+
+    z = h.t1()
+
+    try:
+        h.setpointer(a(0.5)._ref_v, "p1", z)
+    except:
+        print(sys.exc_info()[0], ": ", sys.exc_info()[1])
+
+    try:
+        z._ref_p1 = a(0.5)._ref_v
+    except:
+        print(sys.exc_info()[0], ": ", sys.exc_info()[1])

--- a/share/examples/nrniv/nmodl/tstpnt2.py
+++ b/share/examples/nrniv/nmodl/tstpnt2.py
@@ -1,39 +1,39 @@
 from neuron import h
 
-h("create a, b")
-for sec in h.allsec():
-    sec.nseg = 5
-    sec.insert("t2")
 
-for seg in h.a:
-    seg.t2.r = 10 + seg.x * 9
-    h.b(seg.x).t2.r = 40 + seg.x * 9
-    # h.setpointer(h.b(seg.x)._ref_r_t2, 'p', seg.t2)
-    # h.setpointer(seg._ref_r_t2, 'p', h.b(seg.x).t2)
-    seg.t2._ref_p = h.b(seg.x)._ref_r_t2
-    h.b(seg.x)._ref_p_t2 = seg.t2._ref_r
+def test_pointer2():
+    h("create a, b")
+    for sec in h.allsec():
+        sec.nseg = 5
+        sec.insert("t2")
 
+    for seg in h.a:
+        seg.t2.r = 10 + seg.x * 9
+        h.b(seg.x).t2.r = 40 + seg.x * 9
+        # h.setpointer(h.b(seg.x)._ref_r_t2, 'p', seg.t2)
+        # h.setpointer(seg._ref_r_t2, 'p', h.b(seg.x).t2)
+        seg.t2._ref_p = h.b(seg.x)._ref_r_t2
+        h.b(seg.x)._ref_p_t2 = seg.t2._ref_r
 
-def pr(sec):
-    sec.push()
-    for seg in sec:
-        print(
-            "%s   x=%g   r=%g   t2.p=%g   p_t2=%g"
-            % (sec.name(), seg.x, seg.t2.r, seg.t2.p, seg.p_t2)
-        )
-        h.setdata_t2(seg.x)
-        print("   f()=%g" % h.f_t2())
-    print("\n")
-    h.pop_section()
+    def pr(sec):
+        sec.push()
+        for seg in sec:
+            print(
+                "%s   x=%g   r=%g   t2.p=%g   p_t2=%g"
+                % (sec.name(), seg.x, seg.t2.r, seg.t2.p, seg.p_t2)
+            )
+            h.setdata_t2(seg.x)
+            print("   f()=%g" % h.f_t2())
+        print("\n")
+        h.pop_section()
 
+    pr(h.a)
+    pr(h.b)
 
-pr(h.a)
-pr(h.b)
-
-z = h.a(0.5).t2
-print(z)
-print(z._ref_p)
-z._ref_p[0] = 5
-print(h.b(0.5).t2.r)
-z.p = 10
-print(h.b(0.5).t2.r)
+    z = h.a(0.5).t2
+    print(z)
+    print(z._ref_p)
+    z._ref_p[0] = 5
+    print(h.b(0.5).t2.r)
+    z.p = 10
+    print(h.b(0.5).t2.r)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -271,7 +271,7 @@ if(NRN_ENABLE_PYTHON)
     NAME example_nmodl
     MODFILE_PATTERNS *.mod *.inc
     SIM_DIRECTORY share/examples/nrniv/nmodl)
-  set(py_exe ${NRN_DEFAULT_PYTHON_EXECUTABLE})
+  set(py_exe ${NRN_DEFAULT_PYTHON_EXECUTABLE} ${pytest})
   set(py_preload PRELOAD_SANITIZER)
   set(hoc_exe special)
   foreach(ext hoc py)
@@ -774,7 +774,7 @@ if(NRN_ENABLE_PYTHON)
       GROUP nrnmusic
       NAME music_tests
       PROCESSORS 2
-      COMMAND ${NRN_DEFAULT_PYTHON_EXECUTABLE} test/music_tests/runtests.py
+      COMMAND ${NRN_DEFAULT_PYTHON_EXECUTABLE} ${pytest} test/music_tests/runtests.py
       SCRIPT_PATTERNS test/music_tests/*.music test/music_tests/*.py)
   endif()
 endif()

--- a/test/hoctests/tests/test_cvinterp.py
+++ b/test/hoctests/tests/test_cvinterp.py
@@ -5,10 +5,9 @@
 # the average of the voltages at the beginning and end of the time step.
 # Prior to this PR, IDA failed this test
 
-from neuron import h
-
-h.load_file("stdrun.hoc")
 import math
+
+from neuron import h
 
 
 def model():
@@ -32,6 +31,7 @@ def points(vecs):
 
 
 def test():
+    h.load_file("stdrun.hoc")
     m = model()
     vref = m[0](0.5)._ref_v
     freerun = [h.Vector().record(h._ref_t), h.Vector().record(vref)]

--- a/test/hoctests/tests/test_eion_cover.py
+++ b/test/hoctests/tests/test_eion_cover.py
@@ -1,8 +1,9 @@
+from math import isclose
+
 from neuron import h
 from neuron.expect_hocerr import expect_err, set_quiet
 
 set_quiet(0)
-from math import isclose
 
 
 def test_nernst():

--- a/test/hoctests/tests/test_hocGUI2.py
+++ b/test/hoctests/tests/test_hocGUI2.py
@@ -1,19 +1,8 @@
 # tests of GUI with hoc variables that go out of scope or move
+import os
 
 from neuron import config, h, gui
 from neuron.expect_hocerr import expect_err, set_quiet
-import os
-
-set_quiet(False)
-
-h(
-    """
-var1 = 0.0
-proc act1() { print "hoc var1 = ", var1 }
-proc actvec() { print "hoc vec.x[0] = ", $o1.x[0] }
-proc actcell() {forall {print secname(), "  ", g_pas(.5)}}
-"""
-)
 
 
 class Cell:
@@ -99,7 +88,20 @@ def test1():  # statebutton, checkbox, slider
     gui.vec = None
     gui.cell = None
     # sliders do not get grayed out
-    return gui
+    assert gui
+
+
+def test_hocGUI2():
+    set_quiet(False)
+
+    h(
+        """
+    var1 = 0.0
+    proc act1() { print "hoc var1 = ", var1 }
+    proc actvec() { print "hoc vec.x[0] = ", $o1.x[0] }
+    proc actcell() {forall {print secname(), "  ", g_pas(.5)}}
+    """
+    )
 
 
 def test2():  # Graph.xexpr
@@ -119,7 +121,7 @@ def test2():  # Graph.xexpr
     h.graphItem.exec_menu("View = plot")
     cells = cells[3]  # moves cell[3] to beginning of soa by deleting all others
     h.run()
-    return cells
+    assert cells
 
 
 def test_Hinton():  # PlotShape.hinton
@@ -146,10 +148,10 @@ def test_Hinton():  # PlotShape.hinton
 
     rval = pnet(net[1])
 
-    return rval  # net[1] is only remaining Net (in rval)
+    assert rval  # net[1] is only remaining Net (in rval)
 
 
 if __name__ == "__main__":
-    gui = test1()
-    cells = test2()
-    net = test_Hinton()
+    test1()
+    test2()
+    test_Hinton()

--- a/test/hoctests/tests/test_hoc_class_instance.py
+++ b/test/hoctests/tests/test_hoc_class_instance.py
@@ -2,16 +2,6 @@ from neuron import h
 import neuron
 import re
 
-h(
-    """
-begintemplate A
-proc init() {
-  x = 2
-}
-endtemplate A
-"""
-)
-
 
 def extract_index(s):
     match = re.search(r"\[(\d+)\]", s)
@@ -41,6 +31,16 @@ def test1():
 
 
 def test2():
+    h(
+        """
+    begintemplate A
+    proc init() {
+      x = 2
+    }
+    endtemplate A
+    """
+    )
+
     a = h.A()
     assert h.A[0] == a
 

--- a/test/hoctests/tests/test_hocmech.py
+++ b/test/hoctests/tests/test_hocmech.py
@@ -1,86 +1,89 @@
+import math
+
 from neuron import h, gui
 from neuron.expect_hocerr import expect_err, set_quiet
 
-set_quiet(False)
-import math
 
-soma = h.Section(name="soma")
-soma.L = soma.diam = math.sqrt(100 / math.pi)
-soma.insert("hh")  # equivalently: soma.insert(h.hh)
+def test_hocmech():
+    set_quiet(False)
 
-stim = h.IClamp(soma(0.5))
-stim.dur = 0.1
-stim.amp = 0.3
+    soma = h.Section(name="soma")
+    soma.L = soma.diam = math.sqrt(100 / math.pi)
+    soma.insert("hh")  # equivalently: soma.insert(h.hh)
 
-# declare a density mechanism using HOC
-h(
-    """
-    begintemplate Max
-        public V, a, b
-        a = 0
-        double b[2]
+    stim = h.IClamp(soma(0.5))
+    stim.dur = 0.1
+    stim.amp = 0.3
 
-        proc initial() {
-            V = v($1)
-        }
+    # declare a density mechanism using HOC
+    h(
+        """
+        begintemplate Max
+            public V, a, b
+            a = 0
+            double b[2]
 
-        proc after_step() {
-            if (V < v($1)) {
+            proc initial() {
                 V = v($1)
             }
-        }
-    endtemplate Max
-"""
-)
-h.make_mechanism("max", "Max", "a b")
 
-# declare a POINT_PROCESS using HOC
-h(
+            proc after_step() {
+                if (V < v($1)) {
+                    V = v($1)
+                }
+            }
+        endtemplate Max
     """
-    begintemplate PMax
-        public V, c, d
-        c = 0
-        double d[2]
+    )
+    h.make_mechanism("max", "Max", "a b")
 
-        proc initial() {
-            V = v($1)
-        }
+    # declare a POINT_PROCESS using HOC
+    h(
+        """
+        begintemplate PMax
+            public V, c, d
+            c = 0
+            double d[2]
 
-        proc after_step() {
-            if (V < v($1)) {
+            proc initial() {
                 V = v($1)
             }
-        }
-    endtemplate PMax
-"""
-)
-pm = h.PMax()
-expect_err('h.make_pointprocess("PMax", "c d")')
-del pm
-h.make_pointprocess("PMax", "c d")
 
-soma.insert("max")
-pm = h.PMax(0.5, sec=soma)
-pm = h.PMax(soma(0.5))
+            proc after_step() {
+                if (V < v($1)) {
+                    V = v($1)
+                }
+            }
+        endtemplate PMax
+    """
+    )
+    pm = h.PMax()
+    expect_err('h.make_pointprocess("PMax", "c d")')
+    del pm
+    h.make_pointprocess("PMax", "c d")
 
-h.run()
+    soma.insert("max")
+    pm = h.PMax(0.5, sec=soma)
+    pm = h.PMax(soma(0.5))
 
-print("V_max = %g" % soma(0.5).V_max)
-print("max.V = %g" % soma(0.5).max.V)
-print("pm.V = %g" % pm.V)
+    h.run()
 
-expect_err('h.make_mechanism("max", "Max")')
-assert pm.has_loc() == True
-expect_err("pm.loc()")
-pm.loc(soma(1.0))
-print(pm.get_loc(), h.secname())
+    print("V_max = %g" % soma(0.5).V_max)
+    print("max.V = %g" % soma(0.5).max.V)
+    print("pm.V = %g" % pm.V)
 
-mt = h.MechanismType(1)
-mt.select("PMax")
-pmaxref = h.ref(None)
-mt.make(pmaxref)  # eventually calls hoc_new_opoint
-print(pmaxref[0])
-expect_err("pmaxref[0].get_loc()")
-del mt, pmaxref
+    expect_err('h.make_mechanism("max", "Max")')
+    assert pm.has_loc() == True
+    expect_err("pm.loc()")
+    pm.loc(soma(1.0))
+    print(pm.get_loc(), h.secname())
 
-expect_err('h.make_mechanism("xmax", "Max", "a 3")')
+    mt = h.MechanismType(1)
+    mt.select("PMax")
+    pmaxref = h.ref(None)
+    mt.make(pmaxref)  # eventually calls hoc_new_opoint
+    print(pmaxref[0])
+    expect_err("pmaxref[0].get_loc()")
+    del mt, pmaxref
+
+    expect_err('h.make_mechanism("xmax", "Max", "a 3")')

--- a/test/hoctests/tests/test_kschan.py
+++ b/test/hoctests/tests/test_kschan.py
@@ -10,41 +10,9 @@ expect_hocerr.quiet = False
 from neuron.tests.utils.capture_stdout import capture_stdout
 from neuron.tests.utils.checkresult import Chk
 
-# Avoid needing different results depending on NRN_ENABLE_CORENEURON
-if hasattr(h, "usetable_hh"):
-    h.usetable_hh = False
-
-# Create a helper for managing reference results
-dir_path = os.path.dirname(os.path.realpath(__file__))
-chk = Chk(os.path.join(dir_path, "test_kschan.json"))
-
-if sys.argv[0].split("/")[-1] == "nrniv":
-
-    def chkstdout(key, capture):
-        print(key, " not checked")
-
-else:
-
-    def chkstdout(key, capture):
-        chk(key, capture)
-
 
 def chkpr(key):
     chkstdout(key, capture_stdout("h.ks.pr()", True))
-
-
-# Cover KSChan::state_consist(int shift) in nrniv/kschan.cpp
-h.load_file("chanbild.hoc")
-
-# For checking if a run is doing something useful
-# To activate graphics, comment the "return" statement in
-# hrun below. Need to press the "Continue" button after each pause.
-# If the graph seems incorrect or unexpected, you can stop by hitting
-# (ctrl)C in the terminal window and then pressing the "Continue" button
-# From the exception you can determine which hrun you are stopping at.
-trec = h.Vector()
-vrec = h.Vector()
-grph = h.Graph()
 
 
 def hrun(name, t_tol=0.0, v_tol=0.0, v_tol_per_time=0.0):
@@ -120,6 +88,39 @@ def cell():
     trec.record(h._ref_t, sec=s)
     vrec.record(s(0.5)._ref_v, sec=s)
     return s, ic
+
+
+# Avoid needing different results depending on NRN_ENABLE_CORENEURON
+if hasattr(h, "usetable_hh"):
+    h.usetable_hh = False
+
+# Create a helper for managing reference results
+dir_path = os.path.dirname(os.path.realpath(__file__))
+chk = Chk(os.path.join(dir_path, "test_kschan.json"))
+
+if sys.argv[0].split("/")[-1] == "nrniv":
+
+    def chkstdout(key, capture):
+        print(key, " not checked")
+
+else:
+
+    def chkstdout(key, capture):
+        chk(key, capture)
+
+
+# Cover KSChan::state_consist(int shift) in nrniv/kschan.cpp
+h.load_file("chanbild.hoc")
+
+# For checking if a run is doing something useful
+# To activate graphics, comment the "return" statement in
+# hrun below. Need to press the "Continue" button after each pause.
+# If the graph seems incorrect or unexpected, you can stop by hitting
+# (ctrl)C in the terminal window and then pressing the "Continue" button
+# From the exception you can determine which hrun you are stopping at.
+trec = h.Vector()
+vrec = h.Vector()
+grph = h.Graph()
 
 
 def test_1():
@@ -237,7 +238,6 @@ def test_1():
     hrun("KSChanTable limits", v_tol=2e-12)
 
     del cb, s, kss, ic, std
-    locals()
 
 
 def mk_khh(chan_name, is_pnt=1):
@@ -318,7 +318,6 @@ objref ks, ksvec, ksgate, ksstates, kstransitions, tobj
 
 
 def test_2():
-    print("test_2")
     mk_khh("khh0")
     s, ic = cell()
     kchan = h.khh0(s(0.5))
@@ -328,7 +327,6 @@ def test_2():
     expect_err("h.ks.single(0)")
     chkstdout("kchan failed to turn off single", capture_stdout("h.psection()", True))
     del kchan
-    locals()
     h.ks.single(0)
     kchan = h.khh0(s(0.5))
     s.gkbar_hh = 0
@@ -367,11 +365,9 @@ def test_2():
     assert h.ks.rseed(10) == 10
 
     del s, ic
-    locals()
 
 
 def test_3():
-    print("test_3")
     # ligand tests (mostly for coverage) start with fresh channel.
     mk_khh("khh2")
     h.ion_register("ca", 2)
@@ -417,7 +413,6 @@ def test_3():
                 "KSTrans cvode={} single={}".format(bool(cvon), bool(singleon)), **tols
             )
             del kchan
-            locals()
 
     h.ks.trans(h.ks.state(2), h.ks.state(3)).type(3, "cai")
     h.ks.trans(h.ks.state(2), h.ks.state(3)).type(0)
@@ -430,11 +425,9 @@ def test_3():
     chkpr("bug? 4 ligands (cl_ion, 2 u238_ion, ca_ion), none in use")
 
     del s, ic
-    locals()
 
 
 def test_4():
-    print("test_4")
     # KSChan.iv_type tests, mostly for coverage
     mk_khh("khh3")
     kpnt = h.ks
@@ -463,10 +456,8 @@ def test_4():
             hrun("khh4 ivtype={} ion={}".format(ivtype, ion), v_tol=2e-7)
             s.uninsert("khh4")
             del kchan
-            locals()
 
     del s, ic
-    locals()
 
 
 if __name__ == "__main__":
@@ -476,4 +467,3 @@ if __name__ == "__main__":
     test_4()
 
     chk.save()
-    print("DONE")

--- a/test/hoctests/tests/test_mechfunc.py
+++ b/test/hoctests/tests/test_mechfunc.py
@@ -31,7 +31,6 @@ def model():  # 3 cables each with nseg=3
 
 
 def test1():
-    print("test1")
     s = h.Section()  # so we can delete later and verify mechs is still ok
     s.nseg = 10
     mechs = model()
@@ -58,7 +57,6 @@ def test1():
         expect_err("mechs[i].A(0, 0, 0)")
 
     del mechs, sec, i
-    locals()
 
 
 def refs(mech):
@@ -79,11 +77,9 @@ def mech_expect_invalid(mech, Af, aref):
     ]
     expect_err("print(mech.name())")
     del mech, Af, aref
-    locals()
 
 
 def test2():
-    print("test2")
     mechs = model()
     sec, seg, mech, Af, aref = refs(mechs[-1])
     assert Af.name() == "sdatats.A"  # covers NPyMechObj_name
@@ -95,11 +91,9 @@ def test2():
     mechs[-1].segment().sec.uninsert(mechs[-1].name())
     mech_expect_invalid(mech, Af, aref)
     del mechs, sec, seg, mech, Af, aref
-    locals()
 
 
 def test3():
-    print("test3")
     mechs = model()
     sec, seg, mech, Af, aref = refs(mechs[-1])
     # internal segment destroyed, should invalidate mechs[-1]
@@ -110,22 +104,18 @@ def test3():
     assert seg.x == 5.0 / 6.0
     assert str(seg) == "cable2(0.833333)"
     del mechs, sec, seg, mech, Af, aref
-    locals()
 
 
 def test4():
-    print("test4")
     mechs = model()
     sec, seg, mech, Af, aref = refs(mechs[-1])
     # section deleted, should invalidate mechs[-1]
     h.delete_section(sec=mechs[-1].segment().sec)
     mech_expect_invalid(mech, Af, aref)
     del mechs, sec, seg, mech, Af, aref
-    locals()
 
 
 def test5():
-    print("test5")
     mechs = model()
     for sec in h.allsec():
         for seg in sec:
@@ -137,7 +127,6 @@ def test5():
 
 
 def test6():
-    print("test6")
     mechs = model()
     m = mechs[0]
     expect_err("m.ft(1)")
@@ -154,7 +143,6 @@ def test6():
     assert isclose(m.bar(), 2 * m.a)
 
     del mechs, m
-    locals()
 
 
 if __name__ == "__main__":

--- a/test/hoctests/tests/test_mechstd.py
+++ b/test/hoctests/tests/test_mechstd.py
@@ -110,17 +110,11 @@ endtemplate Foo
     h.make_mechanism("foo", "Foo", "x")
 
     ms = h.MechanismStandard("foo")
-    print(ms.get("x_foo"))
 
-    print("calling mkmodel")
     s = mkmodel(["foo"])
-    print("return from mkmodel")
-    print(s(0.5).x_foo)
     ms._in(s(0.5))
-    print(ms.get("x_foo"))
     ms.set("x_foo", 6)
     ms.out(s(0.5))
-    print(s(0.5).foo.x)
     ms2 = h.MechanismStandard("foo")
     ms2._in(ms)
     assert ms2.get("x_foo") == ms.get("x_foo")
@@ -153,9 +147,7 @@ def test_mechstd5():
     pp = h.SData(model(0.5))
     pp.a = 5
     ms2 = h.MechanismStandard("SData")
-    print(pp.a)
     ms2._in(pp)
-    print(ms2.get("a"))
     h.save_session("tmp.ses")
     b.unmap()
 

--- a/test/hoctests/tests/test_mode.py
+++ b/test/hoctests/tests/test_mode.py
@@ -1,19 +1,20 @@
 from neuron import h
 
 
-"""Test to make sure mode for show can be changed with and without interviews"""
+def test_mode():
+    """Test to make sure mode for show can be changed with and without interviews"""
 
-# PlotShape
-ps = h.PlotShape()
+    # PlotShape
+    ps = h.PlotShape()
 
-for i in range(3):
-    ps.show(i)
-    if ps.show() != i:
-        raise RuntimeError("PlotShape error")
+    for i in range(3):
+        ps.show(i)
+        if ps.show() != i:
+            raise RuntimeError("PlotShape error")
 
-try:
-    ps.show(3)
-    raise Exception("ps.show should only take 0, 1, or 2")
-except RuntimeError:
-    # RuntimeError is expected because ps.show(3) should fail
-    ...
+    try:
+        ps.show(3)
+        raise Exception("ps.show should only take 0, 1, or 2")
+    except RuntimeError:
+        # RuntimeError is expected because ps.show(3) should fail
+        ...

--- a/test/hoctests/tests/test_mview.py
+++ b/test/hoctests/tests/test_mview.py
@@ -3,6 +3,8 @@
 
 from neuron import h, gui
 
-h.load_file(h.neuronhome() + "/demo/dynclamp.hoc")
-h.load_file("mview.hoc")
-h.mview()
+
+def test_mview():
+    h.load_file(h.neuronhome() + "/demo/dynclamp.hoc")
+    h.load_file("mview.hoc")
+    h.mview()

--- a/test/hoctests/tests/test_neurondemo.py
+++ b/test/hoctests/tests/test_neurondemo.py
@@ -1,9 +1,16 @@
+import io
 import os
-import pytest
-from neuron import config
+import sys
 
-from neuron.tests.utils.checkresult import Chk
+
+from math import isclose
+from platform import machine
 from subprocess import Popen, PIPE
+
+import pytest
+
+from neuron import config, h, load_mechanisms
+from neuron.tests.utils.checkresult import Chk
 
 
 @pytest.mark.skipif(
@@ -141,7 +148,6 @@ def test_neurondemo():
             except AssertionError:
                 err = 1
             if err:
-                from math import isclose
 
                 reltol = 1e-5
                 std = chk.d[key]
@@ -207,11 +213,6 @@ def test_neurondemo():
     # the neurondemo mod file shared library which will create the ca ion
     # along with several mechanisms that write to cai.
 
-    from neuron import h, load_mechanisms
-    from platform import machine
-    import sys
-    import io
-
     # return True if name exists in h
     def exists(name):
         try:
@@ -238,7 +239,6 @@ def test_neurondemo():
     # Following Aborts prior to PR#3055 with
     # eion.cpp:431: void nrn_check_conc_write(Prop*, Prop*, int): Assertion `k < sizeof(long) * 8' failed.
     nrnmechlibpath = "%s/demo/release" % h.neuronhome()
-    print(nrnmechlibpath)
     assert load_mechanisms(nrnmechlibpath)
 
     # ca_ion now exists and has a mechanism index > nion

--- a/test/hoctests/tests/test_neurondemo.py
+++ b/test/hoctests/tests/test_neurondemo.py
@@ -1,303 +1,294 @@
 import os
+import pytest
 from neuron import config
-
-# skip test if no InterViews GUI
-if not config.arguments["NRN_ENABLE_INTERVIEWS"] or os.getenv("DISPLAY") is None:
-    print("No GUI for running neurondemo. Skip this test.")
-    quit()
 
 from neuron.tests.utils.checkresult import Chk
 from subprocess import Popen, PIPE
 
-# Create a helper for managing reference results
-dir_path = os.path.dirname(os.path.realpath(__file__))
-chk = Chk(os.path.join(dir_path, "test_neurondemo.json"))
 
+@pytest.mark.skipif(
+    not config.arguments["NRN_ENABLE_INTERVIEWS"], reason="Interviews disabled"
+)
+@pytest.mark.skipif(os.getenv("DISPLAY") is None, reason="DISPLAY env variable not set")
+def test_neurondemo():
+    # TODO split this into multiple tests for easier debugging and parallelization
 
-# Run a command with input into stdin
-def run(cmd, input):
-    p = Popen(cmd, shell=True, stdin=PIPE, stdout=PIPE, stderr=PIPE, text=True)
-    return p.communicate(input=input)
+    # Create a helper for managing reference results
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    chk = Chk(os.path.join(dir_path, "test_neurondemo.json"))
 
+    # Run a command with input into stdin
+    def run(cmd, input):
+        p = Popen(cmd, shell=True, stdin=PIPE, stdout=PIPE, stderr=PIPE, text=True)
+        return p.communicate(input=input)
 
-# Attempting to run multiple demos under stdin control with one launch
-# of neurondemo with address sanitizer reveals a long-standing issue with
-# regard to accessing freed memory when destroying the gui of the previous
-# demo. This generally happens when switching away from demos that use
-# a demo specific ```destroy()``` function that closes windows with
-# the ```PWManager[0].close(i)``` method.
-# This generally does not occur during circumstances where one
-# mouses over the demos using the selection panel.
-# For this reason we run neurondemo separately while selecting only a
-# single demo. It would be nice if we could run neurondemo once and
-# cycle several times through each demo. Though that works manually for
-# version 8.2, With the current version of the master one can
-# cycle through once but not twice with the mouse.
+    # Attempting to run multiple demos under stdin control with one launch
+    # of neurondemo with address sanitizer reveals a long-standing issue with
+    # regard to accessing freed memory when destroying the gui of the previous
+    # demo. This generally happens when switching away from demos that use
+    # a demo specific ```destroy()``` function that closes windows with
+    # the ```PWManager[0].close(i)``` method.
+    # This generally does not occur during circumstances where one
+    # mouses over the demos using the selection panel.
+    # For this reason we run neurondemo separately while selecting only a
+    # single demo. It would be nice if we could run neurondemo once and
+    # cycle several times through each demo. Though that works manually for
+    # version 8.2, With the current version of the master one can
+    # cycle through once but not twice with the mouse.
 
-# HOC: select demo, run, and print all lines on all Graphs
-#  After selecting demo and before run, allow modifications
-input = r"""
-proc dodemo() {
-  usetable_hh = 0 // Compatible with -DNRN_ENABLE_CORENEURON=ON
-  demo(%d)
-  %s
-  run()
-  printf("\nZZZbegin\n")
-  prgraphs()
-  printf("ZZZend\n")
-}
-dodemo()
-quit()
-"""
-
-
-# run neurondemo and return the stdout lines between ZZZbegin and ZZZend
-def neurondemo(extra, input):
-    input = extra + input
-    stdout, stderr = run("neurondemo -nobanner", input)
-    stdout = stdout.splitlines()
-    stderr = stderr.splitlines()
-    if len(stderr) != 0:
-        for line in stderr:
-            print("stderr:", line.strip())
-        raise Exception("Unexpected stderr")
-    begin_index = stdout.index("ZZZbegin")
-    end_index = stdout.index("ZZZend")
-    prefix = stdout[:begin_index]
-    suffix = stdout[end_index + 1 :]
-    if len(prefix):
-        print("stdout prefix, excluded from comparison:")
-        for line in prefix:
-            print("stdout:", line.strip())
-    if len(suffix):
-        print("stdout suffix, excluded from comparison:")
-        for line in suffix:
-            print("stdout:", line.strip())
-    return stdout[begin_index + 1 : end_index]
-
-
-# HOC: procedure to print all lines of all Graphs
-prgraphs = r"""
-proc prgraphs() {local i, j, k  localobj xvec, yvec, glist
-  xvec = new Vector()
-  yvec = new Vector()
-  glist = new List("Graph")
-  printf("Graphs %d\n", glist.count)
-  for i=0, glist.count-1 {
-    printf("%s\n", glist.o(i))
-    k = 0
-    for (j=-1; (j=glist.o(i).line_info(j, xvec)) != -1; ){
-      k += 1
+    # HOC: select demo, run, and print all lines on all Graphs
+    #  After selecting demo and before run, allow modifications
+    input = r"""
+    proc dodemo() {
+      usetable_hh = 0 // Compatible with -DNRN_ENABLE_CORENEURON=ON
+      demo(%d)
+      %s
+      run()
+      printf("\nZZZbegin\n")
+      prgraphs()
+      printf("ZZZend\n")
     }
-    printf("lines %d\n", k)
-    for (j=-1; (j=glist.object(i).getline(j, xvec, yvec)) != -1; ){
-      printf("points %d\n", xvec.size)
-      printf("xvec%d\n", j)
-      xvec.printf("%g\n")
-      printf("yvec%d\n", j)
-      yvec.printf("%g\n")
+    dodemo()
+    quit()
+    """
+
+    # run neurondemo and return the stdout lines between ZZZbegin and ZZZend
+    def neurondemo(extra, input):
+        input = extra + input
+        stdout, stderr = run("neurondemo -nobanner", input)
+        stdout = stdout.splitlines()
+        stderr = stderr.splitlines()
+        if len(stderr) != 0:
+            for line in stderr:
+                print("stderr:", line.strip())
+            raise Exception("Unexpected stderr")
+        begin_index = stdout.index("ZZZbegin")
+        end_index = stdout.index("ZZZend")
+        prefix = stdout[:begin_index]
+        suffix = stdout[end_index + 1 :]
+        if len(prefix):
+            print("stdout prefix, excluded from comparison:")
+            for line in prefix:
+                print("stdout:", line.strip())
+        if len(suffix):
+            print("stdout suffix, excluded from comparison:")
+            for line in suffix:
+                print("stdout:", line.strip())
+        return stdout[begin_index + 1 : end_index]
+
+    # HOC: procedure to print all lines of all Graphs
+    prgraphs = r"""
+    proc prgraphs() {local i, j, k  localobj xvec, yvec, glist
+      xvec = new Vector()
+      yvec = new Vector()
+      glist = new List("Graph")
+      printf("Graphs %d\n", glist.count)
+      for i=0, glist.count-1 {
+        printf("%s\n", glist.o(i))
+        k = 0
+        for (j=-1; (j=glist.o(i).line_info(j, xvec)) != -1; ){
+          k += 1
+        }
+        printf("lines %d\n", k)
+        for (j=-1; (j=glist.object(i).getline(j, xvec, yvec)) != -1; ){
+          printf("points %d\n", xvec.size)
+          printf("xvec%d\n", j)
+          xvec.printf("%g\n")
+          printf("yvec%d\n", j)
+          yvec.printf("%g\n")
+        }
+      }
     }
-  }
-}
-"""
+    """
 
+    def data_compare(key, data):
+        data.reverse()
+        # parse the prgraphs output back into a rich structure
+        rich_data = []
+        graphs, num_graphs = data.pop().split(maxsplit=1)
+        assert graphs == "Graphs"
+        num_graphs = int(num_graphs)
+        for i_graph in range(num_graphs):
+            graph_name = data.pop()
+            lines, num_lines = data.pop().split(maxsplit=1)
+            assert lines == "lines"
+            num_lines = int(num_lines)
+            lines = []
+            for i_line in range(num_lines):
+                points, num_points = data.pop().split(maxsplit=1)
+                assert points == "points"
+                num_points = int(num_points)
+                # not clear if the number after xvec is useful
+                assert data.pop().startswith("xvec")
+                xvals = [data.pop() for _ in range(num_points)]
+                # not clear if the number after yvec is useful
+                assert data.pop().startswith("yvec")
+                yvals = [data.pop() for _ in range(num_points)]
+                lines.append({"x": xvals, "y": yvals})
+            rich_data.append([graph_name, lines])
+        # we should have munched everything
+        assert len(data) == 0
 
-def data_compare(key, data):
-    data.reverse()
-    # parse the prgraphs output back into a rich structure
-    rich_data = []
-    graphs, num_graphs = data.pop().split(maxsplit=1)
-    assert graphs == "Graphs"
-    num_graphs = int(num_graphs)
-    for i_graph in range(num_graphs):
-        graph_name = data.pop()
-        lines, num_lines = data.pop().split(maxsplit=1)
-        assert lines == "lines"
-        num_lines = int(num_lines)
-        lines = []
-        for i_line in range(num_lines):
-            points, num_points = data.pop().split(maxsplit=1)
-            assert points == "points"
-            num_points = int(num_points)
-            # not clear if the number after xvec is useful
-            assert data.pop().startswith("xvec")
-            xvals = [data.pop() for _ in range(num_points)]
-            # not clear if the number after yvec is useful
-            assert data.pop().startswith("yvec")
-            yvals = [data.pop() for _ in range(num_points)]
-            lines.append({"x": xvals, "y": yvals})
-        rich_data.append([graph_name, lines])
-    # we should have munched everything
-    assert len(data) == 0
-
-    if os.uname().sysname == "Darwin":
-        # Sometimes a Graph y value str differs in last digit by 1
-        # Perhaps a locale issue? But float32->float64->str can differ
-        # between machines. For this reason, if a number str is not
-        # identical, demand the relative difference < 1e-5 (float32 accuracy)
-        err = 0
-        try:
+        if os.uname().sysname == "Darwin":
+            # Sometimes a Graph y value str differs in last digit by 1
+            # Perhaps a locale issue? But float32->float64->str can differ
+            # between machines. For this reason, if a number str is not
+            # identical, demand the relative difference < 1e-5 (float32 accuracy)
             err = 0
+            try:
+                err = 0
+                chk(key, rich_data)
+            except AssertionError:
+                err = 1
+            if err:
+                from math import isclose
+
+                reltol = 1e-5
+                std = chk.d[key]
+
+                for ig, gstd in enumerate(std):
+                    gname = gstd[0]
+                    for iline, line in enumerate(gstd[1]):
+                        for coord in line:
+                            vstd = [float(a) for a in line[coord]]
+                            vd = [float(a) for a in rich_data[ig][1][iline][coord]]
+                            if vstd != vd:
+                                for i, sval in enumerate(vstd):
+                                    if not isclose(sval, vd[i], rel_tol=reltol):
+                                        print(
+                                            gname,
+                                            iline,
+                                            coord,
+                                            i,
+                                            ": %g %g" % (sval, vd[i]),
+                                        )
+                                        assert isclose(sval, vd[i], rel_tol=reltol)
+                                print(
+                                    gname,
+                                    iline,
+                                    coord,
+                                    " float32 not identical but within rel_tol=%g"
+                                    % reltol,
+                                )
+        else:
             chk(key, rich_data)
-        except AssertionError:
-            err = 1
-        if err:
-            from math import isclose
 
-            reltol = 1e-5
-            std = chk.d[key]
+    # Run all the demos and compare their results to the reference
+    for i in range(1, 8):
+        data = neurondemo(prgraphs, input % (i, ""))
+        key = f"demo{i}"
+        data_compare(key, data)
 
-            for ig, gstd in enumerate(std):
-                gname = gstd[0]
-                for iline, line in enumerate(gstd[1]):
-                    for coord in line:
-                        vstd = [float(a) for a in line[coord]]
-                        vd = [float(a) for a in rich_data[ig][1][iline][coord]]
-                        if vstd != vd:
-                            for i, sval in enumerate(vstd):
-                                if not isclose(sval, vd[i], rel_tol=reltol):
-                                    print(
-                                        gname,
-                                        iline,
-                                        coord,
-                                        i,
-                                        ": %g %g" % (sval, vd[i]),
-                                    )
-                                    assert isclose(sval, vd[i], rel_tol=reltol)
-                            print(
-                                gname,
-                                iline,
-                                coord,
-                                " float32 not identical but within rel_tol=%g" % reltol,
-                            )
-    else:
-        chk(key, rich_data)
+    def special_run(key, demo_index, pre_run_stmts):
+        data = neurondemo(prgraphs, input % (demo_index, pre_run_stmts))
+        data_compare(key, data)
 
+    # For full coverage of #3454, do another run of Dynamic Clamp with cvode active.
+    special_run("cover3454", 6, "cvode_active(1)")
 
-# Run all the demos and compare their results to the reference
-for i in range(1, 8):
-    data = neurondemo(prgraphs, input % (i, ""))
-    key = f"demo{i}"
-    data_compare(key, data)
+    chk.save()
 
+    ################################################
+    # test_many_ions.py copied below and removed to fix a CI coverage test failure:
+    # libgcov profiling error:/home/...demo/release/x86_64/mod_func.gcda:overwriting
+    # an existing profile data with a different timestamp.
+    # I was unable to reproduce the coverage test failure on my linux desktop by
+    # experimenting with parallel runs of the distinct tests. Nevertheless,
+    # CI coverage is successful when the use of the neurondemo shared library is
+    # serialized into this file.
+    # I'd rather keep the file and run from here via something like
+    # run("python test_many_ions.py", "")
+    # but cmake installs each hoctest file in a separate folder and "python" may not
+    # be the name of the program we need to run.
+    ###########################
+    # Test when large number of ion mechanisms exist.
 
-def special_run(key, demo_index, pre_run_stmts):
-    data = neurondemo(prgraphs, input % (demo_index, pre_run_stmts))
-    data_compare(key, data)
+    # Strategy is to create a large number of ion mechanisms before loading
+    # the neurondemo mod file shared library which will create the ca ion
+    # along with several mechanisms that write to cai.
 
+    from neuron import h, load_mechanisms
+    from platform import machine
+    import sys
+    import io
 
-# For full coverage of #3454, do another run of Dynamic Clamp with cvode active.
-special_run("cover3454", 6, "cvode_active(1)")
+    # return True if name exists in h
+    def exists(name):
+        try:
+            exec("h.%s" % name)
+        except:
+            return False
+        return True
 
-chk.save()
+    # use up a large number of mechanism indices for ions. And want to test beyond
+    # 1000 which requires change to max_ions in nrn/src/nrnoc/eion.cpp
+    nion = 250
+    ion_indices = [int(h.ion_register("ca%d" % i, 2)) for i in range(1, nion + 1)]
+    # gain some confidence they exist
+    assert exists("ca%d_ion" % nion)
+    assert (ion_indices[-1] - ion_indices[0]) == (nion - 1)
+    mt = h.MechanismType(0)
+    assert mt.count() > nion
 
-################################################
-# test_many_ions.py copied below and removed to fix a CI coverage test failure:
-# libgcov profiling error:/home/...demo/release/x86_64/mod_func.gcda:overwriting
-# an existing profile data with a different timestamp.
-# I was unable to reproduce the coverage test failure on my linux desktop by
-# experimenting with parallel runs of the distinct tests. Nevertheless,
-# CI coverage is successful when the use of the neurondemo shared library is
-# serialized into this file.
-# I'd rather keep the file and run from here via something like
-# run("python test_many_ions.py", "")
-# but cmake installs each hoctest file in a separate folder and "python" may not
-# be the name of the program we need to run.
-###########################
-# Test when large number of ion mechanisms exist.
+    # this test depends on the ca ion not existing at this point
+    assert exists("ca_ion") is False
 
-# Strategy is to create a large number of ion mechanisms before loading
-# the neurondemo mod file shared library which will create the ca ion
-# along with several mechanisms that write to cai.
+    # load neurondemo mod files. That will create ca_ion and provide two
+    # mod files that write cai
+    # Following Aborts prior to PR#3055 with
+    # eion.cpp:431: void nrn_check_conc_write(Prop*, Prop*, int): Assertion `k < sizeof(long) * 8' failed.
+    nrnmechlibpath = "%s/demo/release" % h.neuronhome()
+    print(nrnmechlibpath)
+    assert load_mechanisms(nrnmechlibpath)
 
-from neuron import h, load_mechanisms
-from platform import machine
-import sys
-import io
+    # ca_ion now exists and has a mechanism index > nion
+    assert exists("ca_ion")
+    mt = h.MechanismType(0)  # new mechanisms do not appear in old MechanismType
+    mt.select("ca_ion")
+    assert mt.selected() > nion
 
+    # return stderr output resulting from sec.insert(mechname)
+    def mech_insert(sec, mechname):
+        # capture stderr
+        old_stderr = sys.stderr
+        sys.stderr = mystderr = io.StringIO()
 
-# return True if name exists in h
-def exists(name):
-    try:
-        exec("h.%s" % name)
-    except:
-        return False
-    return True
+        sec.insert(mechname)
 
+        sys.stderr = old_stderr
+        return mystderr.getvalue()
 
-# use up a large number of mechanism indices for ions. And want to test beyond
-# 1000 which requires change to max_ions in nrn/src/nrnoc/eion.cpp
-nion = 250
-ion_indices = [int(h.ion_register("ca%d" % i, 2)) for i in range(1, nion + 1)]
-# gain some confidence they exist
-assert exists("ca%d_ion" % nion)
-assert (ion_indices[-1] - ion_indices[0]) == (nion - 1)
-mt = h.MechanismType(0)
-assert mt.count() > nion
+    # test if can use the high mechanism index cadifpmp (with USEION ... WRITE cai) along with the high mechanims index ca_ion
+    s = h.Section()
+    s.insert("cadifpmp")
+    h.finitialize(-65)
+    # The ion_style tells whether cai or cao is being written
+    istyle = int(h.ion_style("ca_ion", sec=s))
+    assert istyle & 0o200  # writing cai
+    assert (istyle & 0o400) == 0  # not writing ca0
+    # unfortunately, at present, uninserting does not turn off that bit
+    s.uninsert("cadifpmp")
+    assert s.has_membrane("cadifpmp") is False
+    assert int(h.ion_style("ca_ion", sec=s)) & 0o200
+    # nevertheless, on reinsertion, there is no warning, so can't test the
+    # warning without a second mechanism that WRITE cai
+    assert mech_insert(s, "cadifpmp") == ""
+    assert s.has_membrane("cadifpmp")
+    # uninsert again and insert another mechanism that writes.
+    s.uninsert("cadifpmp")
+    assert mech_insert(s, "capmpr") == ""  # no warning
+    assert mech_insert(s, "cadifpmp") != ""  # now there is a warning.
 
-# this test depends on the ca ion not existing at this point
-assert exists("ca_ion") is False
+    # more serious test
+    # several sections with alternating cadifpmp and capmpr
+    del s
+    secs = [h.Section() for i in range(5)]
+    for i, s in enumerate(secs):
+        if i % 2:
+            assert mech_insert(s, "capmpr") == ""
+        else:
+            assert mech_insert(s, "cadifpmp") == ""
 
-# load neurondemo mod files. That will create ca_ion and provide two
-# mod files that write cai
-# Following Aborts prior to PR#3055 with
-# eion.cpp:431: void nrn_check_conc_write(Prop*, Prop*, int): Assertion `k < sizeof(long) * 8' failed.
-nrnmechlibpath = "%s/demo/release" % h.neuronhome()
-print(nrnmechlibpath)
-assert load_mechanisms(nrnmechlibpath)
-
-# ca_ion now exists and has a mechanism index > nion
-assert exists("ca_ion")
-mt = h.MechanismType(0)  # new mechanisms do not appear in old MechanismType
-mt.select("ca_ion")
-assert mt.selected() > nion
-
-
-# return stderr output resulting from sec.insert(mechname)
-def mech_insert(sec, mechname):
-    # capture stderr
-    old_stderr = sys.stderr
-    sys.stderr = mystderr = io.StringIO()
-
-    sec.insert(mechname)
-
-    sys.stderr = old_stderr
-    return mystderr.getvalue()
-
-
-# test if can use the high mechanism index cadifpmp (with USEION ... WRITE cai) along with the high mechanims index ca_ion
-s = h.Section()
-s.insert("cadifpmp")
-h.finitialize(-65)
-# The ion_style tells whether cai or cao is being written
-istyle = int(h.ion_style("ca_ion", sec=s))
-assert istyle & 0o200  # writing cai
-assert (istyle & 0o400) == 0  # not writing ca0
-# unfortunately, at present, uninserting does not turn off that bit
-s.uninsert("cadifpmp")
-assert s.has_membrane("cadifpmp") is False
-assert int(h.ion_style("ca_ion", sec=s)) & 0o200
-# nevertheless, on reinsertion, there is no warning, so can't test the
-# warning without a second mechanism that WRITE cai
-assert mech_insert(s, "cadifpmp") == ""
-assert s.has_membrane("cadifpmp")
-# uninsert again and insert another mechanism that writes.
-s.uninsert("cadifpmp")
-assert mech_insert(s, "capmpr") == ""  # no warning
-assert mech_insert(s, "cadifpmp") != ""  # now there is a warning.
-
-# more serious test
-# several sections with alternating cadifpmp and capmpr
-del s
-secs = [h.Section() for i in range(5)]
-for i, s in enumerate(secs):
-    if i % 2:
-        assert mech_insert(s, "capmpr") == ""
-    else:
-        assert mech_insert(s, "cadifpmp") == ""
-
-# warnings due to multiple mechanisms at same location that WRITE cai
-assert mech_insert(secs[2], "capmpr") != ""
-assert mech_insert(secs[3], "cadifpmp") != ""
-
-############################################
+    # warnings due to multiple mechanisms at same location that WRITE cai
+    assert mech_insert(secs[2], "capmpr") != ""
+    assert mech_insert(secs[3], "cadifpmp") != ""

--- a/test/hoctests/tests/test_nrniv-launch.py
+++ b/test/hoctests/tests/test_nrniv-launch.py
@@ -7,7 +7,6 @@ import pytest
 
 
 def nrniv(args, input):
-    print(args, input)
     # nrniv is a NEURON executable, so it will be linked against any sanitizer
     # runtimes that are required => LD_PRELOAD is not needed. Delete LD_PRELOAD
     # if it is present, because if dynamic Python is enabled then nrniv will

--- a/test/hoctests/tests/test_nrniv-launch.py
+++ b/test/hoctests/tests/test_nrniv-launch.py
@@ -3,9 +3,7 @@ import shutil
 import subprocess
 from sys import platform
 
-if platform == "win32":  # skip the test.
-    # Cannot get subprocess.run to feed stdin to nrniv
-    quit()
+import pytest
 
 
 def nrniv(args, input):
@@ -31,24 +29,29 @@ def nrniv(args, input):
     )
 
 
-r = nrniv(
-    args=["-isatty", "-nobanner", "-nogui", "-c", "a=5", "-"],
-    input=r"""
-func square() {
-  return $1*$1
-}
-print "a = ", a
-print "square(a)=", square(a)
-quit()
-
-""",
+@pytest.mark.skipif(
+    platform == "win32", reason="Cannot get subprocess.run to feed stdin to nrniv"
 )
+def test_nrniv():
 
-print("status={}".format(r.returncode))
-print("stdout\n----\n{}----".format(r.stdout))
-print("stderr\n----\n{}----".format(r.stderr))
-assert r.returncode == 0
-assert "square(a)=25" in r.stdout
-if platform != "darwin":  # Mac does not print the "oc>" prompt
-    assert "oc>quit()" in r.stdout
-assert len(r.stderr) == 0
+    r = nrniv(
+        args=["-isatty", "-nobanner", "-nogui", "-c", "a=5", "-"],
+        input=r"""
+    func square() {
+      return $1*$1
+    }
+    print "a = ", a
+    print "square(a)=", square(a)
+    quit()
+
+    """,
+    )
+
+    print("status={}".format(r.returncode))
+    print("stdout\n----\n{}----".format(r.stdout))
+    print("stderr\n----\n{}----".format(r.stderr))
+    assert r.returncode == 0
+    assert "square(a)=25" in r.stdout
+    if platform != "darwin":  # Mac does not print the "oc>" prompt
+        assert "oc>quit()" in r.stdout
+    assert len(r.stderr) == 0

--- a/test/hoctests/tests/test_optim_node_order.py
+++ b/test/hoctests/tests/test_optim_node_order.py
@@ -2,12 +2,6 @@ from neuron import h
 from neuron.tests.utils.checkresult import Chk
 import os
 
-# Create a helper for managing reference results
-dir_path = os.path.dirname(os.path.realpath(__file__))
-chk = Chk(os.path.join(dir_path, "test_optim_node_order.json"))
-
-pc = h.ParallelContext()
-
 # Default Node order for simulation given a particular construction order
 # is the order of section creation.
 
@@ -30,45 +24,6 @@ class Cell:
         return "Cell_%d" % self.id
 
 
-cells = [Cell(id) for id in range(1, 4)]
-
-pr = False
-
-
-def printv():
-    s = {}  # associate root sections with thread id.
-    for i in range(pc.nthread()):
-        for sec in pc.get_partition(i):
-            s[sec] = i
-    if pr:
-        print(s)
-    ns = 0
-    for sec in h.allsec():
-        for seg in sec.allseg():
-            if pr:
-                print(
-                    seg,
-                    seg.v,
-                    seg.node_index(),
-                    seg._ref_v,
-                    str(s[sec] if sec in s else ""),
-                )
-            ns += 1
-
-    names = [None for i in range(ns)]
-    for sec in h.allsec():
-        for seg in sec.allseg():
-            ix = int(str(seg._ref_v).split()[1][4:].split("/")[0])
-            names[ix] = seg.v
-    for i, seg in enumerate(names):
-        if pr:
-            print(i, seg)
-    tag = "node order %d   nthread %d" % (pc.optimize_node_order(), pc.nthread())
-    chk(tag, names)
-
-
-# printv()
-
 # Iteration order (sec,seg) is associated with construction order
 # (provided nseg set after each section construction?)
 # and the only difference in simulation order is that all root nodes are at the beginning.
@@ -88,8 +43,52 @@ def p():
         pvmes(i)
 
 
-p()
-pc.nthread(2)
-p()
+def test_optim_node_order():
+    # Create a helper for managing reference results
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    chk = Chk(os.path.join(dir_path, "test_optim_node_order.json"))
 
-chk.save()
+    pc = h.ParallelContext()
+
+    cells = [Cell(id) for id in range(1, 4)]
+
+    pr = False
+
+    def printv():
+        s = {}  # associate root sections with thread id.
+        for i in range(pc.nthread()):
+            for sec in pc.get_partition(i):
+                s[sec] = i
+        if pr:
+            print(s)
+        ns = 0
+        for sec in h.allsec():
+            for seg in sec.allseg():
+                if pr:
+                    print(
+                        seg,
+                        seg.v,
+                        seg.node_index(),
+                        seg._ref_v,
+                        str(s[sec] if sec in s else ""),
+                    )
+                ns += 1
+
+        names = [None for i in range(ns)]
+        for sec in h.allsec():
+            for seg in sec.allseg():
+                ix = int(str(seg._ref_v).split()[1][4:].split("/")[0])
+                names[ix] = seg.v
+        for i, seg in enumerate(names):
+            if pr:
+                print(i, seg)
+        tag = "node order %d   nthread %d" % (pc.optimize_node_order(), pc.nthread())
+        chk(tag, names)
+
+    # printv()
+
+    p()
+    pc.nthread(2)
+    p()
+
+    chk.save()

--- a/test/hoctests/tests/test_optim_node_order.py
+++ b/test/hoctests/tests/test_optim_node_order.py
@@ -1,9 +1,19 @@
+import os
+
 from neuron import h
 from neuron.tests.utils.checkresult import Chk
-import os
 
 # Default Node order for simulation given a particular construction order
 # is the order of section creation.
+# Create a helper for managing reference results
+dir_path = os.path.dirname(os.path.realpath(__file__))
+chk = Chk(os.path.join(dir_path, "test_optim_node_order.json"))
+
+
+pr = False
+
+
+pc = h.ParallelContext()
 
 
 class Cell:
@@ -23,6 +33,8 @@ class Cell:
     def __str__(self):
         return "Cell_%d" % self.id
 
+
+cells = [Cell(id) for id in range(1, 4)]
 
 # Iteration order (sec,seg) is associated with construction order
 # (provided nseg set after each section construction?)
@@ -44,16 +56,6 @@ def p():
 
 
 def test_optim_node_order():
-    # Create a helper for managing reference results
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    chk = Chk(os.path.join(dir_path, "test_optim_node_order.json"))
-
-    pc = h.ParallelContext()
-
-    cells = [Cell(id) for id in range(1, 4)]
-
-    pr = False
-
     def printv():
         s = {}  # associate root sections with thread id.
         for i in range(pc.nthread()):

--- a/test/hoctests/tests/test_random.py
+++ b/test/hoctests/tests/test_random.py
@@ -4,132 +4,133 @@ from neuron.tests.utils.checkresult import Chk
 import os
 import math
 
-pc = h.ParallelContext()
 
-dir_path = os.path.dirname(os.path.realpath(__file__))
-chk = Chk(os.path.join(dir_path, "test_random.json"))
+def test_random():
+    pc = h.ParallelContext()
 
-set_quiet(False)
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    chk = Chk(os.path.join(dir_path, "test_random.json"))
 
-z = h.List("NMODLRandom")
+    set_quiet(False)
 
-# ARTIFICIAL_CELL syntax tests
-rt = h.RanArt()
+    z = h.List("NMODLRandom")
 
-print(rt.ran1)
-assert z.count() == 0
-assert rt.ran1.set_seq(5).set_ids(7, 8, 9).get_seq() == 5
-assert rt.ran1.get_ids().x[2] == 9
-assert z.count() == 0
+    # ARTIFICIAL_CELL syntax tests
+    rt = h.RanArt()
 
-x = rt.ran1
-x.set_seq(25)
-assert rt.ran1.get_seq() == 25
-assert z.count() == 1
-assert x.get_ids().x[1] == 8
+    assert z.count() == 0
+    assert rt.ran1.set_seq(5).set_ids(7, 8, 9).get_seq() == 5
+    assert rt.ran1.get_ids().x[2] == 9
+    assert z.count() == 0
 
-y = rt.ran1.set_seq
-y(50)
-assert x.get_seq() == 50
+    x = rt.ran1
+    x.set_seq(25)
+    assert rt.ran1.get_seq() == 25
+    assert z.count() == 1
+    assert x.get_ids().x[1] == 8
 
-del x, y
-assert z.count() == 0
+    y = rt.ran1.set_seq
+    y(50)
+    assert x.get_seq() == 50
 
-x = rt.ran1
-expect_err("rt.ran1 = rt.ran2")  # cannot assign
-del rt
-expect_err("x.get_seq()")
-del x
-assert z.count() == 0
+    del x, y
+    assert z.count() == 0
 
-# density mechanism tests
-cable = h.Section(name="cable")
-cable.nseg = 3
-cable.insert("rantst")
-nr = [(seg.x, seg.rantst.ran1) for seg in cable]
-for r in nr:
-    assert r[1].get_ids().eq(cable(r[0]).ran1_rantst.get_ids())
-del nr, r
-assert z.count() == 0
+    x = rt.ran1
+    expect_err("rt.ran1 = rt.ran2")  # cannot assign
+    del rt
+    expect_err("x.get_seq()")
+    del x
+    assert z.count() == 0
 
-rt = h.RanArt()
-r1 = rt.ran1
-# wrap around at end
-assert r1.set_seq(2**34 - 1).get_seq() == (2**34 - 1)
-r1.uniform()
-assert r1.get_seq() == 0
-assert r1.set_seq(2**34 + 1).get_seq() == 1
-assert r1.set_seq(-10).get_seq() == 0  # all neg setseq to 0
-assert r1.set_seq(2**40 - 1).get_seq() == 17179869183.0  # up to 2**40 wrap
-assert r1.set_seq(2**40 + 1).get_seq() == 0  # all above 2**40 setseq to 0
+    # density mechanism tests
+    cable = h.Section(name="cable")
+    cable.nseg = 3
+    cable.insert("rantst")
+    nr = [(seg.x, seg.rantst.ran1) for seg in cable]
+    for r in nr:
+        assert r[1].get_ids().eq(cable(r[0]).ran1_rantst.get_ids())
+    del nr, r
+    assert z.count() == 0
 
-# negexp(mean) has proper scale
-r1.set_seq(0)
-x = rt.negexp0()
-r1.set_seq(0)
-assert math.isclose(rt.negexp1(5), 5 * x)
+    rt = h.RanArt()
+    r1 = rt.ran1
+    # wrap around at end
+    assert r1.set_seq(2**34 - 1).get_seq() == (2**34 - 1)
+    r1.uniform()
+    assert r1.get_seq() == 0
+    assert r1.set_seq(2**34 + 1).get_seq() == 1
+    assert r1.set_seq(-10).get_seq() == 0  # all neg setseq to 0
+    assert r1.set_seq(2**40 - 1).get_seq() == 17179869183.0  # up to 2**40 wrap
+    assert r1.set_seq(2**40 + 1).get_seq() == 0  # all above 2**40 setseq to 0
 
-r1 = h.NMODLRandom()
-expect_err("r1.uniform()")
-del r1
+    # negexp(mean) has proper scale
+    r1.set_seq(0)
+    x = rt.negexp0()
+    r1.set_seq(0)
+    assert math.isclose(rt.negexp1(5), 5 * x)
 
-# test the mod random_... functions
-rt = h.RanArt()
-cable = h.Section(name="cable")
-cable.nseg = 3
-cable.insert("rantst")
-mlist = [rt]
-mlist.extend(seg.rantst for seg in cable)
-for i, m in enumerate(mlist):
-    m.ran1.set_ids(i, 1, 0).set_seq(0)
-    m.ran2.set_ids(i, 2, 0).set_seq(0)
+    r1 = h.NMODLRandom()
+    expect_err("r1.uniform()")
+    del r1
 
-results = []
-for m in mlist:
-    results.extend([m.uniform0(), m.negexp0(), m.normal0()])
-    results.extend(
-        [
-            m.uniform2(10, 20),
-            m.negexp1(5),
-            m.normal2(5, 8),
-        ]
-    )
-    results.extend([m.ran1.uniform(), m.ran2.uniform()])
-for m in mlist:
-    results.extend([m.ran1.get_seq(), m.ran2.get_seq()])
+    # test the mod random_... functions
+    rt = h.RanArt()
+    cable = h.Section(name="cable")
+    cable.nseg = 3
+    cable.insert("rantst")
+    mlist = [rt]
+    mlist.extend(seg.rantst for seg in cable)
+    for i, m in enumerate(mlist):
+        m.ran1.set_ids(i, 1, 0).set_seq(0)
+        m.ran2.set_ids(i, 2, 0).set_seq(0)
 
-assert z.count() == 0
+    results = []
+    for m in mlist:
+        results.extend([m.uniform0(), m.negexp0(), m.normal0()])
+        results.extend(
+            [
+                m.uniform2(10, 20),
+                m.negexp1(5),
+                m.normal2(5, 8),
+            ]
+        )
+        results.extend([m.ran1.uniform(), m.ran2.uniform()])
+    for m in mlist:
+        results.extend([m.ran1.get_seq(), m.ran2.get_seq()])
 
-chk("results", results, tol=1e-12)
+    assert z.count() == 0
 
-# test access to hoc cell class
-h(
+    chk("results", results, tol=1e-12)
+
+    # test access to hoc cell class
+    h(
+        """
+    begintemplate Cell
+    public cable, rt
+    create cable
+    objref rpp, rart
+    proc init() {
+      create cable
+      cable {
+        nseg = 3
+        insert rantst
+        rpp = new RanPP(0.1) 
+      }
+      rart = new RanArt()
+      rart.mean = 0.1
+    }
+    endtemplate Cell
     """
-begintemplate Cell
-public cable, rt
-create cable
-objref rpp, rart
-proc init() {
-  create cable
-  cable {
-    nseg = 3
-    insert rantst
-    rpp = new RanPP(0.1) 
-  }
-  rart = new RanArt()
-  rart.mean = 0.1
-}
-endtemplate Cell
-"""
-)
-cell = h.Cell()
-cell.cable(0.1).ran2_rantst.set_seq(10).set_ids(8, 9, 10)
-cell.cable(0.5).ran2_rantst.set_seq(11).set_ids(1, 2, 3)
-assert cell.cable(0.1).rantst.ran2.get_seq() == 10
+    )
+    cell = h.Cell()
+    cell.cable(0.1).ran2_rantst.set_seq(10).set_ids(8, 9, 10)
+    cell.cable(0.5).ran2_rantst.set_seq(11).set_ids(1, 2, 3)
+    assert cell.cable(0.1).rantst.ran2.get_seq() == 10
 
-rp = cell.rpp
-del cell
-expect_err("rp.ran2")
+    rp = cell.rpp
+    del cell
+    expect_err("rp.ran2")
 
 
 def set_gids(cells):
@@ -171,8 +172,3 @@ def test_bbsavestate():
     bbss.restore("bbss_random.txt")
     run(2, False)
     chk("bbsavestate 1 to 2", [v.to_python() for v in rec], tol=1e-12)
-
-
-test_bbsavestate()
-
-chk.save()

--- a/test/hoctests/tests/test_seclist.py
+++ b/test/hoctests/tests/test_seclist.py
@@ -1,9 +1,8 @@
 from neuron import h
 
-secs = [h.Section() for _ in range(10)]
 
-
-def test():
+def test_seclist():
+    secs = [h.Section() for _ in range(10)]
     sl = h.SectionList()
     sl.allroots()
     assert len(sl) == len(list(sl))
@@ -12,7 +11,7 @@ def test():
     for i in range(n):
         for j in range(n):
             assert b[i * n + j][0] == b[i + j * n][1]
-    return sl
 
 
-sl = test()
+if __name__ == "__main__":
+    test_seclist()

--- a/test/hoctests/tests/test_secref.py
+++ b/test/hoctests/tests/test_secref.py
@@ -1,138 +1,135 @@
 from neuron import h
 from neuron.expect_hocerr import expect_err, set_quiet
 
-set_quiet(0)
 
-# SectionRef unname and rename are undocumented but used in implementation
-# of CellBuild
-
-h("create a")
-sr = h.SectionRef(sec=h.a)
-assert sr.sec.name() == "a"
-assert sr.rename("b") == 0  # must first be unnamed
-sr.unname()
-expect_err("sr.unname()")  # already unnamed
-h("foo = 1")
-assert sr.rename("foo") == 0  # already exists
-sr.rename("b")
-assert sr.sec.name() == "b"
-h.delete_section(sec=h.b)
-assert sr.rename("c") == 0
-
-h("create a, b[3]")
-sr = h.SectionRef(sec=h.a)
-sr.unname()
-sr.rename("b")  # no longer an array and the old 3 are deleted
-assert sr.sec.name() == "b"
-h.delete_section(sec=h.b)
-
-# rename a bunch as an array
-h("create a, b, c, d")
-sr = None  # let's start over at 0
-sr = [h.SectionRef(sec=i) for i in h.allsec()]
-assert len(sr) == 4
-
-# the ones to rename into a new array
-lst = h.List()
-for i in [0, 2, 3]:
-    lst.append(sr[i])
-sr[0].unname()
-assert sr[0].rename("x", lst) == 0  # have not unnamed c and d
-for i in lst:
-    i.unname()
-assert sr[0].rename("x", lst) == 1
-h.topology()
-print("cover a deleted section message")
-h.delete_section(sec=h.x[1])
-sr[0].unname()
-assert sr[0].rename("y", lst) == 0
-h.topology()
-
-
-# cleanup
 def cleanup():
     for sec in h.allsec():
         h.delete_section(sec=sec)
 
 
-cleanup()
+def test_secref():
+    set_quiet(0)
 
-# Python sections cannot be unnamed or renamed
-a = h.Section("a")
-sr = h.SectionRef(sec=a)
-assert sr.unname() == 0
-assert a.name() == "a"
-assert sr.rename("b") == 0
-assert a.name() == "a"
-cleanup()
+    # SectionRef unname and rename are undocumented but used in implementation
+    # of CellBuild
 
+    h("create a")
+    sr = h.SectionRef(sec=h.a)
+    assert sr.sec.name() == "a"
+    assert sr.rename("b") == 0  # must first be unnamed
+    sr.unname()
+    expect_err("sr.unname()")  # already unnamed
+    h("foo = 1")
+    assert sr.rename("foo") == 0  # already exists
+    sr.rename("b")
+    assert sr.sec.name() == "b"
+    h.delete_section(sec=h.b)
+    assert sr.rename("c") == 0
 
-# remaining "documented" methods
-sr = None
-lst = None
-h("create a, a1, a2, a3")
-h.a1.connect(h.a(0))
-h.a2.connect(h.a(0.5))
-h.a3.connect(h.a(1))
-h.topology()
-sr = [h.SectionRef(sec=sec) for sec in h.allsec()]
-assert sr[0].nchild() == 3
-assert sr[0].has_parent() is False
-assert sr[0].has_trueparent() is False
-assert sr[1].has_parent() is True
-assert sr[1].has_trueparent() is False
-assert sr[2].has_parent() is True
-assert sr[2].has_trueparent() is True
+    h("create a, b[3]")
+    sr = h.SectionRef(sec=h.a)
+    sr.unname()
+    sr.rename("b")  # no longer an array and the old 3 are deleted
+    assert sr.sec.name() == "b"
+    h.delete_section(sec=h.b)
 
-assert sr[0].is_cas(sec=sr[0].sec) is True
-assert sr[1].is_cas(sec=sr[0].sec) is False
+    # rename a bunch as an array
+    h("create a, b, c, d")
+    sr = None  # let's start over at 0
+    sr = [h.SectionRef(sec=i) for i in h.allsec()]
+    assert len(sr) == 4
 
-assert sr[1].parent == sr[0].sec
-assert sr[2].trueparent == sr[0].sec
-assert sr[2].root == sr[0].sec
-for i in range(sr[0].nchild()):
-    assert sr[0].child[i] == sr[i + 1].sec
+    # the ones to rename into a new array
+    lst = h.List()
+    for i in [0, 2, 3]:
+        lst.append(sr[i])
+    sr[0].unname()
+    assert sr[0].rename("x", lst) == 0  # have not unnamed c and d
+    for i in lst:
+        i.unname()
+    assert sr[0].rename("x", lst) == 1
+    h.topology()
+    print("cover a deleted section message")
+    h.delete_section(sec=h.x[1])
+    sr[0].unname()
+    assert sr[0].rename("y", lst) == 0
+    h.topology()
 
-# can only get to these lines via hoc? (when implementation uses nrn_inpython)
-# May want to eliminate the nrn_inpython fragments for complete coverage
-# I believe hoc_execerror would work also in the python context.
-assert h("%s.child[3] print secname()" % sr[0]) == False
-assert h("%s.child[1][1] print secname()" % sr[0]) == False
-assert h("%s.child print secname()" % sr[0]) == False
-assert h("%s.parent print secname()" % sr[0]) == False
-assert h("%s.trueparent print secname()" % sr[0]) == False
+    cleanup()
 
+    # Python sections cannot be unnamed or renamed
+    a = h.Section("a")
+    sr = h.SectionRef(sec=a)
+    assert sr.unname() == 0
+    assert a.name() == "a"
+    assert sr.rename("b") == 0
+    assert a.name() == "a"
+    cleanup()
 
-h.topology()
+    # remaining "documented" methods
+    sr = None
+    lst = None
+    h("create a, a1, a2, a3")
+    h.a1.connect(h.a(0))
+    h.a2.connect(h.a(0.5))
+    h.a3.connect(h.a(1))
+    h.topology()
+    sr = [h.SectionRef(sec=sec) for sec in h.allsec()]
+    assert sr[0].nchild() == 3
+    assert sr[0].has_parent() is False
+    assert sr[0].has_trueparent() is False
+    assert sr[1].has_parent() is True
+    assert sr[1].has_trueparent() is False
+    assert sr[2].has_parent() is True
+    assert sr[2].has_trueparent() is True
 
-h.delete_section(sec=sr[0].sec)
-expect_err("sr[0].nchild()")
-expect_err("sr[0].has_parent()")
-expect_err("sr[0].has_trueparent()")
-expect_err("sr[0].is_cas()")
-expect_err("sr[1].parent")
-expect_err("sr[2].trueparent")
-assert sr[2].root == sr[2].sec
-expect_err("sr[1].child[5]")
+    assert sr[0].is_cas(sec=sr[0].sec) is True
+    assert sr[1].is_cas(sec=sr[0].sec) is False
 
-h("create soma")
-sr = h.SectionRef(sec=h.soma)
-assert sr.exists() is True
-h.delete_section(sec=h.soma)
-assert sr.exists() is False
+    assert sr[1].parent == sr[0].sec
+    assert sr[2].trueparent == sr[0].sec
+    assert sr[2].root == sr[0].sec
+    for i in range(sr[0].nchild()):
+        assert sr[0].child[i] == sr[i + 1].sec
 
-h(
+    # can only get to these lines via hoc? (when implementation uses nrn_inpython)
+    # May want to eliminate the nrn_inpython fragments for complete coverage
+    # I believe hoc_execerror would work also in the python context.
+    assert h("%s.child[3] print secname()" % sr[0]) == False
+    assert h("%s.child[1][1] print secname()" % sr[0]) == False
+    assert h("%s.child print secname()" % sr[0]) == False
+    assert h("%s.parent print secname()" % sr[0]) == False
+    assert h("%s.trueparent print secname()" % sr[0]) == False
+
+    h.topology()
+
+    h.delete_section(sec=sr[0].sec)
+    expect_err("sr[0].nchild()")
+    expect_err("sr[0].has_parent()")
+    expect_err("sr[0].has_trueparent()")
+    expect_err("sr[0].is_cas()")
+    expect_err("sr[1].parent")
+    expect_err("sr[2].trueparent")
+    assert sr[2].root == sr[2].sec
+    expect_err("sr[1].child[5]")
+
+    h("create soma")
+    sr = h.SectionRef(sec=h.soma)
+    assert sr.exists() is True
+    h.delete_section(sec=h.soma)
+    assert sr.exists() is False
+
+    h(
+        """
+    begintemplate Cell
+    public soma
+    create soma
+    endtemplate Cell
     """
-begintemplate Cell
-public soma
-create soma
-endtemplate Cell
-"""
-)
+    )
 
-cell = h.Cell()
-sr = h.SectionRef(sec=cell.soma)
-print(sr.sec)
-sr.unname()
+    cell = h.Cell()
+    sr = h.SectionRef(sec=cell.soma)
+    sr.unname()
 
-h("create c")  # fix segfault
+    h("create c")  # fix segfault

--- a/test/hoctests/tests/test_setdata.py
+++ b/test/hoctests/tests/test_setdata.py
@@ -46,7 +46,6 @@ def test_setdata(sfx):  #  "" or "ts"
     assert fc(2) == 1000 * 0.5
 
     del s, setdata, seg, mech, x
-    locals()
 
 
 # what happens if the _extcall_prop becomes invalid
@@ -87,7 +86,6 @@ def test_prop_invalid(sfx):  #  "" or "ts"
     assert fk(5) == 15.0
 
     del s, setdata, seg, mech, carray, fk
-    locals()
 
 
 if __name__ == "__main__":

--- a/test/hoctests/tests/test_shape.py
+++ b/test/hoctests/tests/test_shape.py
@@ -1,14 +1,16 @@
 from neuron import h, gui
 
-h.load_file(h.neuronhome() + "/demo/pyramid.nrn")
-for sec in h.allsec():
-    sec.insert("pas")
-h.soma.uninsert("pas")
 
-psh = h.PlotShape()
-psh.variable("g_pas")
-psh.exec_menu("Shape Plot")
+def test_shape():
+    h.load_file(h.neuronhome() + "/demo/pyramid.nrn")
+    for sec in h.allsec():
+        sec.insert("pas")
+    h.soma.uninsert("pas")
 
-# cover a line in ShapeSection::set_range_variable
-h.delete_section(sec=h.soma)
-psh.variable("g_pas")
+    psh = h.PlotShape()
+    psh.variable("g_pas")
+    psh.exec_menu("Shape Plot")
+
+    # cover a line in ShapeSection::set_range_variable
+    h.delete_section(sec=h.soma)
+    psh.variable("g_pas")

--- a/test/hoctests/tests/test_thread_partition.py
+++ b/test/hoctests/tests/test_thread_partition.py
@@ -20,7 +20,6 @@ class Cell:
 
 
 def prroots():
-    print("prroots")
     sr = h.SectionList()
     sr.allroots()
     for s in sr:
@@ -67,7 +66,7 @@ def test_default():
     assertpart("default")
 
 
-def test_parts():
+def test_parts(debug: bool = False):
     cells = [Cell(i) for i in range(10)]
     r = h.Random()
     r.Random123(1, 0, 0)
@@ -88,9 +87,10 @@ def test_parts():
         pc.psolve(tstop)
 
     run(20)
-    print("ith ncell thread_ctime")
-    for ith in range(pc.nthread()):
-        print(ith, len([1 for _ in parts[ith]]), pc.thread_ctime(ith))
+    if debug:
+        print("ith ncell thread_ctime")
+        for ith in range(pc.nthread()):
+            print(ith, len([1 for _ in parts[ith]]), pc.thread_ctime(ith))
 
 
 if __name__ == "__main__":

--- a/test/hoctests/tests/test_vector.py
+++ b/test/hoctests/tests/test_vector.py
@@ -8,32 +8,37 @@ def add_two(x):
     return x + 2
 
 
-vec = h.Vector([4, -1.5, 17])
-vec.apply(add_two)
-assert list(vec) == [6.0, 0.5, 19.0]
-expect_err("vec.apply(add_two, 1, 2, 5, 24, 13)")  # too many args
-expect_err("vec.apply('hocfunctionthatdoesnotexist')")
-expect_err("vec.apply(vec)")
-expect_err("vec.apply(42)")
-
-h(
-    """
-func subtract_two() {
-    return $1 - 2
-}
-"""
-)
-vec.apply("subtract_two")
-assert list(vec) == [4.0, -1.5, 17]
-
-
 def unusable_function(x):
     # this should fail because of the return value
     return unusable_function
 
 
-expect_err("vec.apply(unusable_function)")
+def test_vector():
 
-# check works with ints and not just floats
-vec.apply(int)
-assert list(vec) == [4.0, -1.0, 17.0]
+    vec = h.Vector([4, -1.5, 17])
+    vec.apply(add_two)
+    assert list(vec) == [6.0, 0.5, 19.0]
+    expect_err("vec.apply(add_two, 1, 2, 5, 24, 13)")  # too many args
+    expect_err("vec.apply('hocfunctionthatdoesnotexist')")
+    expect_err("vec.apply(vec)")
+    expect_err("vec.apply(42)")
+
+    h(
+        """
+    func subtract_two() {
+        return $1 - 2
+    }
+    """
+    )
+    vec.apply("subtract_two")
+    assert list(vec) == [4.0, -1.5, 17]
+
+    expect_err("vec.apply(unusable_function)")
+
+    # check works with ints and not just floats
+    vec.apply(int)
+    assert list(vec) == [4.0, -1.0, 17.0]
+
+
+if __name__ == "__main__":
+    test_vector()

--- a/test/parallel_tests/test_subworld.py
+++ b/test/parallel_tests/test_subworld.py
@@ -1,49 +1,10 @@
 from neuron import h
 import sys
 
-h.nrnmpi_init()
-pc = h.ParallelContext()
-
-# each subworld has 3 ranks if nhost_world is multiple of subsize
-# (if not, last will have nworld%subsize ranks)
-subsize = 3
-pc.subworlds(subsize)
-
-ibbs = pc.id_world() // subsize
-nbbs = pc.nhost_world() // subsize
-x = 0 if pc.nhost_world() % subsize == 0 else 1
-
-if pc.id_world() == 0:
-    print("id_world nhost_world id_bbs nhost_bbs ibbs nbbs  id  nhost")
-
-print(
-    "%5d %9d %8d %8d %7d %3d %5d %4d"
-    % (
-        pc.id_world(),
-        pc.nhost_world(),
-        pc.id_bbs(),
-        pc.nhost_bbs(),
-        ibbs,
-        nbbs + x,
-        pc.id(),
-        pc.nhost(),
-    )
-)
-
-assert pc.nhost() == (subsize if ibbs < nbbs else (pc.nhost_world() - subsize * nbbs))
-assert pc.id() == pc.id_world() % subsize
-
-# id_bbs and nhost_bbs for non-zero id not -1.
-assert pc.nhost_bbs() == ((nbbs + x) if pc.id() == 0 else -1)
-assert pc.id_bbs() == (ibbs if pc.id() == 0 else -1)
-
 
 def f(arg):
     print("f(%s) id_world=%d id=%d" % (str(arg), pc.id_world(), pc.id()))
     return (arg, pc.id_world(), pc.id())
-
-
-x = 0
 
 
 def gcntxt(arg):
@@ -59,25 +20,65 @@ def gtest(arg):
     # print("gtest x=%d id_world=%d" % (x, pc.id_world()))
 
 
-pc.runworker()
+def test_subworld():
+    h.nrnmpi_init()
+    pc = h.ParallelContext()
 
-for i in range(5):
-    pc.submit(f, "submit %d" % i)
-hs = h.ref("")
-while pc.working():
-    pc.upkstr(hs)
-    print("working returned %s (submit passed %s)" % (str(pc.pyret()), hs[0]))
+    # each subworld has 3 ranks if nhost_world is multiple of subsize
+    # (if not, last will have nworld%subsize ranks)
+    subsize = 3
+    pc.subworlds(subsize)
 
-pc.context(gcntxt, 6)
+    ibbs = pc.id_world() // subsize
+    nbbs = pc.nhost_world() // subsize
+    x = 0 if pc.nhost_world() % subsize == 0 else 1
 
-for i in range(3 * pc.nhost_world()):
-    pc.submit(gtest, 6)
+    if pc.id_world() == 0:
+        print("id_world nhost_world id_bbs nhost_bbs ibbs nbbs  id  nhost")
 
+    print(
+        "%5d %9d %8d %8d %7d %3d %5d %4d"
+        % (
+            pc.id_world(),
+            pc.nhost_world(),
+            pc.id_bbs(),
+            pc.nhost_bbs(),
+            ibbs,
+            nbbs + x,
+            pc.id(),
+            pc.nhost(),
+        )
+    )
 
-x = 6
-while pc.working():
-    pass
+    assert pc.nhost() == (
+        subsize if ibbs < nbbs else (pc.nhost_world() - subsize * nbbs)
+    )
+    assert pc.id() == pc.id_world() % subsize
 
-pc.done()
+    # id_bbs and nhost_bbs for non-zero id not -1.
+    assert pc.nhost_bbs() == ((nbbs + x) if pc.id() == 0 else -1)
+    assert pc.id_bbs() == (ibbs if pc.id() == 0 else -1)
 
-h.quit()
+    x = 0
+
+    pc.runworker()
+
+    for i in range(5):
+        pc.submit(f, "submit %d" % i)
+    hs = h.ref("")
+    while pc.working():
+        pc.upkstr(hs)
+        print("working returned %s (submit passed %s)" % (str(pc.pyret()), hs[0]))
+
+    pc.context(gcntxt, 6)
+
+    for i in range(3 * pc.nhost_world()):
+        pc.submit(gtest, 6)
+
+    x = 6
+    while pc.working():
+        pass
+
+    pc.done()
+
+    h.quit()


### PR DESCRIPTION
This is a first attempt at fixing the situation with testing the Python components via pytest.

Currently there are a bunch of Python files which cannot be tested via pytest since they are not properly set-up (i.e. the whole file runs upon import, which breaks pytest). With this PR, we should be able to do the following:

```sh
PYTHONPATH="${BUILD_DIR}/test/external_ringtest_nrn/optim_node_order:${SRC_DIR}/docs/nmodl/python_scripts:${BUILD_DIR}/lib/python/:${BUILD_DIR}/test/rxdmod_tests/rxd_tests/test/rxd:${BUILD_DIR}/test/rxdmod_tests/rxd_tests/test" python -m pytest --collect-only -q ${BUILD_DIR}/test
```

The idea is to eventually be able to collect all of the tests via pytest, and then set-up ctest so that it runs all of them in parallel (by manipulating the collected tests, we can `add_test` each one individually, so we only need to worry about one layer of parallelization, namely the ctest one).