### PR TITLE
ion_style doc for 0200 and 0400 ciwrite and cowrite return bits.

### DIFF
--- a/docs/python/modelspec/programmatic/ions.rst
+++ b/docs/python/modelspec/programmatic/ions.rst
@@ -23,15 +23,17 @@ Ions
         appropriate to the set of mechanisms inserted in each section. 
          
         The ``oldstyle`` value is the previous internal setting of 
-        c_style + 4*cinit + 8*e_style + 32*einit + 64*eadvance. 
+        c_style + 4*cinit + 8*e_style + 32*einit + 64*eadvance. Additionally
+        the two internal bit values of 128*ciwrite and 256*cowrite are
+        present and set (not setable by user) only if the section has mechanisms that USEION
+        WRITE the internal or external ion concentration, e.g. nai or nao.
         That is, to get the parameter values from ``oldstyle``, use
         ``c_style = oldstyle % 4``, ``cinit = (oldstyle // 4) % 2``, 
         ``e_style = (oldstyle // 8) % 4``, ``einit = (oldstyle // 32) % 2``, 
-        ``eadvance = (oldstyle // 64) % 2``
+        ``eadvance = (oldstyle // 64) % 2``, ``ci_is_written = ((oldstyle & 128) != 0)``,
+        ``co_is_written = ((oldsytle & 256) != 0)``
 
          
-
-
         c_style: 0, 1, 2, 3. 
             Concentrations respectively treated as UNUSED, 
             PARAMETER, ASSIGNED, or STATE variables.  Determines which panel (if 


### PR DESCRIPTION
Promised to update ion_style doc since https://neuron.yale.edu/phpBB/viewtopic.php?t=782