### PR TITLE
Automate fetching latest installer information

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-patch.md
+++ b/.github/ISSUE_TEMPLATE/release-patch.md
@@ -17,13 +17,12 @@ Pre-release
 - [ ] Update cherrypicks PR:
   - [ ] Update semantic version in `CMakeLists.txt`
   - [ ] Update changelog below and agree on it with everyone; then commit it to `docs/changelog` in the cherrypicks PR (copy structure as-is)
-  - [ ] Update `docs/index.rst` accordingly with the new `.pkg` and `.exe` links for `PKG installer` and `Windows Installer`
 - [ ] Activate ReadtheDocs for the cherry-pick branch and ensure the documentation builds (when logged in, go to [the versions page](https://readthedocs.org/projects/nrn/versions/) and set the version for your branch to Active and Hidden)
 - [ ] Run a test wheel build WITHOUT upload on the cherry-pick branch to ensure all the wheels build ([see details](https://nrn.readthedocs.io/en/latest/install/python_wheels.html#publishing-the-wheels-on-pypi-via-azure))
 
 Sanity checks
 ---
-- [ ] After cherrypicks PR is merged, make sure GitHub, Azure and CircleCI builds pass for `release/x.y` branch
+- [ ] After cherrypicks PR is merged, make sure GitHub and Azure builds pass for `release/x.y` branch
 - [ ] Run [nrn-build-ci](https://github.com/neuronsimulator/nrn-build-ci/actions/workflows/build-neuron.yml) for the `release/x.y` branch; see [nrn-build-ci guide](https://github.com/neuronsimulator/nrn-build-ci#azure-wheels-testing---manual-workflow)
 - [ ] Activate ReadTheDocs build for `release/x.y` & make it hidden. Check docs are fine after build is done.
 - [ ] Run BBP Simulation Stack & other relevant tests
@@ -35,11 +34,8 @@ Releasing
 - [ ] Build release wheels but WITHOUT upload ([see details](https://nrn.readthedocs.io/en/latest/install/python_wheels.html#publishing-the-wheels-on-pypi-via-azure))
 - [ ] Create, test and upload manual artifacts
   - [ ] MacOS package installer (manual task, ask Michael)
-  - [ ] arm64 wheels (manual task, check with Erik, Goran or Pramod)
-  - [ ] aarch64 wheels (use existing `release/x.y-aarch64` branch for this, see [guide](https://nrn.readthedocs.io/en/latest/install/python_wheels.html#publishing-the-wheels-on-pypi-via-circleci))
 - [ ] Publish the `x.y.z` wheels on PyPI; see [wheel publishing instructions](https://nrn.readthedocs.io/en/latest/install/python_wheels.html#publishing-the-wheels-on-pypi-via-azure)
 - [ ] Once wheels are published, activate the `x.y.z` tag on ReadTheDocs
-- [ ] Rename the Windows installer in the GitHub release to match the new version and the supported python versions (i.e. `nrn-8.2.2.w64-mingw-py-39-310-311-312-setup.exe`)
 - [ ] Publish release on GitHub (edit https://github.com/neuronsimulator/nrn/releases/tag/x.y.z and un-tick the pre-release checkbox)
 
 
@@ -48,7 +44,7 @@ Post-release
 - [ ] Deactivate ReadTheDocs build for `release/x.y`
 - [ ] Go to [ReadTheDocs advanced settings](https://readthedocs.org/dashboard/nrn/advanced/) and set `Default version` to `x.y.z`
 - [ ] Let people know :rocket:
-- [ ] Cherrypick changelog and installer links to `master`
+- [ ] Cherrypick changelog to `master`
 - [ ] Update the changelog for the release on GitHub
 - [ ] Update `codemeta.json` (`master` branch only) with the new version, changelog, date, and links
 

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -20,7 +20,6 @@ Releasing
 ---
 - [ ] Update semantic version in `CMakeLists.txt`
 - [ ] Update changelog below and agree on it with everyone; then commit it to `docs/changelog` (copy structure as-is)
-- [ ] Update `docs/index.rst` accordingly with the new `.pkg` and `.exe` links for `PKG installer` and `Windows Installer`
 - [ ] Run the ReadTheDocs build again for `release/x.y`, make sure the build passes and inspect the Changelog page.
 - [ ] Create, test and upload manual artifacts
   - [ ] MacOS package installer (manual task, ask Michael)
@@ -37,7 +36,7 @@ Post-release
 - [ ] Deactivate ReadTheDocs build for `release/x.y`
 - [ ] Go to [ReadTheDocs advanced settings](https://readthedocs.org/dashboard/nrn/advanced/) and set `Default version` to `x.y.z`
 - [ ] Let people know :rocket:
-- [ ] Cherrypick changelog and installer links to `master`
+- [ ] Cherrypick changelog to `master`
 - [ ] Update the changelog for the release on GitHub
 - [ ] Update `codemeta.json` (`master` branch only) with the new version, changelog, date, and links
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -888,6 +888,10 @@ if(NRN_ENABLE_DOCS)
       COMMENT "Generating documentation with Sphinx")
   endfunction()
 
+  include(cmake/FetchLatestRelease.cmake)
+  fetch_latest_release()
+  configure_file("${PROJECT_SOURCE_DIR}/docs/index.rst.in" "${PROJECT_SOURCE_DIR}/docs/index.rst")
+
   add_sphinx_target(sphinx)
 
   if(NRN_ENABLE_DOCS_WITH_EXTERNAL_INSTALLATION)

--- a/cmake/FetchLatestRelease.cmake
+++ b/cmake/FetchLatestRelease.cmake
@@ -1,0 +1,105 @@
+# =============================================================================
+# Fetch the latest release JSON from GitHub API, and put the information into the variables
+# `NRN_WINDOWS_INSTALLER_LINK` and `NRN_MACOS_INSTALLER_LINK`. Note that, according to the GitHub
+# API docs:
+#
+# > The latest release is the most recent non-prerelease, non-draft release, sorted by the
+# created_at attribute. The created_at attribute is the date of the commit used for the release, and
+# not the date when the release was drafted or published.
+#
+# which means that after we make a release on GitHub, this function will always that one, regardless
+# of which version tag it uses. This is good because then we do not need to worry about version
+# (x-1).y (say, a bugfix for an old release) having the wrong links; if it has chronologically been
+# released the latest, the API will fetch that one.
+# =============================================================================
+function(fetch_latest_release)
+  set(GITHUB_USER "neuronsimulator/nrn")
+  set(GITHUB_REPO "nrn")
+  set(API_URL "https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest")
+  set(JSON_FILE "${CMAKE_CURRENT_BINARY_DIR}/latest_release.json")
+  set(WINDOWS_INSTALLER_PATTERN ".*\\.w64-mingw.*setup\\.exe$")
+  set(MACOS_INSTALLER_PATTERN ".*macosx.*\\.pkg$")
+
+  message(STATUS "Fetching latest release info from ${API_URL}")
+  file(
+    DOWNLOAD "${API_URL}" "${JSON_FILE}"
+    STATUS DOWNLOAD_STATUS
+    TIMEOUT 10)
+
+  # Check if download was successful
+  list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
+  if(NOT STATUS_CODE EQUAL 0)
+    message(FATAL_ERROR "Failed to download release information")
+  endif()
+
+  # Read the JSON file
+  file(READ "${JSON_FILE}" JSON_CONTENT)
+
+  # Extract the number of assets
+  string(JSON ASSETS_LENGTH ERROR_VARIABLE JSON_ERROR LENGTH "${JSON_CONTENT}" "assets")
+  if(JSON_ERROR)
+    message(FATAL_ERROR "Failed to parse JSON: ${JSON_ERROR}")
+  endif()
+
+  message(DEBUG "Found ${ASSETS_LENGTH} assets in latest release")
+
+  # Initialize variables for installer URLs
+  set(WINDOWS_INSTALLER_URL "")
+  set(MACOS_INSTALLER_URL "")
+
+  # Iterate through assets to find installers
+  math(EXPR LAST_INDEX "${ASSETS_LENGTH} - 1")
+  foreach(INDEX RANGE 0 ${LAST_INDEX})
+    # Get asset name
+    string(
+      JSON
+      ASSET_NAME
+      GET
+      "${JSON_CONTENT}"
+      "assets"
+      ${INDEX}
+      "name")
+
+    # Get browser download URL
+    string(
+      JSON
+      ASSET_URL
+      GET
+      "${JSON_CONTENT}"
+      "assets"
+      ${INDEX}
+      "browser_download_url")
+
+    if(ASSET_NAME MATCHES "${WINDOWS_INSTALLER_PATTERN}")
+      set(WINDOWS_INSTALLER_URL "${ASSET_URL}")
+      message(STATUS "Found Windows installer: ${ASSET_NAME}")
+      message(STATUS "  URL: ${ASSET_URL}")
+    endif()
+
+    if(ASSET_NAME MATCHES "${MACOS_INSTALLER_PATTERN}")
+      set(MACOS_INSTALLER_URL "${ASSET_URL}")
+      message(STATUS "Found macOS installer: ${ASSET_NAME}")
+      message(STATUS "  URL: ${ASSET_URL}")
+    endif()
+  endforeach()
+
+  # ===============================================
+  # Verify we found both installers
+  #
+  # TODO should this issue a `FATAL_ERROR` instead?
+  # ===============================================
+  if(NOT WINDOWS_INSTALLER_URL)
+    message(WARNING "Windows installer not found in latest release")
+  endif()
+
+  if(NOT MACOS_INSTALLER_URL)
+    message(WARNING "macOS installer not found in latest release")
+  endif()
+
+  set(NRN_WINDOWS_INSTALLER_LINK
+      "${WINDOWS_INSTALLER_URL}"
+      PARENT_SCOPE)
+  set(NRN_MACOS_INSTALLER_LINK
+      "${MACOS_INSTALLER_URL}"
+      PARENT_SCOPE)
+endfunction()

--- a/cmake/FetchLatestRelease.cmake
+++ b/cmake/FetchLatestRelease.cmake
@@ -1,7 +1,7 @@
 # =============================================================================
 # Fetch the latest release JSON from GitHub API, and put the information into the variables
-# `NRN_WINDOWS_INSTALLER_URL` and `NRN_MACOS_INSTALLER_URL`. Note that, according to the GitHub
-# API docs:
+# `NRN_WINDOWS_INSTALLER_URL` and `NRN_MACOS_INSTALLER_URL`. Note that, according to the GitHub API
+# docs:
 #
 # > The latest release is the most recent non-prerelease, non-draft release, sorted by the
 # created_at attribute. The created_at attribute is the date of the commit used for the release, and
@@ -13,6 +13,9 @@
 # released the latest, the API will fetch that one.
 # =============================================================================
 function(fetch_latest_release)
+  if(CMAKE_VERSION VERSION_LESS "3.19")
+    message(FATAL_ERROR "CMake 3.19 or above is required for building the docs")
+  endif()
   set(GITHUB_USER "neuronsimulator")
   set(GITHUB_REPO "nrn")
   set(API_URL "https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest")
@@ -24,6 +27,7 @@ function(fetch_latest_release)
   file(
     DOWNLOAD "${API_URL}" "${JSON_FILE}"
     STATUS DOWNLOAD_STATUS
+    HTTPHEADER "X-GitHub-Api-Version: 2022-11-28"
     TIMEOUT 10)
 
   # Check if download was successful

--- a/cmake/FetchLatestRelease.cmake
+++ b/cmake/FetchLatestRelease.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # Fetch the latest release JSON from GitHub API, and put the information into the variables
-# `NRN_WINDOWS_INSTALLER_LINK` and `NRN_MACOS_INSTALLER_LINK`. Note that, according to the GitHub
+# `NRN_WINDOWS_INSTALLER_URL` and `NRN_MACOS_INSTALLER_URL`. Note that, according to the GitHub
 # API docs:
 #
 # > The latest release is the most recent non-prerelease, non-draft release, sorted by the
@@ -13,7 +13,7 @@
 # released the latest, the API will fetch that one.
 # =============================================================================
 function(fetch_latest_release)
-  set(GITHUB_USER "neuronsimulator/nrn")
+  set(GITHUB_USER "neuronsimulator")
   set(GITHUB_REPO "nrn")
   set(API_URL "https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest")
   set(JSON_FILE "${CMAKE_CURRENT_BINARY_DIR}/latest_release.json")
@@ -96,10 +96,10 @@ function(fetch_latest_release)
     message(WARNING "macOS installer not found in latest release")
   endif()
 
-  set(NRN_WINDOWS_INSTALLER_LINK
+  set(NRN_WINDOWS_INSTALLER_URL
       "${WINDOWS_INSTALLER_URL}"
       PARENT_SCOPE)
-  set(NRN_MACOS_INSTALLER_LINK
+  set(NRN_MACOS_INSTALLER_URL
       "${MACOS_INSTALLER_URL}"
       PARENT_SCOPE)
 endfunction()

--- a/docs/index.rst.in
+++ b/docs/index.rst.in
@@ -99,7 +99,7 @@ Installation
 
          pip3 install neuron
 
-      Alternatively, you can use the `PKG installer <https://github.com/neuronsimulator/nrn/releases/download/9.0.0/nrn-9.0.0-macosx-10.15-universal2-py-39-310-311-312-313.pkg>`_.
+      Alternatively, you can use the `PKG installer <@NRN_MACOS_INSTALLER_URL@>`_.
 
       For troubleshooting, see the `detailed installation instructions <install/install_instructions.md>`_.
 
@@ -116,7 +116,7 @@ Installation
 
    .. tab-item:: Windows
 
-      `Download the Windows Installer <https://github.com/neuronsimulator/nrn/releases/download/9.0.0/nrn-9.0.0.w64-mingw-py-39-310-311-312-313-setup.exe>`_.
+      `Download the Windows Installer <@NRN_WINDOWS_INSTALLER_URL@>`_.
 
       You can also install the Linux wheel via the Windows Subsystem for Linux (WSL). See `instructions <install/install_instructions.html#windows-subsystem-for-linux-wsl-python-wheel>`_.
 


### PR DESCRIPTION
We can use GitHub's API for fetching the information about the (chronologically) latest release. This removes the tedious and error-prone "make a PR which updates links to the installer in `index.rst`" step from the release process.