### PR TITLE
Add support for Python free-threaded build

### DIFF
--- a/.github/workflows/wheels-ci.yml
+++ b/.github/workflows/wheels-ci.yml
@@ -19,7 +19,9 @@ jobs:
     strategy:
       matrix:
         os: ['macos-14', 'ubuntu-22.04-arm']
-        python_version: ['3.9', '3.13']
+        # TODO put this back before merging
+        #python_version: ['3.9', '3.13']
+        python_version: ['3.13t']
 
   merge:
     name: Merge artifacts and post artifacts URL

--- a/.github/workflows/wheels-template.yml
+++ b/.github/workflows/wheels-template.yml
@@ -69,7 +69,7 @@ jobs:
           if [[ "${formal_version}" =~ .*t$ ]]; then
             # taken from:
             # https://docs.python.org/3.13/using/mac.html#installing-using-the-command-line
-            cat > ./choicechanges.plist <<EOF
+            cat > ./choicechanges.plist <<'PLIST_END'
             <?xml version="1.0" encoding="UTF-8"?>
             <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
             <plist version="1.0">
@@ -84,7 +84,7 @@ jobs:
                     </dict>
             </array>
             </plist>
-            EOF
+            PLIST_END
             sudo installer -pkg $installer_filename -applyChoiceChangesXML ./choicechanges.plist -target /
           else
             sudo installer -pkg $installer_filename -target /

--- a/.github/workflows/wheels-template.yml
+++ b/.github/workflows/wheels-template.yml
@@ -51,20 +51,44 @@ jobs:
           # I would've preferred the versions to be in their own YAML file for
           # readability, but alas, GitHub Actions does not support expanding
           # nested expressions, so we do this the brute-force way with Bash
-          case "${{ inputs.python_version }}" in
+          formal_version=${{ inputs.python_version }}
+          case ${formal_version} in
             3.9) version="3.9.13" ;;
             3.10) version="3.10.11" ;;
             3.11) version="3.11.7" ;;
             3.12) version="3.12.0" ;;
             3.13) version="3.13.0" ;;
-            *) echo "Unknown Python version"; exit 1 ;;
+            3.13t) version="3.13.0" ;;
+            *) echo "Unknown Python version: ${formal_version}"; exit 1 ;;
           esac
 
           installer_name="macos11.pkg"
           installer_filename="python-${version}-${installer_name}"
           url="https://www.python.org/ftp/python/${version}/${installer_filename}"
           curl $url -o $installer_filename
-          sudo installer -pkg $installer_filename -target /
+          if [[ "${formal_version}" =~ .*t$ ]]; then
+            # taken from:
+            # https://docs.python.org/3.13/using/mac.html#installing-using-the-command-line
+            cat > ./choicechanges.plist <<EOF
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <array>
+                    <dict>
+                            <key>attributeSetting</key>
+                            <integer>1</integer>
+                            <key>choiceAttribute</key>
+                            <string>selected</string>
+                            <key>choiceIdentifier</key>
+                            <string>org.python.Python.PythonTFramework-${formal_version%%t}</string>
+                    </dict>
+            </array>
+            </plist>
+            EOF
+            sudo installer -pkg $installer_filename -applyChoiceChangesXML ./choicechanges.plist -target /
+          else
+            sudo installer -pkg $installer_filename -target /
+          fi
 
       - name: Install system dependencies
         if: runner.os == 'macOS'
@@ -105,7 +129,7 @@ jobs:
 
       - name: Build wheel
         run: |
-          bash packaging/python/build_wheels.bash $(uname -s) ${{ inputs.python_version }}
+          CIBW_ENABLE=cpython-freethreading bash packaging/python/build_wheels.bash $(uname -s) ${{ inputs.python_version }}
 
       - name: Upload wheel files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels-template.yml
+++ b/.github/workflows/wheels-template.yml
@@ -67,25 +67,7 @@ jobs:
           url="https://www.python.org/ftp/python/${version}/${installer_filename}"
           curl $url -o $installer_filename
           if [[ "${formal_version}" =~ .*t$ ]]; then
-            # taken from:
-            # https://docs.python.org/3.13/using/mac.html#installing-using-the-command-line
-            cat > ./choicechanges.plist <<'PLIST_END'
-            <?xml version="1.0" encoding="UTF-8"?>
-            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-            <plist version="1.0">
-            <array>
-                    <dict>
-                            <key>attributeSetting</key>
-                            <integer>1</integer>
-                            <key>choiceAttribute</key>
-                            <string>selected</string>
-                            <key>choiceIdentifier</key>
-                            <string>org.python.Python.PythonTFramework-${formal_version%%t}</string>
-                    </dict>
-            </array>
-            </plist>
-PLIST_END
-            sudo installer -pkg $installer_filename -applyChoiceChangesXML ./choicechanges.plist -target /
+            sudo installer -pkg $installer_filename -applyChoiceChangesXML packaging/python/macos_installer_patch${formal_version}.plist -target /
           else
             sudo installer -pkg $installer_filename -target /
           fi

--- a/.github/workflows/wheels-template.yml
+++ b/.github/workflows/wheels-template.yml
@@ -84,7 +84,7 @@ jobs:
                     </dict>
             </array>
             </plist>
-            PLIST_END
+PLIST_END
             sudo installer -pkg $installer_filename -applyChoiceChangesXML ./choicechanges.plist -target /
           else
             sudo installer -pkg $installer_filename -target /

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -155,7 +155,7 @@ stages:
                     </dict>
             </array>
             </plist>
-            PLIST_END
+PLIST_END
             sudo installer -pkg $installer_filename -applyChoiceChangesXML ./choicechanges.plist -target /
           else
             sudo installer -pkg $installer_filename -target /

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,6 +49,9 @@ stages:
           Python313:
             python.version: '3.13'
             python.nodot: '313'
+          Python313t:
+            python.version: '3.13t'
+            python.nodot: '313t'
 
       steps:
 
@@ -75,7 +78,7 @@ stages:
           fi
           sudo mkdir -p /opt/nrnwheel/mpt
           sudo tar -zxf $(mpt_headersSF.secureFilePath) --directory /opt/nrnwheel/mpt
-          packaging/python/build_wheels.bash linux $(python.nodot)
+          CIBW_ENABLE=cpython-freethreading packaging/python/build_wheels.bash linux $(python.nodot)
         displayName: 'Building ManyLinux Wheel'
 
       - script: |
@@ -118,6 +121,11 @@ stages:
             python.nodot: '313'
             python.org.version: '3.13.0'
             python.installer.name: 'macos11.pkg'
+          Python313t:
+            python.version: '3.13t'
+            python.nodot: '313t'
+            python.org.version: '3.13.0'
+            python.installer.name: 'macos11.pkg'
 
       steps:
 
@@ -125,7 +133,31 @@ stages:
           installer=python-$(python.org.version)-$(python.installer.name)
           url=https://www.python.org/ftp/python/$(python.org.version)/$installer
           curl $url -o $installer
-          sudo installer -pkg $installer -target /
+          if [[ "$(python.version)" =~ .*t$ ]]; then
+            version=$(python.version)"
+            version="${version%%t}"
+            # taken from:
+            # https://docs.python.org/3.13/using/mac.html#installing-using-the-command-line
+            cat > ./choicechanges.plist <<EOF
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <array>
+                    <dict>
+                            <key>attributeSetting</key>
+                            <integer>1</integer>
+                            <key>choiceAttribute</key>
+                            <string>selected</string>
+                            <key>choiceIdentifier</key>
+                            <string>org.python.Python.PythonTFramework-${version}</string>
+                    </dict>
+            </array>
+            </plist>
+            EOF
+            sudo installer -pkg $installer_filename -applyChoiceChangesXML ./choicechanges.plist -target /
+          else
+            sudo installer -pkg $installer_filename -target /
+          fi
         displayName: 'Install Python from python.org'
 
       - script: |
@@ -172,7 +204,7 @@ stages:
           fi
           sudo mkdir -p /opt/nrnwheel/$(uname -m)
           sudo tar -zxf $(readlineSF.secureFilePath) --directory /opt/nrnwheel/$(uname -m)
-          packaging/python/build_wheels.bash osx $(python.nodot)
+          CIBW_ENABLE=cpython-freethreading packaging/python/build_wheels.bash osx $(python.nodot)
         displayName: 'Build MacOS Wheel'
 
       - template: ci/azure-wheel-test-upload.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,18 +34,19 @@ stages:
         vmImage: 'ubuntu-22.04'
       strategy:
         matrix:
-          Python39:
-            python.version: '3.9'
-            python.nodot: '39'
-          Python310:
-            python.version: '3.10'
-            python.nodot: '310'
-          Python311:
-            python.version: '3.11'
-            python.nodot: '311'
-          Python312:
-            python.version: '3.12'
-            python.nodot: '312'
+          # TODO put this back before merging
+          #Python39:
+          #  python.version: '3.9'
+          #  python.nodot: '39'
+          #Python310:
+          #  python.version: '3.10'
+          #  python.nodot: '310'
+          #Python311:
+          #  python.version: '3.11'
+          #  python.nodot: '311'
+          #Python312:
+          #  python.version: '3.12'
+          #  python.nodot: '312'
           Python313:
             python.version: '3.13'
             python.nodot: '313'
@@ -96,26 +97,27 @@ stages:
         vmImage: 'macOS-13'
       strategy:
         matrix:
-          Python39:
-            python.version: '3.9'
-            python.nodot: '39'
-            python.org.version: '3.9.13'
-            python.installer.name: 'macos11.pkg'
-          Python310:
-            python.version: '3.10'
-            python.nodot: '310'
-            python.org.version: '3.10.11'
-            python.installer.name: 'macos11.pkg'
-          Python311:
-            python.version: '3.11'
-            python.nodot: '311'
-            python.org.version: '3.11.7'
-            python.installer.name: 'macos11.pkg'
-          Python312:
-            python.version: '3.12'
-            python.nodot: '312'
-            python.org.version: '3.12.0'
-            python.installer.name: 'macos11.pkg'
+          # TODO put this back before merging
+          #Python39:
+          #  python.version: '3.9'
+          #  python.nodot: '39'
+          #  python.org.version: '3.9.13'
+          #  python.installer.name: 'macos11.pkg'
+          #Python310:
+          #  python.version: '3.10'
+          #  python.nodot: '310'
+          #  python.org.version: '3.10.11'
+          #  python.installer.name: 'macos11.pkg'
+          #Python311:
+          #  python.version: '3.11'
+          #  python.nodot: '311'
+          #  python.org.version: '3.11.7'
+          #  python.installer.name: 'macos11.pkg'
+          #Python312:
+          #  python.version: '3.12'
+          #  python.nodot: '312'
+          #  python.org.version: '3.12.0'
+          #  python.installer.name: 'macos11.pkg'
           Python313:
             python.version: '3.13'
             python.nodot: '313'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,7 +136,7 @@ stages:
           url=https://www.python.org/ftp/python/$(python.org.version)/$installer
           curl $url -o $installer
           if [[ "$(python.version)" =~ .*t$ ]]; then
