### PR TITLE
ci: fix YAML expression syntax in wheels-template.yml conditional checks

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -292,4 +292,5 @@ jobs:
           directory: ./build
           fail_ci_if_error: true
           verbose: true
-          token: ${{ contains(github.head_ref, 'dependabot/') && secrets.CODECOV_TOKEN || '' }}
+          # token: ${{ contains(github.head_ref, 'dependabot/') && secrets.CODECOV_TOKEN || '' }}
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/wheels-template.yml
+++ b/.github/workflows/wheels-template.yml
@@ -142,13 +142,13 @@ jobs:
           sudo dpkg --install mpich_4.2.0-5.1_amd64.deb libmpich12_4.2.0-5.1_amd64.deb
 
       - name: Set env vars for testing (Linux)
-        if: startsWith(inputs.platform, "ubuntu")
+        if: startsWith(inputs.platform, 'ubuntu')
         run: |
           echo CMAKE_BUILD_PARALLEL_LEVEL=4 >> $GITHUB_ENV
           echo CMAKE_GENERATOR=Ninja >> $GITHUB_ENV
 
       - name: Set env vars for testing (MacOS)
-        if: startsWith(runner.os, "macOS")
+        if: startsWith(runner.os, 'macOS')
         run: |
           if [[ "${{runner.os}}" == "macOS-15-intel" ]]; then
             echo CMAKE_BUILD_PARALLEL_LEVEL=4 >> $GITHUB_ENV


### PR DESCRIPTION
Fixes "Unexpected symbol" parsing errors in startsWith() expressions by using single quotes for platform names.

Prevents workflow validation failures when full parsing occurs.

Tested via temporary branch triggering coverage workflow.

Note that 4c65b99 basically reverts my coverage.yml change in the dependabot #3723 that bumped tornado to 6.5.5. Grok summarizes with the speculation "it's likely just Codecov being flaky on certain branches during a buggy period, and unconditional token is the pragmatic fix."