### PR TITLE
ci: raise MACOSX_DEPLOYMENT_TARGET to 14.0 on macOS 15+ runners

### DIFF
--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -174,6 +174,28 @@ build_wheel_portable() {
     if [ "${platform}" = 'macos' ]; then
         if [ "$(uname -m)" = 'arm64' ]; then
             export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
+        else
+            # On Intel (x86_64) runners, especially newer ones like macos-15-intel,
+            # the toolchain (Xcode 16+) often links libraries (e.g. libunwind) with
+            # a minimum deployment target of 14.0 or higher. This causes delocate
+            # to fail when the wheel declares a lower target (e.g. 10.15).
+            #
+            # Detect runner macOS version and raise the target accordingly.
+            # - macOS 15.x (Sequoia) runners --> force 14.0 (or 15.0 if stricter needed)
+            # - macOS 14.x --> 14.0 is safe and consistent
+            # - Older runners --> keep existing fallback (10.15)
+            if command -v sw_vers >/dev/null 2>&1; then
+                os_ver=$(sw_vers -productVersion | cut -d. -f1)
+                if [[ "$os_ver" -ge 15 ]]; then
+                    export MACOSX_DEPLOYMENT_TARGET=14.0
+                    echo "macOS 15+ runner detected: forcing MACOSX_DEPLOYMENT_TARGET=14.0 to match toolchain libs"
+                elif [[ "$os_ver" -eq 14 ]]; then
+                    export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-14.0}"
+                    echo "macOS 14 runner: setting MACOSX_DEPLOYMENT_TARGET=14.0 (or existing value)"
+                fi
+            else
+                echo "Warning: sw_vers not found; MACOSX_DEPLOYMENT_TARGET unchanged"
+            fi
         fi
     fi
 


### PR DESCRIPTION
This fixes delocate failures on macos-15-intel runners where bundled libraries (e.g. libunwind) require a minimum deployment target of 14.0. The script now detects the runner's macOS version via sw_vers and sets the target accordingly, keeping lower values for older runners and arm64 builds.

It this passes CI, then it may fix the CI failure for #3727 
```
 Build and test NEURON Python wheels (macos-15-intel, 3.9) / Build and test Python 3.9 wheel on macos-15-intel
```
with the log fragment 
```
    raise DelocationError(
2026-03-18T19:09:03.9535860Z delocate.libsana.DelocationError: Library dependencies do not satisfy target MacOS version 10.15:
2026-03-18T19:09:03.9539640Z /private/var/folders/9n/h1d0pgxn4f5bbpg9mrrft9140000gn/T/tmp41_hwv46/wheel/neuron/.dylibs/libunwind.1.0.dylib has a minimum target of 14.0
2026-03-18T19:09:03.9542670Z Set the environment variable 'MACOSX_DEPLOYMENT_TARGET=14.0' to update minimum supported macOS for this wheel.
```
