### PR TITLE
neuronapi: add nrn_object_ptr_push for writable objref arguments

### DIFF
--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -873,6 +873,35 @@ Functions, objects, and the stack
 
     Used when passing objects as arguments to functions or methods.
 
+.. c:function:: void nrn_object_ref_push(Object** obj_ref)
+
+    Push a writable object-reference cell onto the stack.
+
+    :param obj_ref: Address of the caller's ``Object*`` cell.
+
+    Unlike :c:func:`nrn_object_push`, which pushes an object by value, this
+    pushes the *cell* holding the object. When the callee assigns to the
+    matching ``$oN`` argument, the assignment writes back through the cell and
+    updates ``*obj_ref`` in place. This is the out-parameter form used by the
+    ``h.ref(obj)`` idiom, where a function returns a value by storing it in a
+    caller-supplied object reference.
+
+    **Usage Pattern:**
+
+    .. code-block:: c
+
+        // proc setit() { $o1 = new Vector(3) }
+        Object* slot = nullptr;
+        nrn_object_ref_push(&slot);
+        nrn_function_call(nrn_symbol("setit"), 1);
+        // slot now points to the newly created Vector; unref when done.
+        nrn_object_unref(slot);
+
+    .. seealso::
+
+        :c:func:`nrn_object_push`,
+        :c:func:`nrn_object_unref`
+
 .. c:function:: Object* nrn_object_pop(void)
 
     Pop an object from the stack.

--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -871,9 +871,13 @@ Functions, objects, and the stack
 
     **Usage Pattern:**
 
-    Used when passing objects as arguments to functions or methods.
+    Used when passing objects as arguments to functions or methods. The callee
+    receives the object by value; if the callee's argument was not declared as
+    an ``objref`` and it tries to assign to it (``$oN = ...``), HOC raises an
+    error. To pass an object reference a callee can assign back into, use
+    :c:func:`nrn_object_ptr_push`.
 
-.. c:function:: void nrn_object_ref_push(Object** obj_ref)
+.. c:function:: void nrn_object_ptr_push(Object** obj_ref)
 
     Push a writable object-reference cell onto the stack.
 
@@ -884,7 +888,9 @@ Functions, objects, and the stack
     matching ``$oN`` argument, the assignment writes back through the cell and
     updates ``*obj_ref`` in place. This is the out-parameter form used by the
     ``h.ref(obj)`` idiom, where a function returns a value by storing it in a
-    caller-supplied object reference.
+    caller-supplied object reference. ("ptr", as in :c:func:`nrn_double_ptr_push`,
+    is the pushed-pointer naming; the "ref" in :c:func:`nrn_object_ref` is
+    reference counting.)
 
     **Usage Pattern:**
 
@@ -892,7 +898,7 @@ Functions, objects, and the stack
 
         // proc setit() { $o1 = new Vector(3) }
         Object* slot = nullptr;
-        nrn_object_ref_push(&slot);
+        nrn_object_ptr_push(&slot);
         nrn_function_call(nrn_symbol("setit"), 1);
         // slot now points to the newly created Vector; unref when done.
         nrn_object_unref(slot);

--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -879,13 +879,13 @@ Functions, objects, and the stack
 
 .. c:function:: void nrn_object_ptr_push(Object** obj_ref)
 
-    Push a writable object-reference cell onto the stack.
+    Push a writable object-reference slot onto the stack.
 
-    :param obj_ref: Address of the caller's ``Object*`` cell.
+    :param obj_ref: Address of the caller's ``Object*`` slot.
 
     Unlike :c:func:`nrn_object_push`, which pushes an object by value, this
