### PR TITLE
Fix CI for release/8.2

### DIFF
--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -22,7 +22,7 @@ on:
 env:
   BUILD_TYPE: Release
   DESIRED_CMAKE_VERSION: 3.15.0
-  PY_MIN_VERSION: '3.7'
+  PY_MIN_VERSION: '3.9'
   PY_MAX_VERSION: '3.13'
 
 jobs:
@@ -39,13 +39,13 @@ jobs:
       SKIP_WHEELHOUSE_REPAIR: true
       BUILD_TYPE: Release
       DESIRED_CMAKE_VERSION: 3.15.0
-      PY_MIN_VERSION: ${{ matrix.config.python_min_version || '3.8' }}
-      PY_MAX_VERSION: ${{ matrix.config.python_max_version || '3.12' }}
+      PY_MIN_VERSION: ${{ matrix.config.python_min_version || '3.9' }}
+      PY_MAX_VERSION: ${{ matrix.config.python_max_version || '3.13' }}
       MUSIC_INSTALL_DIR: /opt/MUSIC
 
     strategy:
       matrix:
-        os: [ macOS-13, ubuntu-22.04]
+        os: [ macOS-15, ubuntu-22.04]
         config:
           - { matrix_eval : "CC=gcc-9 CXX=g++-9",   build_mode: "setuptools"}
           - { matrix_eval : "CC=gcc-10 CXX=g++-10", build_mode: "cmake", music: ON}
@@ -153,7 +153,7 @@ jobs:
           unzip MUSIC.zip && mv MUSIC-* MUSIC && cd MUSIC
           ./autogen.sh
           # workaround for MUSIC on MacOS 12
-          if [[ "${{matrix.os}}" == "macOS-13" ]]; then
+          if [[ "${{matrix.os}}" == "macOS-15" ]]; then
             MPI_CXXFLAGS="-g" MPI_CFLAGS="-g" MPI_LDFLAGS="-g" CC=mpicc CXX=mpicxx ./configure --with-python-sys-prefix --prefix=$MUSIC_INSTALL_DIR --disable-anysource
           else
             ./configure --with-python-sys-prefix --prefix=$MUSIC_INSTALL_DIR --disable-anysource

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ stages:
     - job: 'MacOSWheels'
       timeoutInMinutes: 40
       pool:
-        vmImage: 'macOS-13'
+        vmImage: 'macOS-15'
       strategy:
         matrix:
           Python39:


### PR DESCRIPTION
Get CI to pass for release/8.2 . The first strategy is to adopt master  way of doing things as much as possible.
First strategy failed. Couldn't figure out how to wholesale adopt master. Second strategy is minimal changes for passign CI.