### PR TITLE
fix: `cell-permute` setting from python

### DIFF
--- a/share/lib/python/neuron/coreneuron.py
+++ b/share/lib/python/neuron/coreneuron.py
@@ -302,7 +302,9 @@ class coreneuron(object):
             if self._skip_write_model_to_disk:
                 arg += " --skip-write-model-to-disk"
         arg += f" --tstop {tstop:g}"
-        arg += f" --cell-permute {self.cell_permute}"
+        # set parameters only if explicitly set. These override sim_config
+        if self._cell_permute is not None:
+            arg += f" --cell-permute {self.cell_permute}"
         if self._warp_balance > 0:
             arg += f" --nwarp {self.warp_balance}"
         if self._prcellstate >= 0:


### PR DESCRIPTION
Python `nrncore_arg` was overriding `cell-permute` from file even if the value was not given. In fact, if the value is already set CLI11 does not apply the value (as it should be).

Solution: check that the value was set (and not taken from default) before, eventually, setting it

Fix: #3583 

## Question: 

do you want a test for this? Where can I put it? Maybe add it to an existing one?