-    pushes the *cell* holding the object. When the callee assigns to the
-    matching ``$oN`` argument, the assignment writes back through the cell and
+    pushes the *slot* holding the object. When the callee assigns to the
+    matching ``$oN`` argument, the assignment writes back through the slot and
     updates ``*obj_ref`` in place. This is the out-parameter form used by the
     ``h.ref(obj)`` idiom, where a function returns a value by storing it in a
     caller-supplied object reference. ("ptr", as in :c:func:`nrn_double_ptr_push`,

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -317,6 +317,15 @@ void nrn_object_push(Object* obj) {
     hoc_push_object(obj);
 }
 
+void nrn_object_ref_push(Object** obj_ref) {
+    // Push a writable object-reference cell (the out-parameter form of
+    // nrn_object_push). When a callee assigns to the corresponding $oN arg,
+    // hoc assigns through this cell, updating *obj_ref in place. Unlike
+    // nrn_object_push, which pushes an object by value, this exposes the
+    // h.ref(obj) idiom (a callee that writes back into the caller's objref).
+    hoc_pushobj(obj_ref);
+}
+
 Object* nrn_object_pop(void) {
     // NOTE: the returned object should be unref'd when no longer needed
     Object** obptr = hoc_objpop();

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -318,9 +318,9 @@ void nrn_object_push(Object* obj) {
 }
 
 void nrn_object_ptr_push(Object** obj_ref) {
-    // Push a writable object-reference cell (the out-parameter form of
+    // Push a writable object-reference slot (the out-parameter form of
     // nrn_object_push). When a callee assigns to the corresponding $oN arg,
-    // hoc assigns through this cell, updating *obj_ref in place. Unlike
+    // hoc assigns through this slot, updating *obj_ref in place. Unlike
     // nrn_object_push, which pushes an object by value, this exposes the
     // h.ref(obj) idiom (a callee that writes back into the caller's objref).
     // Named for the pointer it pushes (cf. nrn_double_ptr_push); the "ref" in

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -317,12 +317,14 @@ void nrn_object_push(Object* obj) {
     hoc_push_object(obj);
 }
 
-void nrn_object_ref_push(Object** obj_ref) {
+void nrn_object_ptr_push(Object** obj_ref) {
     // Push a writable object-reference cell (the out-parameter form of
     // nrn_object_push). When a callee assigns to the corresponding $oN arg,
     // hoc assigns through this cell, updating *obj_ref in place. Unlike
     // nrn_object_push, which pushes an object by value, this exposes the
     // h.ref(obj) idiom (a callee that writes back into the caller's objref).
+    // Named for the pointer it pushes (cf. nrn_double_ptr_push); the "ref" in
+    // nrn_object_ref/unref is reference counting, a different concept.
     hoc_pushobj(obj_ref);
 }
 

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -91,6 +91,7 @@ char** nrn_str_pop(void);
 void nrn_int_push(int i);
 int nrn_int_pop(void);
 void nrn_object_push(Object* obj);
+void nrn_object_ref_push(Object** obj_ref);
 Object* nrn_object_pop(void);
 nrn_stack_types_t nrn_stack_type(void);
 char const* nrn_stack_type_name(nrn_stack_types_t id);

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -91,7 +91,7 @@ char** nrn_str_pop(void);
 void nrn_int_push(int i);
 int nrn_int_pop(void);
 void nrn_object_push(Object* obj);
-void nrn_object_ref_push(Object** obj_ref);
+void nrn_object_ptr_push(Object** obj_ref);
 Object* nrn_object_pop(void);
 nrn_stack_types_t nrn_stack_type(void);
 char const* nrn_stack_type_name(nrn_stack_types_t id);

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -5,7 +5,7 @@ foreach(
   netcon.cpp
   node_index.cpp
   object_new_wrap.cpp
-  object_ref_push.cpp
+  object_ptr_push.cpp
   segment_diam.cpp
   sections.cpp
   vclamp.cpp)

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -5,6 +5,7 @@ foreach(
   netcon.cpp
   node_index.cpp
   object_new_wrap.cpp
+  object_ref_push.cpp
   segment_diam.cpp
   sections.cpp
   vclamp.cpp)

--- a/test/api/object_ptr_push.cpp
+++ b/test/api/object_ptr_push.cpp
@@ -1,5 +1,5 @@
 // NOTE: this assumes neuronapi.h is on your CPLUS_INCLUDE_PATH
-// Exercises nrn_object_ref_push, which pushes a writable object-reference cell
+// Exercises nrn_object_ptr_push, which pushes a writable object-reference cell
 // (an Object**) rather than an object by value. This is the out-parameter form
 // behind the h.ref(obj) idiom: a callee that assigns to its $oN arg writes back
 // through the cell. nrn_object_push (by value) cannot express this.
@@ -20,7 +20,7 @@ static bool check(bool cond, const char* msg) {
 }
 
 int main(void) {
-    static std::array<const char*, 4> argv = {"object_ref_push", "-nogui", "-nopython", nullptr};
+    static std::array<const char*, 4> argv = {"object_ptr_push", "-nogui", "-nopython", nullptr};
     nrn_init(3, argv.data());
 
     bool ok = true;
@@ -33,13 +33,13 @@ int main(void) {
     // Write-back: push the address of an empty cell, call make3, and confirm the
     // cell was populated. A by-value push could not update `slot` here.
     Object* slot = nullptr;
-    nrn_object_ref_push(&slot);
+    nrn_object_ptr_push(&slot);
     nrn_function_call(nrn_symbol("make3"), 1);
     ok &= check(slot != nullptr, "objref cell was written back by the callee");
     ok &= check(nrn_vector_capacity(slot) == 3, "written-back Vector has capacity 3");
 
     // Read direction: push the now-populated cell and have HOC read $o1.size().
-    nrn_object_ref_push(&slot);
+    nrn_object_ptr_push(&slot);
     nrn_function_call(nrn_symbol("readsize"), 1);
     double* ac = nrn_symbol_dataptr(nrn_symbol("hoc_ac_"));
     ok &= check(ac != nullptr && *ac == 3.0, "HOC read the pushed object's size through the cell");

--- a/test/api/object_ref_push.cpp
+++ b/test/api/object_ref_push.cpp
@@ -1,0 +1,49 @@
+// NOTE: this assumes neuronapi.h is on your CPLUS_INCLUDE_PATH
+// Exercises nrn_object_ref_push, which pushes a writable object-reference cell
+// (an Object**) rather than an object by value. This is the out-parameter form
+// behind the h.ref(obj) idiom: a callee that assigns to its $oN arg writes back
+// through the cell. nrn_object_push (by value) cannot express this.
+#include <array>
+#include <iostream>
+#include "neuronapi.h"
+
+using std::cerr;
+using std::endl;
+
+extern "C" void modl_reg(){/* No modl_reg */};
+
+static bool check(bool cond, const char* msg) {
+    if (!cond) {
+        cerr << "FAIL: " << msg << endl;
+    }
+    return cond;
+}
+
+int main(void) {
+    static std::array<const char*, 4> argv = {"object_ref_push", "-nogui", "-nopython", nullptr};
+    nrn_init(3, argv.data());
+
+    bool ok = true;
+
+    // A proc whose sole job is to write a fresh Vector back into its objref arg.
+    nrn_hoc_call("proc make3() { $o1 = new Vector(3) }");
+    // And one that reads the passed object's size into the built-in hoc_ac_.
+    nrn_hoc_call("proc readsize() { hoc_ac_ = $o1.size() }");
+
+    // Write-back: push the address of an empty cell, call make3, and confirm the
+    // cell was populated. A by-value push could not update `slot` here.
+    Object* slot = nullptr;
+    nrn_object_ref_push(&slot);
+    nrn_function_call(nrn_symbol("make3"), 1);
+    ok &= check(slot != nullptr, "objref cell was written back by the callee");
+    ok &= check(nrn_vector_capacity(slot) == 3, "written-back Vector has capacity 3");
+
+    // Read direction: push the now-populated cell and have HOC read $o1.size().
+    nrn_object_ref_push(&slot);
+    nrn_function_call(nrn_symbol("readsize"), 1);
+    double* ac = nrn_symbol_dataptr(nrn_symbol("hoc_ac_"));
+    ok &= check(ac != nullptr && *ac == 3.0, "HOC read the pushed object's size through the cell");
+
+    nrn_object_unref(slot);
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
Adds `nrn_object_ref_push(Object\*\* obj_ref)` to the public C API.

## What and why

`nrn_object_push(Object\*)` pushes an object by value, which is fine for read-only arguments. It cannot express the *out-parameter* idiom, where a callee assigns to its `$oN` argument and the value is written back into the caller's object reference (HOC's `h.ref(obj)` / `foo(objref_var)` pattern). Internally that path goes through `hoc_pushobj(Object\*\*)`, which pushes the writable cell rather than the object.

Bindings that need this (myneuron's `h.ref(obj)` support, and equivalently the MATLAB interface) currently reach for the C++-mangled `hoc_pushobj` symbol because the public header exposes only the by-value push. This adds the missing Python-free primitive so no consumer has to bind an internal symbol.

## Changes

- `src/nrniv/neuronapi.h`, `src/nrniv/neuronapi.cpp`: declare and define `nrn_object_ref_push`, a thin wrapper over `hoc_pushobj`.
- `docs/capi.rst`: documented with a C usage example, cross-linked to `nrn_object_push` / `nrn_object_unref`.
- `test/api/object_ref_push.cpp`: exercises both directions. Write-back (a proc that does `$o1 = new Vector(3)` updates the caller's cell) and read (HOC reads `$o1.size()` through the pushed cell). Registered in `test/api/CMakeLists.txt`.

Same structure as #3810. `make format-pr` clean (clang-format 12.0.1, cmakelang 0.6.13). The api test passes locally (`ctest -R object_ref_push`).