### PR TITLE
Bump Eigen and change rotate3d to use eigen

### DIFF
--- a/src/nrniv/rot3band.h
+++ b/src/nrniv/rot3band.h
@@ -19,7 +19,7 @@
 
 class Rotate3Band: public Rubberband {
   public:
-    Rotate3Band(Rotation3d* = NULL, RubberAction* = NULL, Canvas* = NULL);
+    Rotate3Band(RubberAction* = NULL, Canvas* = NULL);
     virtual ~Rotate3Band();
 
     virtual void press(Event&);

--- a/src/nrniv/rotate3d.cpp
+++ b/src/nrniv/rotate3d.cpp
@@ -58,13 +58,10 @@ std::array<float, 2> Rotation3d::z_axis() const {
     return {mat(0, 2), mat(2, 1)};
 }
 
-Rotate3Band::Rotate3Band(Rotation3d* r3, RubberAction* ra, Canvas* c)
-    : Rubberband(ra, c) {
-    if (r3) {
-        rot_ = r3;
-    } else {
-        rot_ = new Rotation3d();
-    }
+Rotate3Band::Rotate3Band(RubberAction* ra, Canvas* c)
+    : Rubberband(ra, c)
+    , rot_(new Rotation3d{})
+{
     Resource::ref(rot_);
 }
 
@@ -168,7 +165,6 @@ void Rotate3Band::drag(Event&) {
 void Rotate3Band::draw(Coord, Coord) {
     Canvas* c = canvas();
     const Font* f = WidgetKit::instance()->font();
-    float x, y;
     float x0, y0;
 
     c->push_transform();

--- a/src/nrniv/rotate3d.cpp
+++ b/src/nrniv/rotate3d.cpp
@@ -16,112 +16,46 @@
 
 Rotation3d::Rotation3d() {
     identity();
-    int i, j;
-    for (i = 0; i < 2; ++i)
-        for (j = 0; j < 3; ++j)
-            o_[i][j] = 0.;
 }
 
-Rotation3d::~Rotation3d() {}
-
 void Rotation3d::identity() {
-    int i, j;
-    for (i = 0; i < 3; ++i) {
-        for (j = 0; j < 3; ++j) {
-            a_[i][j] = 0.;
-        }
-        a_[i][i] = 1.;
-    }
+    mat.setIdentity();
+    tr.setIdentity();
+    orig.setIdentity();
 }
 
 void Rotation3d::rotate_x(float radian) {
-    Rotation3d m;
-    m.a_[1][1] = m.a_[2][2] = cos(radian);
-    m.a_[2][1] = -(m.a_[1][2] = sin(radian));
-    post_multiply(m);
+    mat *= Eigen::AngleAxisf(radian, Eigen::Vector3f::UnitX()).toRotationMatrix();
 }
 void Rotation3d::rotate_y(float radian) {
-    Rotation3d m;
-    m.a_[2][2] = m.a_[0][0] = cos(radian);
-    m.a_[2][0] = -(m.a_[0][2] = sin(radian));
-    post_multiply(m);
+    mat *= Eigen::AngleAxisf(-radian, Eigen::Vector3f::UnitY()).toRotationMatrix();
 }
 void Rotation3d::rotate_z(float radian) {
-    Rotation3d m;
-    m.a_[0][0] = m.a_[1][1] = cos(radian);
-    m.a_[1][0] = -(m.a_[0][1] = sin(radian));
-    post_multiply(m);
+    mat *= Eigen::AngleAxisf(radian, Eigen::Vector3f::UnitZ()).toRotationMatrix();
 }
 
-void Rotation3d::post_multiply(Rotation3d& m) {  // r = m*r
-    float x[3][3];
-    int i, j, k;
-    for (i = 0; i < 3; ++i) {
-        for (j = 0; j < 3; ++j) {
-            x[i][j] = 0;
-            for (k = 0; k < 3; ++k) {
-                x[i][j] += m.a_[i][k] * a_[k][j];
-            }
-        }
-    }
-    for (i = 0; i < 3; ++i) {
-        for (j = 0; j < 3; ++j) {
-            a_[i][j] = x[i][j];
-        }
-    }
-}
-
-void Rotation3d::rotate(float x, float y, float z, float* tr) const {
-    float r[3];
-    r[0] = x;
-    r[1] = y;
-    r[2] = z;
-    rotate(r, tr);
-}
-
-void Rotation3d::rotate(float* r, float* tr) const {
-    int i;
-    float x[3];
-    for (i = 0; i < 3; ++i) {
-        x[i] = r[i] - o_[0][i];
-    }
-    for (i = 0; i < 3; ++i) {
-        tr[i] = a_[i][0] * x[0] + a_[i][1] * x[1] + a_[i][2] * x[2] + o_[1][i];
-    }
+Eigen::Vector3f Rotation3d::rotate(const Eigen::Vector3f& v) const {
+    auto r = orig * v;
+    auto t = mat.transpose() * r;
+    auto e = tr * t;
+    return e;
 }
 
 void Rotation3d::origin(float x, float y, float z) {
-    o_[0][0] = x;
-    o_[0][1] = y;
-    o_[0][2] = z;
+    orig = Eigen::Translation<float, 3>(-x, -y, -z);
 }
 void Rotation3d::offset(float x, float y) {
-    o_[1][0] = x;
-    o_[1][1] = y;
-    o_[1][2] = 0.;
+    tr = Eigen::Translation<float, 3>(x, y, 0.);
 }
 
-void Rotation3d::x_axis(float& x, float& y) const {
-    x = a_[0][0];
-    y = a_[1][0];
+std::array<float, 2> Rotation3d::x_axis() const {
+    return {mat(0, 0), mat(0, 1)};
 }
-void Rotation3d::y_axis(float& x, float& y) const {
-    x = a_[0][1];
-    y = a_[1][1];
+std::array<float, 2> Rotation3d::y_axis() const {
+    return {mat(0, 1), mat(1, 1)};
 }
-void Rotation3d::z_axis(float& x, float& y) const {
-    x = a_[0][2];
-    y = a_[1][2];
-}
-void Rotation3d::inverse_rotate(float* tr, float* r) const {
-    int i;
-    float x[3];
-    for (i = 0; i < 3; ++i) {
-        x[i] = tr[i];
-    }
-    for (i = 0; i < 3; ++i) {
-        r[i] = a_[0][i] * x[0] + a_[1][i] * x[1] + a_[2][i] * x[2];
-    }
+std::array<float, 2> Rotation3d::z_axis() const {
+    return {mat(0, 2), mat(2, 1)};
 }
 
 Rotate3Band::Rotate3Band(Rotation3d* r3, RubberAction* ra, Canvas* c)
@@ -216,8 +150,7 @@ void Rotate3Band::press(Event& e) {
     // this is the point we want to stay fixed.
     int i = ssec->get_coord(ss->arc_selected(), x1, y1);
     // what is it now
-    float r[3];
-    rot_->rotate(s->pt3d[i].x, s->pt3d[i].y, s->pt3d[i].z, r);
+    auto r = rot_->rotate({s->pt3d[i].x, s->pt3d[i].y, s->pt3d[i].z});
     rot_->origin(s->pt3d[i].x, s->pt3d[i].y, s->pt3d[i].z);
     rot_->offset(r[0], r[1]);
 }
@@ -245,18 +178,11 @@ void Rotate3Band::draw(Coord, Coord) {
     for (GlyphIndex i = 0; i < cnt; ++i) {
         Section* sec = ((ShapeSection*) sg->component(i))->section();
         if (sec->npt3d) {
-            float r[3];
             int i = 0;
-            r[0] = sec->pt3d[i].x;
-            r[1] = sec->pt3d[i].y;
-            r[2] = sec->pt3d[i].z;
-            rot_->rotate(r, r);
+            auto r = rot_->rotate({sec->pt3d[i].x, sec->pt3d[i].y, sec->pt3d[i].z});
             c->move_to(r[0], r[1]);
             i = sec->npt3d - 1;
-            r[0] = sec->pt3d[i].x;
-            r[1] = sec->pt3d[i].y;
-            r[2] = sec->pt3d[i].z;
-            rot_->rotate(r, r);
+            r = rot_->rotate({sec->pt3d[i].x, sec->pt3d[i].y, sec->pt3d[i].z});
             c->line_to(r[0], r[1]);
             c->stroke(color(), brush());
         }
@@ -270,24 +196,27 @@ void Rotate3Band::draw(Coord, Coord) {
     c->transformer(t);
     c->new_path();
     Coord w = canvas()->width() / 4;
-    rot_->x_axis(x, y);
-    // printf("x_axis %g %g\n", x, y);
-    c->line(x0, y0, x0 + x * w, y0 + y * w, color(), brush());
+    {
+        auto [x, y] = rot_->x_axis();
+        c->line(x0, y0, x0 + x * w, y0 + y * w, color(), brush());
 #ifndef WIN32
-    c->character(f, 'x', f->width('x'), color(), x0 + x * w * 1.1, y0 + y * w * 1.1);
+        c->character(f, 'x', f->width('x'), color(), x0 + x * w * 1.1, y0 + y * w * 1.1);
 #endif
-    rot_->y_axis(x, y);
-    // printf("y_axis %g %g\n", x, y);
-    c->line(x0, y0, x0 + x * w, y0 + y * w, color(), brush());
+    }
+    {
+        auto [x, y] = rot_->y_axis();
+        c->line(x0, y0, x0 + x * w, y0 + y * w, color(), brush());
 #ifndef WIN32
-    c->character(f, 'y', f->width('y'), color(), x0 + x * w * 1.1, y0 + y * w * 1.1);
+        c->character(f, 'y', f->width('y'), color(), x0 + x * w * 1.1, y0 + y * w * 1.1);
 #endif
-    rot_->z_axis(x, y);
-    // printf("z_axis %g %g\n", x, y);
-    c->line(x0, y0, x0 + x * w, y0 + y * w, color(), brush());
+    }
+    {
+        auto [x, y] = rot_->z_axis();
+        c->line(x0, y0, x0 + x * w, y0 + y * w, color(), brush());
 #ifndef WIN32
-    c->character(f, 'z', f->width('z'), color(), x0 + x * w * 1.1, y0 + y * w * 1.1);
+        c->character(f, 'z', f->width('z'), color(), x0 + x * w * 1.1, y0 + y * w * 1.1);
 #endif
+    }
     c->pop_transform();
 }
 #endif

--- a/src/nrniv/rotate3d.h
+++ b/src/nrniv/rotate3d.h
@@ -1,15 +1,14 @@
 #pragma once
 
+#include <Eigen/Eigen>
+
 /*  3-D rotation matrix */
 
-class Rotation3d: public Resource {
+class Rotation3d final: public Resource {
   public:
     Rotation3d();
-    virtual ~Rotation3d();
 
-    void rotate(float x, float y, float z, float* tr) const;
-    void rotate(float* r, float* tr) const;
-    void inverse_rotate(float* tr, float* r) const;
+    Eigen::Vector3f rotate(const Eigen::Vector3f&) const;
 
     void identity();
 
@@ -19,12 +18,12 @@ class Rotation3d: public Resource {
     void rotate_z(float radians);
     void origin(float x, float y, float z);
     void offset(float x, float y);
-    void post_multiply(Rotation3d&);
-    void x_axis(float& x, float& y) const;
-    void y_axis(float& x, float& y) const;
-    void z_axis(float& x, float& y) const;
+    std::array<float, 2> x_axis() const;
+    std::array<float, 2> y_axis() const;
+    std::array<float, 2> z_axis() const;
 
   private:
-    float a_[3][3];
-    float o_[2][3];
+    Eigen::Matrix3f mat;
+    Eigen::Transform<float, 3, Eigen::Affine> tr;
+    Eigen::Transform<float, 3, Eigen::Affine> orig;
 };

--- a/src/nrniv/shape.cpp
+++ b/src/nrniv/shape.cpp
@@ -879,7 +879,7 @@ ShapeScene::ShapeScene(SectionList* sl)
     sg_ = new PolyGlyph();
     sg_->ref();
     shape_changed_ = NULL;  // observe not ready for it yet
-    r3b_ = new Rotate3Band(NULL, new RubberCallback(ShapeScene)(this, &ShapeScene::transform3d));
+    r3b_ = new Rotate3Band(new RubberCallback(ShapeScene)(this, &ShapeScene::transform3d));
     r3b_->ref();
     observe(sl);
     wk.style()->find_attribute("shape_beveljoin", beveljoin_);

--- a/src/nrniv/shape.cpp
+++ b/src/nrniv/shape.cpp
@@ -1302,12 +1302,8 @@ void ShapeSection::transform3d(Rotation3d* rot) {
         x_ = new float[n_];
         y_ = new float[n_];
     }
-    float r[3];
     Coord x0, y0, xp, yp;
-    r[0] = sec_->pt3d[0].x;
-    r[1] = sec_->pt3d[0].y;
-    r[2] = sec_->pt3d[0].z;
-    rot->rotate(r, r);
+    auto r = rot->rotate({sec_->pt3d[0].x, sec_->pt3d[0].y, sec_->pt3d[0].z});
     xp = x0 = r[0];
     yp = y0 = r[1];
 
@@ -1338,10 +1334,7 @@ void ShapeSection::transform3d(Rotation3d* rot) {
         }
     }
     if (logic_con) {
-        r[0] = logic_con->x;
-        r[1] = logic_con->y;
-        r[2] = logic_con->z;
-        rot->rotate(r, r);
+        auto r = rot->rotate({logic_con->x, logic_con->y, logic_con->z});
         xinc = x0 - r[0];
         yinc = y0 - r[1];
     }
@@ -1349,10 +1342,7 @@ void ShapeSection::transform3d(Rotation3d* rot) {
     yp += yinc;
 
     for (i = 0; i < n_; ++i) {
-        r[0] = sec_->pt3d[i].x;
-        r[1] = sec_->pt3d[i].y;
-        r[2] = sec_->pt3d[i].z;
-        rot->rotate(r, r);
+        auto r = rot->rotate({sec_->pt3d[i].x, sec_->pt3d[i].y, sec_->pt3d[i].z});
         x_[i] = xp + len_scale_ * (r[0] - x0);  // *100./(100. - r[2]);
         y_[i] = yp + len_scale_ * (r[1] - y0);  // *100./(100. - r[2]);
     }


### PR DESCRIPTION
Eigen has a new 5.0.1 version (previously 3.4).

In the same time I rewrote `Rotation3d` to use Eigen, this is easier if we deduplicate all our matrixes code and libraries.