### PR TITLE
Function wrappers for parameter-reading functions (API)

### DIFF
--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -617,3 +617,30 @@ void nrn_register_function(void (*proc)(), const char* func_name, int type) {
     sym->u.u_proc->nobjauto = 0;
 }
 }
+
+void nrn_hoc_ret() {
+    hoc_ret();
+}
+
+/****************************************
+ * Parameter-reading functions
+ ****************************************/
+Object** nrn_objgetarg(int arg) {
+    return hoc_objgetarg(arg);
+}
+
+char* nrn_gargstr(int arg) {
+    return hoc_gargstr(arg);
+}
+
+double* nrn_getarg(int arg) {
+    return hoc_getarg(arg);
+}
+
+IvocVect* nrn_vector_arg(int arg) {
+    return vector_arg(arg);
+}
+
+std::FILE* nrn_obj_file_arg(int i) {
+    return hoc_obj_file_arg(i);
+}

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -132,6 +132,14 @@ Symlist* nrn_global_symbol_table(void);
 Symlist* nrn_top_level_symbol_table(void);
 int nrn_symbol_array_length(const Symbol* sym);
 void nrn_register_function(void (*proc)(), const char* func_name, int type);
+/****************************************
+ * Parameter-reading functions
+ ****************************************/
+Object** nrn_objgetarg(int arg);
+char* nrn_gargstr(int arg);
+double* nrn_getarg(int arg);
+IvocVect* nrn_vector_arg(int arg);
+std::FILE* nrn_obj_file_arg(int i);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I found the parameter-reading functions in `src/oc/oc_ansi.h` and the "Arguments" part of `https://nrn.readthedocs.io/en/8.2.7/dev/how-do-i/how-do-i.html`. A review of those to see if the list of the ones I added is comprehensive would be appreciated. hoc_ret is also a function that is needed for `finitialize_callback` in the MATLAB interface. 