### PR TITLE
Fix buffer overflow in output_spikes_parallel with zero spikes

### DIFF
--- a/src/coreneuron/io/output_spikes.cpp
+++ b/src/coreneuron/io/output_spikes.cpp
@@ -220,7 +220,7 @@ static void output_spikes_parallel(const char* outpath, const SpikesInfo& spikes
 
     // Allocate at least 1 byte to avoid undefined behavior from malloc(0)
     // followed by strcpy (triggers FORTIFY_SOURCE buffer overflow on Linux).
-    char* spike_data = (char*) malloc(num_bytes > 0 ? num_bytes : 1);
+    char* spike_data = (char*) malloc(std::max(num_bytes, (size_t) 1));
 
     if (spike_data == nullptr) {
         printf("Error while writing spikes due to memory allocation\n");

--- a/src/coreneuron/io/output_spikes.cpp
+++ b/src/coreneuron/io/output_spikes.cpp
@@ -217,7 +217,10 @@ static void output_spikes_parallel(const char* outpath, const SpikesInfo& spikes
     const int SPIKE_RECORD_LEN = 64;
     size_t num_spikes = spikevec_gid.size();
     size_t num_bytes = (sizeof(char) * num_spikes * SPIKE_RECORD_LEN);
-    char* spike_data = (char*) malloc(num_bytes);
+
+    // Allocate at least 1 byte to avoid undefined behavior from malloc(0)
+    // followed by strcpy (triggers FORTIFY_SOURCE buffer overflow on Linux).
+    char* spike_data = (char*) malloc(num_bytes > 0 ? num_bytes : 1);
 
     if (spike_data == nullptr) {
         printf("Error while writing spikes due to memory allocation\n");
@@ -225,7 +228,7 @@ static void output_spikes_parallel(const char* outpath, const SpikesInfo& spikes
     }
 
     // empty if no spikes
-    strcpy(spike_data, "");
+    spike_data[0] = '\0';
 
     // populate buffer with all spike entries
     char spike_entry[SPIKE_RECORD_LEN];

--- a/src/coreneuron/io/output_spikes.cpp
+++ b/src/coreneuron/io/output_spikes.cpp
@@ -218,8 +218,7 @@ static void output_spikes_parallel(const char* outpath, const SpikesInfo& spikes
     size_t num_spikes = spikevec_gid.size();
     size_t num_bytes = (sizeof(char) * num_spikes * SPIKE_RECORD_LEN);
 
-    // Allocate at least 1 byte to avoid undefined behavior from malloc(0)
-    // followed by strcpy (triggers FORTIFY_SOURCE buffer overflow on Linux).
+    // ensure space for at least the null terminator when there are no spikes
     char* spike_data = (char*) malloc(std::max(num_bytes, (size_t) 1));
 
     if (spike_data == nullptr) {


### PR DESCRIPTION
Fixes: https://github.com/neuronsimulator/nrn/issues/3812

## What

When `num_spikes == 0`, `malloc(0)` followed by `strcpy(spike_data, "")` triggers glibc's FORTIFY_SOURCE buffer overflow detection on Linux.

## Fix

- Allocate at least 1 byte: `malloc(num_bytes > 0 ? num_bytes : 1)`
- Use direct assignment `spike_data[0] = '\0'` instead of `strcpy`

## Testing

Reproduces in neurodamus CI (`test_v5_coreneuron_no_lfp_smoke`) on Ubuntu when tstop is too short for any cell to fire.