### PR TITLE
Implement nrnivmodl in python

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -48,7 +48,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nrnpyenv.sh.in ${PROJECT_BINARY_DIR}/
 # prepare test files. This can be done more elegantly in newer CMake versions; v3.19+ have
 # file(CHMOD ...) and v3.20+ support setting permissions directly in configure_file(...).
 set(NRNIVMODL_NEURON ON)
-set(NRN_CONFIG_EXE_FILES "nrnivmodl" "neurondemo" "nrnivmodl-cmake")
+set(NRN_CONFIG_EXE_FILES "nrnivmodl" "neurondemo" "nrnivmodl-cmake" "nrnivmodl.py")
 foreach(NRN_CONFIG_EXE_FILE ${NRN_CONFIG_EXE_FILES})
   configure_file("${NRN_CONFIG_EXE_FILE}.in" "tmp/${NRN_CONFIG_EXE_FILE}" @ONLY)
   file(
@@ -91,6 +91,7 @@ file(REMOVE_RECURSE "${CMAKE_CURRENT_BINARY_DIR}/bin/tmp")
 # =============================================================================
 install(PROGRAMS ${PROJECT_BINARY_DIR}/bin/nrngui ${PROJECT_BINARY_DIR}/bin/neurondemo
                  ${PROJECT_BINARY_DIR}/bin/nrnivmodl ${PROJECT_BINARY_DIR}/bin/nrnivmodl-cmake
+                 ${PROJECT_BINARY_DIR}/bin/nrnivmodl.py
         DESTINATION ${NRN_INSTALL_DATA_PREFIX}bin)
 if(NRN_ENABLE_CORENEURON)
   install(PROGRAMS ${PROJECT_BINARY_DIR}/bin/nrnivmodl-all-cmake

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -91,8 +91,7 @@ file(REMOVE_RECURSE "${CMAKE_CURRENT_BINARY_DIR}/bin/tmp")
 # =============================================================================
 install(PROGRAMS ${PROJECT_BINARY_DIR}/bin/nrngui ${PROJECT_BINARY_DIR}/bin/neurondemo
                  ${PROJECT_BINARY_DIR}/bin/nrnivmodl ${PROJECT_BINARY_DIR}/bin/nrnivmodl-cmake
-                 ${PROJECT_BINARY_DIR}/bin/nrnivmodl.py
-        DESTINATION ${NRN_INSTALL_DATA_PREFIX}bin)
+                 ${PROJECT_BINARY_DIR}/bin/nrnivmodl.py DESTINATION ${NRN_INSTALL_DATA_PREFIX}bin)
 if(NRN_ENABLE_CORENEURON)
   install(PROGRAMS ${PROJECT_BINARY_DIR}/bin/nrnivmodl-all-cmake
           DESTINATION ${NRN_INSTALL_DATA_PREFIX}bin)

--- a/bin/nrnivmodl-cmake.in
+++ b/bin/nrnivmodl-cmake.in
@@ -71,4 +71,4 @@ cmake \
     -DNRNIVMODL_CORENEURON=@NRNIVMODL_CORENEURON@
 
 # Actually build them
-NMODL_PYLIB=@PYTHON_LIBRARY@ NMODLHOME=@CMAKE_INSTALL_PREFIX@ cmake --build "${bindir}"
+NMODLHOME=@CMAKE_INSTALL_PREFIX@ cmake --build "${bindir}"

--- a/bin/nrnivmodl-cmake.in
+++ b/bin/nrnivmodl-cmake.in
@@ -71,4 +71,4 @@ cmake \
     -DNRNIVMODL_CORENEURON=@NRNIVMODL_CORENEURON@
 
 # Actually build them
-cmake --build "${bindir}"
+NMODL_PYLIB=@PYTHON_LIBRARY@ NMODLHOME=@CMAKE_INSTALL_PREFIX@ cmake --build "${bindir}"

--- a/bin/nrnivmodl.py.in
+++ b/bin/nrnivmodl.py.in
@@ -1,0 +1,75 @@
+#!/usr/bin/python
+
+"""
+Simple wrapper for CMake that builds mechanisms from mod files
+"""
+
+from pathlib import Path
+from subprocess import run
+from argparse import ArgumentParser
+import os
+import platform
+import shutil
+import sys
+
+parser = ArgumentParser()
+parser.add_argument("MOD_FILES", nargs="*", help="")
+parser.add_argument("--CMAKE_PREFIX_PATH", type=Path, default=None, help="")
+args = parser.parse_args()
+
+env = os.environ.copy()
+
+# Where the output files will be placed
+bin_dir = platform.machine()
+
+# The name of the current program
+program_name = Path(sys.argv[0]).name
+
+# Where the `*.cmake` files are located
+cmake_prefix = Path(sys.argv[0]).resolve().parent.parent.joinpath("lib").joinpath("cmake")
+env["CMAKE_PREFIX_PATH"] = cmake_prefix
+
+# On MacOS we need to set the deployment target to be equal to the one of NEURON
+if shutil.which("xcrun") is not None:
+    @NRN_OSX_BUILD_TRUE@ env["SDKROOT"] = "$(xcrun --sdk macosx --show-sdk-path)"
+    @NRN_OSX_BUILD_TRUE@ env["MACOSX_DEPLOYMENT_TARGET"] = "@CMAKE_OSX_DEPLOYMENT_TARGET@"
+    if not "@CMAKE_OSX_DEPLOYMENT_TARGET@":
+        del env["MACOSX_DEPLOYMENT_TARGET"]
+
+# We use the CMakeLists.txt from the NEURON installation directory to not have
+# to deal with any pre-existing CMakeLists.txt in the current directory
+src_dir = cmake_prefix.joinpath("neuron").joinpath("nrnivmodl")
+
+mod_files = [Path(path) for path in args.MOD_FILES]
+
+# In case of no files, default to using the files in the current dir
+if not mod_files:
+    mod_files = list(Path.cwd().glob("*.mod"))
+
+# In case of a single input, check if it's a directory; if it is, collect all mod files in it
+elif len(mod_files) == 1 and mod_files[0].is_dir():
+    mod_files = list(mod_files[0].glob("*.mod"))
+
+# Convert all mod file paths to absolute paths because the source dir is in the NEURON install
+mod_files = [path.resolve() for path in mod_files]
+
+# After collecting the mod files, check each mod file actually exists
+for path in mod_files:
+    if not path.exists():
+        print(f"[{program_name}] ERROR: Mod file {path} does not exist!", file=sys.stderr)
+        exit(1)
+
+# print(f"[{program_name}] Collecting mod files under %s\n" "$(readlink -f "${1}")")
+
+mod_files_str = ";".join(str(path) for path in mod_files)
+
+# Configure the mod files
+run(["cmake", "-S", str(src_dir), "-B", str(bin_dir),
+    "-DNRNIVMODL_MOD_FILES=" + mod_files_str,
+    "-DNRNIVMODL_NEURON=@NRNIVMODL_NEURON@",
+    "-DNRNIVMODL_CORENEURON=@NRNIVMODL_CORENEURON@"],
+    env=env, check=True)
+
+# Actually build them
+env["NMODLHOME"] = "@CMAKE_INSTALL_PREFIX@"
+run(["cmake", "--build", str(bin_dir)], env=env, check=True)

--- a/bin/nrnivmodl.py.in
+++ b/bin/nrnivmodl.py.in
@@ -1,9 +1,7 @@
 #!/usr/bin/python
-
 """
-Simple wrapper for CMake that builds mechanisms from mod files
+Compile mechanisms for NEURON
 """
-
 from pathlib import Path
 from subprocess import run
 from argparse import ArgumentParser
@@ -12,9 +10,14 @@ import platform
 import shutil
 import sys
 
-parser = ArgumentParser()
-parser.add_argument("MOD_FILES", nargs="*", help="")
+parser = ArgumentParser(description=__doc__)
+parser.add_argument("FILES", nargs="*", help="mod files or directory with mod files")
 parser.add_argument("--CMAKE_PREFIX_PATH", type=Path, default=None, help="")
+# TODO: arguments for nrnivmodl
+# -coreneuron                      Compile MOD files for CoreNEURON using nrnivmodl-core.
+# -incflags    "include flags"     Extra include flags and paths when MOD (C++) files are compiled.
+# -loadflags   "link flags"        Extra link flags, paths, and libraries when MOD (C++) files are linked.
+# -nmodlflags  "CLI flags"         Additional CLI flags for new NMODL transpiler
 args = parser.parse_args()
 
 env = os.environ.copy()
@@ -26,13 +29,21 @@ bin_dir = platform.machine()
 program_name = Path(sys.argv[0]).name
 
 # Where the `*.cmake` files are located
-cmake_prefix = Path(sys.argv[0]).resolve().parent.parent.joinpath("lib").joinpath("cmake")
+if args.CMAKE_PREFIX_PATH
+    cmake_prefix = Path(args.CMAKE_PREFIX_PATH)
+else:
+    cmake_prefix = Path(sys.argv[0]).resolve().parent.parent.joinpath("lib").joinpath("cmake")
 env["CMAKE_PREFIX_PATH"] = cmake_prefix
 
 # On MacOS we need to set the deployment target to be equal to the one of NEURON
 if shutil.which("xcrun") is not None:
-    @NRN_OSX_BUILD_TRUE@ env["SDKROOT"] = "$(xcrun --sdk macosx --show-sdk-path)"
-    @NRN_OSX_BUILD_TRUE@ env["MACOSX_DEPLOYMENT_TARGET"] = "@CMAKE_OSX_DEPLOYMENT_TARGET@"
+    if "@NRN_OSX_BUILD_TRUE@" != "#":
+        env["SDKROOT"] = subprocess.run(["xcrun", "--sdk", "macosx", "--show-sdk-path"],
+                    check=True,
+                    text=True,
+                    capture_output=True
+                    ).stdout.strip()
+        env["MACOSX_DEPLOYMENT_TARGET"] = "@CMAKE_OSX_DEPLOYMENT_TARGET@"
     if not "@CMAKE_OSX_DEPLOYMENT_TARGET@":
         del env["MACOSX_DEPLOYMENT_TARGET"]
 
@@ -40,15 +51,21 @@ if shutil.which("xcrun") is not None:
 # to deal with any pre-existing CMakeLists.txt in the current directory
 src_dir = cmake_prefix.joinpath("neuron").joinpath("nrnivmodl")
 
-mod_files = [Path(path) for path in args.MOD_FILES]
+mod_files = [Path(path) for path in args.FILES]
 
 # In case of no files, default to using the files in the current dir
 if not mod_files:
+    print(f"[{program_name}] Collecting mod files in current directory: {Path.cwd()}")
     mod_files = list(Path.cwd().glob("*.mod"))
 
 # In case of a single input, check if it's a directory; if it is, collect all mod files in it
 elif len(mod_files) == 1 and mod_files[0].is_dir():
+    print(f"[{program_name}] Collecting mod files in directory: {mod_files[0]}")
     mod_files = list(mod_files[0].glob("*.mod"))
+
+else:
+    mod_files_str = ' '.join(str(path) for path in mod_files)
+    print(f"[{program_name}] Collecting mod files: {mod_files_str}")
 
 # Convert all mod file paths to absolute paths because the source dir is in the NEURON install
 mod_files = [path.resolve() for path in mod_files]
@@ -59,8 +76,6 @@ for path in mod_files:
         print(f"[{program_name}] ERROR: Mod file {path} does not exist!", file=sys.stderr)
         exit(1)
 
-# print(f"[{program_name}] Collecting mod files under %s\n" "$(readlink -f "${1}")")
-
 mod_files_str = ";".join(str(path) for path in mod_files)
 
 # Configure the mod files
@@ -70,6 +85,6 @@ run(["cmake", "-S", str(src_dir), "-B", str(bin_dir),
     "-DNRNIVMODL_CORENEURON=@NRNIVMODL_CORENEURON@"],
     env=env, check=True)
 
-# Actually build them
+# Process and compile the mod files
 env["NMODLHOME"] = "@CMAKE_INSTALL_PREFIX@"
 run(["cmake", "--build", str(bin_dir)], env=env, check=True)

--- a/bin/nrnivmodl.py.in
+++ b/bin/nrnivmodl.py.in
@@ -26,14 +26,18 @@ env = os.environ.copy()
 bin_dir = platform.machine()
 
 # The name of the current program
-program_name = Path(sys.argv[0]).name
+program_path = Path(sys.argv[0]).resolve(strict=True)
+program_name = program_path.name
 
 # Where the `*.cmake` files are located
-if args.CMAKE_PREFIX_PATH
+if args.CMAKE_PREFIX_PATH:
     cmake_prefix = Path(args.CMAKE_PREFIX_PATH)
 else:
-    cmake_prefix = Path(sys.argv[0]).resolve().parent.parent.joinpath("lib").joinpath("cmake")
+    cmake_prefix = program_path.parent.parent.joinpath("lib").joinpath("cmake")
 env["CMAKE_PREFIX_PATH"] = cmake_prefix
+
+# Get the install root for NEURON and the NMODL project
+env["NMODLHOME"] = program_path.parent.parent
 
 # On MacOS we need to set the deployment target to be equal to the one of NEURON
 if shutil.which("xcrun") is not None:
@@ -86,5 +90,4 @@ run(["cmake", "-S", str(src_dir), "-B", str(bin_dir),
     env=env, check=True)
 
 # Process and compile the mod files
-env["NMODLHOME"] = "@CMAKE_INSTALL_PREFIX@"
 run(["cmake", "--build", str(bin_dir)], env=env, check=True)

--- a/cmake/neuronMechMaker.cmake
+++ b/cmake/neuronMechMaker.cmake
@@ -263,6 +263,11 @@ function(create_nrnmech)
   # nmodl by default generates code for coreNEURON, so we toggle this via an option
   if(NRN_MECH_NMODL_NEURON_CODEGEN)
     set(NEURON_TRANSPILER_LAUNCHER ${NMODL_EXECUTABLE} --neuron)
+
+    find_package(Python 3.9 REQUIRED COMPONENTS Development.Embed)
+    if(NOT Python_Development.Embed_FOUND)
+      message("FATAL_ERROR" "Embedded python not found")
+    endif()
   else()
     set(NEURON_TRANSPILER_LAUNCHER ${NOCMODL_EXECUTABLE})
   endif()
@@ -396,7 +401,8 @@ function(create_nrnmech)
       list(APPEND L_MECH_REGISTRE "_${MOD_STUB}_reg()\;")
 
       add_custom_command(
-        COMMAND ${ENV_COMMAND} ${NEURON_TRANSPILER_LAUNCHER} -o "${ARTIFACTS_OUTPUT_DIR}/cpp"
+        COMMAND ${ENV_COMMAND} NMODL_PYLIB=${Python_LIBRARIES}
+                ${NEURON_TRANSPILER_LAUNCHER} -o "${ARTIFACTS_OUTPUT_DIR}/cpp"
                 "${MOD_ABSPATH}" ${NRN_MECH_NMODL_NEURON_EXTRA_ARGS}
         OUTPUT "${ARTIFACTS_OUTPUT_DIR}/${CPP_FILE}"
         COMMENT "Converting ${MOD_ABSPATH} to ${ARTIFACTS_OUTPUT_DIR}/${CPP_FILE}"
@@ -468,7 +474,8 @@ function(create_nrnmech)
       list(APPEND L_CORE_MECH_REGISTRE "_${MOD_STUB}_reg()\;")
 
       add_custom_command(
-        COMMAND ${ENV_COMMAND} ${NMODL_EXECUTABLE} -o "${ARTIFACTS_OUTPUT_DIR}/cpp_core"
+        COMMAND ${ENV_COMMAND} NMODL_PYLIB=${Python_LIBRARIES}
+                ${NMODL_EXECUTABLE} -o "${ARTIFACTS_OUTPUT_DIR}/cpp_core"
                 "${MOD_ABSPATH}" ${NRN_MECH_NMODL_CORENEURON_EXTRA_ARGS}
         OUTPUT "${ARTIFACTS_OUTPUT_DIR}/${CPP_FILE}"
         COMMENT "Converting ${MOD_ABSPATH} to ${ARTIFACTS_OUTPUT_DIR}/${CPP_FILE}"

--- a/cmake/neuronMechMaker.cmake
+++ b/cmake/neuronMechMaker.cmake
@@ -41,14 +41,12 @@ API reference
             [NEURON]
             [CORENEURON]
             [SPECIAL]
-            [NMODL_NEURON_CODEGEN]
             [TARGET_LIBRARY_NAME lib_tgt]
             [TARGET_EXECUTABLE_NAME exe_tgt]
             [LIBRARY_OUTPUT_DIR lib_outdir]
             [EXECUTABLE_OUTPUT_DIR exe_outdir]
             [ARTIFACTS_OUTPUT_DIR art_outdir]
             [LIBRARY_TYPE type]
-            [NOCMODL_EXECUTABLE path/to/nocmodl]
             [NMODL_EXECUTABLE path/to/nmodl]
             [MOD_FILES mod1 mod2 ...]
             [NMODL_NEURON_EXTRA_ARGS arg1 arg2 ...]
@@ -67,9 +65,6 @@ API reference
     ``SPECIAL``
         (*optional*) whether a ``special`` (or ``special-core`` in case of coreNEURON) executable should be created.
 
-    ``NMODL_NEURON_CODEGEN``
-        (*optional*) whether to use NMODL to generate files compatible with NEURON.
-
     ``TARGET_LIBRARY_NAME``
         (*optional*, default: ``nrnmech``) the name of the CMake target for the library. Note that ``core`` is prepended to the coreNEURON target.
 
@@ -87,9 +82,6 @@ API reference
 
     ``LIBRARY_TYPE``
         (*optional*, default: ``SHARED``) the type of library to build.
-
-    ``NOCMODL_EXECUTABLE``
-        (*optional*) the path to the NOCMODL executable. If not specified, attempts to find deduce the location of the executable from the NEURON CMake configuration.
 
     ``NMODL_EXECUTABLE``
         (*optional*) the path to the NMODL executable. If not specified, attempts to find deduce the location of the executable from the NEURON CMake configuration.
@@ -157,7 +149,7 @@ The ``nrnmech`` library will then be available under ``build``, and can be loade
 #]=======================================================================]
 
 function(create_nrnmech)
-  set(options NEURON CORENEURON SPECIAL NMODL_NEURON_CODEGEN)
+  set(options NEURON CORENEURON SPECIAL)
   set(oneValueArgs
       MECHANISM_NAME
       TARGET_LIBRARY_NAME
@@ -166,7 +158,6 @@ function(create_nrnmech)
       EXECUTABLE_OUTPUT_DIR
       ARTIFACTS_OUTPUT_DIR
       LIBRARY_TYPE
-      NOCMODL_EXECUTABLE
       NMODL_EXECUTABLE)
   set(multiValueArgs MOD_FILES NMODL_NEURON_EXTRA_ARGS NMODL_CORENEURON_EXTRA_ARGS EXTRA_ENV)
   cmake_parse_arguments(NRN_MECH "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -232,7 +223,7 @@ function(create_nrnmech)
 
   message("${MESSAGE_PRIORITY}" "MECHANISM_NAME | ${MECHANISM_NAME}")
 
-  # the `nmodl` and `nocmodl` executables are usually found through `find_program` on the user's
+  # the `nmodl` executable is usually found through `find_program` on the user's
   # system, but we allow overrides (for testing purposes only)
   if(NRN_MECH_NMODL_EXECUTABLE)
     set(NMODL_EXECUTABLE "${NRN_MECH_NMODL_EXECUTABLE}")
@@ -241,14 +232,6 @@ function(create_nrnmech)
   endif()
 
   message("${MESSAGE_PRIORITY}" "NMODL_EXECUTABLE | ${NMODL_EXECUTABLE}")
-
-  if(NRN_MECH_NOCMODL_EXECUTABLE)
-    set(NOCMODL_EXECUTABLE "${NRN_MECH_NOCMODL_EXECUTABLE}")
-  else()
-    set(NOCMODL_EXECUTABLE $<TARGET_FILE:neuron::nocmodl>)
-  endif()
-
-  message("${MESSAGE_PRIORITY}" "NOCMODL_EXECUTABLE | ${NOCMODL_EXECUTABLE}")
 
   # the option `CORENRN_ENABLE_SHARED` toggles the kind of library we want to build, so we respect
   # it here
@@ -260,29 +243,11 @@ function(create_nrnmech)
 
   message("${MESSAGE_PRIORITY}" "LIBRARY_TYPE | ${LIBRARY_TYPE}")
 
-  # nmodl by default generates code for coreNEURON, so we toggle this via an option
-  if(NRN_MECH_NMODL_NEURON_CODEGEN)
-    set(NEURON_TRANSPILER_LAUNCHER ${NMODL_EXECUTABLE} --neuron)
+  set(NEURON_TRANSPILER_LAUNCHER ${NMODL_EXECUTABLE} --neuron)
 
-    find_package(Python 3.9 REQUIRED COMPONENTS Development.Embed)
-    if(NOT Python_Development.Embed_FOUND)
-      message("FATAL_ERROR" "Embedded python not found")
-    endif()
-  else()
-    set(NEURON_TRANSPILER_LAUNCHER ${NOCMODL_EXECUTABLE})
-  endif()
-
-  # raise warning that NMODL extra args will be ignored if we use NEURON codegen with NOCMODL
-  if(NRN_MECH_NEURON
-     AND NOT NRN_MECH_NMODL_NEURON_CODEGEN
-     AND NRN_MECH_NMODL_NEURON_EXTRA_ARGS)
-    message(
-      WARNING
-        "${CMAKE_CURRENT_FUNCTION}: requested NEURON library with NOCMODL codegen, but NMODL_NEURON_EXTRA_ARGS is not empty; "
-        "will ignore NMODL_NEURON_EXTRA_ARGS when building NEURON library.\n"
-        "Hint: if you want to use NMODL for codegen for NEURON, add the NMODL_NEURON_CODEGEN option when calling this function."
-    )
-    set(NRN_MECH_NMODL_NEURON_EXTRA_ARGS)
+  find_package(Python 3.9 REQUIRED COMPONENTS Development.Embed)
+  if(NOT Python_Development.Embed_FOUND)
+    message("FATAL_ERROR" "Embedded python not found")
   endif()
 
   list(JOIN NRN_MECH_NMODL_NEURON_EXTRA_ARGS "" NMODL_NEURON_EXTRA_ARGS_SPACES)

--- a/cmake/neuronMechMaker.cmake
+++ b/cmake/neuronMechMaker.cmake
@@ -223,8 +223,8 @@ function(create_nrnmech)
 
   message("${MESSAGE_PRIORITY}" "MECHANISM_NAME | ${MECHANISM_NAME}")
 
-  # the `nmodl` executable is usually found through `find_program` on the user's
-  # system, but we allow overrides (for testing purposes only)
+  # the `nmodl` executable is usually found through `find_program` on the user's system, but we
+  # allow overrides (for testing purposes only)
   if(NRN_MECH_NMODL_EXECUTABLE)
     set(NMODL_EXECUTABLE "${NRN_MECH_NMODL_EXECUTABLE}")
   else()
@@ -366,9 +366,8 @@ function(create_nrnmech)
       list(APPEND L_MECH_REGISTRE "_${MOD_STUB}_reg()\;")
 
       add_custom_command(
-        COMMAND ${ENV_COMMAND} NMODL_PYLIB=${Python_LIBRARIES}
-                ${NEURON_TRANSPILER_LAUNCHER} -o "${ARTIFACTS_OUTPUT_DIR}/cpp"
-                "${MOD_ABSPATH}" ${NRN_MECH_NMODL_NEURON_EXTRA_ARGS}
+        COMMAND ${ENV_COMMAND} NMODL_PYLIB=${Python_LIBRARIES} ${NEURON_TRANSPILER_LAUNCHER} -o
+                "${ARTIFACTS_OUTPUT_DIR}/cpp" "${MOD_ABSPATH}" ${NRN_MECH_NMODL_NEURON_EXTRA_ARGS}
         OUTPUT "${ARTIFACTS_OUTPUT_DIR}/${CPP_FILE}"
         COMMENT "Converting ${MOD_ABSPATH} to ${ARTIFACTS_OUTPUT_DIR}/${CPP_FILE}"
         # TODO some mod files may include other files, and NMODL can get the AST of a given file in
@@ -439,9 +438,10 @@ function(create_nrnmech)
       list(APPEND L_CORE_MECH_REGISTRE "_${MOD_STUB}_reg()\;")
 
       add_custom_command(
-        COMMAND ${ENV_COMMAND} NMODL_PYLIB=${Python_LIBRARIES}
-                ${NMODL_EXECUTABLE} -o "${ARTIFACTS_OUTPUT_DIR}/cpp_core"
-                "${MOD_ABSPATH}" ${NRN_MECH_NMODL_CORENEURON_EXTRA_ARGS}
+        COMMAND
+          ${ENV_COMMAND} NMODL_PYLIB=${Python_LIBRARIES} ${NMODL_EXECUTABLE} -o
+          "${ARTIFACTS_OUTPUT_DIR}/cpp_core" "${MOD_ABSPATH}"
+          ${NRN_MECH_NMODL_CORENEURON_EXTRA_ARGS}
         OUTPUT "${ARTIFACTS_OUTPUT_DIR}/${CPP_FILE}"
         COMMENT "Converting ${MOD_ABSPATH} to ${ARTIFACTS_OUTPUT_DIR}/${CPP_FILE}"
         DEPENDS "${MOD_ABSPATH}"


### PR DESCRIPTION
Continued from and requires PR #3707

Python is cross platform, and is nicer to work with than bash. Since we're already undertaking a rewrite of nrnivmodl I figure now would be the best time to get a python rewrite started.