### PR TITLE
sonarcloud issue : scanf("%s", buf) buf can overflow

### DIFF
--- a/src/ivoc/ocfile.cpp
+++ b/src/ivoc/ocfile.cpp
@@ -117,7 +117,9 @@ static double f_scanstr(void* v) {
     OcFile* f = (OcFile*) v;
     char** pbuf = hoc_pgargstr(1);
     char* buf = hoc_tmpbuf->buf;
-    int i = fscanf(f->file(), "%s", buf);
+    char format[32];
+    snprintf(format, sizeof(format), "%%%zus", hoc_tmpbuf->size - 1);
+    int i = fscanf(f->file(), format, buf);
     if (i == 1) {
         hoc_assign_str(pbuf, buf);
         return double(strlen(buf));

--- a/src/oc/fileio.cpp
+++ b/src/oc/fileio.cpp
@@ -351,7 +351,9 @@ void hoc_Getstr(void) /* read a line (or word) from input file */
     }
     if (word) {
         buf = hoc_tmpbuf->buf;
-        if (nrn_fw_fscanf(fi, "%s", buf) != 1) {
+        char format[32];
+        snprintf(format, sizeof(format), "%%%zus", hoc_tmpbuf->size - 1);
+        if (nrn_fw_fscanf(fi, format, buf) != 1) {
             hoc_execerror("EOF in getstr", (char*) 0);
         }
     } else {

--- a/test/pytest_coreneuron/test_py2nrnstring.py
+++ b/test/pytest_coreneuron/test_py2nrnstring.py
@@ -85,7 +85,28 @@ def test_py2nrnstring():
     expect_err("soma(.5).hh.à = 1")
 
 
+def test_getstr_word():
+    import tempfile
+
+    words = "a space separated   series of words \n\n goodbye"
+    wordlist = words.split()
+    with tempfile.NamedTemporaryFile(mode="w", delete=True, suffix=".txt") as temp_file:
+        temp_file.write(words)
+        temp_file.flush()
+        # print(f"temp_file {temp_file.name}")
+
+        h.ropen(temp_file.name)
+        word = h.ref("")
+        for i in range(100):
+            h.getstr(word, 1)
+            assert word[0] == wordlist[i]
+            if word[0] == "goodbye":
+                break
+        h.ropen()
+
+
 if __name__ == "__main__":
     set_quiet(False)
     quiet = False
     test_py2nrnstring()
+    test_getstr_word()


### PR DESCRIPTION
Fix two sonarcloud issues:

"scanf()" and "fscanf()" format strings should specify a field width for the "%s" string placeholder
High
#2 opened on Oct 2, 2023 • Detected by SonarCloud in src/ivoc/ocfile.cpp :120

"scanf()" and "fscanf()" format strings should specify a field width for the "%s" string placeholder
High
#1 opened on Oct 2, 2023 • Detected by SonarCloud in src/oc/fileio.cpp :354
master
