### PR TITLE
Recompute 3d-derived diam in nrn_segment_diam_get

### DIFF
--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -526,10 +526,15 @@ Segments
     :param x: Normalized position along Section (0.0 to 1.0).
     :returns: Diameter in microns at the specified position.
 
+    When the section geometry is defined by 3d points (:func:`pt3dadd`), the
+    segment diameter is derived from those points. This getter triggers that
+    recompute if it is pending, so the value is correct even before an explicit
+    geometry pass such as :func:`define_shape` or :func:`finitialize`.
+
     **C Usage:**
-    
+
     .. code-block:: c
-    
+
         double diameter = nrn_segment_diam_get(soma, 0.5);  // Get diameter at middle
 
     **Python Equivalent:**

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -9,6 +9,7 @@
 #include "ocfunc.h"
 #include "ocjump.h"
 #include "parse.hpp"
+#include "nrn_ansi.h"
 #include "section.h"
 #include "shapeplt.h"
 #include <cstring>
@@ -195,6 +196,12 @@ void nrn_segment_diam_set(Section* const sec, const double x, const double diam)
 }
 
 double nrn_segment_diam_get(Section* const sec, const double x) {
+    // Geometry from 3d points writes diam lazily, gated per-section on
+    // recalc_area_. Mirror the range-variable read path (nrnpy_nrn.cpp) so a
+    // diam read after pt3dadd returns the 3d-derived value, not a stale default.
+    if (sec && sec->recalc_area_) {
+        nrn_area_ri(sec);
+    }
     Node* const node = node_exact(sec, x);
     for (auto prop = node->prop; prop; prop = prop->next) {
         if (prop->_type == MORPHOLOGY) {

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -1,4 +1,4 @@
-foreach(api_test_file hh_sim.cpp netcon.cpp node_index.cpp sections.cpp vclamp.cpp)
+foreach(api_test_file hh_sim.cpp netcon.cpp node_index.cpp segment_diam.cpp sections.cpp vclamp.cpp)
   string(REPLACE "." "_" api_test_name "${api_test_file}")
   add_executable(${api_test_name} ${api_test_file})
   cpp_cc_configure_sanitizers(TARGET ${api_test_name})

--- a/test/api/segment_diam.cpp
+++ b/test/api/segment_diam.cpp
@@ -1,0 +1,58 @@
+// NOTE: this assumes neuronapi.h is on your CPLUS_INCLUDE_PATH
+// Exercises nrn_segment_diam_get's lazy recompute of 3d-derived diameter.
+// When a section's geometry comes from pt3dadd, NEURON rewrites the segment
+// diam lazily (gated per-section on recalc_area_). nrn_segment_diam_get must
+// trigger that recompute so a read before any geometry pass returns the
+// 3d-derived value, matching what Python's seg.diam already does.
+#include <array>
+#include <cmath>
+#include <iostream>
+#include "neuronapi.h"
+
+using std::cerr;
+using std::endl;
+
+extern "C" void modl_reg(){/* No modl_reg */};
+
+static bool close_to(double got, double want, const char* msg) {
+    if (std::fabs(got - want) > 1e-9) {
+        cerr << "FAIL: " << msg << " — got " << got << ", want " << want << endl;
+        return false;
+    }
+    return true;
+}
+
+static void pt3dadd(Section* sec, double xx, double yy, double zz, double diam) {
+    nrn_section_push(sec);
+    nrn_double_push(xx);
+    nrn_double_push(yy);
+    nrn_double_push(zz);
+    nrn_double_push(diam);
+    nrn_function_call(nrn_symbol("pt3dadd"), 4);
+    nrn_double_pop();  // pt3dadd returns a number
+    nrn_section_pop();
+}
+
+int main(void) {
+    static std::array<const char*, 4> argv = {"segment_diam", "-nogui", "-nopython", nullptr};
+    nrn_init(3, argv.data());
+
+    // Uniform 3d geometry: two points, both diam 10, so diam is 10 everywhere.
+    Section* s = nrn_section_new("s");
+    pt3dadd(s, 0, 0, 0, 10);
+    pt3dadd(s, 10, 0, 0, 10);
+
+    bool ok = true;
+
+    // Read BEFORE any geometry pass. Without the recompute this returns the
+    // 500.0 default; with it, the 3d-derived 10.0.
+    ok &= close_to(nrn_segment_diam_get(s, 0.5), 10.0, "diam read before geometry pass");
+
+    // A geometry pass must not change the already-correct value.
+    nrn_double_push(-65);
+    nrn_function_call(nrn_symbol("finitialize"), 1);
+    nrn_double_pop();
+    ok &= close_to(nrn_segment_diam_get(s, 0.5), 10.0, "diam read after finitialize");
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## What

Makes `nrn_segment_diam_get` return the 3d-derived segment diameter even before
an explicit geometry pass. When a section's geometry comes from `pt3dadd`, NEURON
derives the segment diam from those points lazily, and the getter now triggers
that recompute if it's pending.

## Why

When geometry is defined by 3d points, NEURON rewrites the segment diam from
those points lazily, gated per-section on `recalc_area_`. `nrn_segment_diam_get`
read the range-variable pointer without checking that flag, so a diam read after
`pt3dadd` (before `define_shape` or `finitialize`) returned a stale default
rather than the 3d-derived value. The Python getter already does this recompute
(`nrnpy_nrn.cpp`), so this brings the C API in line and removes a foot-gun for
the MATLAB, C++, and ctypes consumers of the header.

## Implementation

Mirror the range-variable read path: if the section has a pending recompute, run
it before reading.

```c
if (sec && sec->recalc_area_) {
    nrn_area_ri(sec);
}
```

Uses the per-section `recalc_area_` flag and `nrn_area_ri`, not the global
`diam_changed` / `recalc_diam`. `recalc_diam` rebuilds the whole solver matrix
over every section (heavy, surprising from a getter) and asserts `!tree_changed`,
so it can abort if called before topology is set up. Staleness is per-section,
which is why the normal read paths guard on `recalc_area_`.

## Test

`test/api/segment_diam.cpp` builds a section with two 3d points of diameter 10,
so diam is 10 everywhere, and checks `nrn_segment_diam_get` returns 10 both before
any geometry pass (the fix) and after `finitialize`. Documented in `capi.rst`.
