### PR TITLE
Bump minimal python to 3.10

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,8 +22,8 @@ on:
 #      - 'docs/**'
 
 env:
-  PY_MIN_VERSION: '3.9'
-  PY_MID_VERSION: '3.10'
+  PY_MIN_VERSION: '3.10'
+  PY_MID_VERSION: '3.11'
   PY_MAX_VERSION: '3.14'
   # The Linux runners have 4 cores:
   # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

--- a/.github/workflows/neuron-ci.yml
+++ b/.github/workflows/neuron-ci.yml
@@ -38,7 +38,7 @@ jobs:
       BUILD_TYPE: Release
       DESIRED_CMAKE_VERSION: 3.19
       DYNAMIC_PYTHON_CMAKE_VERSION: 3.19
-      PY_MIN_VERSION: ${{ matrix.config.python_min_version || '3.9' }}
+      PY_MIN_VERSION: ${{ matrix.config.python_min_version || '3.10' }}
       PY_MAX_VERSION: ${{ matrix.config.python_max_version || '3.14' }}
       MUSIC_INSTALL_DIR: /opt/MUSIC
       # hash of commit containing mpi4py 4 fix
@@ -162,7 +162,7 @@ jobs:
         id: cache-python-min-packages-restore
         uses: actions/cache/restore@v4
         with:
-          path: ${{ github.workspace }}/pip_cache${{ matrix.config.python_min_version || '3.9' }}
+          path: ${{ github.workspace }}/pip_cache${{ matrix.config.python_min_version || '3.10' }}
           key: cache-${{ matrix.os }}-${{ env.PY_MIN_VERSION }}-${{ hashFiles('ci/requirements.txt') }}
 
       - name: Set up Python@${{ env.PY_MIN_VERSION }}
@@ -176,7 +176,7 @@ jobs:
         working-directory: ${{runner.workspace}}/nrn
         run: |
           python -m pip install -r ci/uv_requirements.txt
-          python -m uv pip install -r ci/requirements.txt --cache-dir ${{ github.workspace }}/pip_cache${{ matrix.config.python_min_version || '3.9' }}
+          python -m uv pip install -r ci/requirements.txt --cache-dir ${{ github.workspace }}/pip_cache${{ matrix.config.python_min_version || '3.10' }}
 
       - name: Save Python@${{ env.PY_MIN_VERSION }} dependencies
         if: ${{matrix.config.python_dynamic == 'ON'}} && steps.cache-python-min-packages-restore.outputs.cache-hit != 'true'
@@ -184,7 +184,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           key: ${{ steps.cache-python-min-packages-restore.outputs.cache-primary-key }}
-          path: ${{ github.workspace }}/pip_cache${{ matrix.config.python_min_version || '3.9' }}
+          path: ${{ github.workspace }}/pip_cache${{ matrix.config.python_min_version || '3.10' }}
 
       # Restore (and later save) dependencies for max version of Python
       - name: Restore Python@${{ env.PY_MAX_VERSION }} dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
         required: true
       python_versions:
         description: "Comma-separated list of supported Python versions"
-        default: "3.9,3.10,3.11,3.12,3.13,3.14"
+        default: "3.10,3.11,3.12,3.13,3.14"
         required: true
         type: string
       os:
@@ -56,7 +56,7 @@ jobs:
       - id: set-matrix
         run: |
           OS_INPUT="${{ github.event.inputs.os || 'macos-15-intel,macos-14,ubuntu-24.04,ubuntu-24.04-arm' }}"
-          PY_INPUT="${{ github.event.inputs.python_versions || '3.9,3.10,3.11,3.12,3.13,3.14' }}"
+          PY_INPUT="${{ github.event.inputs.python_versions || '3.10,3.11,3.12,3.13,3.14' }}"
           OS_JSON=$(echo "$OS_INPUT" | jq -R 'split(",")')
           PY_JSON=$(echo "$PY_INPUT" | jq -R 'split(",")')
           echo "matrix=$(jq -c -n --argjson os "$OS_JSON" --argjson py "$PY_JSON" '{os: $os, python_version: $py}')" >> "$GITHUB_OUTPUT"