-            sudo installer -pkg $installer_filename -applyChoiceChangesXML packaging/python/macos_installer_patch_$(python.version).plist -target /
+            sudo installer -pkg $installer_filename -applyChoiceChangesXML packaging/python/macos_installer_patch$(python.version).plist -target /
           else
             sudo installer -pkg $installer_filename -target /
           fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,27 +136,7 @@ stages:
           url=https://www.python.org/ftp/python/$(python.org.version)/$installer
           curl $url -o $installer
           if [[ "$(python.version)" =~ .*t$ ]]; then
-            version="$(python.version)"
-            version="${version%%t}"
-            # taken from:
-            # https://docs.python.org/3.13/using/mac.html#installing-using-the-command-line
-            cat > ./choicechanges.plist <<'PLIST_END'
-            <?xml version="1.0" encoding="UTF-8"?>
-            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-            <plist version="1.0">
-            <array>
-                    <dict>
-                            <key>attributeSetting</key>
-                            <integer>1</integer>
-                            <key>choiceAttribute</key>
-                            <string>selected</string>
-                            <key>choiceIdentifier</key>
-                            <string>org.python.Python.PythonTFramework-${version}</string>
-                    </dict>
-            </array>
-            </plist>
-PLIST_END
-            sudo installer -pkg $installer_filename -applyChoiceChangesXML ./choicechanges.plist -target /
+            sudo installer -pkg $installer_filename -applyChoiceChangesXML packaging/python/macos_installer_patch_$(python.version).plist -target /
           else
             sudo installer -pkg $installer_filename -target /
           fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,11 +136,11 @@ stages:
           url=https://www.python.org/ftp/python/$(python.org.version)/$installer
           curl $url -o $installer
           if [[ "$(python.version)" =~ .*t$ ]]; then
-            version=$(python.version)"
+            version="$(python.version)"
             version="${version%%t}"
             # taken from:
             # https://docs.python.org/3.13/using/mac.html#installing-using-the-command-line
-            cat > ./choicechanges.plist <<EOF
+            cat > ./choicechanges.plist <<'PLIST_END'
             <?xml version="1.0" encoding="UTF-8"?>
             <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
             <plist version="1.0">
@@ -155,7 +155,7 @@ stages:
                     </dict>
             </array>
             </plist>
-            EOF
+            PLIST_END
             sudo installer -pkg $installer_filename -applyChoiceChangesXML ./choicechanges.plist -target /
           else
             sudo installer -pkg $installer_filename -target /

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -4,12 +4,6 @@ alabaster==0.7.16 \
     --hash=sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65 \
     --hash=sha256:b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92
     # via sphinx
-anyio==4.9.0 \
-    --hash=sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028 \
-    --hash=sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c
-    # via
-    #   httpx
-    #   jupyter-server
 anywidget==0.9.13 \
     --hash=sha256:43d1658f1043b8c95cd350b2f5deccb123fd37810a36f656d6163aefe8163705 \
     --hash=sha256:c655455bf51f82182eb23c5947d37cc41f0b1ffacaf7e2b763147a2332cb3f07
@@ -17,49 +11,10 @@ anywidget==0.9.13 \
     #   -r ci_requirements.txt
     #   -r docs/docs_requirements.txt
     #   -r packaging/python/test_requirements.txt
-appnope==0.1.4 ; sys_platform == 'darwin' \
-    --hash=sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee \
-    --hash=sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c
-    # via ipykernel
-argon2-cffi==23.1.0 \
-    --hash=sha256:879c3e79a2729ce768ebb7d36d4609e3a78a4ca2ec3a9f12286ca057e3d0db08 \
-    --hash=sha256:c670642b78ba29641818ab2e68bd4e6a78ba53b7eff7b4c3815ae16abf91c7ea
-    # via jupyter-server
-argon2-cffi-bindings==21.2.0 \
-    --hash=sha256:20ef543a89dee4db46a1a6e206cd015360e5a75822f76df533845c3cbaf72670 \
-    --hash=sha256:2c3e3cc67fdb7d82c4718f19b4e7a87123caf8a93fde7e23cf66ac0337d3cb3f \
-    --hash=sha256:3b9ef65804859d335dc6b31582cad2c5166f0c3e7975f324d9ffaa34ee7e6583 \
-    --hash=sha256:3e385d1c39c520c08b53d63300c3ecc28622f076f4c2b0e6d7e796e9f6502194 \
-    --hash=sha256:58ed19212051f49a523abb1dbe954337dc82d947fb6e5a0da60f7c8471a8476c \
-    --hash=sha256:5e00316dabdaea0b2dd82d141cc66889ced0cdcbfa599e8b471cf22c620c329a \
-    --hash=sha256:603ca0aba86b1349b147cab91ae970c63118a0f30444d4bc80355937c950c082 \
-    --hash=sha256:6a22ad9800121b71099d0fb0a65323810a15f2e292f2ba450810a7316e128ee5 \
-    --hash=sha256:8cd69c07dd875537a824deec19f978e0f2078fdda07fd5c42ac29668dda5f40f \
-    --hash=sha256:93f9bf70084f97245ba10ee36575f0c3f1e7d7724d67d8e5b08e61787c320ed7 \
-    --hash=sha256:9524464572e12979364b7d600abf96181d3541da11e23ddf565a32e70bd4dc0d \
-    --hash=sha256:b2ef1c30440dbbcba7a5dc3e319408b59676e2e039e2ae11a8775ecf482b192f \
-    --hash=sha256:b746dba803a79238e925d9046a63aa26bf86ab2a2fe74ce6b009a1c3f5c8f2ae \
-    --hash=sha256:bb89ceffa6c791807d1305ceb77dbfacc5aa499891d2c55661c6459651fc39e3 \
-    --hash=sha256:bd46088725ef7f58b5a1ef7ca06647ebaf0eb4baff7d1d0d177c6cc8744abd86 \
-    --hash=sha256:ccb949252cb2ab3a08c02024acb77cfb179492d5701c7cbdbfd776124d4d2367 \
-    --hash=sha256:d4966ef5848d820776f5f562a7d45fdd70c2f330c961d0d745b784034bd9f48d \
-    --hash=sha256:e415e3f62c8d124ee16018e491a009937f8cf7ebf5eb430ffc5de21b900dad93 \
-    --hash=sha256:ed2937d286e2ad0cc79a7087d3c272832865f779430e0cc2b4f3718d3159b0cb \
-    --hash=sha256:f1152ac548bd5b8bcecfb0b0371f082037e47128653df2e8ba6e914d384f3c3e \
-    --hash=sha256:f9f8b450ed0547e3d473fdc8612083fd08dd2120d6ac8f73828df9b7d45bb351
-    # via argon2-cffi
-arrow==1.3.0 \
-    --hash=sha256:c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80 \
-    --hash=sha256:d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85
-    # via isoduration
 asttokens==3.0.0 \
     --hash=sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7 \
     --hash=sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2
     # via stack-data
-async-lru==2.0.5 \
-    --hash=sha256:481d52ccdd27275f42c43a928b4a50c3bfb2d67af4e78b170e3e0bb39c66e5bb \
-    --hash=sha256:ab95404d8d2605310d345932697371a5f40def0487c03d6d0ad9138de52c9943
-    # via jupyterlab
 attrs==25.3.0 \
     --hash=sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3 \
     --hash=sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b
@@ -69,9 +24,7 @@ attrs==25.3.0 \
 babel==2.17.0 \
     --hash=sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d \
     --hash=sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2
-    # via
-    #   jupyterlab-server
-    #   sphinx
+    # via sphinx
 beautifulsoup4==4.13.4 \
     --hash=sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b \
     --hash=sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195
@@ -91,11 +44,8 @@ bokeh==3.7.2 ; python_full_version >= '3.10' \
 certifi==2025.4.26 \
     --hash=sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6 \
     --hash=sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3
-    # via
-    #   httpcore
-    #   httpx
-    #   requests
-cffi==1.17.1 \
+    # via requests
+cffi==1.17.1 ; implementation_name == 'pypy' \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
     --hash=sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2 \
     --hash=sha256:0e2b1fac190ae3ebfe37b979cc1ce69c81f4e4fe5746bb401dca63a9062cdaf1 \
@@ -163,9 +113,7 @@ cffi==1.17.1 \
     --hash=sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99 \
     --hash=sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87 \
     --hash=sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b
-    # via
-    #   argon2-cffi-bindings
-    #   pyzmq
+    # via pyzmq
 charset-normalizer==3.4.2 \
     --hash=sha256:005fa3432484527f9732ebd315da8da8001593e2cf46a3d817669f062c3d9ed4 \
     --hash=sha256:046595208aae0120559a67693ecc65dd75d46f7bf687f159127046628178dc45 \
@@ -270,9 +218,7 @@ colorama==0.4.6 ; sys_platform == 'win32' \
 comm==0.2.2 \
     --hash=sha256:3fd7a84065306e07bea1773df6eb8282de51ba82f77c72f9c85716ab11fe980e \
     --hash=sha256:e6fb86cb70ff661ee8c9c14e7d36d6de3b4066f1441be4063df9c5009f0a64d3
-    # via
-    #   ipykernel
-    #   ipywidgets
+    # via ipywidgets
 contourpy==1.3.0 ; python_full_version < '3.10' \
     --hash=sha256:00ccd0dbaad6d804ab259820fa7cb0b8036bda0686ef844d24125d8287178ce0 \
     --hash=sha256:0be4d8425bfa755e0fd76ee1e019636ccc7c29f77a7c86b4328a9eb6a26d0639 \
@@ -472,100 +418,70 @@ cycler==0.12.1 \
     --hash=sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30 \
     --hash=sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c
     # via matplotlib
