### PR TITLE
HOC object operator overloading: arithmetic and comparison

### DIFF
--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -19,6 +19,8 @@
 #include "seclist.h"  // lvappendsec_and_ref, seclist_size
 
 #include <cstdint>
+#include <climits>
+#include <cmath>
 #include <vector>
 #include <sstream>
 #include <unordered_map>
@@ -3609,13 +3611,32 @@ static int nrnpy_call_obj_method_(Object* obj, const char* method, Object* obj2)
 }
 
 static int nrnpy_call_obj_method_double_(Object* obj, const char* method, double value) {
-    // Convert double to PyObject
-    PyObject* py_arg = PyFloat_FromDouble(value);
+    // Convert double to PyObject. If the double is finite and very close to
+    // an integer value (within floating point tolerance) then pass a Python
+    // integer. This preserves expected semantics for libraries (e.g. RxD)
+    // that treat integer stoichiometric coefficients specially while still
+    // allowing non-integer values to be passed as floats.
+    PyObject* py_arg = nullptr;
+    if (std::isfinite(value)) {
+        double intpart;
+        double frac = std::modf(value, &intpart);
+        if (std::fabs(frac) < 1e-12) {
+            long long vll = (long long)intpart;
+            if ((double)vll == intpart) {
+                py_arg = PyLong_FromLongLong(vll);
+            }
+        }
+    }
+
+    if (!py_arg) {
+        py_arg = PyFloat_FromDouble(value);
+    }
+
     if (!py_arg) {
         PyErr_Clear();
         return 0;
     }
-    
+
     int result = nrnpy_call_obj_method_helper_(obj, method, py_arg);
     Py_DECREF(py_arg);
     return result;

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -3600,11 +3600,11 @@ static int nrnpy_call_obj_method_(Object* obj, const char* method, Object* obj2)
         py_arg = Py_None;
         Py_INCREF(py_arg);
     }
-    
+
     if (!py_arg) {
         return 0;
     }
-    
+
     int result = nrnpy_call_obj_method_helper_(obj, method, py_arg);
     Py_DECREF(py_arg);
     return result;

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -3532,38 +3532,38 @@ static int nrnpy_call_obj_method_helper_(Object* obj, const char* method, PyObje
     if (!obj || obj->ctemplate->sym != nrnpy_pyobj_sym_) {
         return 0;
     }
-    
+
     // Convert obj to PyObject
     PyObject* py_obj = nrnpy_hoc2pyobject(obj);
     if (!py_obj) {
         return 0;
     }
-    
+
     // Check if method exists and is callable
     if (!PyObject_HasAttrString(py_obj, method)) {
         return 0;
     }
-    
+
     PyObject* py_method = PyObject_GetAttrString(py_obj, method);
     if (!py_method) {
         PyErr_Clear();
         return 0;
     }
-    
+
     if (!PyCallable_Check(py_method)) {
         Py_DECREF(py_method);
         return 0;
     }
-    
+
     // Call the method
     auto result = nb::steal(PyObject_CallFunctionObjArgs(py_method, py_arg, nullptr));
     Py_DECREF(py_method);
-    
+
     if (!result) {
         PyErr_Clear();
         return 0;
     }
-    
+
     // Check return type and push to stack
     if (PyNumber_Check(result.ptr())) {
         // Push number to stack
@@ -3581,7 +3581,7 @@ static int nrnpy_call_obj_method_helper_(Object* obj, const char* method, PyObje
             hoc_obj_unref(result_obj);
         }
     }
-    
+
     return 1;
 }
 
