### PR TITLE
Fix cross wheel-building on ARM-based MacOS

### DIFF
--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -94,6 +94,7 @@ set_cibw_environment() {
             [NRN_ENABLE_CORENEURON]="ON"
             [NRN_BINARY_DIST_BUILD]="ON"
             [NRN_RX3D_OPT_LEVEL]="0"
+            [NRN_ENABLE_INTERVIEWS]="ON"
             # 10.14 is required for full C++17 support according to
             # https://cibuildwheel.readthedocs.io/en/stable/cpp_standards, but it
             # seems that 10.15 is actually needed for std::filesystem::path.
@@ -110,6 +111,7 @@ set_cibw_environment() {
             [CORENRN_ENABLE_OPENMP]="ON"
             [NRN_BINARY_DIST_BUILD]="ON"
             [NRN_RX3D_OPT_LEVEL]="0"
+            [NRN_ENABLE_INTERVIEWS]="ON"
         )
     fi
 
@@ -138,7 +140,14 @@ build_wheel_portable() {
     rm -rf "${build_dir}"
 
     if [ "${platform}" = 'linux' ]; then
-        NRN_MPI_DYNAMIC="/usr/include/openmpi-$(uname -m);/usr/include/mpich-$(uname -m)"
+        # detect whether we are cross compiling, see:
+        # https://github.com/neuronsimulator/nrn/issues/3535
+        if [ "$(uname -s)" = 'Darwin' ] && [ "$(uname -m)" = 'arm64' ]; then
+            NRN_MPI_DYNAMIC="${NRN_MPI_DYNAMIC:-/usr/include/openmpi-aarch64;/usr/include/mpich-aarch64}"
+        else
+            NRN_MPI_DYNAMIC="${NRN_MPI_DYNAMIC:-/usr/include/openmpi-$(uname -m);/usr/include/mpich-$(uname -m)}"
+        fi
+
         # if we are building on Azure, we can use the MPT headers as well
         if [ -n "${TF_BUILD:-}" ]; then
             NRN_MPI_DYNAMIC="${NRN_MPI_DYNAMIC};/host/opt/nrnwheel/mpt/include"
@@ -148,7 +157,7 @@ build_wheel_portable() {
 
     if [ "${platform}" = 'macos' ]; then
         if [ "$(uname -m)" = 'arm64' ]; then
-            export MACOSX_DEPLOYMENT_TARGET='11.0'
+            export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
         fi
     fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ environment-pass = [
   "CORENRN_ENABLE_OPENMP",
   "NRN_BINARY_DIST_BUILD",
   "NRN_RX3D_OPT_LEVEL",
+  "NRN_ENABLE_INTERVIEWS",
   # when making a release, we need to override the version
   "SETUPTOOLS_SCM_PRETEND_VERSION",
   # in case the user wants to use less resources


### PR DESCRIPTION
* Add special case when building Linux NEURON wheels on ARM MacOS host
* Fix #3535
* Pass `NRN_ENABLE_INTERVIEWS` env var to container