### PR TITLE
In yml files `key: value` requires a space after the `:`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,7 +41,7 @@ jobs:
       with:
         ref: ${{ inputs.tag }}
         submodules: recursive
-        fetch-tags:true  # Ensures tags are available for git describe
+        fetch-tags: true  # Ensures tags are available for git describe
 
     - name: Retrieve rxd test data
       run: |

--- a/packaging/python/build_static_readline_osx.bash
+++ b/packaging/python/build_static_readline_osx.bash
@@ -34,7 +34,7 @@ fi
     && ./configure --prefix="${NRNWHEEL_DIR}/ncurses" --without-shared CFLAGS="-fPIC" \
     && make -j install)
 
-(curl -L -o readline-7.0.tar.gz https://ftp.gnu.org/gnu/readline/readline-7.0.tar.gz \
+(curl -L -o readline-7.0.tar.gz https://ftpmirror.gnu.org/gnu/readline/readline-7.0.tar.gz \
     && tar -xvzf readline-7.0.tar.gz \
     && cd readline-7.0  \
     && ./configure --prefix="${NRNWHEEL_DIR}/readline" --disable-shared CFLAGS="-fPIC" \


### PR DESCRIPTION
Just a missing space causing a ```Invalid workflow file: .github/workflows/windows.yml#L44``` 