### PR TITLE
ci: for macosx wheels, try to use system clang.

### DIFF
--- a/.github/workflows/wheels-ci.yml
+++ b/.github/workflows/wheels-ci.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - master
+      - hines/explore
   pull_request:
     branches:
       - master

--- a/.github/workflows/wheels-ci.yml
+++ b/.github/workflows/wheels-ci.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - master
-      - hines/explore
   pull_request:
     branches:
       - master

--- a/.github/workflows/wheels-template.yml
+++ b/.github/workflows/wheels-template.yml
@@ -80,6 +80,8 @@ jobs:
           # For debugging
           bash --version
           cmake --version
+          bison --version
+          flex --version
 
           # Handle libomp: ensure it's installed (no longer pre-installed on recent macos-15 runners)
           if ! brew list --versions libomp >/dev/null 2>&1; then

--- a/.github/workflows/wheels-template.yml
+++ b/.github/workflows/wheels-template.yml
@@ -80,8 +80,6 @@ jobs:
           # For debugging
           bash --version
           cmake --version
-          bison --version
-          flex --version
 
           # Handle libomp: ensure it's installed (no longer pre-installed on recent macos-15 runners)
           if ! brew list --versions libomp >/dev/null 2>&1; then
@@ -97,6 +95,18 @@ jobs:
           echo "LDFLAGS=-L${LIBOMP_PREFIX}/lib ${LDFLAGS:-}" >> $GITHUB_ENV
           echo "CPPFLAGS=-I${LIBOMP_PREFIX}/include ${CPPFLAGS:-}" >> $GITHUB_ENV
           echo "DYLD_LIBRARY_PATH=${LIBOMP_PREFIX}/lib:${DYLD_LIBRARY_PATH:-}" >> $GITHUB_ENV
+
+          # Force Homebrew bison/flex/cmake to the FRONT of PATH (keg-only, so required)
+          BREW_PREFIX=$(brew --prefix)
+          export PATH="${BREW_PREFIX}/opt/bison/bin:${BREW_PREFIX}/opt/flex/bin:${BREW_PREFIX}/opt/cmake/bin:$PATH"
+          echo "${BREW_PREFIX}/opt/bison/bin:${BREW_PREFIX}/opt/flex/bin:${BREW_PREFIX}/opt/cmake/bin" >> $GITHUB_PATH
+
+          # DEBUG: confirm the correct versions are used for the rest of the job
+          echo "=== DEBUG: bison/flex after PATH force"
+          which bison
+          bison --version | head -n 1
+          which flex
+          flex --version | head -n 1
 
       - name: Install readline
         if: runner.os == 'macOS'

--- a/.github/workflows/wheels-template.yml
+++ b/.github/workflows/wheels-template.yml
@@ -80,9 +80,21 @@ jobs:
           # For debugging
           bash --version
           cmake --version
-          # Uninstall libomp for compatibility with issue #817
-          brew uninstall --ignore-dependencies libomp || echo "libomp doesn't exist"
-          echo "$(brew --prefix)/opt/cmake/bin:$(brew --prefix)/opt/flex/bin:$(brew --prefix)/opt/bison/bin" >> $GITHUB_PATH
+
+          # Handle libomp: ensure it's installed (no longer pre-installed on recent macos-15 runners)
+          if ! brew list --versions libomp >/dev/null 2>&1; then
+            echo "libomp not found --> installing"
+            brew install libomp
+          else
+            echo "libomp already installed"
+          fi
+          brew link --force libomp || true
+
+          # Export paths so later build steps (cibuildwheel, compilers) can find libomp
+          LIBOMP_PREFIX=$(brew --prefix libomp)
+          echo "LDFLAGS=-L${LIBOMP_PREFIX}/lib ${LDFLAGS:-}" >> $GITHUB_ENV
+          echo "CPPFLAGS=-I${LIBOMP_PREFIX}/include ${CPPFLAGS:-}" >> $GITHUB_ENV
+          echo "DYLD_LIBRARY_PATH=${LIBOMP_PREFIX}/lib:${DYLD_LIBRARY_PATH:-}" >> $GITHUB_ENV
 
       - name: Install readline
         if: runner.os == 'macOS'

--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -5,7 +5,7 @@ set -eux
 #
 # Note: It should be invoked from nrn directory
 #
-# PREREQUESITES:
+# PREREQUISITES:
 #  - cmake (>=3.15.0)
 #  - flex
 #  - bison
@@ -172,6 +172,21 @@ build_wheel_portable() {
     fi
 
     if [ "${platform}" = 'macos' ]; then
+
+        # Force use of system Apple clang/clang++ on macOS runners to avoid
+        # linking against Homebrew LLVM (which bundles newer libunwind requiring
+        # macOS 14+). Apple's clang uses system libunwind (no separate dylib).
+        # This should prevent delocate from bundling libunwind.1.0.dylib at all.
+        if command -v /usr/bin/clang >/dev/null 2>&1; then
+            export CC=/usr/bin/clang
+            export CXX=/usr/bin/clang++
+            echo "Forcing system clang: CC=$CC CXX=$CXX"
+            # Prioritize /usr/bin over any Homebrew paths
+            export PATH="/usr/bin:$PATH"
+        else
+            echo "Warning: /usr/bin/clang not found; using default compiler"
+        fi
++
         if [ "$(uname -m)" = 'arm64' ]; then
             export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
         fi

--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -186,7 +186,7 @@ build_wheel_portable() {
         else
             echo "Warning: /usr/bin/clang not found; using default compiler"
         fi
-+
+
         if [ "$(uname -m)" = 'arm64' ]; then
             export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
         fi

--- a/packaging/python/build_wheels.bash
+++ b/packaging/python/build_wheels.bash
@@ -177,14 +177,12 @@ build_wheel_portable() {
         # linking against Homebrew LLVM (which bundles newer libunwind requiring
         # macOS 14+). Apple's clang uses system libunwind (no separate dylib).
         # This should prevent delocate from bundling libunwind.1.0.dylib at all.
-        if command -v /usr/bin/clang >/dev/null 2>&1; then
+        if command -v /usr/bin/clang++ >/dev/null 2>&1; then
             export CC=/usr/bin/clang
             export CXX=/usr/bin/clang++
             echo "Forcing system clang: CC=$CC CXX=$CXX"
-            # Prioritize /usr/bin over any Homebrew paths
-            export PATH="/usr/bin:$PATH"
         else
-            echo "Warning: /usr/bin/clang not found; using default compiler"
+            echo "Warning: /usr/bin/clang++ not found; using default compiler"
         fi
 
         if [ "$(uname -m)" = 'arm64' ]; then


### PR DESCRIPTION
This allows minimization of MACOSX_DEPLOYMENT_TARGET Otherwise linkage to libunwind requires a deployment target of 14

This explores the https://grok.com/share/bGVnYWN5LWNvcHk_9c6351ad-5ff0-4728-81d4-b47767c8848a (search for ZZZ)
'Best' Practical way to avoid bundling libunwind on the macosx intel runner.

Additionally we ensure the brew versions of flex and bison are used.

This supercedes #3728