-cython==3.0.12 \
-    --hash=sha256:0038c9bae46c459669390e53a1ec115f8096b2e4647ae007ff1bf4e6dee92806 \
-    --hash=sha256:0faa5e39e5c8cdf6f9c3b1c3f24972826e45911e7f5b99cf99453fca5432f45e \
-    --hash=sha256:120681093772bf3600caddb296a65b352a0d3556e962b9b147efcfb8e8c9801b \
-    --hash=sha256:1e5eadef80143026944ea8f9904715a008f5108d1d644a89f63094cc37351e73 \
-    --hash=sha256:25529ee948f44d9a165ff960c49d4903267c20b5edf2df79b45924802e4cca6e \
-    --hash=sha256:2d53de996ed340e9ab0fc85a88aaa8932f2591a2746e1ab1c06e262bd4ec4be7 \
-    --hash=sha256:3083465749911ac3b2ce001b6bf17f404ac9dd35d8b08469d19dc7e717f5877a \
-    --hash=sha256:309c081057930bb79dc9ea3061a1af5086c679c968206e9c9c2ec90ab7cb471a \
-    --hash=sha256:3109e1d44425a2639e9a677b66cd7711721a5b606b65867cb2d8ef7a97e2237b \
-    --hash=sha256:34ce459808f7d8d5d4007bc5486fe50532529096b43957af6cbffcb4d9cc5c8d \
-    --hash=sha256:36fcd584dae547de6f095500a380f4a0cce72b7a7e409e9ff03cb9beed6ac7a1 \
-    --hash=sha256:398d4576c1e1f6316282aa0b4a55139254fbed965cba7813e6d9900d3092b128 \
-    --hash=sha256:3ccd1228cc203b1f1b8a3d403f5a20ad1c40e5879b3fbf5851ce09d948982f2c \
-    --hash=sha256:3e4fa855d98bc7bd6a2049e0c7dc0dcf595e2e7f571a26e808f3efd84d2db374 \
-    --hash=sha256:43c48b5789398b228ea97499f5b864843ba9b1ab837562a9227c6f58d16ede8b \
-    --hash=sha256:4aa255781b093a8401109d8f2104bbb2e52de7639d5896aefafddc85c30e0894 \
-    --hash=sha256:4ee6f1ea1bead8e6cbc4e64571505b5d8dbdb3b58e679d31f3a84160cebf1a1a \
-    --hash=sha256:54115fcc126840926ff3b53cfd2152eae17b3522ae7f74888f8a41413bd32f25 \
-    --hash=sha256:563de1728c8e48869d2380a1b76bbc1b1b1d01aba948480d68c1d05e52d20c92 \
-    --hash=sha256:57aefa6d3341109e46ec1a13e3a763aaa2cbeb14e82af2485b318194be1d9170 \
-    --hash=sha256:5a93cbda00a5451175b97dea5a9440a3fcee9e54b4cba7a7dbcba9a764b22aec \
-    --hash=sha256:5e5f17c48a4f41557fbcc7ee660ccfebe4536a34c557f553b6893c1b3c83df2d \
-    --hash=sha256:629db614b9c364596d7c975fa3fb3978e8c5349524353dbe11429896a783fc1e \
-    --hash=sha256:62b79dcc0de49efe9e84b9d0e2ae0a6fc9b14691a65565da727aa2e2e63c6a28 \
-    --hash=sha256:63d840f2975e44d74512f8f34f1f7cb8121c9428e26a3f6116ff273deb5e60a2 \
-    --hash=sha256:680f1d6ed4436ae94805db264d6155ed076d2835d84f20dcb31a7a3ad7f8668c \
-    --hash=sha256:712c3f31adec140dc60d064a7f84741f50e2c25a8edd7ae746d5eb4d3ef7072a \
-    --hash=sha256:731d719423e041242c9303c80cae4327467299b90ffe62d4cc407e11e9ea3160 \
-    --hash=sha256:75c5acd40b97cff16fadcf6901a91586cbca5dcdba81f738efaf1f4c6bc8dccb \
-    --hash=sha256:77d48f2d4bab9fe1236eb753d18f03e8b2619af5b6f05d51df0532a92dfb38ab \
-    --hash=sha256:7cffc3464f641c8d0dda942c7c53015291beea11ec4d32421bed2f13b386b819 \
-    --hash=sha256:86c304b20bd57c727c7357e90d5ba1a2b6f1c45492de2373814d7745ef2e63b4 \
-    --hash=sha256:879ae9023958d63c0675015369384642d0afb9c9d1f3473df9186c42f7a9d265 \
-    --hash=sha256:8ab9f5198af74eb16502cc143cdde9ca1cbbf66ea2912e67440dd18a36e3b5fa \
-    --hash=sha256:8c9efe9a0895abee3cadfdad4130b30f7b5e57f6e6a51ef2a44f9fc66a913880 \
-    --hash=sha256:8d32856716c369d01f2385ad9177cdd1a11079ac89ea0932dc4882de1aa19174 \
-    --hash=sha256:8ee841c0e114efa1e849c281ac9b8df8aa189af10b4a103b1c5fd71cbb799679 \
-    --hash=sha256:90cf599372c5a22120609f7d3a963f17814799335d56dd0dcf8fe615980a8ae1 \
-    --hash=sha256:9f8c48748a9c94ea5d59c26ab49ad0fad514d36f894985879cf3c3ca0e600bf4 \
-    --hash=sha256:a4032e48d4734d2df68235d21920c715c451ac9de15fa14c71b378e8986b83be \
-    --hash=sha256:a7fec4f052b8fe173fe70eae75091389955b9a23d5cec3d576d21c5913b49d47 \
-    --hash=sha256:af081838b0f9e12a83ec4c3809a00a64c817f489f7c512b0e3ecaf5f90a2a816 \
-    --hash=sha256:b588c0a089a9f4dd316d2f9275230bad4a7271e5af04e1dc41d2707c816be44b \
-    --hash=sha256:b988bb297ce76c671e28c97d017b95411010f7c77fa6623dd0bb47eed1aee1bc \
-    --hash=sha256:ba67eee9413b66dd9fbacd33f0bc2e028a2a120991d77b5fd4b19d0b1e4039b9 \
-    --hash=sha256:bee2717e5b5f7d966d0c6e27d2efe3698c357aa4d61bb3201997c7a4f9fe485a \
-    --hash=sha256:bfb75123dd4ff767baa37d7036da0de2dfb6781ff256eef69b11b88b9a0691d1 \
-    --hash=sha256:c0b91c7ebace030dd558ea28730de8c580680b50768e5af66db2904a3716c3e3 \
-    --hash=sha256:c151082884be468f2f405645858a857298ac7f7592729e5b54788b5c572717ba \
-    --hash=sha256:c1879c073e2b34924ce9b7ca64c212705dcc416af4337c45f371242b2e5f6d32 \
-    --hash=sha256:c3238a29f37999e27494d120983eca90d14896b2887a0bd858a381204549137a \
-    --hash=sha256:d3a8f81980ffbd74e52f9186d8f1654e347d0c44bfea6b5997028977f481a179 \
-    --hash=sha256:d4b70fc339adba1e2111b074ee6119fe9fd6072c957d8597bce9a0dd1c3c6784 \
-    --hash=sha256:d6945694c5b9170cfbd5f2c0d00ef7487a2de7aba83713a64ee4ebce7fad9e05 \
-    --hash=sha256:d6c6cd6a75c8393e6805d17f7126b96a894f310a1a9ea91c47d141fb9341bfa8 \
-    --hash=sha256:dcdc3e5d4ce0e7a4af6903ed580833015641e968d18d528d8371e2435a34132c \
-    --hash=sha256:dfdbea486e702c328338314adb8e80f5f9741f06a0ae83aaec7463bc166d12e8 \
-    --hash=sha256:e62564457851db1c40399bd95a5346b9bb99e17a819bf583b362f418d8f3457a \
-    --hash=sha256:ea3a0e19ab77266c738aa110684a753a04da4e709472cadeff487133354d6ab8 \
-    --hash=sha256:ebc24609613fa06d0d896309f7164ba168f7e8d71c1e490ed2a08d23351c3f41 \
-    --hash=sha256:f39640f8df0400cde6882e23c734f15bb8196de0a008ae5dc6c8d1ec5957d7c8 \
-    --hash=sha256:fe030d4a00afb2844f5f70896b7f2a1a0d7da09bf3aa3d884cbe5f73fff5d310 \
-    --hash=sha256:feb86122a823937cc06e4c029d80ff69f082ebb0b959ab52a5af6cdd271c5dc3 \
-    --hash=sha256:ff5c0b6a65b08117d0534941d404833d516dac422eee88c6b4fd55feb409a5ed
+cython==3.1.2 \
+    --hash=sha256:06789eb7bd2e55b38b9dd349e9309f794aee0fed99c26ea5c9562d463877763f \
+    --hash=sha256:0b58e859889dd0fc6c3a990445b930f692948b28328bb4f3ed84b51028b7e183 \
+    --hash=sha256:0d6248a2ae155ca4c42d7fa6a9a05154d62e695d7736bc17e1b85da6dcc361df \
+    --hash=sha256:0f2add8b23cb19da3f546a688cd8f9e0bfc2776715ebf5e283bc3113b03ff008 \
+    --hash=sha256:12c5902f105e43ca9af7874cdf87a23627f98c15d5a4f6d38bc9d334845145c0 \
+    --hash=sha256:18161ef3dd0e90a944daa2be468dd27696712a5f792d6289e97d2a31298ad688 \
+    --hash=sha256:1c0ecc71e60a051732c2607b8eb8f2a03a5dac09b28e52b8af323c329db9987b \
+    --hash=sha256:20ce53951d06ab2bca39f153d9c5add1d631c2a44d58bf67288c9d631be9724e \
+    --hash=sha256:262bf49d9da64e2a34c86cbf8de4aa37daffb0f602396f116cca1ed47dc4b9f2 \
+    --hash=sha256:2d8291dbbc1cb86b8d60c86fe9cbf99ec72de28cb157cbe869c95df4d32efa96 \
+    --hash=sha256:3b1a69b9b4fe0a48a8271027c0703c71ab1993c4caca01791c0fd2e2bd9031aa \
+    --hash=sha256:3d439d9b19e7e70f6ff745602906d282a853dd5219d8e7abbf355de680c9d120 \
+    --hash=sha256:42c7bffb0fe9898996c7eef9eb74ce3654553c7a3a3f3da66e5a49f801904ce0 \
+    --hash=sha256:4896fc2b0f90820ea6fcf79a07e30822f84630a404d4e075784124262f6d0adf \
+    --hash=sha256:4bf3ea5bc50d80762c490f42846820a868a6406fdb5878ae9e4cc2f11b50228a \
+    --hash=sha256:5548573e0912d7dc80579827493315384c462e2f15797b91a8ed177686d31eb9 \
+    --hash=sha256:58d4d45e40cadf4f602d96b7016cf24ccfe4d954c61fa30b79813db8ccb7818f \
+    --hash=sha256:604c39cd6d152498a940aeae28b6fd44481a255a3fdf1b0051c30f3873c88b7f \
+    --hash=sha256:63335513c06dcec4ecdaa8598f36c969032149ffd92a461f641ee363dc83c7ad \
+    --hash=sha256:63da49672c4bb022b4de9d37bab6c29953dbf5a31a2f40dffd0cf0915dcd7a17 \
+    --hash=sha256:6bbf7a953fa6762dfecdec015e3b054ba51c0121a45ad851fa130f63f5331381 \
+    --hash=sha256:7542f1d18ab2cd22debc72974ec9e53437a20623d47d6001466e430538d7df54 \
+    --hash=sha256:80d0ce057672ca50728153757d022842d5dcec536b50c79615a22dda2a874ea0 \
+    --hash=sha256:855f2ae06438c7405997cf0df42d5b508ec3248272bb39df4a7a4a82a5f7c8cb \
+    --hash=sha256:88dc7fd54bfae78c366c6106a759f389000ea4dfe8ed9568af9d2f612825a164 \
+    --hash=sha256:8ab1319c77f15b0ae04b3fb03588df3afdec4cf79e90eeea5c961e0ebd8fdf72 \
+    --hash=sha256:8efa44ee2f1876e40eb5e45f6513a19758077c56bf140623ccab43d31f873b61 \
+    --hash=sha256:919ff38a93f7c21829a519693b336979feb41a0f7ca35969402d7e211706100e \
+    --hash=sha256:955bc6032d89ce380458266e65dcf5ae0ed1e7c03a7a4457e3e4773e90ba7373 \
+    --hash=sha256:970cc1558519f0f108c3e2f4b3480de4945228d9292612d5b2bb687e36c646b8 \
+    --hash=sha256:992a6504aa3eed50dd1fc3d1fa998928b08c1188130bd526e177b6d7f3383ec4 \
+    --hash=sha256:9be3d4954b46fd0f2dceac011d470f658eaf819132db52fbd1cf226ee60348db \
+    --hash=sha256:9c2c4b6f9a941c857b40168b3f3c81d514e509d985c2dcd12e1a4fea9734192e \
+    --hash=sha256:9e3016ca7a86728bfcbdd52449521e859a977451f296a7ae4967cefa2ec498f7 \
+    --hash=sha256:a3bb893e85f027a929c1764bb14db4c31cbdf8a96f59a78f608f2ba7cfbbce95 \
+    --hash=sha256:a965b81eb4f5a5f3f6760b162cb4de3907c71a9ba25d74de1ad7a0e4856f0412 \
+    --hash=sha256:aaae97d6d07610224be2b73a93e9e3dd85c09aedfd8e47054e3ef5a863387dae \
+    --hash=sha256:aca994519645ba8fb5e99c0f9d4be28d61435775552aaf893a158c583cd218a5 \
+    --hash=sha256:ae53ae93c699d5f113953a9869df2fc269d8e173f9aa0616c6d8d6e12b4e9827 \
+    --hash=sha256:af127da4b956e0e906e552fad838dc3fb6b6384164070ceebb0d90982a8ae25a \
+    --hash=sha256:b377d542299332bfeb61ec09c57821b10f1597304394ba76544f4d07780a16df \
+    --hash=sha256:b417c5d046ce676ee595ec7955ed47a68ad6f419cbf8c2a8708e55a3b38dfa35 \
+    --hash=sha256:b4c516d103e87c2e9c1ab85227e4d91c7484c1ba29e25f8afbf67bae93fee164 \
+    --hash=sha256:b7e1d3c383a5f4ca5319248b9cb1b16a04fb36e153d651e558897171b7dbabb9 \
+    --hash=sha256:bdbc115bbe1b8c1dcbcd1b03748ea87fa967eb8dfc3a1a9bb243d4a382efcff4 \
+    --hash=sha256:c05111f89db1ca98edc0675cfaa62be47b3ff519a29876eb095532a9f9e052b8 \
+    --hash=sha256:c1661c1701c96e1866f839e238570c96a97535a81da76a26f45f99ede18b3897 \
+    --hash=sha256:c9ec7d2baea122d94790624f743ff5b78f4e777bf969384be65b69d92fa4bc3f \
+    --hash=sha256:ca45020950cd52d82189d6dfb6225737586be6fe7b0b9d3fadd7daca62eff531 \
+    --hash=sha256:cc22e5f18af436c894b90c257130346930fdc860d7f42b924548c591672beeef \
+    --hash=sha256:d23fd7ffd7457205f08571a42b108a3cf993e83a59fe4d72b42e6fc592cf2639 \
+    --hash=sha256:d8c43566701133f53bf13485839d8f3f309095fe0d3b9d0cd5873073394d2edc \
+    --hash=sha256:dbc0fc0777c7ab82297c01c61a1161093a22a41714f62e8c35188a309bd5db8e \
+    --hash=sha256:dbc1f225cb9f9be7a025589463507e10bb2d76a3258f8d308e0e2d0b966c556e \
+    --hash=sha256:df57827185874f29240b02402e615547ab995d90182a852c6ec4f91bbae355a4 \
+    --hash=sha256:e05a36224e3002d48c7c1c695b3771343bd16bc57eab60d6c5d5e08f3cbbafd8 \
+    --hash=sha256:e1f30a1339e03c80968a371ef76bf27a6648c5646cccd14a97e731b6957db97a \
+    --hash=sha256:eda6a43f1b78eae0d841698916eef661d15f8bc8439c266a964ea4c504f05612 \
+    --hash=sha256:f27143cf88835c8bcc9bf3304953f23f377d1d991e8942982fe7be344c7cfce3 \
+    --hash=sha256:f3d03077938b02ec47a56aa156da7bfc2379193738397d4e88086db5b0a374e0 \
+    --hash=sha256:f6e7188df8709be32cfdfadc7c3782e361c929df9132f95e1bbc90a340dca3c7 \
+    --hash=sha256:fe7f1ee4c13f8a773bd6c66b3d25879f40596faeab49f97d28c39b16ace5fff9
     # via -r packaging/python/build_requirements.txt