@@ -3616,12 +3616,12 @@ static int nrnpy_call_obj_method_double_(Object* obj, const char* method, double
     // This preserves integer semantics for libraries like RxD that distinguish
     // between integer and float coefficients.
     PyObject* py_arg = nullptr;
-    
+
     if (value == floor(value)) {
         // Value has no fractional part, try to convert to integer
-        long long vll = (long long)value;
+        long long vll = (long long) value;
         // Verify the conversion is exact (handles very large values)
-        if ((double)vll == value) {
+        if ((double) vll == value) {
             py_arg = PyLong_FromLongLong(vll);
         }
     }

--- a/src/nrnpython/nrnpy_hoc.cpp
+++ b/src/nrnpython/nrnpy_hoc.cpp
@@ -3611,20 +3611,18 @@ static int nrnpy_call_obj_method_(Object* obj, const char* method, Object* obj2)
 }
 
 static int nrnpy_call_obj_method_double_(Object* obj, const char* method, double value) {
-    // Convert double to PyObject. If the double is finite and very close to
-    // an integer value (within floating point tolerance) then pass a Python
-    // integer. This preserves expected semantics for libraries (e.g. RxD)
-    // that treat integer stoichiometric coefficients specially while still
-    // allowing non-integer values to be passed as floats.
+    // Convert double to PyObject. Pass as Python int if the value is exactly
+    // equal to its floor (i.e., has no fractional part), otherwise pass as float.
+    // This preserves integer semantics for libraries like RxD that distinguish
+    // between integer and float coefficients.
     PyObject* py_arg = nullptr;
-    if (std::isfinite(value)) {
-        double intpart;
-        double frac = std::modf(value, &intpart);
-        if (std::fabs(frac) < 1e-12) {
-            long long vll = (long long)intpart;
-            if ((double)vll == intpart) {
-                py_arg = PyLong_FromLongLong(vll);
-            }
+    
+    if (value == floor(value)) {
+        // Value has no fractional part, try to convert to integer
+        long long vll = (long long)value;
+        // Verify the conversion is exact (handles very large values)
+        if ((double)vll == value) {
+            py_arg = PyLong_FromLongLong(vll);
         }
     }
 

--- a/src/oc/code.cpp
+++ b/src/oc/code.cpp
@@ -1968,6 +1968,20 @@ void hoc_evalpointer() {
 
 void hoc_add(void) /* add top two elems on stack */
 {
+    // Check if we have objects on the stack
+    auto const& entry1 = get_stack_entry_variant(0);
+    auto const& entry2 = get_stack_entry_variant(1);
+    auto stack_type_1 = get_legacy_int_type(entry1);
+    auto stack_type_2 = get_legacy_int_type(entry2);
+
+    if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) &&
+        (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
+        // Both operands are objects, call object addition
+        hoc_object_add();
+        return;
+    }
+
+    // Regular numeric addition
     double d1, d2;
     d2 = hoc_xpop();
     d1 = hoc_xpop();
@@ -1977,6 +1991,19 @@ void hoc_add(void) /* add top two elems on stack */
 
 void hoc_sub(void) /* subtract top two elems on stack */
 {
+    // Check if we have objects on the stack
+    auto const& entry1 = get_stack_entry_variant(0);
+    auto const& entry2 = get_stack_entry_variant(1);
+    auto stack_type_1 = get_legacy_int_type(entry1);
+    auto stack_type_2 = get_legacy_int_type(entry2);
+
+    if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) &&
+        (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
+        // Both operands are objects, call object subtraction
+        hoc_object_sub();
+        return;
+    }
+
     double d1, d2;
     d2 = hoc_xpop();
     d1 = hoc_xpop();
@@ -1986,6 +2013,19 @@ void hoc_sub(void) /* subtract top two elems on stack */
 
 void hoc_mul(void) /* multiply top two elems on stack */
 {
+    // Check if we have objects on the stack
+    auto const& entry1 = get_stack_entry_variant(0);
+    auto const& entry2 = get_stack_entry_variant(1);
+    auto stack_type_1 = get_legacy_int_type(entry1);
+    auto stack_type_2 = get_legacy_int_type(entry2);
+
+    if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) &&
+        (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
+        // Both operands are objects, call object multiplication
+        hoc_object_mul();
+        return;
+    }
+
     double d1, d2;
     d2 = hoc_xpop();
     d1 = hoc_xpop();
@@ -1995,6 +2035,19 @@ void hoc_mul(void) /* multiply top two elems on stack */
 
 void hoc_div(void) /* divide top two elems on stack */
 {
+    // Check if we have objects on the stack
+    auto const& entry1 = get_stack_entry_variant(0);
+    auto const& entry2 = get_stack_entry_variant(1);
+    auto stack_type_1 = get_legacy_int_type(entry1);
+    auto stack_type_2 = get_legacy_int_type(entry2);
+
+    if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) &&
+        (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
+        // Both operands are objects, call object division
+        hoc_object_div();
+        return;
+    }
+
     double d1, d2;
     d2 = hoc_xpop();
     if (d2 == 0.0)
@@ -2069,9 +2122,20 @@ void hoc_le(void) {
 }
 
 void hoc_eq() {
-    /* auto const& entry1 = */ get_stack_entry_variant(0);
+    // Check if we have objects on the stack
+    auto const& entry1 = get_stack_entry_variant(0);
     auto const& entry2 = get_stack_entry_variant(1);
-    auto const type2 = get_legacy_int_type(entry2);
+    auto stack_type_1 = get_legacy_int_type(entry1);
+    auto stack_type_2 = get_legacy_int_type(entry2);
+    
+    if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) &&
+        (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
+        // Both operands are objects, call object equality
+        hoc_object_eq();
+        return;
+    }
+
+    auto const type2 = stack_type_2;
     double result{};
     switch (type2) {
     case NUMBER: {
@@ -2084,8 +2148,8 @@ void hoc_eq() {
         break;
     case OBJECTTMP:
     case OBJECTVAR: {
-        Object** o1{hoc_objpop()};
         Object** o2{hoc_objpop()};
+        Object** o1{hoc_objpop()};
         result = (*o1 == *o2);
         hoc_tobj_unref(o1);
         hoc_tobj_unref(o2);
@@ -2098,8 +2162,16 @@ void hoc_eq() {
 
 void hoc_ne() {
     auto const& entry1 = get_stack_entry_variant(0);
-    /* auto const& entry2 = */ get_stack_entry_variant(1);
+    auto const& entry2 = get_stack_entry_variant(1);
     auto const type1 = get_legacy_int_type(entry1);
+    auto const type2 = get_legacy_int_type(entry2);
+
+    // Check if either operand is an object
+    if (type1 == OBJECTVAR || type1 == OBJECTTMP || type2 == OBJECTVAR || type2 == OBJECTTMP) {
+        hoc_object_ne();
+        return;
+    }
+
     double result{};
     switch (type1) {
     case NUMBER: {
@@ -2110,14 +2182,6 @@ void hoc_ne() {
     case STRING:
         result = (strcmp(*hoc_strpop(), *hoc_strpop()) != 0);
         break;
-    case OBJECTTMP:
-    case OBJECTVAR: {
-        Object** o1{hoc_objpop()};
-        Object** o2{hoc_objpop()};
-        result = (*o1 != *o2);
-        hoc_tobj_unref(o1);
-        hoc_tobj_unref(o2);
-    } break;
     default:
         hoc_execerror("don't know how to compare these types", nullptr);
     }
@@ -2148,6 +2212,19 @@ void hoc_not(void) {
 
 // arg1 raised to arg2
 void hoc_power() {
+    // Check if we have objects on the stack
+    auto const& entry1 = get_stack_entry_variant(0);
+    auto const& entry2 = get_stack_entry_variant(1);
+    auto stack_type_1 = get_legacy_int_type(entry1);
+    auto stack_type_2 = get_legacy_int_type(entry2);
+
+    if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) &&
+        (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
+        // Both operands are objects, call object power
+        hoc_object_pow();
+        return;
+    }
+
     double d1, d2;
     d2 = hoc_xpop();
     d1 = hoc_xpop();

--- a/src/oc/code.cpp
+++ b/src/oc/code.cpp
@@ -1969,8 +1969,8 @@ void hoc_evalpointer() {
 void hoc_add(void) /* add top two elems on stack */
 {
     // Check if we have objects on the stack
-    auto const& entry1 = get_stack_entry_variant(0);
-    auto const& entry2 = get_stack_entry_variant(1);
+    auto const& entry1 = get_stack_entry_variant(0);  // Top of stack (second operand)
+    auto const& entry2 = get_stack_entry_variant(1);  // Below top (first operand)
     auto stack_type_1 = get_legacy_int_type(entry1);
     auto stack_type_2 = get_legacy_int_type(entry2);
 
@@ -1978,6 +1978,16 @@ void hoc_add(void) /* add top two elems on stack */
         (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
         // Both operands are objects, call object addition
         hoc_object_add();
+        return;
+    } else if (stack_type_1 == NUMBER && 
+               (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
+        // object + number (first operand=object, second operand=number)
+        hoc_object_add_number();
+        return;
+    } else if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) && 
+               stack_type_2 == NUMBER) {
+        // number + object (first operand=number, second operand=object)
+        hoc_number_add_object();
         return;
     }
 
@@ -2002,6 +2012,16 @@ void hoc_sub(void) /* subtract top two elems on stack */
         // Both operands are objects, call object subtraction
         hoc_object_sub();
         return;
+    } else if (stack_type_1 == NUMBER && 
+               (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
+        // object - number (first operand=object, second operand=number)
+        hoc_object_sub_number();
+        return;
+    } else if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) && 
+               stack_type_2 == NUMBER) {
+        // number - object (first operand=number, second operand=object)
+        hoc_number_sub_object();
+        return;
     }
 
     double d1, d2;
@@ -2024,6 +2044,16 @@ void hoc_mul(void) /* multiply top two elems on stack */
         // Both operands are objects, call object multiplication
         hoc_object_mul();
         return;
+    } else if (stack_type_1 == NUMBER && 
+               (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
+        // object * number (first operand=object, second operand=number)
+        hoc_object_mul_number();
+        return;
+    } else if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) && 
+               stack_type_2 == NUMBER) {
+        // number * object (first operand=number, second operand=object)
+        hoc_number_mul_object();
+        return;
     }
 
     double d1, d2;
@@ -2045,6 +2075,16 @@ void hoc_div(void) /* divide top two elems on stack */
         (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
         // Both operands are objects, call object division
         hoc_object_div();
+        return;
+    } else if (stack_type_1 == NUMBER && 
+               (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
+        // object / number (first operand=object, second operand=number)
+        hoc_object_div_number();
+        return;
+    } else if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) && 
+               stack_type_2 == NUMBER) {
+        // number / object (first operand=number, second operand=object)
+        hoc_number_div_object();
         return;
     }
 
@@ -2222,6 +2262,16 @@ void hoc_power() {
         (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
         // Both operands are objects, call object power
         hoc_object_pow();
+        return;
+    } else if (stack_type_1 == NUMBER && 
+               (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
+        // object ^ number (first operand=object, second operand=number)
+        hoc_object_pow_number();
+        return;
+    } else if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) && 
+               stack_type_2 == NUMBER) {
+        // number ^ object (first operand=number, second operand=object)
+        hoc_number_pow_object();
         return;
     }
 

--- a/src/oc/code.cpp
+++ b/src/oc/code.cpp
@@ -1979,13 +1979,11 @@ void hoc_add(void) /* add top two elems on stack */
         // Both operands are objects, call object addition
         hoc_object_add();
         return;
-    } else if (stack_type_1 == NUMBER && 
-               (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
+    } else if (stack_type_1 == NUMBER && (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
         // object + number (first operand=object, second operand=number)
         hoc_object_add_number();
         return;
-    } else if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) && 
-               stack_type_2 == NUMBER) {
+    } else if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) && stack_type_2 == NUMBER) {
         // number + object (first operand=number, second operand=object)
         hoc_number_add_object();
         return;
@@ -2012,13 +2010,11 @@ void hoc_sub(void) /* subtract top two elems on stack */
         // Both operands are objects, call object subtraction
         hoc_object_sub();
         return;
-    } else if (stack_type_1 == NUMBER && 
-               (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
+    } else if (stack_type_1 == NUMBER && (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
         // object - number (first operand=object, second operand=number)
         hoc_object_sub_number();
         return;
-    } else if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) && 
-               stack_type_2 == NUMBER) {
+    } else if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) && stack_type_2 == NUMBER) {
         // number - object (first operand=number, second operand=object)
         hoc_number_sub_object();
         return;
@@ -2044,13 +2040,11 @@ void hoc_mul(void) /* multiply top two elems on stack */
         // Both operands are objects, call object multiplication
         hoc_object_mul();
         return;
-    } else if (stack_type_1 == NUMBER && 
-               (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
+    } else if (stack_type_1 == NUMBER && (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
         // object * number (first operand=object, second operand=number)
         hoc_object_mul_number();
         return;
-    } else if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) && 
-               stack_type_2 == NUMBER) {
+    } else if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) && stack_type_2 == NUMBER) {
         // number * object (first operand=number, second operand=object)
         hoc_number_mul_object();
         return;
@@ -2076,13 +2070,11 @@ void hoc_div(void) /* divide top two elems on stack */
         // Both operands are objects, call object division
         hoc_object_div();
         return;
-    } else if (stack_type_1 == NUMBER && 
-               (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
+    } else if (stack_type_1 == NUMBER && (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
         // object / number (first operand=object, second operand=number)
         hoc_object_div_number();
         return;
-    } else if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) && 
-               stack_type_2 == NUMBER) {
+    } else if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) && stack_type_2 == NUMBER) {
         // number / object (first operand=number, second operand=object)
         hoc_number_div_object();
         return;
@@ -2167,7 +2159,7 @@ void hoc_eq() {
     auto const& entry2 = get_stack_entry_variant(1);
     auto stack_type_1 = get_legacy_int_type(entry1);
     auto stack_type_2 = get_legacy_int_type(entry2);
-    
+
     if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) &&
         (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
         // Both operands are objects, call object equality
@@ -2263,13 +2255,11 @@ void hoc_power() {
         // Both operands are objects, call object power
         hoc_object_pow();
         return;
-    } else if (stack_type_1 == NUMBER && 
-               (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
+    } else if (stack_type_1 == NUMBER && (stack_type_2 == OBJECTVAR || stack_type_2 == OBJECTTMP)) {
         // object ^ number (first operand=object, second operand=number)
         hoc_object_pow_number();
         return;
-    } else if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) && 
-               stack_type_2 == NUMBER) {
+    } else if ((stack_type_1 == OBJECTVAR || stack_type_1 == OBJECTTMP) && stack_type_2 == NUMBER) {
         // number ^ object (first operand=number, second operand=object)
         hoc_number_pow_object();
         return;

--- a/src/oc/code.h
+++ b/src/oc/code.h
@@ -36,6 +36,12 @@ extern void hoc_arayinstal(void);
 
 /* OOP */
 extern void hoc_objectvar(void), hoc_object_component(void), hoc_object_eval(void);
+extern void hoc_object_add(void), hoc_object_sub(void), hoc_object_mul(void), hoc_object_div(void),
+    hoc_object_pow(void), hoc_object_eq(void), hoc_object_ne(void);
+extern void hoc_object_add_expr(void), hoc_expr_add_object(void), hoc_object_sub_expr(void),
+    hoc_expr_sub_object(void), hoc_object_mul_expr(void), hoc_expr_mul_object(void),
+    hoc_object_div_expr(void), hoc_expr_div_object(void), hoc_object_pow_expr(void),
+    hoc_expr_pow_object(void);
 extern void hoc_object_asgn(void), hoc_objvardecl(void), hoc_cmp_otype(void), hoc_newobj(void);
 extern void hoc_asgn_obj_to_str(void), hoc_known_type(void);
 extern void hoc_objectarg(void), hoc_ob_pointer(void), hoc_constobject(void);

--- a/src/oc/code.h
+++ b/src/oc/code.h
@@ -38,6 +38,10 @@ extern void hoc_arayinstal(void);
 extern void hoc_objectvar(void), hoc_object_component(void), hoc_object_eval(void);
 extern void hoc_object_add(void), hoc_object_sub(void), hoc_object_mul(void), hoc_object_div(void),
     hoc_object_pow(void), hoc_object_eq(void), hoc_object_ne(void);
+extern void hoc_object_add_number(void), hoc_number_add_object(void), hoc_object_sub_number(void),
+    hoc_number_sub_object(void), hoc_object_mul_number(void), hoc_number_mul_object(void),
+    hoc_object_div_number(void), hoc_number_div_object(void), hoc_object_pow_number(void),
+    hoc_number_pow_object(void);
 extern void hoc_object_add_expr(void), hoc_expr_add_object(void), hoc_object_sub_expr(void),
     hoc_expr_sub_object(void), hoc_object_mul_expr(void), hoc_expr_mul_object(void),
     hoc_object_div_expr(void), hoc_expr_div_object(void), hoc_object_pow_expr(void),

--- a/src/oc/hoc_oop.cpp
+++ b/src/oc/hoc_oop.cpp
@@ -42,6 +42,9 @@ int hoc_max_builtin_class_id = -1;
 
 static Symbol* hoc_obj_;
 
+int (*nrnpy_call_obj_method)(Object* obj, const char* method, Object* obj2) = nullptr;
+
+
 void hoc_install_hoc_obj(void) {
     /* see void hoc_objvardecl(void) */
     Object** pobj;
@@ -2138,6 +2141,12 @@ void hoc_object_add() {
         hoc_execerror("Object arithmetic: first operand is null", nullptr);
     }
 
+    // Try Python first if available
+    if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__add__", obj2) != 0) {
+        // Python handled the operation, result is on the stack
+        return;
+    }
+
     // Look up the __add__ method
     Symbol* method_sym = nrn_method_symbol(obj1, "__add__");
     if (!method_sym) {
@@ -2164,6 +2173,13 @@ void hoc_object_sub() {
     if (!obj1) {
         hoc_execerror("Object arithmetic: first operand is null", nullptr);
     }
+
+    // Try Python first if available
+    if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__sub__", obj2) != 0) {
+        // Python handled the operation, result is on the stack
+        return;
+    }
+
 
     Symbol* method_sym = nrn_method_symbol(obj1, "__sub__");
     if (!method_sym) {
@@ -2192,6 +2208,13 @@ void hoc_object_mul() {
                           obj1->ctemplate->sym->name);
     }
 
+    // Try Python first if available
+    if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__mul__", obj2) != 0) {
+        // Python handled the operation, result is on the stack
+        return;
+    }
+
+
     hoc_pushobj(obj2_ptr);
     nrn_method_call(obj1, method_sym, 1);
 }
@@ -2206,6 +2229,13 @@ void hoc_object_div() {
     if (!obj1) {
         hoc_execerror("Object arithmetic: first operand is null", nullptr);
     }
+
+    // Try Python first if available
+    if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__div__", obj2) != 0) {
+        // Python handled the operation, result is on the stack
+        return;
+    }
+
 
     Symbol* method_sym = nrn_method_symbol(obj1, "__div__");
     if (!method_sym) {
@@ -2226,6 +2256,12 @@ void hoc_object_pow() {
 
     if (!obj1) {
         hoc_execerror("Object arithmetic: first operand is null", nullptr);
+    }
+
+    // Try Python first if available
+    if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__pow__", obj2) != 0) {
+        // Python handled the operation, result is on the stack
+        return;
     }
 
     Symbol* method_sym = nrn_method_symbol(obj1, "__pow__");
@@ -2252,6 +2288,13 @@ void hoc_object_eq() {
         hoc_pushx(result);
         return;
     }
+
+    // Try Python first if available
+    if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__eq__", obj2) != 0) {
+        // Python handled the operation, result is on the stack
+        return;
+    }
+
 
     // Look up the __eq__ method
     Symbol* method_sym = nrn_method_symbol(obj1, "__eq__");
@@ -2285,6 +2328,13 @@ void hoc_object_ne() {
         hoc_pushx(result);
         return;
     }
+
+    // Try Python first if available
+    if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__ne__", obj2) != 0) {
+        // Python handled the operation, result is on the stack
+        return;
+    }
+
 
     // Look up the __ne__ method first
     Symbol* method_sym = nrn_method_symbol(obj1, "__ne__");

--- a/src/oc/hoc_oop.cpp
+++ b/src/oc/hoc_oop.cpp
@@ -43,6 +43,7 @@ int hoc_max_builtin_class_id = -1;
 static Symbol* hoc_obj_;
 
 int (*nrnpy_call_obj_method)(Object* obj, const char* method, Object* obj2) = nullptr;
+int (*nrnpy_call_obj_method_double)(Object* obj, const char* method, double value) = nullptr;
 
 
 void hoc_install_hoc_obj(void) {
@@ -2376,6 +2377,12 @@ void hoc_object_add_number() {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
     }
 
+    // Try Python first if available
+    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__add__", d) != 0) {
+        // Python handled the operation, result is on the stack
+        return;
+    }
+
     Symbol* method_sym = nrn_method_symbol(obj, "__add__");
     if (!method_sym) {
         hoc_execerror_fmt("Object arithmetic: method '__add__' not found in object '{}'",
@@ -2398,6 +2405,13 @@ void hoc_number_add_object() {
     if (!obj) {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
     }
+
+    // Try Python first if available
+    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__radd__", d) != 0) {
+        // Python handled the operation, result is on the stack
+        return;
+    }
+
 
     Symbol* method_sym = nrn_method_symbol(obj, "__radd__");
     if (!method_sym) {
@@ -2422,6 +2436,12 @@ void hoc_object_sub_number() {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
     }
 
+    // Try Python first if available
+    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__sub__", d) != 0) {
+        // Python handled the operation, result is on the stack
+        return;
+    }
+
     Symbol* method_sym = nrn_method_symbol(obj, "__sub__");
     if (!method_sym) {
         hoc_execerror_fmt("Object arithmetic: method '__sub__' not found in object '{}'",
@@ -2440,6 +2460,12 @@ void hoc_number_sub_object() {
     Object* obj = *obj_ptr;
     if (!obj) {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
+    }
+
+    // Try Python first if available
+    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__rsub__", d) != 0) {
+        // Python handled the operation, result is on the stack
+        return;
     }
 
     Symbol* method_sym = nrn_method_symbol(obj, "__rsub__");
@@ -2462,6 +2488,13 @@ void hoc_object_mul_number() {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
     }
 
+    // Try Python first if available
+    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__mul__", d) != 0) {
+        // Python handled the operation, result is on the stack
+        return;
+    }
+
+
     Symbol* method_sym = nrn_method_symbol(obj, "__mul__");
     if (!method_sym) {
         hoc_execerror_fmt("Object arithmetic: method '__mul__' not found in object '{}'",
@@ -2480,6 +2513,12 @@ void hoc_number_mul_object() {
     Object* obj = *obj_ptr;
     if (!obj) {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
+    }
+
+    // Try Python first if available
+    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__rmul__", d) != 0) {
+        // Python handled the operation, result is on the stack
+        return;
     }
 
     Symbol* method_sym = nrn_method_symbol(obj, "__rmul__");
@@ -2502,6 +2541,12 @@ void hoc_object_div_number() {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
     }
 
+    // Try Python first if available
+    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__div__", d) != 0) {
+        // Python handled the operation, result is on the stack
+        return;
+    }
+
     Symbol* method_sym = nrn_method_symbol(obj, "__div__");
     if (!method_sym) {
         hoc_execerror_fmt("Object arithmetic: method '__div__' not found in object '{}'",
@@ -2520,6 +2565,12 @@ void hoc_number_div_object() {
     Object* obj = *obj_ptr;
     if (!obj) {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
+    }
+
+    // Try Python first if available
+    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__rdiv__", d) != 0) {
+        // Python handled the operation, result is on the stack
+        return;
     }
 
     Symbol* method_sym = nrn_method_symbol(obj, "__rdiv__");
@@ -2542,6 +2593,13 @@ void hoc_object_pow_number() {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
     }
 
+    // Try Python first if available
+    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__pow__", d) != 0) {
+        // Python handled the operation, result is on the stack
+        return;
+    }
+
+
     Symbol* method_sym = nrn_method_symbol(obj, "__pow__");
     if (!method_sym) {
         hoc_execerror_fmt("Object arithmetic: method '__pow__' not found in object '{}'",
@@ -2560,6 +2618,12 @@ void hoc_number_pow_object() {
     Object* obj = *obj_ptr;
     if (!obj) {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
+    }
+
+    // Try Python first if available
+    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__rpow__", d) != 0) {
+        // Python handled the operation, result is on the stack
+        return;
     }
 
     Symbol* method_sym = nrn_method_symbol(obj, "__rpow__");

--- a/src/oc/hoc_oop.cpp
+++ b/src/oc/hoc_oop.cpp
@@ -2318,46 +2318,46 @@ void hoc_object_ne() {
 // Mixed-type arithmetic functions (object with number)
 void hoc_object_add_number() {
     // object + number: call obj.__add__(number)
-    double d = hoc_xpop();        // Second operand (number)
-    Object** obj_ptr = hoc_objpop(); // First operand (object)
-    
+    double d = hoc_xpop();            // Second operand (number)
+    Object** obj_ptr = hoc_objpop();  // First operand (object)
+
     Object* obj = *obj_ptr;
     if (!obj) {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
     }
-    
+
     Symbol* method_sym = nrn_method_symbol(obj, "__add__");
     if (!method_sym) {
         hoc_execerror_fmt("Object arithmetic: method '__add__' not found in object '{}'",
                           obj->ctemplate->sym->name);
     }
-    
+
     // Push the number as argument for the method call
     hoc_pushx(d);
-    
+
     // Call the method: obj.__add__(number)
     nrn_method_call(obj, method_sym, 1);
 }
 
 void hoc_number_add_object() {
     // number + object: call obj.__radd__(number)
-    Object** obj_ptr = hoc_objpop(); // Second operand (object)
-    double d = hoc_xpop();        // First operand (number)
-    
+    Object** obj_ptr = hoc_objpop();  // Second operand (object)
+    double d = hoc_xpop();            // First operand (number)
+
     Object* obj = *obj_ptr;
     if (!obj) {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
     }
-    
+
     Symbol* method_sym = nrn_method_symbol(obj, "__radd__");
     if (!method_sym) {
         hoc_execerror_fmt("Object arithmetic: method '__radd__' not found in object '{}'",
                           obj->ctemplate->sym->name);
     }
-    
+
     // Push the number as argument for the method call
     hoc_pushx(d);
-    
+
     // Call the method: obj.__radd__(number)
     nrn_method_call(obj, method_sym, 1);
 }
@@ -2366,18 +2366,18 @@ void hoc_object_sub_number() {
     // object - number: call obj.__sub__(number)
     double d = hoc_xpop();
     Object** obj_ptr = hoc_objpop();
-    
+
     Object* obj = *obj_ptr;
     if (!obj) {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
     }
-    
+
     Symbol* method_sym = nrn_method_symbol(obj, "__sub__");
     if (!method_sym) {
         hoc_execerror_fmt("Object arithmetic: method '__sub__' not found in object '{}'",
                           obj->ctemplate->sym->name);
     }
-    
+
     hoc_pushx(d);
     nrn_method_call(obj, method_sym, 1);
 }
@@ -2386,18 +2386,18 @@ void hoc_number_sub_object() {
     // number - object: call obj.__rsub__(number)
     Object** obj_ptr = hoc_objpop();
     double d = hoc_xpop();
-    
+
     Object* obj = *obj_ptr;
     if (!obj) {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
     }
-    
+
     Symbol* method_sym = nrn_method_symbol(obj, "__rsub__");
     if (!method_sym) {
         hoc_execerror_fmt("Object arithmetic: method '__rsub__' not found in object '{}'",
                           obj->ctemplate->sym->name);
     }
-    
+
     hoc_pushx(d);
     nrn_method_call(obj, method_sym, 1);
 }
@@ -2406,18 +2406,18 @@ void hoc_object_mul_number() {
     // object * number: call obj.__mul__(number)
     double d = hoc_xpop();
     Object** obj_ptr = hoc_objpop();
-    
+
     Object* obj = *obj_ptr;
     if (!obj) {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
     }
-    
+
     Symbol* method_sym = nrn_method_symbol(obj, "__mul__");
     if (!method_sym) {
         hoc_execerror_fmt("Object arithmetic: method '__mul__' not found in object '{}'",
                           obj->ctemplate->sym->name);
     }
-    
+
     hoc_pushx(d);
     nrn_method_call(obj, method_sym, 1);
 }
@@ -2426,18 +2426,18 @@ void hoc_number_mul_object() {
     // number * object: call obj.__rmul__(number)
     Object** obj_ptr = hoc_objpop();
     double d = hoc_xpop();
-    
+
     Object* obj = *obj_ptr;
     if (!obj) {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
     }
-    
+
     Symbol* method_sym = nrn_method_symbol(obj, "__rmul__");
     if (!method_sym) {
         hoc_execerror_fmt("Object arithmetic: method '__rmul__' not found in object '{}'",
                           obj->ctemplate->sym->name);
     }
-    
+
     hoc_pushx(d);
     nrn_method_call(obj, method_sym, 1);
 }
@@ -2446,18 +2446,18 @@ void hoc_object_div_number() {
     // object / number: call obj.__div__(number)
     double d = hoc_xpop();
     Object** obj_ptr = hoc_objpop();
-    
+
     Object* obj = *obj_ptr;
     if (!obj) {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
     }
-    
+
     Symbol* method_sym = nrn_method_symbol(obj, "__div__");
     if (!method_sym) {
         hoc_execerror_fmt("Object arithmetic: method '__div__' not found in object '{}'",
                           obj->ctemplate->sym->name);
     }
-    
+
     hoc_pushx(d);
     nrn_method_call(obj, method_sym, 1);
 }
@@ -2466,18 +2466,18 @@ void hoc_number_div_object() {
     // number / object: call obj.__rdiv__(number)
     Object** obj_ptr = hoc_objpop();
     double d = hoc_xpop();
-    
+
     Object* obj = *obj_ptr;
     if (!obj) {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
     }
-    
+
     Symbol* method_sym = nrn_method_symbol(obj, "__rdiv__");
     if (!method_sym) {
         hoc_execerror_fmt("Object arithmetic: method '__rdiv__' not found in object '{}'",
                           obj->ctemplate->sym->name);
     }
-    
+
     hoc_pushx(d);
     nrn_method_call(obj, method_sym, 1);
 }
@@ -2486,18 +2486,18 @@ void hoc_object_pow_number() {
     // object ^ number: call obj.__pow__(number)
     double d = hoc_xpop();
     Object** obj_ptr = hoc_objpop();
-    
+
     Object* obj = *obj_ptr;
     if (!obj) {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
     }
-    
+
     Symbol* method_sym = nrn_method_symbol(obj, "__pow__");
     if (!method_sym) {
         hoc_execerror_fmt("Object arithmetic: method '__pow__' not found in object '{}'",
                           obj->ctemplate->sym->name);
     }
-    
+
     hoc_pushx(d);
     nrn_method_call(obj, method_sym, 1);
 }
@@ -2506,18 +2506,18 @@ void hoc_number_pow_object() {
     // number ^ object: call obj.__rpow__(number)
     Object** obj_ptr = hoc_objpop();
     double d = hoc_xpop();
-    
+
     Object* obj = *obj_ptr;
     if (!obj) {
         hoc_execerror("Object arithmetic: object operand is null", nullptr);
     }
-    
+
     Symbol* method_sym = nrn_method_symbol(obj, "__rpow__");
     if (!method_sym) {
         hoc_execerror_fmt("Object arithmetic: method '__rpow__' not found in object '{}'",
                           obj->ctemplate->sym->name);
     }
-    
+
     hoc_pushx(d);
     nrn_method_call(obj, method_sym, 1);
 }

--- a/src/oc/hoc_oop.cpp
+++ b/src/oc/hoc_oop.cpp
@@ -2314,3 +2314,210 @@ void hoc_object_ne() {
     double result = (*obj1_ptr != *obj2_ptr) ? 1.0 : 0.0;
     hoc_pushx(result);
 }
+
+// Mixed-type arithmetic functions (object with number)
+void hoc_object_add_number() {
+    // object + number: call obj.__add__(number)
+    double d = hoc_xpop();        // Second operand (number)
+    Object** obj_ptr = hoc_objpop(); // First operand (object)
+    
+    Object* obj = *obj_ptr;
+    if (!obj) {
+        hoc_execerror("Object arithmetic: object operand is null", nullptr);
+    }
+    
+    Symbol* method_sym = nrn_method_symbol(obj, "__add__");
+    if (!method_sym) {
+        hoc_execerror_fmt("Object arithmetic: method '__add__' not found in object '{}'",
+                          obj->ctemplate->sym->name);
+    }
+    
+    // Push the number as argument for the method call
+    hoc_pushx(d);
+    
+    // Call the method: obj.__add__(number)
+    nrn_method_call(obj, method_sym, 1);
+}
+
+void hoc_number_add_object() {
+    // number + object: call obj.__radd__(number)
+    Object** obj_ptr = hoc_objpop(); // Second operand (object)
+    double d = hoc_xpop();        // First operand (number)
+    
+    Object* obj = *obj_ptr;
+    if (!obj) {
+        hoc_execerror("Object arithmetic: object operand is null", nullptr);
+    }
+    
+    Symbol* method_sym = nrn_method_symbol(obj, "__radd__");
+    if (!method_sym) {
+        hoc_execerror_fmt("Object arithmetic: method '__radd__' not found in object '{}'",
+                          obj->ctemplate->sym->name);
+    }
+    
+    // Push the number as argument for the method call
+    hoc_pushx(d);
+    
+    // Call the method: obj.__radd__(number)
+    nrn_method_call(obj, method_sym, 1);
+}
+
+void hoc_object_sub_number() {
+    // object - number: call obj.__sub__(number)
+    double d = hoc_xpop();
+    Object** obj_ptr = hoc_objpop();
+    
+    Object* obj = *obj_ptr;
+    if (!obj) {
+        hoc_execerror("Object arithmetic: object operand is null", nullptr);
+    }
+    
+    Symbol* method_sym = nrn_method_symbol(obj, "__sub__");
+    if (!method_sym) {
+        hoc_execerror_fmt("Object arithmetic: method '__sub__' not found in object '{}'",
+                          obj->ctemplate->sym->name);
+    }
+    
+    hoc_pushx(d);
+    nrn_method_call(obj, method_sym, 1);
+}
+
+void hoc_number_sub_object() {
+    // number - object: call obj.__rsub__(number)
+    Object** obj_ptr = hoc_objpop();
+    double d = hoc_xpop();
+    
+    Object* obj = *obj_ptr;
+    if (!obj) {
+        hoc_execerror("Object arithmetic: object operand is null", nullptr);
+    }
+    
+    Symbol* method_sym = nrn_method_symbol(obj, "__rsub__");
+    if (!method_sym) {
+        hoc_execerror_fmt("Object arithmetic: method '__rsub__' not found in object '{}'",
+                          obj->ctemplate->sym->name);
+    }
+    
+    hoc_pushx(d);
+    nrn_method_call(obj, method_sym, 1);
+}
+
+void hoc_object_mul_number() {
+    // object * number: call obj.__mul__(number)
+    double d = hoc_xpop();
+    Object** obj_ptr = hoc_objpop();
+    
+    Object* obj = *obj_ptr;
+    if (!obj) {
+        hoc_execerror("Object arithmetic: object operand is null", nullptr);
+    }
+    
+    Symbol* method_sym = nrn_method_symbol(obj, "__mul__");
+    if (!method_sym) {
+        hoc_execerror_fmt("Object arithmetic: method '__mul__' not found in object '{}'",
+                          obj->ctemplate->sym->name);
+    }
+    
+    hoc_pushx(d);
+    nrn_method_call(obj, method_sym, 1);
+}
+
+void hoc_number_mul_object() {
+    // number * object: call obj.__rmul__(number)
+    Object** obj_ptr = hoc_objpop();
+    double d = hoc_xpop();
+    
+    Object* obj = *obj_ptr;
+    if (!obj) {
+        hoc_execerror("Object arithmetic: object operand is null", nullptr);
+    }
+    
+    Symbol* method_sym = nrn_method_symbol(obj, "__rmul__");
+    if (!method_sym) {
+        hoc_execerror_fmt("Object arithmetic: method '__rmul__' not found in object '{}'",
+                          obj->ctemplate->sym->name);
+    }
+    
+    hoc_pushx(d);
+    nrn_method_call(obj, method_sym, 1);
+}
+
+void hoc_object_div_number() {
+    // object / number: call obj.__div__(number)
+    double d = hoc_xpop();
+    Object** obj_ptr = hoc_objpop();
+    
+    Object* obj = *obj_ptr;
+    if (!obj) {
+        hoc_execerror("Object arithmetic: object operand is null", nullptr);
+    }
+    
+    Symbol* method_sym = nrn_method_symbol(obj, "__div__");
+    if (!method_sym) {
+        hoc_execerror_fmt("Object arithmetic: method '__div__' not found in object '{}'",
+                          obj->ctemplate->sym->name);
+    }
+    
+    hoc_pushx(d);
+    nrn_method_call(obj, method_sym, 1);
+}
+
+void hoc_number_div_object() {
+    // number / object: call obj.__rdiv__(number)
+    Object** obj_ptr = hoc_objpop();
+    double d = hoc_xpop();
+    
+    Object* obj = *obj_ptr;
+    if (!obj) {
+        hoc_execerror("Object arithmetic: object operand is null", nullptr);
+    }
+    
+    Symbol* method_sym = nrn_method_symbol(obj, "__rdiv__");
+    if (!method_sym) {
+        hoc_execerror_fmt("Object arithmetic: method '__rdiv__' not found in object '{}'",
+                          obj->ctemplate->sym->name);
+    }
+    
+    hoc_pushx(d);
+    nrn_method_call(obj, method_sym, 1);
+}
+
+void hoc_object_pow_number() {
+    // object ^ number: call obj.__pow__(number)
+    double d = hoc_xpop();
+    Object** obj_ptr = hoc_objpop();
+    
+    Object* obj = *obj_ptr;
+    if (!obj) {
+        hoc_execerror("Object arithmetic: object operand is null", nullptr);
+    }
+    
+    Symbol* method_sym = nrn_method_symbol(obj, "__pow__");
+    if (!method_sym) {
+        hoc_execerror_fmt("Object arithmetic: method '__pow__' not found in object '{}'",
+                          obj->ctemplate->sym->name);
+    }
+    
+    hoc_pushx(d);
+    nrn_method_call(obj, method_sym, 1);
+}
+
+void hoc_number_pow_object() {
+    // number ^ object: call obj.__rpow__(number)
+    Object** obj_ptr = hoc_objpop();
+    double d = hoc_xpop();
+    
+    Object* obj = *obj_ptr;
+    if (!obj) {
+        hoc_execerror("Object arithmetic: object operand is null", nullptr);
+    }
+    
+    Symbol* method_sym = nrn_method_symbol(obj, "__rpow__");
+    if (!method_sym) {
+        hoc_execerror_fmt("Object arithmetic: method '__rpow__' not found in object '{}'",
+                          obj->ctemplate->sym->name);
+    }
+    
+    hoc_pushx(d);
+    nrn_method_call(obj, method_sym, 1);
+}

--- a/src/oc/hoc_oop.cpp
+++ b/src/oc/hoc_oop.cpp
@@ -2145,6 +2145,8 @@ void hoc_object_add() {
     // Try Python first if available
     if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__add__", obj2) != 0) {
         // Python handled the operation, result is on the stack
+        hoc_tobj_unref(obj1_ptr);
+        hoc_tobj_unref(obj2_ptr);
         return;
     }
 
@@ -2161,7 +2163,9 @@ void hoc_object_add() {
     // Call the method: obj1.__add__(obj2)
     nrn_method_call(obj1, method_sym, 1);
 
-    // The result should now be on the stack
+    // Clean up temporary object references
+    hoc_tobj_unref(obj1_ptr);
+    hoc_tobj_unref(obj2_ptr);
 }
 
 void hoc_object_sub() {
@@ -2178,6 +2182,8 @@ void hoc_object_sub() {
     // Try Python first if available
     if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__sub__", obj2) != 0) {
         // Python handled the operation, result is on the stack
+        hoc_tobj_unref(obj1_ptr);
+        hoc_tobj_unref(obj2_ptr);
         return;
     }
 
@@ -2190,6 +2196,8 @@ void hoc_object_sub() {
 
     hoc_pushobj(obj2_ptr);
     nrn_method_call(obj1, method_sym, 1);
+    hoc_tobj_unref(obj1_ptr);
+    hoc_tobj_unref(obj2_ptr);
 }
 
 void hoc_object_mul() {
@@ -2212,12 +2220,16 @@ void hoc_object_mul() {
     // Try Python first if available
     if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__mul__", obj2) != 0) {
         // Python handled the operation, result is on the stack
+        hoc_tobj_unref(obj1_ptr);
+        hoc_tobj_unref(obj2_ptr);
         return;
     }
 
 
     hoc_pushobj(obj2_ptr);
     nrn_method_call(obj1, method_sym, 1);
+    hoc_tobj_unref(obj1_ptr);
+    hoc_tobj_unref(obj2_ptr);
 }
 
 void hoc_object_div() {
@@ -2234,6 +2246,8 @@ void hoc_object_div() {
     // Try Python first if available
     if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__div__", obj2) != 0) {
         // Python handled the operation, result is on the stack
+        hoc_tobj_unref(obj1_ptr);
+        hoc_tobj_unref(obj2_ptr);
         return;
     }
 
@@ -2246,6 +2260,8 @@ void hoc_object_div() {
 
     hoc_pushobj(obj2_ptr);
     nrn_method_call(obj1, method_sym, 1);
+    hoc_tobj_unref(obj1_ptr);
+    hoc_tobj_unref(obj2_ptr);
 }
 
 void hoc_object_pow() {
@@ -2262,6 +2278,8 @@ void hoc_object_pow() {
     // Try Python first if available
     if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__pow__", obj2) != 0) {
         // Python handled the operation, result is on the stack
+        hoc_tobj_unref(obj1_ptr);
+        hoc_tobj_unref(obj2_ptr);
         return;
     }
 
@@ -2273,6 +2291,8 @@ void hoc_object_pow() {
 
     hoc_pushobj(obj2_ptr);
     nrn_method_call(obj1, method_sym, 1);
+    hoc_tobj_unref(obj1_ptr);
+    hoc_tobj_unref(obj2_ptr);
 }
 
 void hoc_object_eq() {
@@ -2286,6 +2306,8 @@ void hoc_object_eq() {
     // Handle null object cases with pointer equality fallback
     if (!obj1 || !obj2) {
         double result = (*obj1_ptr == *obj2_ptr) ? 1.0 : 0.0;
+        hoc_tobj_unref(obj1_ptr);
+        hoc_tobj_unref(obj2_ptr);
         hoc_pushx(result);
         return;
     }
@@ -2293,6 +2315,8 @@ void hoc_object_eq() {
     // Try Python first if available
     if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__eq__", obj2) != 0) {
         // Python handled the operation, result is on the stack
+        hoc_tobj_unref(obj1_ptr);
+        hoc_tobj_unref(obj2_ptr);
         return;
     }
 
@@ -2302,6 +2326,8 @@ void hoc_object_eq() {
     if (!method_sym) {
         // No __eq__ method found, fall back to pointer equality
         double result = (*obj1_ptr == *obj2_ptr) ? 1.0 : 0.0;
+        hoc_tobj_unref(obj1_ptr);
+        hoc_tobj_unref(obj2_ptr);
         hoc_pushx(result);
         return;
     }
@@ -2312,7 +2338,9 @@ void hoc_object_eq() {
     // Call the method: obj1.__eq__(obj2)
     nrn_method_call(obj1, method_sym, 1);
 
-    // The result should now be on the stack
+    // Clean up temporary object references
+    hoc_tobj_unref(obj1_ptr);
+    hoc_tobj_unref(obj2_ptr);
 }
 
 void hoc_object_ne() {
@@ -2326,6 +2354,8 @@ void hoc_object_ne() {
     // Handle null object cases with pointer equality fallback
     if (!obj1 || !obj2) {
         double result = (*obj1_ptr != *obj2_ptr) ? 1.0 : 0.0;
+        hoc_tobj_unref(obj1_ptr);
+        hoc_tobj_unref(obj2_ptr);
         hoc_pushx(result);
         return;
     }
@@ -2333,6 +2363,8 @@ void hoc_object_ne() {
     // Try Python first if available
     if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__ne__", obj2) != 0) {
         // Python handled the operation, result is on the stack
+        hoc_tobj_unref(obj1_ptr);
+        hoc_tobj_unref(obj2_ptr);
         return;
     }
 
@@ -2344,7 +2376,9 @@ void hoc_object_ne() {
         hoc_pushobj(obj2_ptr);
         // Call the method: obj1.__ne__(obj2)
         nrn_method_call(obj1, method_sym, 1);
-        // The result should now be on the stack
+        // Clean up temporary object references
+        hoc_tobj_unref(obj1_ptr);
+        hoc_tobj_unref(obj2_ptr);
         return;
     }
 
@@ -2357,12 +2391,16 @@ void hoc_object_ne() {
         nrn_method_call(obj1, method_sym, 1);
         // Negate the result
         double eq_result = hoc_xpop();
+        hoc_tobj_unref(obj1_ptr);
+        hoc_tobj_unref(obj2_ptr);
         hoc_pushx(eq_result ? 0.0 : 1.0);
         return;
     }
 
     // No magic methods found, fall back to pointer inequality
     double result = (*obj1_ptr != *obj2_ptr) ? 1.0 : 0.0;
+    hoc_tobj_unref(obj1_ptr);
+    hoc_tobj_unref(obj2_ptr);
     hoc_pushx(result);
 }
 
@@ -2380,6 +2418,7 @@ void hoc_object_add_number() {
     // Try Python first if available
     if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__add__", d) != 0) {
         // Python handled the operation, result is on the stack
+        hoc_tobj_unref(obj_ptr);
         return;
     }
 
@@ -2394,6 +2433,7 @@ void hoc_object_add_number() {
 
     // Call the method: obj.__add__(number)
     nrn_method_call(obj, method_sym, 1);
+    hoc_tobj_unref(obj_ptr);
 }
 
 void hoc_number_add_object() {
@@ -2409,6 +2449,7 @@ void hoc_number_add_object() {
     // Try Python first if available
     if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__radd__", d) != 0) {
         // Python handled the operation, result is on the stack
+        hoc_tobj_unref(obj_ptr);
         return;
     }
 
@@ -2424,6 +2465,7 @@ void hoc_number_add_object() {
 
     // Call the method: obj.__radd__(number)
     nrn_method_call(obj, method_sym, 1);
+    hoc_tobj_unref(obj_ptr);
 }
 
 void hoc_object_sub_number() {
@@ -2439,6 +2481,7 @@ void hoc_object_sub_number() {
     // Try Python first if available
     if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__sub__", d) != 0) {
         // Python handled the operation, result is on the stack
+        hoc_tobj_unref(obj_ptr);
         return;
     }
 
@@ -2450,6 +2493,7 @@ void hoc_object_sub_number() {
 
     hoc_pushx(d);
     nrn_method_call(obj, method_sym, 1);
+    hoc_tobj_unref(obj_ptr);
 }
 
 void hoc_number_sub_object() {
@@ -2465,6 +2509,7 @@ void hoc_number_sub_object() {
     // Try Python first if available
     if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__rsub__", d) != 0) {
         // Python handled the operation, result is on the stack
+        hoc_tobj_unref(obj_ptr);
         return;
     }
 
@@ -2476,6 +2521,7 @@ void hoc_number_sub_object() {
 
     hoc_pushx(d);
     nrn_method_call(obj, method_sym, 1);
+    hoc_tobj_unref(obj_ptr);
 }
 
 void hoc_object_mul_number() {
@@ -2491,6 +2537,7 @@ void hoc_object_mul_number() {
     // Try Python first if available
     if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__mul__", d) != 0) {
         // Python handled the operation, result is on the stack
+        hoc_tobj_unref(obj_ptr);
         return;
     }
 
@@ -2503,6 +2550,7 @@ void hoc_object_mul_number() {
 
     hoc_pushx(d);
     nrn_method_call(obj, method_sym, 1);
+    hoc_tobj_unref(obj_ptr);
 }
 
 void hoc_number_mul_object() {
@@ -2518,6 +2566,7 @@ void hoc_number_mul_object() {
     // Try Python first if available
     if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__rmul__", d) != 0) {
         // Python handled the operation, result is on the stack
+        hoc_tobj_unref(obj_ptr);
         return;
     }
 
@@ -2529,6 +2578,7 @@ void hoc_number_mul_object() {
 
     hoc_pushx(d);
     nrn_method_call(obj, method_sym, 1);
+    hoc_tobj_unref(obj_ptr);
 }
 
 void hoc_object_div_number() {
@@ -2544,6 +2594,7 @@ void hoc_object_div_number() {
     // Try Python first if available
     if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__div__", d) != 0) {
         // Python handled the operation, result is on the stack
+        hoc_tobj_unref(obj_ptr);
         return;
     }
 
@@ -2555,6 +2606,7 @@ void hoc_object_div_number() {
 
     hoc_pushx(d);
     nrn_method_call(obj, method_sym, 1);
+    hoc_tobj_unref(obj_ptr);
 }
 
 void hoc_number_div_object() {
@@ -2570,6 +2622,7 @@ void hoc_number_div_object() {
     // Try Python first if available
     if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__rdiv__", d) != 0) {
         // Python handled the operation, result is on the stack
+        hoc_tobj_unref(obj_ptr);
         return;
     }
 
@@ -2581,6 +2634,7 @@ void hoc_number_div_object() {
 
     hoc_pushx(d);
     nrn_method_call(obj, method_sym, 1);
+    hoc_tobj_unref(obj_ptr);
 }
 
 void hoc_object_pow_number() {
@@ -2596,6 +2650,7 @@ void hoc_object_pow_number() {
     // Try Python first if available
     if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__pow__", d) != 0) {
         // Python handled the operation, result is on the stack
+        hoc_tobj_unref(obj_ptr);
         return;
     }
 
@@ -2608,6 +2663,7 @@ void hoc_object_pow_number() {
 
     hoc_pushx(d);
     nrn_method_call(obj, method_sym, 1);
+    hoc_tobj_unref(obj_ptr);
 }
 
 void hoc_number_pow_object() {
@@ -2623,6 +2679,7 @@ void hoc_number_pow_object() {
     // Try Python first if available
     if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__rpow__", d) != 0) {
         // Python handled the operation, result is on the stack
+        hoc_tobj_unref(obj_ptr);
         return;
     }
 
@@ -2634,4 +2691,5 @@ void hoc_number_pow_object() {
 
     hoc_pushx(d);
     nrn_method_call(obj, method_sym, 1);
+    hoc_tobj_unref(obj_ptr);
 }

--- a/src/oc/hoc_oop.cpp
+++ b/src/oc/hoc_oop.cpp
@@ -2155,7 +2155,8 @@ static void hoc_object_binary_op_helper(const char* method_name) {
     Symbol* method_sym = nrn_method_symbol(obj1, method_name);
     if (!method_sym) {
         hoc_execerror_fmt("Object arithmetic: method '{}' not found in object '{}'",
-                          method_name, obj1->ctemplate->sym->name);
+                          method_name,
+                          obj1->ctemplate->sym->name);
     }
 
     // Call the HOC method: obj1.method(obj2)
@@ -2187,7 +2188,8 @@ static void hoc_object_number_binary_op_helper(const char* method_name) {
     Symbol* method_sym = nrn_method_symbol(obj, method_name);
     if (!method_sym) {
         hoc_execerror_fmt("Object arithmetic: method '{}' not found in object '{}'",
-                          method_name, obj->ctemplate->sym->name);
+                          method_name,
+                          obj->ctemplate->sym->name);
     }
 
     // Push the number as argument for the method call
@@ -2219,7 +2221,8 @@ static void hoc_number_object_binary_op_helper(const char* method_name) {
     Symbol* method_sym = nrn_method_symbol(obj, method_name);
     if (!method_sym) {
         hoc_execerror_fmt("Object arithmetic: method '{}' not found in object '{}'",
-                          method_name, obj->ctemplate->sym->name);
+                          method_name,
+                          obj->ctemplate->sym->name);
     }
 
     // Push the number as argument for the method call
@@ -2255,9 +2258,12 @@ void hoc_object_pow() {
 // Handles common setup, null checks, and Python attempts
 // Returns true if the operation was handled (caller should return)
 // Returns false if caller needs to handle HOC method lookup
-static bool hoc_object_comparison_setup(Object** &obj1_ptr, Object** &obj2_ptr, 
-                                         Object* &obj1, Object* &obj2,
-                                         const char* method_name, bool is_equality) {
+static bool hoc_object_comparison_setup(Object**& obj1_ptr,
+                                        Object**& obj2_ptr,
+                                        Object*& obj1,
+                                        Object*& obj2,
+                                        const char* method_name,
+                                        bool is_equality) {
     obj2_ptr = hoc_objpop();  // Second operand
     obj1_ptr = hoc_objpop();  // First operand
 
@@ -2266,7 +2272,7 @@ static bool hoc_object_comparison_setup(Object** &obj1_ptr, Object** &obj2_ptr,
 
     // Handle null object cases with pointer comparison fallback
     if (!obj1 || !obj2) {
-        double result = is_equality ? ((*obj1_ptr == *obj2_ptr) ? 1.0 : 0.0) 
+        double result = is_equality ? ((*obj1_ptr == *obj2_ptr) ? 1.0 : 0.0)
                                     : ((*obj1_ptr != *obj2_ptr) ? 1.0 : 0.0);
         hoc_tobj_unref(obj1_ptr);
         hoc_tobj_unref(obj2_ptr);
@@ -2286,8 +2292,10 @@ static bool hoc_object_comparison_setup(Object** &obj1_ptr, Object** &obj2_ptr,
 }
 
 // Helper to call a comparison method and cleanup
-static void hoc_object_comparison_call(Object** obj1_ptr, Object** obj2_ptr, 
-                                        Object* obj1, Symbol* method_sym) {
+static void hoc_object_comparison_call(Object** obj1_ptr,
+                                       Object** obj2_ptr,
+                                       Object* obj1,
+                                       Symbol* method_sym) {
     hoc_pushobj(obj2_ptr);
     nrn_method_call(obj1, method_sym, 1);
     hoc_tobj_unref(obj1_ptr);
@@ -2296,7 +2304,7 @@ static void hoc_object_comparison_call(Object** obj1_ptr, Object** obj2_ptr,
 
 // Helper for pointer comparison fallback
 static void hoc_object_comparison_fallback(Object** obj1_ptr, Object** obj2_ptr, bool is_equality) {
-    double result = is_equality ? ((*obj1_ptr == *obj2_ptr) ? 1.0 : 0.0) 
+    double result = is_equality ? ((*obj1_ptr == *obj2_ptr) ? 1.0 : 0.0)
                                 : ((*obj1_ptr != *obj2_ptr) ? 1.0 : 0.0);
     hoc_tobj_unref(obj1_ptr);
     hoc_tobj_unref(obj2_ptr);

--- a/src/oc/hoc_oop.cpp
+++ b/src/oc/hoc_oop.cpp
@@ -2129,9 +2129,10 @@ void* nrn_opaque_obj2pyobj(Object* ho) {
     return nullptr;
 }
 
-// Object arithmetic functions that call HOC object methods
-void hoc_object_add() {
-    // Pop two objects from the stack properly
+// Helper functions for object arithmetic operations
+
+// Helper for object-object binary operations
+static void hoc_object_binary_op_helper(const char* method_name) {
     Object** obj2_ptr = hoc_objpop();  // Second operand
     Object** obj1_ptr = hoc_objpop();  // First operand (the one that has the method)
 
@@ -2143,24 +2144,22 @@ void hoc_object_add() {
     }
 
     // Try Python first if available
-    if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__add__", obj2) != 0) {
+    if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, method_name, obj2) != 0) {
         // Python handled the operation, result is on the stack
         hoc_tobj_unref(obj1_ptr);
         hoc_tobj_unref(obj2_ptr);
         return;
     }
 
-    // Look up the __add__ method
-    Symbol* method_sym = nrn_method_symbol(obj1, "__add__");
+    // Look up the method
+    Symbol* method_sym = nrn_method_symbol(obj1, method_name);
     if (!method_sym) {
-        hoc_execerror_fmt("Object arithmetic: method '__add__' not found in object '{}'",
-                          obj1->ctemplate->sym->name);
+        hoc_execerror_fmt("Object arithmetic: method '{}' not found in object '{}'",
+                          method_name, obj1->ctemplate->sym->name);
     }
 
-    // Push the second object as argument for the method call
+    // Call the HOC method: obj1.method(obj2)
     hoc_pushobj(obj2_ptr);
-
-    // Call the method: obj1.__add__(obj2)
     nrn_method_call(obj1, method_sym, 1);
 
     // Clean up temporary object references
@@ -2168,226 +2167,185 @@ void hoc_object_add() {
     hoc_tobj_unref(obj2_ptr);
 }
 
-void hoc_object_sub() {
-    Object** obj2_ptr = hoc_objpop();
-    Object** obj1_ptr = hoc_objpop();
+// Helper for object-number binary operations (object op number)
+static void hoc_object_number_binary_op_helper(const char* method_name) {
+    double d = hoc_xpop();            // Second operand (number)
+    Object** obj_ptr = hoc_objpop();  // First operand (object)
 
-    Object* obj1 = *obj1_ptr;
-    Object* obj2 = *obj2_ptr;
-
-    if (!obj1) {
-        hoc_execerror("Object arithmetic: first operand is null", nullptr);
+    Object* obj = *obj_ptr;
+    if (!obj) {
+        hoc_execerror("Object arithmetic: object operand is null", nullptr);
     }
 
     // Try Python first if available
-    if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__sub__", obj2) != 0) {
+    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, method_name, d) != 0) {
         // Python handled the operation, result is on the stack
-        hoc_tobj_unref(obj1_ptr);
-        hoc_tobj_unref(obj2_ptr);
+        hoc_tobj_unref(obj_ptr);
         return;
     }
 
-
-    Symbol* method_sym = nrn_method_symbol(obj1, "__sub__");
+    Symbol* method_sym = nrn_method_symbol(obj, method_name);
     if (!method_sym) {
-        hoc_execerror_fmt("Object arithmetic: method '__sub__' not found in object '{}'",
-                          obj1->ctemplate->sym->name);
+        hoc_execerror_fmt("Object arithmetic: method '{}' not found in object '{}'",
+                          method_name, obj->ctemplate->sym->name);
     }
 
-    hoc_pushobj(obj2_ptr);
-    nrn_method_call(obj1, method_sym, 1);
-    hoc_tobj_unref(obj1_ptr);
-    hoc_tobj_unref(obj2_ptr);
+    // Push the number as argument for the method call
+    hoc_pushx(d);
+
+    // Call the method: obj.method(number)
+    nrn_method_call(obj, method_sym, 1);
+    hoc_tobj_unref(obj_ptr);
+}
+
+// Helper for number-object binary operations (number op object)
+// This uses the reverse magic method (e.g., __radd__ for addition)
+static void hoc_number_object_binary_op_helper(const char* method_name) {
+    Object** obj_ptr = hoc_objpop();  // Second operand (object)
+    double d = hoc_xpop();            // First operand (number)
+
+    Object* obj = *obj_ptr;
+    if (!obj) {
+        hoc_execerror("Object arithmetic: object operand is null", nullptr);
+    }
+
+    // Try Python first if available
+    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, method_name, d) != 0) {
+        // Python handled the operation, result is on the stack
+        hoc_tobj_unref(obj_ptr);
+        return;
+    }
+
+    Symbol* method_sym = nrn_method_symbol(obj, method_name);
+    if (!method_sym) {
+        hoc_execerror_fmt("Object arithmetic: method '{}' not found in object '{}'",
+                          method_name, obj->ctemplate->sym->name);
+    }
+
+    // Push the number as argument for the method call
+    hoc_pushx(d);
+
+    // Call the method: obj.method(number)
+    nrn_method_call(obj, method_sym, 1);
+    hoc_tobj_unref(obj_ptr);
+}
+
+// Object arithmetic functions that call HOC object methods
+void hoc_object_add() {
+    hoc_object_binary_op_helper("__add__");
+}
+
+void hoc_object_sub() {
+    hoc_object_binary_op_helper("__sub__");
 }
 
 void hoc_object_mul() {
-    Object** obj2_ptr = hoc_objpop();
-    Object** obj1_ptr = hoc_objpop();
-
-    Object* obj1 = *obj1_ptr;
-    Object* obj2 = *obj2_ptr;
-
-    if (!obj1) {
-        hoc_execerror("Object arithmetic: first operand is null", nullptr);
-    }
-
-    Symbol* method_sym = nrn_method_symbol(obj1, "__mul__");
-    if (!method_sym) {
-        hoc_execerror_fmt("Object arithmetic: method '__mul__' not found in object '{}'",
-                          obj1->ctemplate->sym->name);
-    }
-
-    // Try Python first if available
-    if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__mul__", obj2) != 0) {
-        // Python handled the operation, result is on the stack
-        hoc_tobj_unref(obj1_ptr);
-        hoc_tobj_unref(obj2_ptr);
-        return;
-    }
-
-
-    hoc_pushobj(obj2_ptr);
-    nrn_method_call(obj1, method_sym, 1);
-    hoc_tobj_unref(obj1_ptr);
-    hoc_tobj_unref(obj2_ptr);
+    hoc_object_binary_op_helper("__mul__");
 }
 
 void hoc_object_div() {
-    Object** obj2_ptr = hoc_objpop();
-    Object** obj1_ptr = hoc_objpop();
-
-    Object* obj1 = *obj1_ptr;
-    Object* obj2 = *obj2_ptr;
-
-    if (!obj1) {
-        hoc_execerror("Object arithmetic: first operand is null", nullptr);
-    }
-
-    // Try Python first if available
-    if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__div__", obj2) != 0) {
-        // Python handled the operation, result is on the stack
-        hoc_tobj_unref(obj1_ptr);
-        hoc_tobj_unref(obj2_ptr);
-        return;
-    }
-
-
-    Symbol* method_sym = nrn_method_symbol(obj1, "__div__");
-    if (!method_sym) {
-        hoc_execerror_fmt("Object arithmetic: method '__div__' not found in object '{}'",
-                          obj1->ctemplate->sym->name);
-    }
-
-    hoc_pushobj(obj2_ptr);
-    nrn_method_call(obj1, method_sym, 1);
-    hoc_tobj_unref(obj1_ptr);
-    hoc_tobj_unref(obj2_ptr);
+    hoc_object_binary_op_helper("__div__");
 }
 
 void hoc_object_pow() {
-    Object** obj2_ptr = hoc_objpop();
-    Object** obj1_ptr = hoc_objpop();
+    hoc_object_binary_op_helper("__pow__");
+}
 
-    Object* obj1 = *obj1_ptr;
-    Object* obj2 = *obj2_ptr;
+// Helper for comparison operations
+// Handles common setup, null checks, and Python attempts
+// Returns true if the operation was handled (caller should return)
+// Returns false if caller needs to handle HOC method lookup
+static bool hoc_object_comparison_setup(Object** &obj1_ptr, Object** &obj2_ptr, 
+                                         Object* &obj1, Object* &obj2,
+                                         const char* method_name, bool is_equality) {
+    obj2_ptr = hoc_objpop();  // Second operand
+    obj1_ptr = hoc_objpop();  // First operand
 
-    if (!obj1) {
-        hoc_execerror("Object arithmetic: first operand is null", nullptr);
+    obj1 = *obj1_ptr;
+    obj2 = *obj2_ptr;
+
+    // Handle null object cases with pointer comparison fallback
+    if (!obj1 || !obj2) {
+        double result = is_equality ? ((*obj1_ptr == *obj2_ptr) ? 1.0 : 0.0) 
+                                    : ((*obj1_ptr != *obj2_ptr) ? 1.0 : 0.0);
+        hoc_tobj_unref(obj1_ptr);
+        hoc_tobj_unref(obj2_ptr);
+        hoc_pushx(result);
+        return true;  // Handled
     }
 
     // Try Python first if available
-    if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__pow__", obj2) != 0) {
+    if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, method_name, obj2) != 0) {
         // Python handled the operation, result is on the stack
         hoc_tobj_unref(obj1_ptr);
         hoc_tobj_unref(obj2_ptr);
-        return;
+        return true;  // Handled
     }
 
-    Symbol* method_sym = nrn_method_symbol(obj1, "__pow__");
-    if (!method_sym) {
-        hoc_execerror_fmt("Object arithmetic: method '__pow__' not found in object '{}'",
-                          obj1->ctemplate->sym->name);
-    }
+    return false;  // Not handled, caller should proceed with HOC method lookup
+}
 
+// Helper to call a comparison method and cleanup
+static void hoc_object_comparison_call(Object** obj1_ptr, Object** obj2_ptr, 
+                                        Object* obj1, Symbol* method_sym) {
     hoc_pushobj(obj2_ptr);
     nrn_method_call(obj1, method_sym, 1);
     hoc_tobj_unref(obj1_ptr);
     hoc_tobj_unref(obj2_ptr);
 }
 
+// Helper for pointer comparison fallback
+static void hoc_object_comparison_fallback(Object** obj1_ptr, Object** obj2_ptr, bool is_equality) {
+    double result = is_equality ? ((*obj1_ptr == *obj2_ptr) ? 1.0 : 0.0) 
+                                : ((*obj1_ptr != *obj2_ptr) ? 1.0 : 0.0);
+    hoc_tobj_unref(obj1_ptr);
+    hoc_tobj_unref(obj2_ptr);
+    hoc_pushx(result);
+}
+
 void hoc_object_eq() {
-    // Pop two objects from the stack properly
-    Object** obj2_ptr = hoc_objpop();  // Second operand
-    Object** obj1_ptr = hoc_objpop();  // First operand (the one that has the method)
+    Object** obj1_ptr;
+    Object** obj2_ptr;
+    Object* obj1;
+    Object* obj2;
 
-    Object* obj1 = *obj1_ptr;
-    Object* obj2 = *obj2_ptr;
-
-    // Handle null object cases with pointer equality fallback
-    if (!obj1 || !obj2) {
-        double result = (*obj1_ptr == *obj2_ptr) ? 1.0 : 0.0;
-        hoc_tobj_unref(obj1_ptr);
-        hoc_tobj_unref(obj2_ptr);
-        hoc_pushx(result);
-        return;
+    if (hoc_object_comparison_setup(obj1_ptr, obj2_ptr, obj1, obj2, "__eq__", true)) {
+        return;  // Already handled by setup (Python or null case)
     }
-
-    // Try Python first if available
-    if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__eq__", obj2) != 0) {
-        // Python handled the operation, result is on the stack
-        hoc_tobj_unref(obj1_ptr);
-        hoc_tobj_unref(obj2_ptr);
-        return;
-    }
-
 
     // Look up the __eq__ method
     Symbol* method_sym = nrn_method_symbol(obj1, "__eq__");
     if (!method_sym) {
         // No __eq__ method found, fall back to pointer equality
-        double result = (*obj1_ptr == *obj2_ptr) ? 1.0 : 0.0;
-        hoc_tobj_unref(obj1_ptr);
-        hoc_tobj_unref(obj2_ptr);
-        hoc_pushx(result);
+        hoc_object_comparison_fallback(obj1_ptr, obj2_ptr, true);
         return;
     }
 
-    // Push the second object as argument for the method call
-    hoc_pushobj(obj2_ptr);
-
-    // Call the method: obj1.__eq__(obj2)
-    nrn_method_call(obj1, method_sym, 1);
-
-    // Clean up temporary object references
-    hoc_tobj_unref(obj1_ptr);
-    hoc_tobj_unref(obj2_ptr);
+    // Call the method and cleanup
+    hoc_object_comparison_call(obj1_ptr, obj2_ptr, obj1, method_sym);
 }
 
 void hoc_object_ne() {
-    // Pop two objects from the stack properly
-    Object** obj2_ptr = hoc_objpop();  // Second operand
-    Object** obj1_ptr = hoc_objpop();  // First operand (the one that has the method)
+    Object** obj1_ptr;
+    Object** obj2_ptr;
+    Object* obj1;
+    Object* obj2;
 
-    Object* obj1 = *obj1_ptr;
-    Object* obj2 = *obj2_ptr;
-
-    // Handle null object cases with pointer equality fallback
-    if (!obj1 || !obj2) {
-        double result = (*obj1_ptr != *obj2_ptr) ? 1.0 : 0.0;
-        hoc_tobj_unref(obj1_ptr);
-        hoc_tobj_unref(obj2_ptr);
-        hoc_pushx(result);
-        return;
+    if (hoc_object_comparison_setup(obj1_ptr, obj2_ptr, obj1, obj2, "__ne__", false)) {
+        return;  // Already handled by setup (Python or null case)
     }
-
-    // Try Python first if available
-    if (nrnpy_call_obj_method && nrnpy_call_obj_method(obj1, "__ne__", obj2) != 0) {
-        // Python handled the operation, result is on the stack
-        hoc_tobj_unref(obj1_ptr);
-        hoc_tobj_unref(obj2_ptr);
-        return;
-    }
-
 
     // Look up the __ne__ method first
     Symbol* method_sym = nrn_method_symbol(obj1, "__ne__");
     if (method_sym) {
-        // Push the second object as argument for the method call
-        hoc_pushobj(obj2_ptr);
-        // Call the method: obj1.__ne__(obj2)
-        nrn_method_call(obj1, method_sym, 1);
-        // Clean up temporary object references
-        hoc_tobj_unref(obj1_ptr);
-        hoc_tobj_unref(obj2_ptr);
+        hoc_object_comparison_call(obj1_ptr, obj2_ptr, obj1, method_sym);
         return;
     }
 
     // No __ne__ method, try __eq__ method and negate result
     method_sym = nrn_method_symbol(obj1, "__eq__");
     if (method_sym) {
-        // Push the second object as argument for the method call
         hoc_pushobj(obj2_ptr);
-        // Call the method: obj1.__eq__(obj2)
         nrn_method_call(obj1, method_sym, 1);
         // Negate the result
         double eq_result = hoc_xpop();
@@ -2398,298 +2356,46 @@ void hoc_object_ne() {
     }
 
     // No magic methods found, fall back to pointer inequality
-    double result = (*obj1_ptr != *obj2_ptr) ? 1.0 : 0.0;
-    hoc_tobj_unref(obj1_ptr);
-    hoc_tobj_unref(obj2_ptr);
-    hoc_pushx(result);
+    hoc_object_comparison_fallback(obj1_ptr, obj2_ptr, false);
 }
 
 // Mixed-type arithmetic functions (object with number)
 void hoc_object_add_number() {
-    // object + number: call obj.__add__(number)
-    double d = hoc_xpop();            // Second operand (number)
-    Object** obj_ptr = hoc_objpop();  // First operand (object)
-
-    Object* obj = *obj_ptr;
-    if (!obj) {
-        hoc_execerror("Object arithmetic: object operand is null", nullptr);
-    }
-
-    // Try Python first if available
-    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__add__", d) != 0) {
-        // Python handled the operation, result is on the stack
-        hoc_tobj_unref(obj_ptr);
-        return;
-    }
-
-    Symbol* method_sym = nrn_method_symbol(obj, "__add__");
-    if (!method_sym) {
-        hoc_execerror_fmt("Object arithmetic: method '__add__' not found in object '{}'",
-                          obj->ctemplate->sym->name);
-    }
-
-    // Push the number as argument for the method call
-    hoc_pushx(d);
-
-    // Call the method: obj.__add__(number)
-    nrn_method_call(obj, method_sym, 1);
-    hoc_tobj_unref(obj_ptr);
+    hoc_object_number_binary_op_helper("__add__");
 }
 
 void hoc_number_add_object() {
-    // number + object: call obj.__radd__(number)
-    Object** obj_ptr = hoc_objpop();  // Second operand (object)
-    double d = hoc_xpop();            // First operand (number)
-
-    Object* obj = *obj_ptr;
-    if (!obj) {
-        hoc_execerror("Object arithmetic: object operand is null", nullptr);
-    }
-
-    // Try Python first if available
-    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__radd__", d) != 0) {
-        // Python handled the operation, result is on the stack
-        hoc_tobj_unref(obj_ptr);
-        return;
-    }
-
-
-    Symbol* method_sym = nrn_method_symbol(obj, "__radd__");
-    if (!method_sym) {
-        hoc_execerror_fmt("Object arithmetic: method '__radd__' not found in object '{}'",
-                          obj->ctemplate->sym->name);
-    }
-
-    // Push the number as argument for the method call
-    hoc_pushx(d);
-
-    // Call the method: obj.__radd__(number)
-    nrn_method_call(obj, method_sym, 1);
-    hoc_tobj_unref(obj_ptr);
+    hoc_number_object_binary_op_helper("__radd__");
 }
 
 void hoc_object_sub_number() {
-    // object - number: call obj.__sub__(number)
-    double d = hoc_xpop();
-    Object** obj_ptr = hoc_objpop();
-
-    Object* obj = *obj_ptr;
-    if (!obj) {
-        hoc_execerror("Object arithmetic: object operand is null", nullptr);
-    }
-
-    // Try Python first if available
-    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__sub__", d) != 0) {
-        // Python handled the operation, result is on the stack
-        hoc_tobj_unref(obj_ptr);
-        return;
-    }
-
-    Symbol* method_sym = nrn_method_symbol(obj, "__sub__");
-    if (!method_sym) {
-        hoc_execerror_fmt("Object arithmetic: method '__sub__' not found in object '{}'",
-                          obj->ctemplate->sym->name);
-    }
-
-    hoc_pushx(d);
-    nrn_method_call(obj, method_sym, 1);
-    hoc_tobj_unref(obj_ptr);
+    hoc_object_number_binary_op_helper("__sub__");
 }
 
 void hoc_number_sub_object() {
-    // number - object: call obj.__rsub__(number)
-    Object** obj_ptr = hoc_objpop();
-    double d = hoc_xpop();
-
-    Object* obj = *obj_ptr;
-    if (!obj) {
-        hoc_execerror("Object arithmetic: object operand is null", nullptr);
-    }
-
-    // Try Python first if available
-    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__rsub__", d) != 0) {
-        // Python handled the operation, result is on the stack
-        hoc_tobj_unref(obj_ptr);
-        return;
-    }
-
-    Symbol* method_sym = nrn_method_symbol(obj, "__rsub__");
-    if (!method_sym) {
-        hoc_execerror_fmt("Object arithmetic: method '__rsub__' not found in object '{}'",
-                          obj->ctemplate->sym->name);
-    }
-
-    hoc_pushx(d);
-    nrn_method_call(obj, method_sym, 1);
-    hoc_tobj_unref(obj_ptr);
+    hoc_number_object_binary_op_helper("__rsub__");
 }
 
 void hoc_object_mul_number() {
-    // object * number: call obj.__mul__(number)
-    double d = hoc_xpop();
-    Object** obj_ptr = hoc_objpop();
-
-    Object* obj = *obj_ptr;
-    if (!obj) {
-        hoc_execerror("Object arithmetic: object operand is null", nullptr);
-    }
-
-    // Try Python first if available
-    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__mul__", d) != 0) {
-        // Python handled the operation, result is on the stack
-        hoc_tobj_unref(obj_ptr);
-        return;
-    }
-
-
-    Symbol* method_sym = nrn_method_symbol(obj, "__mul__");
-    if (!method_sym) {
-        hoc_execerror_fmt("Object arithmetic: method '__mul__' not found in object '{}'",
-                          obj->ctemplate->sym->name);
-    }
-
-    hoc_pushx(d);
-    nrn_method_call(obj, method_sym, 1);
-    hoc_tobj_unref(obj_ptr);
+    hoc_object_number_binary_op_helper("__mul__");
 }
 
 void hoc_number_mul_object() {
-    // number * object: call obj.__rmul__(number)
-    Object** obj_ptr = hoc_objpop();
-    double d = hoc_xpop();
-
-    Object* obj = *obj_ptr;
-    if (!obj) {
-        hoc_execerror("Object arithmetic: object operand is null", nullptr);
-    }
-
-    // Try Python first if available
-    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__rmul__", d) != 0) {
-        // Python handled the operation, result is on the stack
-        hoc_tobj_unref(obj_ptr);
-        return;
-    }
-
-    Symbol* method_sym = nrn_method_symbol(obj, "__rmul__");
-    if (!method_sym) {
-        hoc_execerror_fmt("Object arithmetic: method '__rmul__' not found in object '{}'",
-                          obj->ctemplate->sym->name);
-    }
-
-    hoc_pushx(d);
-    nrn_method_call(obj, method_sym, 1);
-    hoc_tobj_unref(obj_ptr);
+    hoc_number_object_binary_op_helper("__rmul__");
 }
 
 void hoc_object_div_number() {
-    // object / number: call obj.__div__(number)
-    double d = hoc_xpop();
-    Object** obj_ptr = hoc_objpop();
-
-    Object* obj = *obj_ptr;
-    if (!obj) {
-        hoc_execerror("Object arithmetic: object operand is null", nullptr);
-    }
-
-    // Try Python first if available
-    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__div__", d) != 0) {
-        // Python handled the operation, result is on the stack
-        hoc_tobj_unref(obj_ptr);
-        return;
-    }
-
-    Symbol* method_sym = nrn_method_symbol(obj, "__div__");
-    if (!method_sym) {
-        hoc_execerror_fmt("Object arithmetic: method '__div__' not found in object '{}'",
-                          obj->ctemplate->sym->name);
-    }
-
-    hoc_pushx(d);
-    nrn_method_call(obj, method_sym, 1);
-    hoc_tobj_unref(obj_ptr);
+    hoc_object_number_binary_op_helper("__div__");
 }
 
 void hoc_number_div_object() {
-    // number / object: call obj.__rdiv__(number)
-    Object** obj_ptr = hoc_objpop();
-    double d = hoc_xpop();
-
-    Object* obj = *obj_ptr;
-    if (!obj) {
-        hoc_execerror("Object arithmetic: object operand is null", nullptr);
-    }
-
-    // Try Python first if available
-    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__rdiv__", d) != 0) {
-        // Python handled the operation, result is on the stack
-        hoc_tobj_unref(obj_ptr);
-        return;
-    }
-
-    Symbol* method_sym = nrn_method_symbol(obj, "__rdiv__");
-    if (!method_sym) {
-        hoc_execerror_fmt("Object arithmetic: method '__rdiv__' not found in object '{}'",
-                          obj->ctemplate->sym->name);
-    }
-
-    hoc_pushx(d);
-    nrn_method_call(obj, method_sym, 1);
-    hoc_tobj_unref(obj_ptr);
+    hoc_number_object_binary_op_helper("__rdiv__");
 }
 
 void hoc_object_pow_number() {
-    // object ^ number: call obj.__pow__(number)
-    double d = hoc_xpop();
-    Object** obj_ptr = hoc_objpop();
-
-    Object* obj = *obj_ptr;
-    if (!obj) {
-        hoc_execerror("Object arithmetic: object operand is null", nullptr);
-    }
-
-    // Try Python first if available
-    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__pow__", d) != 0) {
-        // Python handled the operation, result is on the stack
-        hoc_tobj_unref(obj_ptr);
-        return;
-    }
-
-
-    Symbol* method_sym = nrn_method_symbol(obj, "__pow__");
-    if (!method_sym) {
-        hoc_execerror_fmt("Object arithmetic: method '__pow__' not found in object '{}'",
-                          obj->ctemplate->sym->name);
-    }
-
-    hoc_pushx(d);
-    nrn_method_call(obj, method_sym, 1);
-    hoc_tobj_unref(obj_ptr);
+    hoc_object_number_binary_op_helper("__pow__");
 }
 
 void hoc_number_pow_object() {
-    // number ^ object: call obj.__rpow__(number)
-    Object** obj_ptr = hoc_objpop();
-    double d = hoc_xpop();
-
-    Object* obj = *obj_ptr;
-    if (!obj) {
-        hoc_execerror("Object arithmetic: object operand is null", nullptr);
-    }
-
-    // Try Python first if available
-    if (nrnpy_call_obj_method_double && nrnpy_call_obj_method_double(obj, "__rpow__", d) != 0) {
-        // Python handled the operation, result is on the stack
-        hoc_tobj_unref(obj_ptr);
-        return;
-    }
-
-    Symbol* method_sym = nrn_method_symbol(obj, "__rpow__");
-    if (!method_sym) {
-        hoc_execerror_fmt("Object arithmetic: method '__rpow__' not found in object '{}'",
-                          obj->ctemplate->sym->name);
-    }
-
-    hoc_pushx(d);
-    nrn_method_call(obj, method_sym, 1);
-    hoc_tobj_unref(obj_ptr);
+    hoc_number_object_binary_op_helper("__rpow__");
 }

--- a/test/hoctests/tests/test_hoc_rxd.hoc
+++ b/test/hoctests/tests/test_hoc_rxd.hoc
@@ -1,0 +1,22 @@
+objref pyobj, rxd, cyt, ca, cl, n, reaction, cacl2
+
+{
+    if (nrnpython("from neuron import n, rxd")) {
+        pyobj = new PythonObject()
+        rxd = pyobj.rxd
+        n = pyobj.n
+        create soma
+        cyt = rxd.Region(n.allsec())
+        ca = rxd.Species(cyt, 0, "ca", 2, 1)
+        print "created ca"
+        cl = rxd.Species(cyt, 0, "cl", -1, 1)
+        print "created cl"
+        cacl2 = rxd.Species(cyt, 0, "cacl2", 0, 0)
+        print "preparing to define reaction"
+        reaction = rxd.Reaction(ca + 2 * cl, cacl2, 1)
+        print "defined reaction"
+        finitialize(-65)
+        fadvance()
+        print "advanced"
+    }
+}

--- a/test/hoctests/tests/test_object_ops.hoc
+++ b/test/hoctests/tests/test_object_ops.hoc
@@ -1,0 +1,115 @@
+// Test object arithmetic and equality operations
+
+// Test utility function
+proc assert() {
+    if ($1 == 0) {
+        execerror("assert failed", "")
+    }
+}
+
+print "Testing object arithmetic and equality operations..."
+
+// Define a test class with magic methods
+begintemplate MathClass
+public value, __add__, __sub__, __mul__, __div__, __pow__, __eq__
+
+proc init() {
+    value = $1
+}
+
+func __add__() {
+    return value + $o1.value
+}
+
+func __sub__() {
+    return value - $o1.value
+}
+
+func __mul__() {
+    return value * $o1.value
+}
+
+func __div__() {
+    return value / $o1.value
+}
+
+func __pow__() {
+    return value ^ $o1.value
+}
+
+func __eq__() {
+    return value == $o1.value
+}
+endtemplate MathClass
+
+// Define a class with both __eq__ and __ne__ methods
+begintemplate CompareClass
+public value, __eq__, __ne__
+
+proc init() {
+    value = $1
+}
+
+func __eq__() {
+    print "__eq__ called for CompareClass"
+    return value == $o1.value
+}
+
+func __ne__() {
+    print "__ne__ called for CompareClass"
+    return value != $o1.value
+}
+endtemplate CompareClass
+
+// Test arithmetic operations
+objref a, b, c
+a = new MathClass(6)
+b = new MathClass(3)
+c = new MathClass(6)
+
+// Test arithmetic
+assert((a + b) == 9)     // 6 + 3 = 9
+assert((a - b) == 3)     // 6 - 3 = 3
+assert((a * b) == 18)    // 6 * 3 = 18
+assert((a / b) == 2)     // 6 / 3 = 2
+assert((a ^ b) == 216)   // 6^3 = 216
+
+// Test equality with custom __eq__
+assert(a == a)           // same object
+assert(a == c)           // same value (6 == 6)
+assert(!(a != c))        // test != using __eq__ negation
+assert(!(a == b))        // different values (6 != 3)
+assert(a != b)           // test != using __eq__ negation
+
+// Test class with explicit __ne__ method
+objref d, e, f
+d = new CompareClass(10)
+e = new CompareClass(10)
+f = new CompareClass(20)
+
+print "Testing __ne__ method explicitly:"
+assert(d == e)           // should call __eq__ method
+assert(!(d != e))        // should call __ne__ method
+assert(d != f)           // should call __ne__ method
+assert(!(d == f))        // should call __eq__ method
+
+// Test objects without magic methods (fallback to pointer equality)
+objref v1, v2, v3
+v1 = new Vector(5)
+v2 = new Vector(5)
+v3 = v1
+
+assert(v1 == v1)         // same object
+assert(!(v1 == v2))      // different objects, same contents
+assert(!(v1 != v1))
+assert(v1 == v3)         // same reference
+
+// Test null object handling
+objref nullobj
+assert(!(v1 == nullobj)) // object vs null
+assert(nullobj == nullobj)
+assert(v1 != nullobj)
+
+print "All object operation tests passed!"
+
+quit()

--- a/test/hoctests/tests/test_object_ops.hoc
+++ b/test/hoctests/tests/test_object_ops.hoc
@@ -110,6 +110,155 @@ assert(!(v1 == nullobj)) // object vs null
 assert(nullobj == nullobj)
 assert(v1 != nullobj)
 
+// ===== MIXED-TYPE ARITHMETIC TESTS (Object + Number) =====
+print "Testing mixed-type arithmetic operations (returning objects)..."
+
+// Define a class that supports mixed-type operations returning objects
+begintemplate MixedMathClass
+public value, __add__, __radd__, __sub__, __rsub__, __mul__, __rmul__, __div__, __rdiv__, __pow__, __rpow__
+
+proc init() {
+    value = $1
+}
+
+// Addition operations
+obfunc __add__() {
+    if (numarg() == 1) {
+        // obj + number
+        return new MixedMathClass(value + $1)
+    } else {
+        // obj + obj (shouldn't happen in mixed-type, but for completeness)
+        return new MixedMathClass(value + $o1.value)
+    }
+}
+
+obfunc __radd__() {
+    // number + obj
+    return new MixedMathClass($1 + value)
+}
+
+// Subtraction operations  
+obfunc __sub__() {
+    if (numarg() == 1) {
+        // obj - number
+        return new MixedMathClass(value - $1)
+    } else {
+        // obj - obj
+        return new MixedMathClass(value - $o1.value)
+    }
+}
+
+obfunc __rsub__() {
+    // number - obj
+    return new MixedMathClass($1 - value)
+}
+
+// Multiplication operations
+obfunc __mul__() {
+    if (numarg() == 1) {
+        // obj * number
+        return new MixedMathClass(value * $1)
+    } else {
+        // obj * obj
+        return new MixedMathClass(value * $o1.value)
+    }
+}
+
+obfunc __rmul__() {
+    // number * obj
+    return new MixedMathClass($1 * value)
+}
+
+// Division operations
+obfunc __div__() {
+    if (numarg() == 1) {
+        // obj / number
+        return new MixedMathClass(value / $1)
+    } else {
+        // obj / obj
+        return new MixedMathClass(value / $o1.value)
+    }
+}
+
+obfunc __rdiv__() {
+    // number / obj
+    return new MixedMathClass($1 / value)
+}
+
+// Power operations
+obfunc __pow__() {
+    if (numarg() == 1) {
+        // obj ^ number
+        return new MixedMathClass(value ^ $1)
+    } else {
+        // obj ^ obj
+        return new MixedMathClass(value ^ $o1.value)
+    }
+}
+
+obfunc __rpow__() {
+    // number ^ obj
+    return new MixedMathClass($1 ^ value)
+}
+
+endtemplate MixedMathClass
+
+// Create test objects for mixed-type operations
+objref mix1, result_obj
+mix1 = new MixedMathClass(10)
+
+print "Testing object + number operations (both orders):"
+
+// Test addition: obj + num and num + obj
+result_obj = mix1 + 5
+assert(result_obj.value == 15)  // 10 + 5
+print "  obj + 5 = ", result_obj.value
+
+result_obj = 7 + mix1
+assert(result_obj.value == 17)  // 7 + 10
+print "  7 + obj = ", result_obj.value
+
+// Test subtraction: obj - num and num - obj
+result_obj = mix1 - 3
+assert(result_obj.value == 7)   // 10 - 3
+print "  obj - 3 = ", result_obj.value
+
+result_obj = 15 - mix1
+assert(result_obj.value == 5)   // 15 - 10
+print "  15 - obj = ", result_obj.value
+
+// Test multiplication: obj * num and num * obj
+result_obj = mix1 * 4
+assert(result_obj.value == 40)  // 10 * 4
+print "  obj * 4 = ", result_obj.value
+
+result_obj = 6 * mix1
+assert(result_obj.value == 60)  // 6 * 10
+print "  6 * obj = ", result_obj.value
+
+// Test division: obj / num and num / obj
+result_obj = mix1 / 2
+assert(result_obj.value == 5)   // 10 / 2
+print "  obj / 2 = ", result_obj.value
+
+result_obj = 50 / mix1
+assert(result_obj.value == 5)   // 50 / 10
+print "  50 / obj = ", result_obj.value
+
+// Test power: obj ^ num and num ^ obj  
+result_obj = mix1 ^ 2
+assert(result_obj.value == 100) // 10 ^ 2
+print "  obj ^ 2 = ", result_obj.value
+
+// Create object with smaller value for reasonable power test
+objref mix2
+mix2 = new MixedMathClass(3)
+result_obj = 2 ^ mix2
+assert(result_obj.value == 8)   // 2 ^ 3
+print "  2 ^ obj(3) = ", result_obj.value
+
+print "All mixed-type arithmetic tests passed!"
+
 print "All object operation tests passed!"
 
 quit()


### PR DESCRIPTION
This is most of #3570 BUT PythonObjects don't work, which was the point. Regular HocObjects do.

A test that almost worked on a previous commit:

```
oc>objref pyobj, rxd, cyt, ca, cl, n, reaction, cacl2
oc>
oc>{
>       oc>    if (nrnpython("from neuron import n, rxd")) {
>               oc>        pyobj = new PythonObject()
>               oc>        rxd = pyobj.rxd
>               oc>        n = pyobj.n
>               oc>        create soma
>               oc>        cyt = rxd.Region(n.allsec())
>               oc>        ca = rxd.Species(cyt, 0, "ca", 2, 1)
>               oc>        print "created ca"
>               oc>        cl = rxd.Species(cyt, 0, "cl", -1, 1)
>               oc>        print "created cl"
>               oc>        cacl2 = rxd.Species(cyt, 0, "cacl2", 0, 0)
>               oc>        print "preparing to define reaction"
>               oc>    }
>       oc>}
created ca
created cl
preparing to define reaction
oc>objref cacl2
oc>cacl2 = ca + 2 * cl
initcode failed with 1 left
oc>cacl2 = ca 
oc>cacl2 = ca + cl
oc>cacl2 = ca + cl + cl
initcode failed with 1 left
oc>
```

and at some poimnt I printed out ca + cl and that was fine.