@@ -103,7 +103,6 @@ jobs:
     uses: neuronsimulator/nrn-modeldb-ci/.github/workflows/nrn-modeldb-ci.yaml@master
     with:
       # v1 is the latest stable wheel, while v2 is the currently-built wheel.
-      # Note that v2 needs to at least contain an x86_64 Linux Python 3.9 wheel since that is the platform that modelDB CI uses
       neuron_v1: neuron==${{ needs.get-latest-wheel-version.outputs.latest_version }}
       neuron_v2: ${{ needs.merge-wheels.outputs.artifacts-url }}
 
@@ -311,7 +310,7 @@ jobs:
       - name: Rename Windows installer
         id: rename
         run: |
-          # convert "3.9,3.10..." into "39-310-..."
+          # convert "3.10,3.11..." into "310-311-..."
           py_version_string="$(echo "${{ github.event.inputs.python_versions }}" | sed 's/\.//g; s/,/-/g')"
           win_installer_name="nrn-${{ env.REL_TAG }}.w64-mingw-py-${py_version_string}-setup.exe"
           echo "win_installer_name=${win_installer_name}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/wheels-ci.yml
+++ b/.github/workflows/wheels-ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: ['macos-15-intel', 'ubuntu-24.04']
-        python_version: ['3.9', '3.14']
+        python_version: ['3.10', '3.14']
 
   merge:
     name: Merge artifacts and post artifacts URL

--- a/.github/workflows/wheels-nightly.yml
+++ b/.github/workflows/wheels-nightly.yml
@@ -17,7 +17,7 @@ on:
       python_versions:
         description: "Comma-separated list of Python versions"
         required: false
-        default: "3.9,3.10,3.11,3.12,3.13,3.14"
+        default: "3.10,3.11,3.12,3.13,3.14"
       commit:
         description: The commit of NEURON for which to build the wheel
         required: false
@@ -48,7 +48,7 @@ jobs:
       - id: set-matrix
         run: |
           OS_INPUT="${{ github.event.inputs.os || 'macos-14,ubuntu-24.04-arm' }}"
-          PY_INPUT="${{ github.event.inputs.python_versions || '3.9,3.10,3.11,3.12,3.13,3.14' }}"
+          PY_INPUT="${{ github.event.inputs.python_versions || '3.10,3.11,3.12,3.13,3.14' }}"
           OS_JSON=$(echo "$OS_INPUT" | jq -R 'split(",")')
           PY_JSON=$(echo "$PY_INPUT" | jq -R 'split(",")')
           echo "matrix=$(jq -c -n --argjson os "$OS_JSON" --argjson py "$PY_JSON" '{os: $os, python_version: $py}')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/wheels-template.yml
+++ b/.github/workflows/wheels-template.yml
@@ -53,7 +53,6 @@ jobs:
           # readability, but alas, GitHub Actions does not support expanding
           # nested expressions, so we do this the brute-force way with Bash
           case "${{ inputs.python_version }}" in
-            3.9) version="3.9.13" ;;
             3.10) version="3.10.11" ;;
             3.11) version="3.11.7" ;;
             3.12) version="3.12.0" ;;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,7 +287,7 @@ if(NOT PYTHON_EXECUTABLE)
   message(STATUS "\tSetting PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}")
 endif()
 
-find_package(Python 3.9 REQUIRED)
+find_package(Python 3.10 REQUIRED)
 
 # Try and emit an intelligent warning if the version number currently set in the CMake project(...)
 # call is inconsistent with the output of git describe.