-debugpy==1.8.14 \
-    --hash=sha256:0f920c7f9af409d90f5fd26e313e119d908b0dd2952c2393cd3247a462331f15 \
-    --hash=sha256:1b2ac8c13b2645e0b1eaf30e816404990fbdb168e193322be8f545e8c01644a9 \
-    --hash=sha256:281d44d248a0e1791ad0eafdbbd2912ff0de9eec48022a5bfbc332957487ed3f \
-    --hash=sha256:329a15d0660ee09fec6786acdb6e0443d595f64f5d096fc3e3ccf09a4259033f \
-    --hash=sha256:3784ec6e8600c66cbdd4ca2726c72d8ca781e94bce2f396cc606d458146f8f4e \
-    --hash=sha256:3d937d93ae4fa51cdc94d3e865f535f185d5f9748efb41d0d49e33bf3365bd79 \
-    --hash=sha256:413512d35ff52c2fb0fd2d65e69f373ffd24f0ecb1fac514c04a668599c5ce7f \
-    --hash=sha256:4c9156f7524a0d70b7a7e22b2e311d8ba76a15496fb00730e46dcdeedb9e1eea \
-    --hash=sha256:5349b7c3735b766a281873fbe32ca9cca343d4cc11ba4a743f84cb854339ff35 \
-    --hash=sha256:5aa56ef8538893e4502a7d79047fe39b1dae08d9ae257074c6464a7b290b806f \
-    --hash=sha256:5cd9a579d553b6cb9759a7908a41988ee6280b961f24f63336835d9418216a20 \
-    --hash=sha256:684eaf43c95a3ec39a96f1f5195a7ff3d4144e4a18d69bb66beeb1a6de605d6e \
-    --hash=sha256:7118d462fe9724c887d355eef395fae68bc764fd862cdca94e70dcb9ade8a23d \
-    --hash=sha256:7816acea4a46d7e4e50ad8d09d963a680ecc814ae31cdef3622eb05ccacf7b01 \
-    --hash=sha256:7cd287184318416850aa8b60ac90105837bb1e59531898c07569d197d2ed5322 \
-    --hash=sha256:8899c17920d089cfa23e6005ad9f22582fd86f144b23acb9feeda59e84405b84 \
-    --hash=sha256:93fee753097e85623cab1c0e6a68c76308cd9f13ffdf44127e6fab4fbf024339 \
-    --hash=sha256:b1528cfee6c1b1c698eb10b6b096c598738a8238822d218173d21c3086de8123 \
-    --hash=sha256:b44985f97cc3dd9d52c42eb59ee9d7ee0c4e7ecd62bca704891f997de4cef23d \
-    --hash=sha256:c442f20577b38cc7a9aafecffe1094f78f07fb8423c3dddb384e6b8f49fd2987 \
-    --hash=sha256:c99295c76161ad8d507b413cd33422d7c542889fbb73035889420ac1fad354f2 \
-    --hash=sha256:cf431c343a99384ac7eab2f763980724834f933a271e90496944195318c619e2 \
-    --hash=sha256:d235e4fa78af2de4e5609073972700523e372cf5601742449970110d565ca28c \
-    --hash=sha256:d5582bcbe42917bc6bbe5c12db1bffdf21f6bfc28d4554b738bf08d50dc0c8c3 \
-    --hash=sha256:f117dedda6d969c5c9483e23f573b38f4e39412845c7bc487b6f2648df30fe84 \
-    --hash=sha256:f6bb5c0dcf80ad5dbc7b7d6eac484e2af34bdacdf81df09b6a3e62792b722826
-    # via ipykernel
 decorator==5.2.1 \
     --hash=sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360 \
     --hash=sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a
@@ -587,7 +503,6 @@ exceptiongroup==1.3.0 ; python_full_version < '3.11' \
     --hash=sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10 \
     --hash=sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88
     # via
-    #   anyio
     #   ipython
     #   pytest
     #   scikit-build-core
@@ -649,30 +564,10 @@ fonttools==4.58.0 \
     --hash=sha256:f95ea3b6a3b9962da3c82db73f46d6a6845a6c3f3f968f5293b3ac1864e771c2 \
     --hash=sha256:fde9b32f5964e2a3a2a58e5269673705eb636f604e3cdde24afb1838bf0a501a
     # via matplotlib
-fqdn==1.5.1 \
-    --hash=sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f \
-    --hash=sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014
-    # via jsonschema
-h11==0.16.0 \
-    --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
-    --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
-    # via httpcore
-httpcore==1.0.9 \
-    --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55 \
-    --hash=sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8
-    # via httpx
-httpx==0.28.1 \
-    --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc \
-    --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
-    # via jupyterlab
 idna==3.10 \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-    # via
-    #   anyio
-    #   httpx
-    #   jsonschema
-    #   requests
+    # via requests
 imagesize==1.4.1 \
     --hash=sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b \
     --hash=sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a
@@ -682,9 +577,6 @@ importlib-metadata==8.7.0 ; python_full_version < '3.10' \
     --hash=sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd
     # via
     #   jupyter-client
-    #   jupyter-lsp
-    #   jupyterlab
-    #   jupyterlab-server
     #   nbconvert
     #   sphinx
 importlib-resources==6.5.2 ; python_full_version < '3.10' \
@@ -695,42 +587,20 @@ iniconfig==2.1.0 \
     --hash=sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7 \
     --hash=sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760
     # via pytest
-ipykernel==6.29.5 \
-    --hash=sha256:afdb66ba5aa354b09b91379bac28ae4afebbb30e8b39510c9690afb7a10421b5 \
-    --hash=sha256:f093a22c4a40f8828f8e330a9c297cb93dcab13bd9678ded6de8e5cf81c56215
-    # via
-    #   jupyter
-    #   jupyter-console
-    #   jupyterlab
 ipython==8.18.1 ; python_full_version < '3.10' \
     --hash=sha256:ca6f079bb33457c66e233e4580ebfc4128855b4cf6370dddd73842a9563e8a27 \
     --hash=sha256:e8267419d72d81955ec1177f8a29aaa90ac80ad647499201119e2f05e99aa397
