### PR TITLE
Fix Python lib name

### DIFF
--- a/cmake/PythonCompileHelper.cmake
+++ b/cmake/PythonCompileHelper.cmake
@@ -125,22 +125,7 @@ function(add_nrn_python_library name)
     set(undefined_link_flag "-Wl,-undefined,dynamic_lookup")
   elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     set(rel_rpath_name "$ORIGIN")
-    # sometimes CMAKE_LIBRARY_ARCHITECTURE is not set, so here we build it manually
-    if(NOT CMAKE_LIBRARY_ARCHITECTURE)
-      set(arch "${CMAKE_SYSTEM_PROCESSOR}")
-      string(TOLOWER "${CMAKE_SYSTEM_NAME}" os)
-
-      if(arch STREQUAL "x86_64" OR arch STREQUAL "aarch64")
-        set(lib_arch "${arch}-linux-gnu")
-      else()
-        set(lib_arch "${arch}-${os}")
-      endif()
-
-      set(CMAKE_LIBRARY_ARCHITECTURE
-          "${lib_arch}"
-          CACHE INTERNAL "Guessed library architecture")
-    endif()
-    set(os_string "${CMAKE_LIBRARY_ARCHITECTURE}")
+    set(os_string "${CMAKE_SYSTEM_PROCESSOR}-linux-gnu")
     set(lib_suffix "${CMAKE_SHARED_MODULE_SUFFIX}")
     set(python_interp "cpython-")
     set(undefined_link_flag "-Wl,--unresolved-symbols=ignore-all")


### PR DESCRIPTION
This popped up while doing some testing in a Fedora 42 container.

Basically, when coming up with the name of the Python libraries (like `hoc.blabla.so`), we use `CMAKE_LIBRARY_ARCHITECTURE`. Now, on Fedora with clang, `CMAKE_LIBRARY_ARCHITECTURE` is set to `x86_64-redhat-linux-gnu`, but Python does not recognize this extension when importing:

```plaintext
$ python -c 'import importlib.machinery;print(importlib.machinery.EXTENSION_SUFFIXES)'
['.cpython-313-x86_64-linux-gnu.so', '.abi3.so', '.so']
```

The solution is to not rely on `CMAKE_LIBRARY_ARCHITECTURE` and just always set the extension to `${ARCH}-linux-gnu`, which should be importable in Python on all "reasonable" Linux platforms.

### Q: Why does this pass in the CI (see for instance [here](https://github.com/neuronsimulator/nrn-build-ci/actions/runs/19916529556/job/57096320999))?

Because the CI uses GCC, which "correctly" (or at least consistently with what Python expects) sets `CMAKE_LIBRARY_ARCHITECTURE` to `x86_64-linux-gnu`. This behavior is specific to clang. I don't know if Fedora/RHEL maintainers override the [target triplet](https://wiki.osdev.org/Target_Triplet) when shipping clang, but in any case, we can work around it with this PR.