### PR TITLE
Fix nvc++ error: input file 'libnrnmech.so' is the same as output file

### DIFF
--- a/bin/nrnivmodl_makefile_cmake.in
+++ b/bin/nrnivmodl_makefile_cmake.in
@@ -130,8 +130,11 @@ $(mech_lib): $(mech_lib_type)
 
 mech_lib_shared: mod_func.o $(mod_objs) build_always
 	@printf " => $(C_GREEN)LINKING$(C_RESET) shared library \"${PWD}/$(mech_lib)\"\n"
-	$(CXX_LINK_SHARED) -I $(incdir) -o ${mech_lib} ${_SONAME} \
-	  $(mod_func_o) $(mod_objs) $(NRNLIB_FLAGS) $(NRNLIB_RPATH_FLAGS) $(LDFLAGS)
+	# .tmp output avoids nvc++ error: input file 'libnrnmech.so' is the same as output file
+	$(CXX_LINK_SHARED) -I $(incdir) -o ${mech_lib}.tmp ${_SONAME} \
+	  $(mod_func_o) $(mod_objs) $(NRNLIB_FLAGS) $(NRNLIB_RPATH_FLAGS) $(LDFLAGS) \
+	  && mv ${mech_lib}.tmp ${mech_lib}
+ 
 
 mech_lib_static: mod_func.o $(mod_objs) build_always
 	@printf " => $(C_GREEN)LINKING$(C_RESET) static library \"${PWD}/$(mech_lib)\"\n"


### PR DESCRIPTION
I see this only with nvc++ when nrnivmodl is run and libnrnmech.so already exists. It is mentioned in #3421. The problem can be worked around by creating a temporary output with ```-o ${mech_lib}.tmp``` and subsequently moving that to ```${mech_lib}```. The nvc++ otherwise seems to interact badly with the argument ```${_SONAME}``` which expands to ```-Wl,-soname,libnrnmech.so```