### PR TITLE
Add NMODL support for multiple INITIAL blocks

### DIFF
--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -28,6 +28,7 @@
 #include "visitors/cvode_visitor.hpp"
 #include "visitors/function_callpath_visitor.hpp"
 #include "visitors/global_var_visitor.hpp"
+#include "visitors/initial_block_visitor.hpp"
 #include "visitors/implicit_argument_visitor.hpp"
 #include "visitors/indexedname_visitor.hpp"
 #include "visitors/inline_visitor.hpp"
@@ -341,6 +342,13 @@ int run_nmodl(int argc, const char* argv[]) {
         {
             logger->info("Running argument renaming visitor");
             RenameFunctionArgumentsVisitor().visit_program(*ast);
+        }
+
+        /// merge all INITIAL blocks into one (this needs to run before SymtabVisitor)
+        {
+            logger->info("Running INITIAL block merge visitor");
+            MergeInitialBlocksVisitor().visit_program(*ast);
+            ast_to_nmodl(*ast, filepath("merge_initial_block"));
         }
 
         /// construct symbol table

--- a/src/nmodl/visitors/CMakeLists.txt
+++ b/src/nmodl/visitors/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(
   neuron_solve_visitor.cpp
   perf_visitor.cpp
   rename_visitor.cpp
+  initial_block_visitor.cpp
   rename_function_arguments.cpp
   semantic_analysis_visitor.cpp
   solve_block_visitor.cpp

--- a/src/nmodl/visitors/initial_block_visitor.cpp
+++ b/src/nmodl/visitors/initial_block_visitor.cpp
@@ -30,7 +30,7 @@ void MergeInitialBlocksVisitor::visit_program(ast::Program& node) {
     for (auto& block: blocks) {
         if (block->is_initial_block()) {
             auto statement_block =
-                std::static_pointer_cast<ast::StatementBlock>(block)->get_statement_block();
+                std::static_pointer_cast<ast::InitialBlock>(block)->get_statement_block();
             // if block is not empty, copy statements into vector
             if (statement_block) {
                 for (const auto& statement: statement_block->get_statements()) {

--- a/src/nmodl/visitors/initial_block_visitor.cpp
+++ b/src/nmodl/visitors/initial_block_visitor.cpp
@@ -24,7 +24,7 @@ void MergeInitialBlocksVisitor::visit_program(ast::Program& node) {
     // collect all blocks in the program
     const auto& blocks = node.get_blocks();
 
-    // collect all statements from INITIAL blocks, and INITIAL blocks themselves
+    // collect all statements from top-level INITIAL blocks, and the blocks themselves
     ast::StatementVector statements;
     std::unordered_set<ast::Node*> blocks_to_delete;
     for (auto& block: blocks) {
@@ -41,12 +41,12 @@ void MergeInitialBlocksVisitor::visit_program(ast::Program& node) {
         }
     }
 
-    // insert new INITIAL block which has the above statements
+    // insert new top-level INITIAL block which has the above statements
     auto new_block = ast::StatementBlock(statements);
     auto new_initial_block = ast::InitialBlock(new_block.clone());
     node.emplace_back_node(new_initial_block.clone());
 
-    // delete all of the previously-found INITIAL blocks
+    // delete all of the previously-found top-level INITIAL blocks
     node.erase_node(blocks_to_delete);
 }
 }  // namespace visitor

--- a/src/nmodl/visitors/initial_block_visitor.cpp
+++ b/src/nmodl/visitors/initial_block_visitor.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 EPFL.
+ * See the top-level LICENSE file for details.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <unordered_set>
+
+#include "visitors/initial_block_visitor.hpp"
+#include "visitors/visitor_utils.hpp"
+
+#include "ast/all.hpp"
+
+namespace nmodl {
+namespace visitor {
+
+void MergeInitialBlocksVisitor::visit_program(ast::Program& node) {
+    // check if there is > 1 INITIAL block
+    if (collect_nodes(node, {ast::AstNodeType::INITIAL_BLOCK}).size() <= 1) {
+        return;
+    }
+
+    // collect all blocks in the program
+    const auto& blocks = node.get_blocks();
+
+    // collect all statements from INITIAL blocks, and INITIAL blocks themselves
+    ast::StatementVector statements;
+    std::unordered_set<ast::Node*> blocks_to_delete;
+    for (auto& block: blocks) {
+        if (block->is_initial_block()) {
+            auto statement_block =
+                std::static_pointer_cast<ast::StatementBlock>(block)->get_statement_block();
+            // if block is not empty, copy statements into vector
+            if (statement_block) {
+                for (const auto& statement: statement_block->get_statements()) {
+                    statements.push_back(statement);
+                }
+            }
+            blocks_to_delete.insert(block.get());
+        }
+    }
+
+    // insert new INITIAL block which has the above statements
+    auto new_block = ast::StatementBlock(statements);
+    auto new_initial_block = ast::InitialBlock(new_block.clone());
+    node.emplace_back_node(new_initial_block.clone());
+
+    // delete all of the previously-found INITIAL blocks
+    node.erase_node(blocks_to_delete);
+}
+}  // namespace visitor
+}  // namespace nmodl

--- a/src/nmodl/visitors/initial_block_visitor.hpp
+++ b/src/nmodl/visitors/initial_block_visitor.hpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 EPFL.
+ * See the top-level LICENSE file for details.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+/**
+ * \file
+ * \brief \copybrief nmodl::visitor::MergeInitialBlocksVisitor
+ */
+
+#include "visitors/ast_visitor.hpp"
+
+namespace nmodl {
+namespace visitor {
+
+/**
+ * \addtogroup visitor_classes
+ * \{
+ */
+
+/**
+ * \class MergeInitialBlocksVisitor
+ * \brief Visitor which merges all INITIAL blocks into one
+ */
+class MergeInitialBlocksVisitor: public AstVisitor {
+  public:
+    void visit_program(ast::Program& node) override;
+};
+
+/** \} */  // end of visitor_classes
+
+}  // namespace visitor
+}  // namespace nmodl

--- a/test/nmodl/transpiler/unit/CMakeLists.txt
+++ b/test/nmodl/transpiler/unit/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(
   visitor/global_to_range.cpp
   visitor/implicit_argument.cpp
   visitor/inline.cpp
+  visitor/initial_block.cpp
   visitor/json.cpp
   visitor/kinetic_block.cpp
   visitor/localize.cpp

--- a/test/nmodl/transpiler/unit/visitor/initial_block.cpp
+++ b/test/nmodl/transpiler/unit/visitor/initial_block.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 Blue Brain Project, EPFL.
+ * See the top-level LICENSE file for details.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ast/program.hpp"
+#include "parser/nmodl_driver.hpp"
+#include "utils/test_utils.hpp"
+#include "visitors/initial_block_visitor.hpp"
+#include "visitors/nmodl_visitor.hpp"
+#include "visitors/symtab_visitor.hpp"
+#include "visitors/visitor_utils.hpp"
+#include "visitors/json_visitor.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+using namespace nmodl;
+using nmodl::test_utils::reindent_text;
+
+using Catch::Matchers::ContainsSubstring;  // ContainsSubstring in newer Catch2
+
+//=============================================================================
+// MergeInitialBlocks visitor tests
+//=============================================================================
+
+auto generate_mod_after_merge_initial_blocks_visitor(std::string const& text) {
+    parser::NmodlDriver driver{};
+    auto ast = driver.parse_string(text);
+    visitor::MergeInitialBlocksVisitor{}.visit_program(*ast);
+    return to_nmodl(*ast);
+}
+
+SCENARIO("Check multiple INITIAL blocks are merged properly", "[visitor][merge_initial_blocks]") {
+    GIVEN("A mod file with multiple INITIAL blocks") {
+        const auto nmodl_text_before = R"(
+            NEURON {
+                SUFFIX InitialBlockTest
+                RANGE foo, bar
+            }
+            INITIAL {
+                foo = 1
+            }
+            INITIAL {
+                bar = 2
+            }
+        )";
+        const auto nmodl_text_after = R"(
+            NEURON {
+              SUFFIX InitialBlockTest
+              RANGE foo, bar
+            }
+            INITIAL {
+              foo = 1
+              bar = 2
+            }
+        )";
+        parser::NmodlDriver driver{};
+        auto ast_expected = driver.parse_string(nmodl_text_after);
+        const auto program_expected = to_nmodl(ast_expected);
+        const auto program_actual = generate_mod_after_merge_initial_blocks_visitor(
+            nmodl_text_before);
+        THEN("expected and actual should be identical at the level of the AST") {
+            // TODO the AST class lacks an overload for `operator==` so here we compare it at the
+            // string level
+            REQUIRE(reindent_text(program_actual) == reindent_text(program_expected));
+        }
+    }
+}

--- a/test/nmodl/transpiler/unit/visitor/initial_block.cpp
+++ b/test/nmodl/transpiler/unit/visitor/initial_block.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Blue Brain Project, EPFL.
+ * Copyright 2025 EPFL.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -33,7 +33,7 @@ auto generate_mod_after_merge_initial_blocks_visitor(std::string const& text) {
     return to_nmodl(*ast);
 }
 
-SCENARIO("Check multiple INITIAL blocks are merged properly", "[visitor][merge_initial_blocks]") {
+SCENARIO("Check multiple INITIAL blocks are handled properly", "[visitor][merge_initial_blocks]") {
     GIVEN("A mod file with multiple INITIAL blocks") {
         const auto nmodl_text_before = R"(
             NEURON {
@@ -66,6 +66,53 @@ SCENARIO("Check multiple INITIAL blocks are merged properly", "[visitor][merge_i
             // TODO the AST class lacks an overload for `operator==` so here we compare it at the
             // string level
             REQUIRE(reindent_text(program_actual) == reindent_text(program_expected));
+        }
+    }
+    GIVEN("A mod file with an INITIAL block only inside of a NET_RECEIVE block") {
+        const auto nmodl_text_before = R"(
+            NEURON {
+                SUFFIX test
+                RANGE foo, bar
+            }
+
+            NET_RECEIVE (w) {
+                INITIAL {
+                    foo = 1
+                }
+            }
+        )";
+        const auto program_actual = generate_mod_after_merge_initial_blocks_visitor(
+            nmodl_text_before);
+        THEN("leave the mod file as-is") {
+            REQUIRE(reindent_text(program_actual) == reindent_text(nmodl_text_before));
+        }
+    }
+    GIVEN("A mod file with an INITIAL block, and one inside of a NET_RECEIVE block") {
+        // Note that the visitor actually modifies the AST (since there is > 1 INITIAL block in the
+        // entire file: one top-level, and one in NET_RECEIVE). If we place the top-level INITIAL
+        // block before NET_RECEIVE in the below, the top-level INITIAL block will be deleted and
+        // appended. However, since the position of the INITIAL block in the mod file has no impact
+        // on the semantics, the visitor works as expected
+        const auto nmodl_text_before = R"(
+            NEURON {
+                SUFFIX test
+                RANGE foo, bar
+            }
+
+            NET_RECEIVE (w) {
+                INITIAL {
+                    foo = 1
+                }
+            }
+
+            INITIAL {
+                bar = 2
+            }
+        )";
+        const auto program_actual = generate_mod_after_merge_initial_blocks_visitor(
+            nmodl_text_before);
+        THEN("leave the mod file as-is") {
+            REQUIRE(reindent_text(program_actual) == reindent_text(nmodl_text_before));
         }
     }
 }


### PR DESCRIPTION
Fixes #3588.

The implementation of `MergeInitialBlocksVisitor` basically does the following:

- check if there is > 1 INITIAL block in the AST. If not, do nothing
- add the found INITIAL blocks to a container, `blocks_to_delete`
- iterate over all of the statements in each INITIAL block found (in the order of their appearance in the mod file), and add them to a container, `statements`
- add an additional INITIAL block to the top-level AST, and dump `statements` in it
- delete `blocks_to_delete` from the AST
- if `passes --nmodl-ast` is enabled, write a file `<modfile>.<number>.merge_initial_block.mod`

Some remarks (for future reference):

- `collect_nodes` doesn't actually collect `Node`s, but rather (a vector of) instances of its parent class, `Ast`. This means that we can't directly pass it to `Program`'s `erase_node`. As a workaround, one can use the following idiom (where `is_<some_type>` is one of the methods [here](https://nrn.readthedocs.io/en/latest/doxygen/structnmodl_1_1ast_1_1_ast.html)):

```cpp
auto& blocks = program.get_blocks();
for (const auto& block: blocks) {
   if (block->is_<some_type>()) {
     // logic goes here
  }
}
```

- the `Ast` class doesn't appear to implement `operator==` so we can't compare values at the AST level, but only at the level of NMODL