### PR TITLE
Fix NMODL install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,9 +53,8 @@ if(SKBUILD)
   set(IV_HEADERS_INSTALL_DIR "${NRN_INSTALL_DATA_PREFIX}/include")
   set(IV_BIN_INSTALL_DIR "${NRN_INSTALL_DATA_PREFIX}/bin")
 else()
-  set(NRN_INSTALL_PYTHON_PREFIX "lib/python/neuron")
-  # TODO figure out if this needs to be set to NRN_INSTALL_DATA_PREFIX instead
-  set(NRN_INSTALL_DATA_PREFIX ".")
+  set(NRN_INSTALL_PYTHON_PREFIX "lib/python/neuron/")
+  set(NRN_INSTALL_DATA_PREFIX)
 endif()
 
 # =============================================================================
@@ -348,7 +347,7 @@ include(cmake/PythonHelper.cmake)
 if(NRN_SANITIZERS)
   configure_file(bin/nrn-enable-sanitizer.in bin/nrn-enable-sanitizer @ONLY)
   install(PROGRAMS ${PROJECT_BINARY_DIR}/bin/nrn-enable-sanitizer
-          DESTINATION ${NRN_INSTALL_DATA_PREFIX}/bin)
+          DESTINATION "${NRN_INSTALL_DATA_PREFIX}bin")
 endif()
 
 # =============================================================================
@@ -627,12 +626,12 @@ if(NRN_ENABLE_NMODL
   # install nrnunits.lib and libpywrapper.so from external/nmodl
   install(
     FILES ${NMODL_PROJECT_PLATLIB_BINARY_DIR}/lib/libpywrapper${CMAKE_SHARED_LIBRARY_SUFFIX}
-    DESTINATION ${NRN_INSTALL_DATA_PREFIX}/lib
+    DESTINATION "${NRN_INSTALL_DATA_PREFIX}lib"
     COMPONENT pywrapper
     OPTIONAL)
   install(
     FILES ${NMODL_PROJECT_PLATLIB_BINARY_DIR}/share/nmodl/nrnunits.lib
-    DESTINATION ${NRN_INSTALL_DATA_PREFIX}/share/nmodl
+    DESTINATION "${NRN_INSTALL_DATA_PREFIX}share/nmodl"
     COMPONENT nrnunits)
 
   # set correct arguments for nmodl for cpu/gpu target
@@ -720,13 +719,13 @@ include(ConfigFileSetting)
 # well. Setting these here as setup.py.in needs it.
 # ~~~
 if(MINGW)
-  set(NRN_INSTALL_SHARE_DIR ${NRN_INSTALL_DATA_PREFIX})
+  set(NRN_INSTALL_SHARE_DIR ${CMAKE_INSTALL_PREFIX})
   set(NRN_BUILD_SHARE_DIR ${CMAKE_BINARY_DIR})
-  set(NRN_INSTALL_SHARE_LIB_DIR ${NRN_INSTALL_DATA_PREFIX}/bin)
+  set(NRN_INSTALL_SHARE_LIB_DIR ${CMAKE_INSTALL_PREFIX}/bin)
 else()
-  set(NRN_INSTALL_SHARE_DIR ${NRN_INSTALL_DATA_PREFIX}/share/nrn)
+  set(NRN_INSTALL_SHARE_DIR ${NRN_INSTALL_DATA_PREFIX}share/nrn)
   set(NRN_BUILD_SHARE_DIR ${CMAKE_BINARY_DIR}/share/nrn)
-  set(NRN_INSTALL_SHARE_LIB_DIR ${NRN_INSTALL_DATA_PREFIX}/lib)
+  set(NRN_INSTALL_SHARE_LIB_DIR ${NRN_INSTALL_DATA_PREFIX}lib)
 endif()
 
 # =============================================================================
@@ -1092,7 +1091,7 @@ add_custom_target(
   COMMENT "Copying headers to build directory"
   DEPENDS ${headers_in_build_dir})
 add_dependencies(nrniv_lib copy_headers_to_build)
-install(DIRECTORY ${PROJECT_BINARY_DIR}/include DESTINATION "${NRN_INSTALL_DATA_PREFIX}")
+install(DIRECTORY ${PROJECT_BINARY_DIR}/include/ DESTINATION "${NRN_INSTALL_DATA_PREFIX}include")
 
 if(NRN_MACOS_BUILD AND NOT SKBUILD)
   # universal build for neurondemo needs to be after, or at end of, install
@@ -1125,10 +1124,10 @@ endif()
 # =============================================================================
 if(NOT NRN_WINDOWS_BUILD)
   # create arch folder under prefix with symlink to bin and lib
-  nrn_install_dir_symlink(${NRN_INSTALL_DATA_PREFIX}/bin
-                          ${NRN_INSTALL_DATA_PREFIX}/${CMAKE_HOST_SYSTEM_PROCESSOR}/bin)
-  nrn_install_dir_symlink(${NRN_INSTALL_DATA_PREFIX}/lib
-                          ${NRN_INSTALL_DATA_PREFIX}/${CMAKE_HOST_SYSTEM_PROCESSOR}/lib)
+  nrn_install_dir_symlink(${NRN_INSTALL_DATA_PREFIX}bin
+                          ${NRN_INSTALL_DATA_PREFIX}${CMAKE_HOST_SYSTEM_PROCESSOR}/bin)
+  nrn_install_dir_symlink(${NRN_INSTALL_DATA_PREFIX}lib
+                          ${NRN_INSTALL_DATA_PREFIX}${CMAKE_HOST_SYSTEM_PROCESSOR}/lib)
 endif()
 
 # =============================================================================

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -68,9 +68,9 @@ file(REMOVE_RECURSE "${CMAKE_CURRENT_BINARY_DIR}/bin/tmp")
 # Install targets
 # =============================================================================
 install(PROGRAMS ${PROJECT_BINARY_DIR}/bin/nrngui ${PROJECT_BINARY_DIR}/bin/neurondemo
-                 ${PROJECT_BINARY_DIR}/bin/nrnivmodl DESTINATION ${NRN_INSTALL_DATA_PREFIX}/bin)
+                 ${PROJECT_BINARY_DIR}/bin/nrnivmodl DESTINATION ${NRN_INSTALL_DATA_PREFIX}bin)
 
