### PR TITLE
Bump compiler version in CI

### DIFF
--- a/ci/win_download_deps.cmd
+++ b/ci/win_download_deps.cmd
@@ -14,7 +14,8 @@ pwsh -command Invoke-WebRequest -MaximumRetryCount 4 -OutFile python-3.14.exe ht
 pwsh -command Invoke-WebRequest -MaximumRetryCount 4 -OutFile msmpisetup.exe https://download.microsoft.com/download/a/5/2/a5207ca5-1203-491a-8fb8-906fd68ae623/msmpisetup.exe || goto :error
 pwsh -command Invoke-WebRequest -MaximumRetryCount 4 -OutFile msmpisdk.msi https://download.microsoft.com/download/a/5/2/a5207ca5-1203-491a-8fb8-906fd68ae623/msmpisdk.msi || goto :error
 
-:: nsis plugin
+:: nsis + plugin
+curl -LO --retry 4 http://prdownloads.sourceforge.net/nsis/nsis-3.05-setup.exe || goto :error
 pwsh -command Invoke-WebRequest -MaximumRetryCount 4 -OutFile EnVar_pugin.zip https://nsis.sourceforge.io/mediawiki/images/7/7f/EnVar_plugin.zip || goto :error
 
 :: if all goes well, go to end

--- a/ci/win_install_deps.cmd
+++ b/ci/win_install_deps.cmd
@@ -33,7 +33,7 @@ C:\Python313\python.exe -m pip install "setuptools<=80.8.0" || goto :error
 C:\Python314\python.exe -m pip install "setuptools<=80.8.0" || goto :error
 
 :: install nsis
-choco install nsis.portable -y || goto :error
+nsis-3.05-setup.exe /S || goto :error
 pwsh -command Expand-Archive EnVar_pugin.zip -DestinationPath "${env:ProgramFiles(x86)}\NSIS" || goto :error
 
 :: install mpi


### PR DESCRIPTION
Bump gcc-9 -> gcc-10, gcc-10 -> gcc-12.
Fixes CI failures caused by https://github.com/actions/runner-images/issues/12898.
Note that NEURON still supports GCC 9, but as time goes on, it will get increasingly more difficult to get it, and we mandate GCC 10 for wheels anyway.

~~Also download NSIS from wherever `choco` fetches it from, since SourceForge started using CloudFlare and now downloading the installer via CLI is impossible, which fixes the Windows CI.~~ Intermittent issue it seems