@@ -343,12 +343,12 @@ string(REPLACE "," ";" NRN_SANITIZERS_LIST "${NRN_SANITIZERS}")
 #   NRN_DEFAULT_PYTHON_LIBRARIES are its include direcory and library
 # * NRN_PYTHON_EXECUTABLES is a list of absolute paths to all Python executables to be built against
 #   (length >=1 if NRN_ENABLE_PYTHON_DYNAMIC else == 1)
-# * NRN_PYTHON_VERSIONS (3.9, 3.11, ...), NRN_PYTHON_INCLUDES and NRN_PYTHON_LIBRARIES are populated
-#   with values patching NRN_PYTHON_EXECUTABLES
+# * NRN_PYTHON_VERSIONS (3.10, 3.12, ...), NRN_PYTHON_INCLUDES and NRN_PYTHON_LIBRARIES are
+#   populated with values patching NRN_PYTHON_EXECUTABLES
 # * NRN_PYTHON_COUNT is set to the number of entries in those lists (i.e. number of Pythons), and
 #   NRN_PYTHON_ITERATION_LIMIT is set to ${NRN_PYTHON_COUNT} - 1
 # =================================================================================================
-set(NRN_MINIMUM_PYTHON_VERSION 3.8)
+set(NRN_MINIMUM_PYTHON_VERSION 3.10)
 include(cmake/PythonHelper.cmake)
 
 # This needs NRN_DEFAULT_PYTHON_EXECUTABLE, which comes from PythonHelper.cmake

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,9 +34,6 @@ stages:
         vmImage: 'ubuntu-24.04'
       strategy:
         matrix:
-          Python39:
-            python.version: '3.9'
-            python.nodot: '39'
           Python310:
             python.version: '3.10'
             python.nodot: '310'
@@ -111,11 +108,6 @@ stages:
         vmImage: 'macOS-15'
       strategy:
         matrix:
-          Python39:
-            python.version: '3.9'
-            python.nodot: '39'
-            python.org.version: '3.9.13'
-            python.installer.name: 'macos11.pkg'
           Python310:
             python.version: '3.10'
             python.nodot: '310'

--- a/bin/nrndiagnose.sh.in
+++ b/bin/nrndiagnose.sh.in
@@ -15,7 +15,7 @@ pysetup='@ac_pysetup@'
 # What python are we supposed to use that allows the possibility
 # of import neuron. Need a Python that is consistent with our build.
 # If not dynamic then just use PYTHONCFG. If dynamic there may be
-# multiple acceptable python versions, e.g 3.8, 3.9 so look in
+# multiple acceptable python versions, e.g 3.10, 3.11 so look in
 # $prefix/$host_cpu/lib for libnrnpython* and see if there are
 # any consistent versions on this machine
 

--- a/bin/nrnpyenv.sh.in
+++ b/bin/nrnpyenv.sh.in
@@ -34,7 +34,7 @@ export originalPYTHONPATH="$PYTHONPATH"
 export originalLDLIBRARYPATH="$LD_LIBRARY_PATH"
 
 # list the Python versions that this NEURON build supports
-# the format is {major}.{minor}, i.e. 3.8, 3.9, 3.10, ...
+# the format is {major}.{minor}, i.e. 3.10, 3.11, 3.12, ...
 _this_neuron_py_versions=(@NRN_PYTHON_VERSIONS_STRING@)
 
 # order of preference is: -pyexe, $NRN_PYTHONEXE, python, python3,

--- a/bldnrnmacpkg.sh
+++ b/bldnrnmacpkg.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-default_pythons="python3.9 python3.10 python3.11 python3.12 python3.13"
+default_pythons="python3.10 python3.11 python3.12 python3.13"
 # distribution built with
 # bash bldnrnmacpkgcmake.sh
 # without args, default are the pythons above.

--- a/ci/win_build_cmake.sh
+++ b/ci/win_build_cmake.sh
@@ -41,9 +41,9 @@ ${CMAKE_COMMAND} \
     -DNRN_ENABLE_RX3D=ON  \
     -DNRN_RX3D_OPT_LEVEL=2 \
     -DNRN_BINARY_DIST_BUILD=ON \
