### PR TITLE
Add `-O0` to NMODL lexer CMake target on MacOS

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -248,7 +248,7 @@ jobs:
               PATH="${PWD}/bin:${PATH}" \
               LD_LIBRARY_PATH="${PWD}/lib:${LD_LIBRARY_PATH}" \
               DYLD_LIBRARY_PATH="${PWD}/lib:${DYLD_LIBRARY_PATH}" \
-              "${python}" -c "from neuron import h; import neuron; neuron.test();neuron.test_rxd();"
+              "${python}" -c "from neuron import h; import neuron; neuron.test();neuron.test_rxd(); from neuron.tests import test_nmodl; test_nmodl.test_nmodl()"
           done
           cmake --build . --target cover_collect
           cmake --build . --target cover_combine

--- a/packaging/python/test_wheels.sh
+++ b/packaging/python/test_wheels.sh
@@ -105,6 +105,7 @@ run_serial_test () {
 
     # Test 3: run coreneuron binary shipped inside wheel
     if [[ "$has_coreneuron" == "true" ]]; then
+        $python_exe -c "from neuron.tests import test_nmodl; test_nmodl.test_nmodl()"
         HOC_LIBRARY_PATH=${PWD}/test/ringtest nrniv test/ringtest/ring.hoc
         mv out.dat out.nrn.dat
         nrniv-core --datpath .

--- a/share/lib/python/neuron/CMakeLists.txt
+++ b/share/lib/python/neuron/CMakeLists.txt
@@ -46,6 +46,7 @@ set(NRN_PYTHON_FILES_LIST
     tests/test_rxd.json)
 
 set(NRN_PYTHON_NMODL_FILES_LIST
+    tests/test_nmodl.py
     nmodl/dsl.py
     nmodl/symtab.py
     nmodl/ext/example/passive.mod

--- a/share/lib/python/neuron/tests/test_nmodl.py
+++ b/share/lib/python/neuron/tests/test_nmodl.py
@@ -3,18 +3,25 @@ import unittest
 from neuron import h
 
 
-def _test_nmodl_ast():
+class NmodlTestCase(unittest.TestCase):
     """
-    Test for https://github.com/neuronsimulator/nrn/issues/3517
+    Tests for NMODL
     """
-    assert h.hh.ast
+
+    def test_nmodl_ast(self):
+        """
+        Test for https://github.com/neuronsimulator/nrn/issues/3517
+        """
+        assert h.hh.ast
+
+
+def suite():
+    return unittest.defaultTestLoader.loadTestsFromTestCase(NmodlTestCase)
 
 
 def test_nmodl():
-    """
-    Controller for all NMODL tests
-    """
-    _test_nmodl_ast()
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite())
 
 
 if __name__ == "__main__":

--- a/share/lib/python/neuron/tests/test_nmodl.py
+++ b/share/lib/python/neuron/tests/test_nmodl.py
@@ -1,0 +1,21 @@
+import unittest
+
+from neuron import h
+
+
+def _test_nmodl_ast():
+    """
+    Test for https://github.com/neuronsimulator/nrn/issues/3517
+    """
+    assert h.hh.ast
+
+
+def test_nmodl():
+    """
+    Controller for all NMODL tests
+    """
+    _test_nmodl_ast()
+
+
+if __name__ == "__main__":
+    test_nmodl()

--- a/src/nmodl/lexer/CMakeLists.txt
+++ b/src/nmodl/lexer/CMakeLists.txt
@@ -228,6 +228,14 @@ add_custom_command(
 
 add_library(lexer STATIC ${LEXER_SOURCE_FILES} ${BISON_GENERATED_SOURCE_FILES}
                          ${AST_GENERATED_SOURCES} ${UNIT_SOURCE_FILES})
+if(NRN_MACOS_BUILD)
+  # ~~~
+  # bug with NMODL lexer, see:
+  # https://github.com/neuronsimulator/nrn/issues/3517
+  # should not have an effect on performance
+  # ~~~
+  target_compile_options(lexer BEFORE PRIVATE "-O0")
+endif()
 set_property(TARGET lexer PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(lexer PRIVATE util)
 


### PR DESCRIPTION
Fixes #3517.
Also added a simple test for it.