-install(FILES ${PROJECT_BINARY_DIR}/bin/nrnmech_makefile DESTINATION ${NRN_INSTALL_DATA_PREFIX}/bin)
+install(FILES ${PROJECT_BINARY_DIR}/bin/nrnmech_makefile DESTINATION ${NRN_INSTALL_DATA_PREFIX}bin)
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/sortspike ${CMAKE_CURRENT_SOURCE_DIR}/mkthreadsafe
                  ${PROJECT_BINARY_DIR}/bin/nrnpyenv.sh ${CMAKE_CURRENT_SOURCE_DIR}/set_nrnpyenv.sh
-        DESTINATION ${NRN_INSTALL_DATA_PREFIX}/bin)
+        DESTINATION ${NRN_INSTALL_DATA_PREFIX}bin)

--- a/src/coreneuron/CMakeLists.txt
+++ b/src/coreneuron/CMakeLists.txt
@@ -462,7 +462,7 @@ if(NRN_ENABLE_MPI AND NRN_ENABLE_MPI_DYNAMIC)
     PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
                LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
                POSITION_INDEPENDENT_CODE ON)
-  install(TARGETS ${corenrn_mpi_targets} DESTINATION ${NRN_INSTALL_DATA_PREFIX}/lib)
+  install(TARGETS ${corenrn_mpi_targets} DESTINATION ${NRN_INSTALL_DATA_PREFIX}lib)
 endif()
 
 # Suppress some compiler warnings.
@@ -602,46 +602,46 @@ endif()
 install(
   TARGETS coreneuron-core ${coreneuron_cuda_target}
   EXPORT coreneuron
-  LIBRARY DESTINATION ${NRN_INSTALL_DATA_PREFIX}/lib
-  ARCHIVE DESTINATION ${NRN_INSTALL_DATA_PREFIX}/lib
+  LIBRARY DESTINATION ${NRN_INSTALL_DATA_PREFIX}lib
+  ARCHIVE DESTINATION ${NRN_INSTALL_DATA_PREFIX}lib
   INCLUDES
-  DESTINATION ${NRN_INSTALL_DATA_PREFIX}/include)
+  DESTINATION ${NRN_INSTALL_DATA_PREFIX}include)
 
 # headers and some standalone code files for nrnivmodl-core
 install(
   DIRECTORY ${CMAKE_BINARY_DIR}/include/coreneuron
-  DESTINATION ${NRN_INSTALL_DATA_PREFIX}/include/
+  DESTINATION ${NRN_INSTALL_DATA_PREFIX}include/
   FILES_MATCHING
   PATTERN "*.h*"
   PATTERN "*.ipp")
 install(FILES ${MODFUNC_SHELL_SCRIPT} ${ENGINEMECH_CODE_FILE}
-        DESTINATION ${NRN_INSTALL_DATA_PREFIX}/share/coreneuron)
+        DESTINATION ${NRN_INSTALL_DATA_PREFIX}share/coreneuron)
 
 # copy nmodl for nrnivmodl-core
-install(PROGRAMS ${CORENRN_NMODL_BINARY} DESTINATION ${NRN_INSTALL_DATA_PREFIX}/bin)
+install(PROGRAMS ${CORENRN_NMODL_BINARY} DESTINATION ${NRN_INSTALL_DATA_PREFIX}bin)
 
 # install nrniv-core app
 install(
   PROGRAMS ${CMAKE_BINARY_DIR}/bin/${CMAKE_HOST_SYSTEM_PROCESSOR}/special-core
-  DESTINATION ${NRN_INSTALL_DATA_PREFIX}/bin
+  DESTINATION ${NRN_INSTALL_DATA_PREFIX}bin
   RENAME nrniv-core)
