### PR TITLE
Add `--oversubscribe` to MPI parallel tests in `test_wheels.sh`

### DIFF
--- a/packaging/python/test_wheels.sh
+++ b/packaging/python/test_wheels.sh
@@ -188,7 +188,7 @@ run_parallel_test() {
       sudo update-alternatives --list mpi-${ARCH_DIR}-linux-gnu
       # choose mpich
       sudo update-alternatives --set mpi-${ARCH_DIR}-linux-gnu /usr/include/${ARCH_DIR}-linux-gnu/mpich
-      run_mpi_test "mpirun.mpich --oversubscribe" "MPICH" ""
+      run_mpi_test "mpirun.mpich" "MPICH" ""
       # choose openmpi
       sudo update-alternatives --set mpi-${ARCH_DIR}-linux-gnu /usr/lib/${ARCH_DIR}-linux-gnu/openmpi/include
       run_mpi_test "mpirun.openmpi --oversubscribe" "OpenMPI" ""


### PR DESCRIPTION
Due to [changes beyond our control](https://learn.microsoft.com/en-us/answers/questions/2286730/pipelines-new-error-not-enough-slots-available-in), MPI and Azure with Linux runners do not play along nicely anymore (random pipelines failures occur). Using `--oversubscribe` with OpenMPI should have minimal impact on the performance, while making the CI actually pass on the first go (otherwise we need to wait another ~25 minutes for the job to pass).