### PR TITLE
fix for file type detection on linux and mac

### DIFF
--- a/share/lib/hoc/import3d/import3d_gui.hoc
+++ b/share/lib/hoc/import3d/import3d_gui.hoc
@@ -431,7 +431,7 @@ func some_format() {local i, a,b,c,d,e,f,g, n
 			return 0
 		}
 		file.gets(tstr)
-		if (hoc_sf_.head(tstr, "^\\<\\?xml", tstr1) != -1) {
+		if (hoc_sf_.head(tstr, "^<\\?xml", tstr1) != -1) {
 			if (nrnpython("")) {
 				swc = new Import3d_MorphML() break
 			}else{


### PR DESCRIPTION
On a mac (running Tahoe), the old expression with the escaped < always evaluated to 0. On Linux, it always evaluated to -1. This meant that the macs always thought files were MorphML and Linux never thought they were.

TODO: Confirm this doesn't break Windows.