-    # via
-    #   -r docs/docs_requirements.txt
-    #   -r nrn_requirements.txt
-    #   ipykernel
-    #   ipywidgets
-    #   jupyter-console
+    # via ipywidgets
 ipython==8.32.0 ; python_full_version >= '3.10' \
     --hash=sha256:be2c91895b0b9ea7ba49d33b23e2040c352b33eb6a519cca7ce6e0c743444251 \
     --hash=sha256:cae85b0c61eff1fc48b0a8002de5958b6528fa9c8defb1894da63f42613708aa
-    # via
-    #   -r docs/docs_requirements.txt
-    #   -r nrn_requirements.txt
-    #   ipykernel
-    #   ipywidgets
-    #   jupyter-console
+    # via ipywidgets
 ipywidgets==8.1.5 \
     --hash=sha256:3290f526f87ae6e77655555baba4f36681c555b8bdbbff430b70e52c34c86245 \
     --hash=sha256:870e43b1a35656a80c18c9503bbf2d16802db1cb487eec6fab27d683381dde17
     # via
     #   -r ci_requirements.txt
     #   anywidget
-    #   jupyter
-isoduration==20.11.0 \
-    --hash=sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9 \
-    --hash=sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042
-    # via jsonschema
 jedi==0.19.2 \
     --hash=sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0 \
     --hash=sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9
@@ -742,100 +612,34 @@ jinja2==3.1.6 \
     #   -r docs/docs_requirements.txt
     #   -r nmodl_requirements.txt
     #   bokeh
-    #   jupyter-server
-    #   jupyterlab
-    #   jupyterlab-server
     #   myst-parser
     #   nbconvert
     #   nbsphinx
     #   sphinx
-json5==0.12.0 \
-    --hash=sha256:0b4b6ff56801a1c7dc817b0241bca4ce474a0e6a163bfef3fc594d3fd263ff3a \
-    --hash=sha256:6d37aa6c08b0609f16e1ec5ff94697e2cbbfbad5ac112afa05794da9ab7810db
-    # via jupyterlab-server
-jsonpointer==3.0.0 \
-    --hash=sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942 \
-    --hash=sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef
-    # via jsonschema
 jsonschema==4.23.0 \
     --hash=sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4 \
     --hash=sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566
-    # via
-    #   jupyter-events
-    #   jupyterlab-server
-    #   nbformat
+    # via nbformat
 jsonschema-specifications==2025.4.1 \
     --hash=sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af \
     --hash=sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608
     # via jsonschema
-jupyter==1.1.1 \
-    --hash=sha256:7a59533c22af65439b24bbe60373a4e95af8f16ac65a6c00820ad378e3f7cc83 \
-    --hash=sha256:d55467bceabdea49d7e3624af7e33d59c37fff53ed3a350e1ac957bed731de7a
-    # via
-    #   -r docs/docs_requirements.txt
-    #   -r nmodl_requirements.txt
 jupyter-client==8.6.3 \
     --hash=sha256:35b3a0947c4a6e9d589eb97d7d4cd5e90f910ee73101611f01283732bd6d9419 \
     --hash=sha256:e8a19cc986cc45905ac3362915f410f3af85424b4c0905e94fa5f2cb08e8f23f
-    # via
-    #   -r nmodl_requirements.txt
-    #   ipykernel
-    #   jupyter-console
-    #   jupyter-server
-    #   nbclient
-jupyter-console==6.6.3 \
-    --hash=sha256:309d33409fcc92ffdad25f0bcdf9a4a9daa61b6f341177570fdac03de5352485 \
-    --hash=sha256:566a4bf31c87adbfadf22cdf846e3069b59a71ed5da71d6ba4d8aaad14a53539
-    # via jupyter
+    # via nbclient
 jupyter-core==5.7.2 \
     --hash=sha256:4f7315d2f6b4bcf2e3e7cb6e46772eba760ae459cd1f59d29eb57b0a01bd7409 \
     --hash=sha256:aa5f8d32bbf6b431ac830496da7392035d6f61b4f54872f15c4bd2a9c3f536d9
     # via
-    #   ipykernel
     #   jupyter-client
-    #   jupyter-console
-    #   jupyter-server
-    #   jupyterlab
     #   nbclient
     #   nbconvert
     #   nbformat
-jupyter-events==0.12.0 \
-    --hash=sha256:6464b2fa5ad10451c3d35fabc75eab39556ae1e2853ad0c0cc31b656731a97fb \
-    --hash=sha256:fc3fce98865f6784c9cd0a56a20644fc6098f21c8c33834a8d9fe383c17e554b
-    # via jupyter-server
-jupyter-lsp==2.2.5 \
-    --hash=sha256:45fbddbd505f3fbfb0b6cb2f1bc5e15e83ab7c79cd6e89416b248cb3c00c11da \
-    --hash=sha256:793147a05ad446f809fd53ef1cd19a9f5256fd0a2d6b7ce943a982cb4f545001
-    # via jupyterlab
-jupyter-server==2.13.0 \
-    --hash=sha256:77b2b49c3831fbbfbdb5048cef4350d12946191f833a24e5f83e5f8f4803e97b \
-    --hash=sha256:c80bfb049ea20053c3d9641c2add4848b38073bf79f1729cea1faed32fc1c78e
-    # via
-    #   jupyter-lsp
-    #   jupyterlab
-    #   jupyterlab-server
-    #   notebook
-    #   notebook-shim
-jupyter-server-terminals==0.5.3 \
-    --hash=sha256:41ee0d7dc0ebf2809c668e0fc726dfaf258fcd3e769568996ca731b6194ae9aa \
-    --hash=sha256:5ae0295167220e9ace0edcfdb212afd2b01ee8d179fe6f23c899590e9b8a5269
-    # via jupyter-server
-jupyterlab==4.4.2 \
-    --hash=sha256:857111a50bed68542bf55dca784522fe728f9f88b4fe69e8c585db5c50900419 \
-    --hash=sha256:afa9caf28c0cb966488be18e5e8daba9f018a1c4273a406b7d5006344cbc6d16
-    # via
-    #   jupyter
-    #   notebook
 jupyterlab-pygments==0.3.0 \
     --hash=sha256:721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d \
     --hash=sha256:841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780
     # via nbconvert
-jupyterlab-server==2.27.3 \
-    --hash=sha256:e697488f66c3db49df675158a77b3b017520d772c6e1548c7d9bcc5df7944ee4 \
-    --hash=sha256:eb36caca59e74471988f0ae25c77945610b887f777255aa21f8065def9e51ed4
-    # via
-    #   jupyterlab
-    #   notebook
 jupyterlab-widgets==3.0.15 \
     --hash=sha256:2920888a0c2922351a9202817957a68c07d99673504d6cd37345299e971bb08b \
     --hash=sha256:d59023d7d7ef71400d51e6fee9a88867f6e65e10a4201605d2d7f3e8f012a31c
@@ -1197,9 +1001,7 @@ matplotlib==3.10.0 ; python_full_version >= '3.10' \
 matplotlib-inline==0.1.7 \
     --hash=sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90 \
     --hash=sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca
-    # via
-    #   ipykernel
-    #   ipython
+    # via ipython
 mdit-py-plugins==0.4.2 \
     --hash=sha256:0c673c3f889399a33b95e88d2f0d111b4447bdfea7f237dab2d488f459835636 \
     --hash=sha256:5f2cd1fdb606ddf152d37ec30e46101a60512bc0e5fa1a7002c36647b09e26b5
@@ -1269,14 +1071,11 @@ nbconvert==7.16.6 \
     # via
     #   -r docs/docs_requirements.txt
     #   -r nmodl_requirements.txt
-    #   jupyter
-    #   jupyter-server
     #   nbsphinx
 nbformat==5.10.4 \
     --hash=sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a \
     --hash=sha256:3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b
     # via
-    #   jupyter-server
     #   nbclient
     #   nbconvert
     #   nbsphinx
@@ -1286,20 +1085,6 @@ nbsphinx==0.9.7 \
     # via
     #   -r docs/docs_requirements.txt
     #   -r nmodl_requirements.txt
-nest-asyncio==1.6.0 \
-    --hash=sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe \
-    --hash=sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c
-    # via ipykernel
-notebook==7.4.2 \
-    --hash=sha256:9ccef602721aaa5530852e3064710b8ae5415c4e2ce26f8896d0433222755259 \
-    --hash=sha256:e739defd28c3f615a6bfb0a2564bd75018a9cc6613aa00bbd9c15e68eed2de1b
-    # via jupyter
-notebook-shim==0.2.4 \
-    --hash=sha256:411a5be4e9dc882a074ccbcae671eda64cceb068767e9a3419096986560e1cef \
-    --hash=sha256:b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb
-    # via
-    #   jupyterlab
-    #   notebook
 numpy==2.0.2 ; python_full_version < '3.10' \
     --hash=sha256:0123ffdaa88fa4ab64835dcbde75dcdf89c453c922f18dced6e27c90d1d0ec5a \
     --hash=sha256:11a76c372d1d37437857280aa142086476136a8c0f373b2e648ab2c8f18fb195 \
@@ -1428,10 +1213,6 @@ numpy==2.2.3 ; python_full_version >= '3.10' \
     #   plotnine
     #   scipy
     #   statsmodels
-overrides==7.7.0 \
-    --hash=sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a \
-    --hash=sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49
-    # via jupyter-server
 packaging==24.2 \
     --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759 \
     --hash=sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f
@@ -1439,11 +1220,6 @@ packaging==24.2 \
     #   -r docs/docs_requirements.txt
     #   -r nrn_requirements.txt
     #   bokeh
-    #   ipykernel
-    #   jupyter-events
-    #   jupyter-server
-    #   jupyterlab
-    #   jupyterlab-server
     #   matplotlib
     #   nbconvert
     #   plotly
@@ -1633,28 +1409,10 @@ pluggy==1.5.0 \
     --hash=sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1 \
     --hash=sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669
     # via pytest
-prometheus-client==0.21.1 \
-    --hash=sha256:252505a722ac04b0456be05c05f75f45d760c2911ffc45f2a06bcaed9f3ae3fb \
-    --hash=sha256:594b45c410d6f4f8888940fe80b5cc2521b305a1fafe1c58609ef715a001f301
-    # via jupyter-server
 prompt-toolkit==3.0.51 \
     --hash=sha256:52742911fde84e2d423e2f9a4cf1de7d7ac4e51958f648d9540e0fb8db077b07 \
     --hash=sha256:931a162e3b27fc90c86f1b48bb1fb2c528c2761475e57c9c06de13311c7b54ed
