### PR TITLE
Better concurrency for wheels CI

### DIFF
--- a/.github/workflows/wheels-ci.yml
+++ b/.github/workflows/wheels-ci.yml
@@ -1,5 +1,10 @@
 name: Build NEURON Python wheels for CI
 
+concurrency:
+  # Don't cancel on master, creating a PR when a push workflow is already going will cancel the push workflow in favour of the PR workflow
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.event.number && github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:


### PR DESCRIPTION
Apparently the job is not cancelled if one pushes additional changes, which is a huge bottleneck in the CI speed.