### PR TITLE
Fixes for nrnivmodl-cmake (try 2)

### DIFF
--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -169,7 +169,7 @@ jobs:
         if: ${{matrix.config.python_dynamic == 'ON'}}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PY_MIN_VERSION }}
+          python-version: ${{ env.PY_MIN_VERSION }}-dev
 
       - name: Install Python@${{ env.PY_MIN_VERSION }} dependencies
         if: ${{ matrix.config.python_dynamic == 'ON' }}
@@ -197,7 +197,7 @@ jobs:
       - name: Set up Python@${{ env.PY_MAX_VERSION }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PY_MAX_VERSION }}
+          python-version: ${{ env.PY_MAX_VERSION }}-dev
 
       - name: Install Python@${{ env.PY_MAX_VERSION }} dependencies
         working-directory: ${{runner.workspace}}/nrn

--- a/bin/nrnivmodl-cmake.in
+++ b/bin/nrnivmodl-cmake.in
@@ -12,6 +12,8 @@ bindir="$(uname -m)"
 # The name of the current program
 program_name="$(basename "${0}")"
 
+CMAKE_INSTALL_PREFIX="$(readlink -f "$(dirname "${0}")/../")"
+
 # Where the `*.cmake` files are located
 NRN_CMAKE_PREFIX_PATH_DEFAULT="$(readlink -f "$(dirname "${0}")/../lib/cmake/")"
 if [ -n "${CMAKE_PREFIX_PATH:-}" ]; then
@@ -71,4 +73,4 @@ cmake \
     -DNRNIVMODL_CORENEURON=@NRNIVMODL_CORENEURON@
 
 # Actually build them
-cmake --build "${bindir}"
+NMODLHOME="${CMAKE_INSTALL_PREFIX}" cmake --build "${bindir}"


### PR DESCRIPTION
Set environment variables for the NMODL transpiler to find:
* the path to the python library
* the path to the NMODL python module