### PR TITLE
Better error message when Python lib is not found

### DIFF
--- a/share/lib/python/scripts/binwrapper.py
+++ b/share/lib/python/scripts/binwrapper.py
@@ -88,7 +88,15 @@ def _config_exe(exe_name):
     if "NMODLHOME" not in os.environ:
         os.environ["NMODLHOME"] = NRN_PREFIX
     if "NMODL_PYLIB" not in os.environ:
-        os.environ["NMODL_PYLIB"] = find_libpython()
+        result = find_libpython()
+        if not result:
+            raise ValueError(
+                "unable to locate the Python shared library; "
+                "please make sure it is installed, "
+                "or set the environmental variable `NMODL_PYLIB` "
+                "manually to the path to the Python shared library"
+            )
+        os.environ["NMODL_PYLIB"] = result
 
     # nmodl module is inside <prefix>/lib directory
     sys.path.insert(0, os.path.join(NRN_PREFIX, "lib"))


### PR DESCRIPTION
Fix #3649.

No test because I would need to setup a whole CI for this (all other CIs have Python built-in, so come with libpython in one form or another).