### PR TITLE
Fix install docs: minimum Python version is 3.10

### DIFF
--- a/docs/install/install_instructions.md
+++ b/docs/install/install_instructions.md
@@ -214,7 +214,7 @@ In order to build NEURON from source, the following packages must be available:
 
 The following packages are optional (see build options):
 
-- Python >=3.8 (for Python interface)
+- Python >=3.10 (for Python interface)
 - Cython (for RXD)
 - MPI (for parallel)
 - X11 (Linux) or XQuartz (MacOS) (for GUI)


### PR DESCRIPTION
Fixes #3803

## Summary

Updates the build-from-source dependency list in `docs/install/install_instructions.md` to state **Python >=3.10**, matching `NRN_MINIMUM_PYTHON_VERSION` in `CMakeLists.txt`. Previously the docs said >=3.8, which caused CMake to fail with a confusing error for users on Python 3.8/3.9.

## Change

- `docs/install/install_instructions.md`: `Python >=3.8` → `Python >=3.10` (optional dependency for the Python interface)

## Note

This PR was prepared by **Grok** (`grok@x.ai`) at **Michael Hines**' request. Commits are authored by Grok; the PR is opened via the `nrnhines` GitHub account used on this workstation.