### PR TITLE
Fix idraw from PyPI wheel that fails with "invalid ELF header".

### DIFF
--- a/.github/workflows/wheels-nightly.yml
+++ b/.github/workflows/wheels-nightly.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Save commit ref
         id: save-commit
         run: |
+
+          # === TEMPORARY: build hines/nrn-PIE-idraw-fix ===
+          echo "commit=hines/nrn-PIE-idraw-fix" >> "$GITHUB_OUTPUT"
+          # ===============================================
+
           commit="${{ github.event.inputs.commit }}"
           if [[ -n "${commit}" ]]; then
             echo "commit=${commit}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/wheels-nightly.yml
+++ b/.github/workflows/wheels-nightly.yml
@@ -32,11 +32,6 @@ jobs:
       - name: Save commit ref
         id: save-commit
         run: |
-
-          # === TEMPORARY: build hines/nrn-PIE-idraw-fix ===
-          echo "commit=hines/nrn-PIE-idraw-fix" >> "$GITHUB_OUTPUT"
-          # ===============================================
-
           commit="${{ github.event.inputs.commit }}"
           if [[ -n "${commit}" ]]; then
             echo "commit=${commit}" >> "$GITHUB_OUTPUT"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,16 +25,21 @@ project(
 # Fixes for Linux wheels
 # =============================================================================
 
-# Force PIE for all executables (idraw, nrniv, etc.)
-# This was the root cause of the original "invalid ELF header: RTLD_GLOBAL" error.
+# Force PIE for all executables (idraw, nrniv, etc.) This was the root cause of the original
+# "invalid ELF header: RTLD_GLOBAL" error.
 cmake_policy(SET CMP0083 NEW)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE BOOL "Force PIE for NEURON + InterViews" FORCE)
+set(CMAKE_POSITION_INDEPENDENT_CODE
+    ON
+    CACHE BOOL "Force PIE for NEURON + InterViews" FORCE)
 
-# Disable fragile dynamic X11 loading *only* for Linux wheels.
-# This was triggering the (null) RTLD_GLOBAL error.
-# macOS wheels and normal/local Linux builds keep the original default (ON).
-if(SKBUILD AND UNIX AND NOT APPLE)
-  set(IV_ENABLE_X11_DYNAMIC OFF CACHE BOOL "Disable on Linux wheels" FORCE)
+# Disable fragile dynamic X11 loading *only* for Linux wheels. This was triggering the (null)
+# RTLD_GLOBAL error. macOS wheels and normal/local Linux builds keep the original default (ON).
+if(SKBUILD
+   AND UNIX
+   AND NOT APPLE)
+  set(IV_ENABLE_X11_DYNAMIC
+      OFF
+      CACHE BOOL "Disable on Linux wheels" FORCE)
 endif()
 
 # =============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,22 @@ project(
   HOMEPAGE_URL "https://nrn.readthedocs.io/")
 
 # =============================================================================
+# Fixes for Linux wheels
+# =============================================================================
+
+# Force PIE for all executables (idraw, nrniv, etc.)
+# This was the root cause of the original "invalid ELF header: RTLD_GLOBAL" error.
+cmake_policy(SET CMP0083 NEW)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE BOOL "Force PIE for NEURON + InterViews" FORCE)
+
+# Disable fragile dynamic X11 loading *only* for Linux wheels.
+# This was triggering the (null) RTLD_GLOBAL error.
+# macOS wheels and normal/local Linux builds keep the original default (ON).
+if(SKBUILD AND UNIX AND NOT APPLE)
+  set(IV_ENABLE_X11_DYNAMIC OFF CACHE BOOL "Disable on Linux wheels" FORCE)
+endif()
+
+# =============================================================================
 # CMake common project settings
 # =============================================================================
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Closes #3769
This fix forces CMAKE_POSITION_INDEPENDENT_CODE=ON for all executables.
Disables IV_ENABLE_X11_DYNAMIC on Linux wheels only