### PR TITLE
Clean up name-mangling PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,3 @@ virtualenv
 docs/_build
 docs/_generated
 .vscode
-.coverage*
-coverage*.xml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1005,11 +1005,6 @@ if(NRN_ENABLE_TESTS)
     if(NOT PYTEST_COV_FOUND)
       message(STATUS "pytest-cov package not installed. Python coverage will not be generated.")
     endif()
-    set(NRN_PYTEST_LAUNCHER -m pytest --capture=tee-sys)
-    # pytest-cov runs extremely slowly under AddressSanitizer
-    if(PYTEST_COV_FOUND AND NOT "address" IN_LIST NRN_SANITIZERS_LIST)
-      list(APPEND NRN_PYTEST_LAUNCHER --cov-report=xml --cov=neuron)
-    endif()
   endif()
   add_dependencies(nrniv_lib copy_share_demo_to_build)
   # Execute neurondemo as part of the build because it lazily calls nrnivmodl. If we don't do this

--- a/share/lib/python/neuron/nmodl/ode.py
+++ b/share/lib/python/neuron/nmodl/ode.py
@@ -5,11 +5,6 @@
 # Lesser General Public License. See top-level LICENSE file for details.
 # ***********************************************************************
 
-# NOTE: because we are testing this via `exec` for the purposes of obtaining
-# the correct coverage, do NOT use triple single quotation marks anywhere in
-# the below because the code will break (should also be enforced by the
-# formatter, but better safe than sorry)!
-
 import itertools
 import re
 from importlib import import_module

--- a/src/nmodl/pybind/CMakeLists.txt
+++ b/src/nmodl/pybind/CMakeLists.txt
@@ -29,9 +29,6 @@ if(WIN32)
   # https://developercommunity.visualstudio.com/t/c-string-literal-max-length-much-shorter-than-docu/758957
   string(REGEX REPLACE "\n\n" "\n)jiowi\" R\"jiowi(\n" NMODL_ODE_PY "${NMODL_ODE_PY}")
 endif()
-if(NRN_ENABLE_COVERAGE)
-  set(NMODL_ODE_PY_PATH "${NMODL_PROJECT_PURELIB_SOURCE_DIR}/ode.py")
-endif()
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ode_py.hpp.inc ${CMAKE_CURRENT_BINARY_DIR}/ode_py.hpp
                @ONLY)
 
@@ -47,11 +44,6 @@ else()
   add_library(pywrapper ${CMAKE_CURRENT_SOURCE_DIR}/wrapper.cpp)
   set_property(TARGET pywrapper PROPERTY POSITION_INDEPENDENT_CODE ON)
   target_compile_definitions(pyembed PRIVATE NMODL_STATIC_PYWRAPPER=1)
-endif()
-
-if(NRN_ENABLE_COVERAGE)
-  target_compile_definitions(pywrapper PRIVATE NRN_ENABLE_COVERAGE)
-  target_link_libraries(pywrapper PRIVATE util)
 endif()
 
 target_link_libraries(pywrapper PRIVATE fmt::fmt)

--- a/src/nmodl/pybind/ode_py.hpp.inc
+++ b/src/nmodl/pybind/ode_py.hpp.inc
@@ -15,7 +15,5 @@ namespace nmodl::pybind_wrappers {
 const std::string ode_py = R"jiowi(
 @NMODL_ODE_PY@
 )jiowi";
-#ifdef NRN_ENABLE_COVERAGE
-const std::string ode_py_path = "@NMODL_ODE_PY_PATH@";
-#endif
+
 }

--- a/test/nmodl/transpiler/unit/CMakeLists.txt
+++ b/test/nmodl/transpiler/unit/CMakeLists.txt
@@ -207,22 +207,8 @@ endif()
 # =============================================================================
 if(NRN_ENABLE_PYTHON)
   if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND NRN_SANITIZERS))
-    # Most of the Python tests added by `add_nrn_test` run in their own directories. Unfortunately,
-    # pytest-cov does not seem to have an option to specify the output file (it _always_ outputs to
-    # `coverage.xml`), which means that the various tests here may clobber each other's coverage
-    # reports. The way out of this is to a) either specify `WORKING_DIRECTORY` of each test, or b)
-    # use a coverage config file (see
-    # https://coverage.readthedocs.io/en/latest/config.html#xml-output); the latter requires far
-    # more work than the former, so we use option a) in the below.
-    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ode)
-    add_test(
-      NAME Ode
-      COMMAND ${PYTHON_EXECUTABLE} ${NRN_PYTEST_LAUNCHER} ${CMAKE_CURRENT_SOURCE_DIR}/ode
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ode)
-    set_tests_properties(
-      Ode
-      PROPERTIES ENVIRONMENT
-                 "PYTHONPATH=${NMODL_TEST_PYTHONPATH};NEURONHOME=${PROJECT_BINARY_DIR}/share/nrn")
+    add_test(NAME Ode COMMAND ${PYTHON_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/ode)
+    set_tests_properties(Ode PROPERTIES ENVIRONMENT "PYTHONPATH=${NMODL_TEST_PYTHONPATH}")
     cpp_cc_configure_sanitizers(TEST Ode PRELOAD)
   endif()
 
@@ -230,17 +216,11 @@ if(NRN_ENABLE_PYTHON)
     # Apple Clang and ASAN do not play along nicely with NMODL's Python bindings, so we skip these
     # tests
     if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND NRN_SANITIZERS))
-      file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/pybind)
-      add_test(
-        NAME Pybind
-        COMMAND ${PYTHON_EXECUTABLE} ${NRN_PYTEST_LAUNCHER} ${CMAKE_CURRENT_SOURCE_DIR}/pybind
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/pybind)
+      add_test(NAME Pybind COMMAND ${PYTHON_EXECUTABLE} -m pytest
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/pybind)
       set_tests_properties(
-        Pybind
-        PROPERTIES
-          ENVIRONMENT
-          "PYTHONPATH=${NMODL_TEST_PYTHONPATH};NMODLHOME=${PROJECT_BINARY_DIR};NEURONHOME=${PROJECT_BINARY_DIR}/share/nrn"
-      )
+        Pybind PROPERTIES ENVIRONMENT
+                          "PYTHONPATH=${NMODL_TEST_PYTHONPATH};NMODLHOME=${PROJECT_BINARY_DIR}")
       cpp_cc_configure_sanitizers(TEST Pybind PRELOAD)
     endif()
   endif()


### PR DESCRIPTION
I'm not sure why PR #3543 depends on PR #3544 ?
This PR will remove the code-coverage related changes from the name-mangling refactor, which should make code review much easier.