-install(FILES apps/coreneuron.cpp DESTINATION ${NRN_INSTALL_DATA_PREFIX}/share/coreneuron)
+install(FILES apps/coreneuron.cpp DESTINATION ${NRN_INSTALL_DATA_PREFIX}share/coreneuron)
 
 # install mechanism library in shared library builds, if we're linking statically then there is no
 # need
 if(CORENRN_ENABLE_SHARED)
-  install(FILES ${corenrn_mech_library} DESTINATION ${NRN_INSTALL_DATA_PREFIX}/lib)
+  install(FILES ${corenrn_mech_library} DESTINATION ${NRN_INSTALL_DATA_PREFIX}lib)
 endif()
 
 # install mod files
-install(DIRECTORY ${CMAKE_BINARY_DIR}/share/modfile DESTINATION ${NRN_INSTALL_DATA_PREFIX}/share)
+install(DIRECTORY ${CMAKE_BINARY_DIR}/share/modfile DESTINATION ${NRN_INSTALL_DATA_PREFIX}share)
 
 # =============================================================================
 # Install for end users
 # =============================================================================
 install(FILES ${CMAKE_BINARY_DIR}/share/coreneuron/nrnivmodl_core_makefile
-        DESTINATION ${NRN_INSTALL_DATA_PREFIX}/share/coreneuron)
-install(PROGRAMS ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core DESTINATION ${NRN_INSTALL_DATA_PREFIX}/bin)
+        DESTINATION ${NRN_INSTALL_DATA_PREFIX}share/coreneuron)
+install(PROGRAMS ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core DESTINATION ${NRN_INSTALL_DATA_PREFIX}bin)
 
 # =============================================================================
 # Set flag for NEURON linking

--- a/src/nmodl/pybind/CMakeLists.txt
+++ b/src/nmodl/pybind/CMakeLists.txt
@@ -110,13 +110,13 @@ file(COPY ${NMODL_PROJECT_PURELIB_SOURCE_DIR}/ext DESTINATION ${NMODL_PROJECT_PU
 # Install python binding components
 # =============================================================================
 if(NOT NRN_LINK_AGAINST_PYTHON)
-  install(TARGETS pywrapper DESTINATION ${NRN_INSTALL_DATA_PREFIX}/lib)
+  install(TARGETS pywrapper DESTINATION ${NRN_INSTALL_DATA_PREFIX}lib)
   if(NMODL_ENABLE_PYTHON_BINDINGS)
-    install(TARGETS _nmodl DESTINATION ${NRN_INSTALL_PYTHON_PREFIX}/nmodl)
+    install(TARGETS _nmodl DESTINATION ${NRN_INSTALL_PYTHON_PREFIX}nmodl)
   endif()
 else()
   install(
     DIRECTORY ${CMAKE_BINARY_DIR}/lib/
-    DESTINATION ${NRN_INSTALL_DATA_PREFIX}/lib
+    DESTINATION ${NRN_INSTALL_DATA_PREFIX}lib
     PATTERN "__pycache__" EXCLUDE)
 endif()

--- a/src/nrniv/CMakeLists.txt
+++ b/src/nrniv/CMakeLists.txt
@@ -574,11 +574,11 @@ endif()
 # For now, we keep this distinction as it reduces the PATH and is
 # expected when ctypes looks for dlls
 # ~~~
-install(TARGETS nrniv nocmodl modlunit DESTINATION ${NRN_INSTALL_DATA_PREFIX}/bin)
+install(TARGETS nrniv nocmodl modlunit RUNTIME DESTINATION ${NRN_INSTALL_DATA_PREFIX}bin)
 install(TARGETS nrniv_lib DESTINATION ${NRN_INSTALL_SHARE_LIB_DIR})
 if(LIBIVX11DYNAM_NAME)
   install(FILES ${PROJECT_BINARY_DIR}/lib/${LIBIVX11DYNAM_NAME}
-          DESTINATION ${NRN_INSTALL_DATA_PREFIX}/lib)
+          DESTINATION ${NRN_INSTALL_DATA_PREFIX}lib)
 endif()
 
 # =============================================================================
@@ -607,4 +607,4 @@ add_custom_target(
 
 # For the installation
 install(FILES ${PROJECT_SOURCE_DIR}/src/ivoc/nrnmain.cpp
-        DESTINATION ${NRN_INSTALL_DATA_PREFIX}/share/nrn)
+        DESTINATION ${NRN_INSTALL_DATA_PREFIX}share/nrn)


### PR DESCRIPTION
Fixes #3580.

Note that the various prefix forward slashes have been removed because if the preceding variable is empty, it will try to install it to the absolute path (for instance, `/bin` instead of `bin`, and the latter gets expanded to `${CMAKE_INSTALL_PREFIX}bin`, where `CMAKE_INSTALL_PREFIX` already takes care of the paths).