-    -DPYTHON_EXECUTABLE=/c/Python39/python.exe \
+    -DPYTHON_EXECUTABLE=/c/Python310/python.exe \
     -DNRN_ENABLE_PYTHON_DYNAMIC=ON  \
-    -DNRN_PYTHON_DYNAMIC='c:/Python39/python.exe;c:/Python310/python.exe;c:/Python311/python.exe;c:/Python312/python.exe;c:/Python313/python.exe;c:/Python314/python.exe'  \
+    -DNRN_PYTHON_DYNAMIC='c:/Python310/python.exe;c:/Python311/python.exe;c:/Python312/python.exe;c:/Python313/python.exe;c:/Python314/python.exe'  \
     -DCMAKE_INSTALL_PREFIX='/c/nrn-install' \
     -DMPI_CXX_LIB_NAMES:STRING=msmpi \
     -DMPI_C_LIB_NAMES:STRING=msmpi \

--- a/ci/win_download_deps.cmd
+++ b/ci/win_download_deps.cmd
@@ -3,7 +3,6 @@
 :: download all installers
 
 :: python
-pwsh -command Invoke-WebRequest -MaximumRetryCount 4 -OutFile python-3.9.exe https://www.python.org/ftp/python/3.9.0/python-3.9.0-amd64.exe || goto :error
 pwsh -command Invoke-WebRequest -MaximumRetryCount 4 -OutFile python-3.10.exe https://www.python.org/ftp/python/3.10.0/python-3.10.0-amd64.exe || goto :error
 pwsh -command Invoke-WebRequest -MaximumRetryCount 4 -OutFile python-3.11.exe https://www.python.org/ftp/python/3.11.1/python-3.11.1-amd64.exe || goto :error
 pwsh -command Invoke-WebRequest -MaximumRetryCount 4 -OutFile python-3.12.exe https://www.python.org/ftp/python/3.12.1/python-3.12.1-amd64.exe || goto :error

--- a/ci/win_install_deps.cmd
+++ b/ci/win_install_deps.cmd
@@ -3,7 +3,6 @@
 :: install all dependencies
 
 :: install python
-python-3.9.exe /passive Include_pip=1 Include_test=0 PrependPath=1 DefaultJustForMeTargetDir=C:\Python39 || goto :error
 python-3.10.exe /passive Include_pip=1 Include_test=0 PrependPath=1 DefaultJustForMeTargetDir=C:\Python310 || goto :error
 python-3.11.exe /passive Include_pip=1 Include_test=0 PrependPath=1 DefaultJustForMeTargetDir=C:\Python311 || goto :error
 python-3.12.exe /passive Include_pip=1 Include_test=0 PrependPath=1 DefaultJustForMeTargetDir=C:\Python312 || goto :error
@@ -11,18 +10,15 @@ python-3.13.exe /passive Include_pip=1 Include_test=0 PrependPath=1 DefaultJustF
 python-3.14.exe /passive Include_pip=1 Include_test=0 PrependPath=1 DefaultJustForMeTargetDir=C:\Python314 || goto :error
 
 :: fix msvcc version for all python3
-pwsh -command "(Get-Content C:\Python39\Lib\distutils\cygwinccompiler.py) -replace 'elif msc_ver == ''1600'':', 'elif msc_ver == ''1927'':' | Out-File C:\Python39\Lib\distutils\cygwinccompiler.py"
 pwsh -command "(Get-Content C:\Python310\Lib\distutils\cygwinccompiler.py) -replace 'elif msc_ver == ''1600'':', 'elif msc_ver == ''1929'':' | Out-File C:\Python310\Lib\distutils\cygwinccompiler.py"
 pwsh -command "(Get-Content C:\Python311\Lib\distutils\cygwinccompiler.py) -replace 'elif msc_ver == ''1600'':', 'elif msc_ver == ''1934'':' | Out-File C:\Python311\Lib\distutils\cygwinccompiler.py"
 
 
 :: fix msvc runtime library for all python