-    # via
-    #   ipython
-    #   jupyter-console
-psutil==7.0.0 \
-    --hash=sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25 \
-    --hash=sha256:1e744154a6580bc968a0195fd25e80432d3afec619daf145b9e5ba16cc1d688e \
-    --hash=sha256:1fcee592b4c6f146991ca55919ea3d1f8926497a713ed7faaf8225e174581e91 \
-    --hash=sha256:39db632f6bb862eeccf56660871433e111b6ea58f2caea825571951d4b6aa3da \
-    --hash=sha256:4b1388a4f6875d7e2aff5c4ca1cc16c545ed41dd8bb596cefea80111db353a34 \
-    --hash=sha256:4cf3d4eb1aa9b348dec30105c55cd9b7d4629285735a102beb4441e38db90553 \
-    --hash=sha256:7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456 \
-    --hash=sha256:84df4eb63e16849689f76b1ffcb36db7b8de703d1bc1fe41773db487621b6c17 \
-    --hash=sha256:a5f098451abc2828f7dc6b58d44b532b22f2088f4999a937557b603ce72b1993 \
-    --hash=sha256:ba3fcef7523064a6c9da440fc4d6bd07da93ac726b5733c29027d7dc95b39d99
-    # via ipykernel
+    # via ipython
 psygnal==0.13.0 \
     --hash=sha256:0402e02448ff064fd3a7df06342404b247c9440d8e81b3450d05cc9ecf835043 \
     --hash=sha256:04dc89f8f2d4d2027e1a47460c5b5bf1d52bface50414764eec3209d27c7796d \
@@ -1684,17 +1442,15 @@ psygnal==0.13.0 \
     --hash=sha256:fb500bd5aaed9cee1123c3cd157747cd4ac2c9b023a6cb9c1b49c51215eedcfa \
     --hash=sha256:ffb04781db0fc11fc36805d64bcc4ac72b48111766f78f2e3bb286f0ec579587
     # via anywidget
-ptyprocess==0.7.0 ; (python_full_version < '3.10' and sys_platform == 'emscripten') or os_name != 'nt' or (sys_platform != 'emscripten' and sys_platform != 'win32') \
+ptyprocess==0.7.0 ; (python_full_version < '3.10' and sys_platform == 'emscripten') or (sys_platform != 'emscripten' and sys_platform != 'win32') \
     --hash=sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35 \
     --hash=sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220
-    # via
-    #   pexpect
-    #   terminado
+    # via pexpect
 pure-eval==0.2.3 \
     --hash=sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0 \
     --hash=sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42
     # via stack-data
-pycparser==2.22 \
+pycparser==2.22 ; implementation_name == 'pypy' \
     --hash=sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6 \
     --hash=sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc
     # via cffi
@@ -1703,7 +1459,6 @@ pygments==2.19.1 \
     --hash=sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c
     # via
     #   ipython
-    #   jupyter-console
     #   nbconvert
     #   sphinx
 pyparsing==3.2.3 \
@@ -1727,14 +1482,9 @@ python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
     # via
-    #   arrow
     #   jupyter-client
     #   matplotlib
     #   pandas
-python-json-logger==3.3.0 \
-    --hash=sha256:12b7e74b17775e7d565129296105bbe3910842d9d0eb083fc83a6a617aa8df84 \
-    --hash=sha256:dd980fae8cffb24c13caf6e158d3d61c0d6d22342f932cb6e9deedab3d35eec7
-    # via jupyter-events
 pytz==2025.2 \
     --hash=sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3 \
     --hash=sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00
@@ -1757,18 +1507,6 @@ pywin32==310 ; platform_python_implementation != 'PyPy' and sys_platform == 'win
     --hash=sha256:c3e78706e4229b915a0821941a84e7ef420bf2b77e08c9dae3c76fd03fd2ae3d \
     --hash=sha256:e308f831de771482b7cf692a1f308f8fca701b2d8f9dde6cc440c7da17e47b33
     # via jupyter-core
-pywinpty==2.0.15 ; os_name == 'nt' \
-    --hash=sha256:312cf39153a8736c617d45ce8b6ad6cd2107de121df91c455b10ce6bba7a39b2 \
-    --hash=sha256:83a8f20b430bbc5d8957249f875341a60219a4e971580f2ba694fbfb54a45ebc \
-    --hash=sha256:8e7f5de756a615a38b96cd86fa3cd65f901ce54ce147a3179c45907fa11b4c4e \
-    --hash=sha256:9a6bcec2df2707aaa9d08b86071970ee32c5026e10bcc3cc5f6f391d85baf7ca \
-    --hash=sha256:a4560ad8c01e537708d2790dbe7da7d986791de805d89dd0d3697ca59e9e4901 \
-    --hash=sha256:ab5920877dd632c124b4ed17bc6dd6ef3b9f86cd492b963ffdb1a67b85b0f408 \
-    --hash=sha256:d261cd88fcd358cfb48a7ca0700db3e1c088c9c10403c9ebc0d8a8b57aa6a117
-    # via
-    #   jupyter-server
-    #   jupyter-server-terminals
-    #   terminado
 pyyaml==6.0.2 \
     --hash=sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff \
     --hash=sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48 \
@@ -1826,7 +1564,6 @@ pyyaml==6.0.2 \
     # via
     #   -r nmodl_requirements.txt
     #   bokeh
-    #   jupyter-events
     #   myst-parser
 pyzmq==26.4.0 \
     --hash=sha256:0329bdf83e170ac133f44a233fc651f6ed66ef8e66693b5af7d54f45d1ef5918 \
@@ -1922,36 +1659,17 @@ pyzmq==26.4.0 \
     --hash=sha256:f8f3c30fb2d26ae5ce36b59768ba60fb72507ea9efc72f8f69fa088450cff1df \
     --hash=sha256:f928eafd15794aa4be75463d537348b35503c1e014c5b663f206504ec1a90fe4 \
     --hash=sha256:fa59e1f5a224b5e04dc6c101d7186058efa68288c2d714aa12d27603ae93318b
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   jupyter-console
-    #   jupyter-server
+    # via jupyter-client
 referencing==0.36.2 \
     --hash=sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa \
     --hash=sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0
     # via
     #   jsonschema
     #   jsonschema-specifications
-    #   jupyter-events
 requests==2.32.4 \
     --hash=sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c \
     --hash=sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422
-    # via
-    #   jupyterlab-server
-    #   sphinx
-rfc3339-validator==0.1.4 \
-    --hash=sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b \
-    --hash=sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa
-    # via
-    #   jsonschema
-    #   jupyter-events
-rfc3986-validator==0.1.1 \
-    --hash=sha256:2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9 \
-    --hash=sha256:3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055
-    # via
-    #   jsonschema
-    #   jupyter-events
+    # via sphinx
 rpds-py==0.24.0 \
     --hash=sha256:0047638c3aa0dbcd0ab99ed1e549bbf0e142c9ecc173b6492868432d8989a046 \
     --hash=sha256:006f4342fe729a368c6df36578d7a348c7c716be1da0a1a0f86e3021f8e98724 \
@@ -2157,16 +1875,11 @@ scipy==1.15.3 ; python_full_version >= '3.10' \
     #   mizani
     #   plotnine
     #   statsmodels
-send2trash==1.8.3 \
-    --hash=sha256:0c31227e0bd08961c7665474a3d1ef7193929fedda4233843689baa056be46c9 \
-    --hash=sha256:b18e7a3966d99871aefeb00cfbcfdced55ce4871194810fc71f4aa484b953abf
-    # via jupyter-server
 setuptools==78.1.1 \
     --hash=sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561 \
     --hash=sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d
     # via
     #   -r nrn_requirements.txt
-    #   jupyterlab
     #   setuptools-scm
 setuptools-scm==8.1.0 \
     --hash=sha256:42dea1b65771cba93b7a515d65a65d8246e560768a66b9106a592c8e7f26c8a7 \
@@ -2177,13 +1890,7 @@ setuptools-scm==8.1.0 \
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
-    # via
-    #   python-dateutil
-    #   rfc3339-validator
-sniffio==1.3.1 \
-    --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2 \
-    --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
-    # via anyio
+    # via python-dateutil
 snowballstemmer==3.0.1 \
     --hash=sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064 \
     --hash=sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895
@@ -2296,12 +2003,6 @@ tenacity==8.3.0 \
     # via
     #   -r ci_requirements.txt
     #   -r docs/docs_requirements.txt
-terminado==0.18.1 \
-    --hash=sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0 \
-    --hash=sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e
-    # via
-    #   jupyter-server
-    #   jupyter-server-terminals
 tinycss2==1.4.0 \
     --hash=sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7 \
     --hash=sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289
@@ -2341,7 +2042,6 @@ tomli==2.2.1 ; python_full_version <= '3.11' \
     --hash=sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7
     # via
     #   coverage
-    #   jupyterlab
     #   pytest
     #   scikit-build-core
     #   setuptools-scm
@@ -2361,47 +2061,30 @@ tornado==6.5.1 \
     --hash=sha256:e0a36e1bc684dca10b1aa75a31df8bdfed656831489bc1e6a6ebed05dc1ec365
     # via
     #   bokeh
-    #   ipykernel
     #   jupyter-client
-    #   jupyter-server
-    #   jupyterlab
-    #   notebook
-    #   terminado
 traitlets==5.14.3 \
     --hash=sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7 \
     --hash=sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f
     # via
     #   comm
-    #   ipykernel
     #   ipython
     #   ipywidgets
     #   jupyter-client
-    #   jupyter-console
     #   jupyter-core
-    #   jupyter-events
-    #   jupyter-server
-    #   jupyterlab
     #   matplotlib-inline
     #   nbclient
     #   nbconvert
     #   nbformat
     #   nbsphinx
-types-python-dateutil==2.9.0.20241206 \
-    --hash=sha256:18f493414c26ffba692a72369fea7a154c502646301ebfe3d56a04b3767284cb \
-    --hash=sha256:e248a4bc70a486d3e3ec84d0dc30eec3a5f979d6e7ee4123ae043eedbb987f53
-    # via arrow
 typing-extensions==4.13.2 \
     --hash=sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c \
     --hash=sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef
     # via
-    #   anyio
     #   anywidget
-    #   async-lru
     #   beautifulsoup4
     #   exceptiongroup
     #   ipython
     #   mistune
-    #   python-json-logger
     #   referencing
     #   setuptools-scm
 tzdata==2025.2 \
@@ -2410,10 +2093,6 @@ tzdata==2025.2 \
     # via
     #   mizani
     #   pandas
-uri-template==1.3.0 \
-    --hash=sha256:0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7 \
-    --hash=sha256:a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363
-    # via jsonschema
 urllib3==2.5.0 \
     --hash=sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760 \
     --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
@@ -2422,20 +2101,12 @@ wcwidth==0.2.13 \
     --hash=sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859 \
     --hash=sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5
     # via prompt-toolkit
-webcolors==24.11.1 \
-    --hash=sha256:515291393b4cdf0eb19c155749a096f779f7d909f7cceea072791cb9095b92e9 \
-    --hash=sha256:ecb3d768f32202af770477b8b65f318fa4f566c22948673a977b00d589dd80f6
-    # via jsonschema
 webencodings==0.5.1 \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
     # via
     #   bleach
     #   tinycss2
