### PR TITLE
Fixed nrn_str_pop's name to match the other push and pop function names

### DIFF
--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -273,7 +273,7 @@ void nrn_str_push(char** str) {
     hoc_pushstr(str);
 }
 
-char** nrn_pop_str(void) {
+char** nrn_str_pop(void) {
     return hoc_strpop();
 }
 

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -82,7 +82,7 @@ double nrn_double_pop(void);
 void nrn_double_ptr_push(double* addr);
 double* nrn_double_ptr_pop(void);
 void nrn_str_push(char** str);
-char** nrn_pop_str(void);
+char** nrn_str_pop(void);
 void nrn_int_push(int i);
 int nrn_int_pop(void);
 void nrn_object_push(Object* obj);


### PR DESCRIPTION
`nrn_pop_str` is `now nrn_str_pop`