-pwsh -command "(Get-Content C:\Python39\Lib\distutils\cygwinccompiler.py) -replace 'msvcr100', 'msvcrt' | Out-File C:\Python39\Lib\distutils\cygwinccompiler.py"
 pwsh -command "(Get-Content C:\Python310\Lib\distutils\cygwinccompiler.py) -replace 'msvcr100', 'msvcrt' | Out-File C:\Python310\Lib\distutils\cygwinccompiler.py"
 pwsh -command "(Get-Content C:\Python311\Lib\distutils\cygwinccompiler.py) -replace 'msvcr100', 'msvcrt' | Out-File C:\Python311\Lib\distutils\cygwinccompiler.py"
 
 :: install numpy
-C:\Python39\python.exe -m pip install "numpy<=2.2.3" "cython<=3.0.12" || goto :error
 C:\Python310\python.exe -m pip install "numpy<=2.2.3" "cython<=3.0.12" || goto :error
 C:\Python311\python.exe -m pip install "numpy<=2.2.3" "cython<=3.0.12" || goto :error
 C:\Python312\python.exe -m pip install "numpy<=2.2.3" "cython<=3.0.12" || goto :error

--- a/ci/win_test_installer.cmd
+++ b/ci/win_test_installer.cmd
@@ -17,7 +17,6 @@ echo %NEURONHOME%
 if not exist association.hoc.out (start /wait /REALTIME %cd%\ci\association.hoc)
 
 :: test all pythons
-C:\Python39\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
 C:\Python310\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
 C:\Python311\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
 C:\Python312\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
@@ -25,7 +24,6 @@ C:\Python313\python -c "import neuron; neuron.test(); quit()" || set "errorfound
 C:\Python314\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
 
 :: install oldest supported numpy
-C:\Python39\python.exe -m pip install -r packaging/python/oldest_numpy_requirements.txt || goto :error
 C:\Python310\python.exe -m pip install -r packaging/python/oldest_numpy_requirements.txt || goto :error
 C:\Python311\python.exe -m pip install -r packaging/python/oldest_numpy_requirements.txt || goto :error
 C:\Python312\python.exe -m pip install -r packaging/python/oldest_numpy_requirements.txt || goto :error
@@ -33,7 +31,6 @@ C:\Python313\python.exe -m pip install -r packaging/python/oldest_numpy_requirem
 C:\Python314\python.exe -m pip install -r packaging/python/oldest_numpy_requirements.txt || goto :error
 
 :: test all pythons again
-C:\Python39\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
 C:\Python310\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
 C:\Python311\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"
 C:\Python312\python -c "import neuron; neuron.test(); quit()" || set "errorfound=y"

--- a/cmake/PythonCompileHelper.cmake
+++ b/cmake/PythonCompileHelper.cmake
@@ -73,7 +73,7 @@ endfunction()
 #                     `hoc.cpython39-darwin.so` or similar). Note that no prefix is added.
 # TARGET            - (optional, defaults to <name>) the name of the CMake
 #                     target. Can be anything, but may not conflict with existing targets.
-# PYTHON_VERSION    - the version of Python to create the library for (for example, 3.9).
+# PYTHON_VERSION    - the version of Python to create the library for (for example, 3.10).
 # LANGUAGE          - the language used for linking the library. See also the LINKER_LANGUAGE CMake variable.
 # OUTPUT_DIR        - the path to the directory where the library will be placed afer building.
 # SOURCES           - the list of source files used for compiling the library.

--- a/docs/cmake_doc/options.rst
+++ b/docs/cmake_doc/options.rst
@@ -330,7 +330,7 @@ NRN_PYTHON_DYNAMIC:STRING=
 
   .. code-block:: shell
 