-websocket-client==1.8.0 \
-    --hash=sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526 \
-    --hash=sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da
-    # via jupyter-server
 widgetsnbextension==4.0.14 \
     --hash=sha256:4875a9eaf72fbf5079dc372a51a9f268fc38d46f767cbf85c43a36da5cb9b575 \
     --hash=sha256:a3629b04e3edb893212df862038c7232f62973373869db5084aed739b437b5af

--- a/cmake/PythonCompileHelper.cmake
+++ b/cmake/PythonCompileHelper.cmake
@@ -56,6 +56,8 @@ endfunction()
 # ~~~
 # add_nrn_python_library(
 # <name>
+# [NO_EXTENSION]
+# [HAS_FREE_THREADING]
 # [TARGET target_name]
 # [PYTHON_VERSION python_version]
 # [LANGUAGE link_language]
@@ -67,23 +69,24 @@ endfunction()
 #
 # Create a target that links to nrnpython.
 #
-# <name>            - the actual name of the library being built
-# NO_EXTENSION      - (optional, default unset) in case one wants to create a
-#                     library without any platform-specific naming (so `hoc.so` instead of
-#                     `hoc.cpython39-darwin.so` or similar). Note that no prefix is added.
-# TARGET            - (optional, defaults to <name>) the name of the CMake
-#                     target. Can be anything, but may not conflict with existing targets.
-# PYTHON_VERSION    - the version of Python to create the library for (for example, 3.9).
-# LANGUAGE          - the language used for linking the library. See also the LINKER_LANGUAGE CMake variable.
-# OUTPUT_DIR        - the path to the directory where the library will be placed afer building.
-# SOURCES           - the list of source files used for compiling the library.
-# INCLUDES          - (optional) the list of include directories.
-# LIBRARIES         - (optional) the list of libraries we are linking with.
-# INSTALL_REL_RPATH - (optional) the list of RPATHs to use when installing the target.
-# BUILD_REL_RPATH   - (optional) the list of RPATHs to use when building the target.
+# <name>             - the actual name of the library being built
+# NO_EXTENSION       - (optional, default unset) in case one wants to create a
+#                      library without any platform-specific naming (so `hoc.so` instead of
+#                      `hoc.cpython39-darwin.so` or similar). Note that no prefix is added.
+# HAS_FREE_THREADING - (optional, default unset) whether the build of Python is free threaded
+# TARGET             - (optional, defaults to <name>) the name of the CMake
+#                      target. Can be anything, but may not conflict with existing targets.
+# PYTHON_VERSION     - the version of Python to create the library for (for example, 3.9).
+# LANGUAGE           - the language used for linking the library. See also the LINKER_LANGUAGE CMake variable.
+# OUTPUT_DIR         - the path to the directory where the library will be placed afer building.
+# SOURCES            - the list of source files used for compiling the library.
+# INCLUDES           - (optional) the list of include directories.
+# LIBRARIES          - (optional) the list of libraries we are linking with.
+# INSTALL_REL_RPATH  - (optional) the list of RPATHs to use when installing the target.
+# BUILD_REL_RPATH    - (optional) the list of RPATHs to use when building the target.
 # ~~~
 function(add_nrn_python_library name)
-  set(options NO_EXTENSION)
+  set(options NO_EXTENSION HAS_FREE_THREADING)
   set(oneValueArgs TARGET PYTHON_VERSION LANGUAGE OUTPUT_DIR)
   set(multiValueArgs SOURCES INCLUDES LIBRARIES INSTALL_REL_RPATH BUILD_REL_RPATH)
   cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -190,6 +193,10 @@ function(add_nrn_python_library name)
   if(ARG_NO_EXTENSION)
     set(output_name "${name}")
   else()
+    if(ARG_HAS_FREE_THREADING)
+      # the free-threaded build needs an additional `t` after the Python version
+      set(pyver_nodot "${pyver_nodot}t")
+    endif()
     set(output_name "${name}.${python_interp}${pyver_nodot}-${os_string}")
   endif()
 

--- a/cmake/PythonHelper.cmake
+++ b/cmake/PythonHelper.cmake
@@ -135,6 +135,22 @@ function(nrn_find_python)
         "${Python_VERSION}"
         PARENT_SCOPE)
   endif()
+
+  # Check if the build is free-threaded
+  execute_process(
+    COMMAND "${opt_NAME}" -c "import sysconfig; print(sysconfig.get_config_var('Py_GIL_DISABLED'))"
+    OUTPUT_VARIABLE has_free_threading
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(has_free_threading EQUAL 1)
+    set("${opt_PREFIX}_HAS_FREE_THREADING"
+        "HAS_FREE_THREADING"
+        PARENT_SCOPE)
+  else()
+    set("${opt_PREFIX}_HAS_FREE_THREADING"
+        ""
+        PARENT_SCOPE)
+  endif()
+
   # Finally do our special treatment for macOS + sanitizers
   if(APPLE AND NRN_SANITIZERS)
     # Detect if the binary we have in opt_NAME points to a virtual environment.
@@ -189,6 +205,7 @@ set(NRN_PYTHON_EXECUTABLES)
 set(NRN_PYTHON_VERSIONS)
 set(NRN_PYTHON_INCLUDES)
 set(NRN_PYTHON_LIBRARIES)
+set(NRN_PYTHON_HAS_FREE_THREADING)
 foreach(pyexe ${python_executables})
   message(STATUS "Checking if ${pyexe} is a working python")
   nrn_find_python(NAME "${pyexe}" PREFIX nrnpy)
@@ -214,6 +231,7 @@ foreach(pyexe ${python_executables})
     list(APPEND NRN_PYTHON_VERSIONS "${nrnpy_VERSION}")
     list(APPEND NRN_PYTHON_INCLUDES "${nrnpy_INCLUDES}")
     list(APPEND NRN_PYTHON_LIBRARIES "${nrnpy_LIBRARIES}")
+    list(APPEND NRN_PYTHON_HAS_FREE_THREADING "${nrnpy_HAS_FREE_THREADING}")
   endif()
   list(APPEND NRN_PYTHON_EXECUTABLES "${nrnpy_EXECUTABLE}")
 endforeach()
@@ -224,6 +242,7 @@ list(GET NRN_PYTHON_VERSIONS 0 NRN_DEFAULT_PYTHON_VERSION)
 if(NRN_ENABLE_PYTHON)
   list(GET NRN_PYTHON_INCLUDES 0 NRN_DEFAULT_PYTHON_INCLUDES)
   list(GET NRN_PYTHON_LIBRARIES 0 NRN_DEFAULT_PYTHON_LIBRARIES)
+  list(GET NRN_PYTHON_HAS_FREE_THREADING 0 NRN_DEFAULT_PYTHON_HAS_FREE_THREADING)
   list(LENGTH NRN_PYTHON_EXECUTABLES NRN_PYTHON_COUNT)
   math(EXPR NRN_PYTHON_ITERATION_LIMIT "${NRN_PYTHON_COUNT} - 1")
 endif()

--- a/cmake/PythonHelper.cmake
+++ b/cmake/PythonHelper.cmake
@@ -52,6 +52,7 @@ endif()
 # * nrnpy_INCLUDES
 # * nrnpy_LIBRARIES
 # * nrnpy_VERSION
+# * nrnpy_HAS_FREE_THREADING
 #
 # If NRN_ENABLE_PYTHON is *not* set then only nrnpy_EXECUTABLE will be set. There is some special
 # handling on macOS when sanitizers are enabled:
@@ -146,8 +147,9 @@ function(nrn_find_python)
         "HAS_FREE_THREADING"
         PARENT_SCOPE)
   else()
+    # we can't use an empty string because CMake does not have native support for lists
     set("${opt_PREFIX}_HAS_FREE_THREADING"
-        ""
+        " "
         PARENT_SCOPE)
   endif()
 

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -1,13 +1,10 @@
 sphinx
 # do not check import of next line
 sphinx_rtd_theme
-jupyter
 nbconvert
 myst_parser
 matplotlib
 bokeh
-# do not check import of next line
-ipython
 plotnine
 numpy
 plotly

--- a/nmodl_requirements.txt
+++ b/nmodl_requirements.txt
@@ -11,8 +11,6 @@ pytest-cov
 numpy>=1.9.3,<=2.2.3
 scipy
 # dependencies for docs
-jupyter-client
-jupyter
 myst_parser<=4.0.1
 mistune<=3.1.3
 nbconvert

--- a/nrn_requirements.txt
+++ b/nrn_requirements.txt
@@ -1,5 +1,4 @@
 matplotlib<=3.10.0
-ipython<=8.32.0
 mpi4py<=4.0.3
 find_libpython<=0.4.0
 packaging<=25.0,>=22.0

--- a/packaging/python/Dockerfile
+++ b/packaging/python/Dockerfile
@@ -86,9 +86,6 @@ RUN yum -y remove ncurses-devel
 # build wheels from there
 WORKDIR /root
 
-# remove Python 3.13t since we do not support the free-threaded build yet
-RUN rm -fr /opt/python/cp313-cp313t
-
 ENV NMODL_PYLIB=/nrnwheel/python/lib/libpython3.10.so.1.0
 
 ENV PATH /usr/lib64/openmpi/bin:$PATH

--- a/packaging/python/build_requirements.txt
+++ b/packaging/python/build_requirements.txt
@@ -1,4 +1,4 @@
 scikit-build-core<=0.11.1
 setuptools-scm<=8.1.0
-cython<=3.0.12
+cython<=3.1.2,>=3.1
 numpy<=2.2.3

