### PR TITLE
several Clang warnings --- tmpnam and variable length arrays

### DIFF
--- a/src/nrnpython/grids.cpp
+++ b/src/nrnpython/grids.cpp
@@ -6,6 +6,7 @@ a linked list of Grid_nodes
 ******************************************************************/
 #include <stdio.h>
 #include <assert.h>
+#include <vector>
 #include "nrnpython.h"
 #include "grids.h"
 #include "rxd.h"
@@ -1307,7 +1308,9 @@ void ICS_Grid_node::divide_x_work(const int nthreads) {
     // To determine which index to put the start node and line length in thread_line_defs
     int* thread_idx_counter = (int*) calloc(nthreads, sizeof(int));
     // To determine which thread array to put the start node and line length in thread_line_defs
-    int line_thread_id[_x_lines_length / 2];
+    // warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
+    // int line_thread_id[_x_lines_length / 2];
+    std::vector<int> line_thread_id(_x_lines_length / 2);
     // Array of nthreads arrays that hold the line defs for each thread
     int** thread_line_defs = (int**) malloc(nthreads * sizeof(int*));
 
@@ -1402,7 +1405,7 @@ void ICS_Grid_node::divide_y_work(const int nthreads) {
     // To determine which index to put the start node and line length in thread_line_defs
     int* thread_idx_counter = (int*) calloc(nthreads, sizeof(int));
     // To determine which thread array to put the start node and line length in thread_line_defs
-    int line_thread_id[_y_lines_length / 2];
+    std::vector<int> line_thread_id(_y_lines_length / 2);
     // Array of nthreads arrays that hold the line defs for each thread
     int** thread_line_defs = (int**) malloc(nthreads * sizeof(int*));
 
@@ -1499,7 +1502,7 @@ void ICS_Grid_node::divide_z_work(const int nthreads) {
     // To determine which index to put the start node and line length in thread_line_defs
     int* thread_idx_counter = (int*) calloc(nthreads, sizeof(int));
     // To determine which thread array to put the start node and line length in thread_line_defs
-    int line_thread_id[_z_lines_length / 2];
+    std::vector<int> line_thread_id(_z_lines_length / 2);
     // Array of nthreads arrays that hold the line defs for each thread
     int** thread_line_defs = (int**) malloc(nthreads * sizeof(int*));
 


### PR DESCRIPTION
Actually, what is bothering me is the incessant
```
Unchanged files with check annotations
GitHub Actions
/ ubuntu-22.04 - cmake (-DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_INTERVIEWS=OFF -DNMODL_SANITIZERS=undefine
'ShapePlotInterface' defined as a class here but previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
```
at the end of the files changed page of a PR.
The ```-DNMODL_SANITIZERS``` is a red herring as that cmake variable has been removed. Cannot reproduce with clang 17 on apple M1. Cannot get ```-DNRN_SANITIZERS=undefined``` to work with ubuntu 24.04 and g++-13