-    -DNRN_PYTHON_DYNAMIC="python3.8;python3.9;python3.10;python3.11"
+    -DNRN_PYTHON_DYNAMIC="python3.10;python3.11"
 
   The first entry in the list is considered to be the default version, followed
   by alternatives in decreasing order of preference.

--- a/docs/install/python_wheels.md
+++ b/docs/install/python_wheels.md
@@ -227,7 +227,6 @@ $ git diff
      resource_class: arm.medium
 
 @@ -54,6 +59,7 @@ jobs:
-               39) pyenv_py_ver="3.9.1" ;;
                310) pyenv_py_ver="3.10.1" ;;
                311) pyenv_py_ver="3.11.0" ;;
 +              312) pyenv_py_ver="3.12.2" ;;
@@ -239,7 +238,7 @@ $ git diff
            matrix:
              parameters:
 -              NRN_PYTHON_VERSION: ["311"]
-+              NRN_PYTHON_VERSION: ["39", "310", "311", "312"]
++              NRN_PYTHON_VERSION: ["310", "311", "312"]
                NRN_NIGHTLY_UPLOAD: ["false"]
 
    nightly:

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -87,9 +87,9 @@ As you can see in the script, a typical configuration would be:
 	-DNRN_ENABLE_PYTHON=ON  \
 	-DNRN_ENABLE_RX3D=ON  \
 	-DNRN_RX3D_OPT_LEVEL=2 \
-	-DPYTHON_EXECUTABLE=/c/Python39/python.exe \
+	-DPYTHON_EXECUTABLE=/c/Python310/python.exe \
 	-DNRN_ENABLE_PYTHON_DYNAMIC=ON  \
-	-DNRN_PYTHON_DYNAMIC='c:/Python39/python.exe;c:/Python310/python.exe;c:/Python311/python.exe'  \
+	-DNRN_PYTHON_DYNAMIC='c:/Python310/python.exe;c:/Python311/python.exe'  \
 	-DCMAKE_INSTALL_PREFIX='/c/nrn-install' \
 	-DMPI_CXX_LIB_NAMES:STRING=msmpi \
 	-DMPI_C_LIB_NAMES:STRING=msmpi \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,17 +35,17 @@ authors = [
   { name = "Yale" },
   { name = "Blue Brain Project" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "License :: Other/Proprietary License",
   "Programming Language :: C++",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering",
 ]
 dynamic = [ "version" ]

--- a/src/nrniv/nrnpy.cpp
+++ b/src/nrniv/nrnpy.cpp
@@ -257,7 +257,7 @@ void nrnpython_reg() {
 static nrnpython_reg_real_t load_nrnpython() {
     std::string pyversion{};
     if (auto const pv10 = nrn_is_python_extension; pv10 > 0) {
-        // pv10 is one of the packed integers like 310 (3.10) or 39 (3.9)
+        // pv10 is one of the packed integers like 310 (3.10) or 311 (3.11)
         auto const factor = (pv10 >= 100) ? 100 : 10;
         pyversion = std::to_string(pv10 / factor) + "." + std::to_string(pv10 % factor);
     } else {

--- a/src/nrnpython/nrnpython.h
+++ b/src/nrnpython/nrnpython.h
@@ -27,8 +27,8 @@
 #define PyInt_AsLong        PyLong_AsLong
 #define PyInt_FromLong      PyLong_FromLong
 
-static_assert(PY_MAJOR_VERSION > 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 9),
-              "Python >= 3.9 required");
+static_assert(PY_MAJOR_VERSION > 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 10),
+              "Python >= 3.10 required");
 
 extern PyObject* nrnpy_hoc_pop(const char* mes);
 extern int nrnpy_numbercheck(PyObject*);


### PR DESCRIPTION
Launched in 2020 python 3.9 reached end of life.

```
Warning: Python 3.9.25 reached end-of-life on 2025-10-31. It is no longer supported and does not receive security updates. We recommend upgrading to the [latest Python release](https://www.python.org/downloads/latest).
```