--- a/packaging/python/macos_installer_patch3.13t.plist
+++ b/packaging/python/macos_installer_patch3.13t.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+        <dict>
+                <key>attributeSetting</key>
+                <integer>1</integer>
+                <key>choiceAttribute</key>
+                <string>selected</string>
+                <key>choiceIdentifier</key>
+                <string>org.python.Python.PythonTFramework-3.13</string>
+        </dict>
+</array>
+</plist>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "scikit_build_core.build"
 # `build-system.requires` nor `project.dependencies`, so we need to list them
 # here manually. These are all of the dependencies that CMake finds as well.
 requires = [
-  "cython<=3.0.12",
+  "cython<=3.1.2,>=3.1",
   "jinja2>=2.9.3,<=3.1.6",
   "numpy<=2.2.3",
   "pyyaml>=3.13,<=6.0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,8 +124,9 @@ NRN_MPI_DYNAMIC = { env = "NRN_MPI_DYNAMIC" }
 
 [tool.cibuildwheel]
 # We can specify a custom Docker image when building NEURON
-manylinux-aarch64-image = "docker.io/neuronsimulator/neuron_wheel:manylinux_2_28_aarch64"
-manylinux-x86_64-image = "docker.io/neuronsimulator/neuron_wheel:manylinux_2_28_x86_64"
+# TODO remove the `_freethreaded` suffix from the images
+manylinux-aarch64-image = "docker.io/neuronsimulator/neuron_wheel:manylinux_2_28_aarch64_freethreaded"
+manylinux-x86_64-image = "docker.io/neuronsimulator/neuron_wheel:manylinux_2_28_x86_64_freethreaded"
 
 # certain platforms are not supported
 skip = [ "pp*", "*-win32", "*-manylinux_i686", "*-musllinux_i686", "*-musllinux_x86_64", "*-musllinux_aarch64" ]

--- a/share/lib/python/neuron/rxd/geometry3d/CMakeLists.txt
+++ b/share/lib/python/neuron/rxd/geometry3d/CMakeLists.txt
@@ -43,9 +43,11 @@ if(NRN_ENABLE_PYTHON_DYNAMIC)
     list(GET NRN_PYTHON_VERSIONS ${val} pyver)
     list(GET NRN_PYTHON_INCLUDES ${val} pyinc)
     list(GET NRN_PYTHON_LIBRARIES ${val} pylib)
+    list(GET NRN_PYTHON_HAS_FREE_THREADING ${val} pyhasthreading)
     foreach(source ${rxd_sources})
       add_nrn_python_library(
         ${source}
+        ${pyhasthreading}
         TARGET
         ${source}${pyver}
         PYTHON_VERSION
@@ -84,6 +86,7 @@ else(NRN_ENABLE_PYTHON_DYNAMIC)
   foreach(source ${rxd_sources})
     add_nrn_python_library(
       ${source}
+      ${NRN_DEFAULT_PYTHON_HAS_FREE_THREADING}
       TARGET
       ${source}
       PYTHON_VERSION

--- a/src/neuronmusic/CMakeLists.txt
+++ b/src/neuronmusic/CMakeLists.txt
@@ -16,9 +16,11 @@ if(NRN_ENABLE_PYTHON_DYNAMIC)
     list(GET NRN_PYTHON_VERSIONS ${val} pyver)
     list(GET NRN_PYTHON_INCLUDES ${val} pyinc)
     list(GET NRN_PYTHON_LIBRARIES ${val} pylib)
+    list(GET NRN_PYTHON_HAS_FREE_THREADING ${val} pyhasthreading)
 
     add_nrn_python_library(
       ${source}
+      ${pyhasthreading}
       TARGET
       ${source}${pyver}
       PYTHON_VERSION
@@ -45,6 +47,7 @@ if(NRN_ENABLE_PYTHON_DYNAMIC)
 else()
   add_nrn_python_library(
     ${source}
+    ${NRN_DEFAULT_PYTHON_HAS_FREE_THREADING}
     TARGET
     ${source}
     PYTHON_VERSION

--- a/src/nmodl/pybind/pynmodl.cpp
+++ b/src/nmodl/pybind/pynmodl.cpp
@@ -136,7 +136,7 @@ void init_visitor_module(py::module& m);
 void init_ast_module(py::module& m);
 void init_symtab_module(py::module& m);
 
-PYBIND11_MODULE(_nmodl, m_nmodl) {
+PYBIND11_MODULE(_nmodl, m_nmodl, py::mod_gil_not_used()) {
     m_nmodl.doc() = "NMODL : Source-to-Source Code Generation Framework";
     m_nmodl.attr("__version__") = nmodl::Version::NMODL_VERSION;
 

--- a/src/nrnpython/CMakeLists.txt
+++ b/src/nrnpython/CMakeLists.txt
@@ -63,6 +63,7 @@ if(NRN_ENABLE_PYTHON_DYNAMIC)
     list(GET NRN_PYTHON_VERSIONS ${val} pyver)
     list(GET NRN_PYTHON_INCLUDES ${val} pyinc)
     list(GET NRN_PYTHON_LIBRARIES ${val} pylib)
+    list(GET NRN_PYTHON_HAS_FREE_THREADING ${val} pyhasthreading)
     set(nanobind_target "nanobind_py${pyver}")
     make_nanobind_target(${nanobind_target} ${pyinc})
     add_library(nrnpython${pyver} SHARED ${NRNPYTHON_FILES_LIST})
@@ -80,6 +81,7 @@ if(NRN_ENABLE_PYTHON_DYNAMIC)
     set(hoc_module_name hoc${pyver})
     add_nrn_python_library(
       hoc
+      ${pyhasthreading}
       TARGET
       ${hoc_module_name}
       PYTHON_VERSION
@@ -138,6 +140,7 @@ else()
   set(hoc_module_name "hoc_module")
   add_nrn_python_library(
     hoc
+    ${NRN_DEFAULT_PYTHON_HAS_FREE_THREADING}
     TARGET
     ${hoc_module_name}
     PYTHON_VERSION

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -3330,6 +3330,9 @@ extern "C" NRN_EXPORT PyObject* nrnpy_hoc() {
     }
     m = PyModule_Create(&hocmodule);
     assert(m);
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
 
     Symbol* s = NULL;
     spec = obj_spec_from_name("hoc.HocObject");

--- a/src/nrnpython/nrnpy_nrn.cpp
+++ b/src/nrnpython/nrnpy_nrn.cpp
@@ -3013,7 +3013,7 @@ PyObject* nrnpy_nrn(void) {
     psection_type = (PyTypeObject*) PyType_FromSpec(&nrnpy_SectionType_spec);
     psection_type->tp_new = PyType_GenericNew;
     if (PyType_Ready(psection_type) < 0)
-        goto fail;
+        return nullptr;
     Py_INCREF(psection_type);
 
     pallseg_of_sec_iter_type = (PyTypeObject*) PyType_FromSpec(&nrnpy_AllSegOfSecIterType_spec);
@@ -3021,20 +3021,20 @@ PyObject* nrnpy_nrn(void) {
     pallseg_of_sec_iter_type->tp_new = PyType_GenericNew;
     pseg_of_sec_iter_type->tp_new = PyType_GenericNew;
     if (PyType_Ready(pallseg_of_sec_iter_type) < 0)
-        goto fail;
+        return nullptr;
     if (PyType_Ready(pseg_of_sec_iter_type) < 0)
-        goto fail;
+        return nullptr;
     Py_INCREF(pallseg_of_sec_iter_type);
     Py_INCREF(pseg_of_sec_iter_type);
 
     psegment_type = (PyTypeObject*) PyType_FromSpec(&nrnpy_SegmentType_spec);
     psegment_type->tp_new = PyType_GenericNew;
     if (PyType_Ready(psegment_type) < 0)
-        goto fail;
+        return nullptr;
     if (PyType_Ready(pallseg_of_sec_iter_type) < 0)
-        goto fail;
+        return nullptr;
     if (PyType_Ready(pseg_of_sec_iter_type) < 0)
-        goto fail;
+        return nullptr;
     Py_INCREF(psegment_type);
     Py_INCREF(pallseg_of_sec_iter_type);
     Py_INCREF(pseg_of_sec_iter_type);
@@ -3042,13 +3042,13 @@ PyObject* nrnpy_nrn(void) {
     range_type = (PyTypeObject*) PyType_FromSpec(&nrnpy_RangeType_spec);
     range_type->tp_new = PyType_GenericNew;
     if (PyType_Ready(range_type) < 0)
-        goto fail;
+        return nullptr;
     Py_INCREF(range_type);
 
     opaque_pointer_type = (PyTypeObject*) PyType_FromSpec(&nrnpy_OpaquePointerType_spec);
     opaque_pointer_type->tp_new = PyType_GenericNew;
     if (PyType_Ready(opaque_pointer_type) < 0)
-        goto fail;
+        return nullptr;
     Py_INCREF(opaque_pointer_type);
 
     m = nb::steal(PyModule_Create(&nrnsectionmodule));  // like nrn but namespace will not include
@@ -3072,14 +3072,11 @@ PyObject* nrnpy_nrn(void) {
     pmechfunc_generic_type->tp_new = PyType_GenericNew;
     pmech_of_seg_iter_generic_type->tp_new = PyType_GenericNew;
     pvar_of_mech_iter_generic_type->tp_new = PyType_GenericNew;
-    if (PyType_Ready(pmech_generic_type) < 0)
-        goto fail;
-    if (PyType_Ready(pmechfunc_generic_type) < 0)
-        goto fail;
-    if (PyType_Ready(pmech_of_seg_iter_generic_type) < 0)
-        goto fail;
-    if (PyType_Ready(pvar_of_mech_iter_generic_type) < 0)
-        goto fail;
+    if (PyType_Ready(pmech_generic_type) < 0 || PyType_Ready(pmechfunc_generic_type) < 0 ||
+        PyType_Ready(pmech_of_seg_iter_generic_type) < 0 ||
+        PyType_Ready(pvar_of_mech_iter_generic_type) < 0) {
+        return nullptr;
+    }
     Py_INCREF(pmech_generic_type);
     Py_INCREF(pmechfunc_generic_type);
     Py_INCREF(pmech_of_seg_iter_generic_type);
@@ -3101,13 +3098,13 @@ PyObject* nrnpy_nrn(void) {
 
     err = PyDict_SetItemString(modules, "nrn", m.ptr());
     assert(err == 0);
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(m.ptr(), Py_MOD_GIL_NOT_USED);
+#endif
     return m.ptr();
-fail:
-    return NULL;
 }
 
 void remake_pmech_types() {
-    int i;
     Py_XDECREF(pmech_types);
     Py_XDECREF(rangevars_);
     pmech_types = PyDict_New();
@@ -3117,7 +3114,7 @@ void remake_pmech_types() {
     rangevars_add(hoc_table_lookup("v", hoc_built_in_symlist));
     rangevars_add(hoc_table_lookup("i_cap", hoc_built_in_symlist));
     rangevars_add(hoc_table_lookup("i_membrane_", hoc_built_in_symlist));
-    for (i = 4; i < n_memb_func; ++i) {  // start at pas
+    for (auto i = 4; i < n_memb_func; ++i) {  // start at pas
         nrnpy_reg_mech(i);
     }
 }


### PR DESCRIPTION
Currently it just builds, there are a lot of test failures. The docs also do not build because jupyter and ipython depend on argon2-cffi, which does not support the free-threaded build yet.

Changes:

- bump pybind11 to 2.13
- bump Cython to at least 3.1
- add CMake support for detecting free-threaded builds
- add free-threaded build to CI
- update Dockerfile

References:

- https://github.com/hynek/argon2-cffi/issues/187
- https://cython.readthedocs.io/en/latest/src/userguide/freethreading.html
- https://docs.python.org/3.13/howto/free-threading-extensions.html
- https://pybind11.readthedocs.io/en/stable/advanced/misc.html#misc-free-threading
- https://github.com/pybind/pybind11/releases/tag/v2.13.0
- https://labs.quansight.org/blog/free-threaded-one-year-recap
- https://nanobind.readthedocs.io/en/latest/free_threaded.html
- https://cibuildwheel.pypa.io/en/stable/options/#enable
- https://docs.python.org/3.13/using/mac.html#installing-using-the-command-line
- https://stackoverflow.com/a/71697223