### PR TITLE
neuronapi: add nrn_object_new_wrap to wrap a C++ payload as an object

### DIFF
--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -949,6 +949,28 @@ Functions, objects, and the stack
         vec = n.Vector(100)           # Vector with 100 elements
         iclamp = n.IClamp(soma(0))    # Current clamp at soma
 
+.. c:function:: Object* nrn_object_new_wrap(Symbol* sym, void* cpp_object)
+
+    Wrap an existing C++ payload as an object of a C++ class.
+
+    :param sym: Symbol for a C++ (``CPLUSOBJECT``) class/template.
+    :param cpp_object: The backing C++ pointer to store as the object's
+        ``this_pointer``, or ``NULL`` to construct an unbacked instance to fill
+        in later.
+    :returns: The new object, with reference count 0.
+
+    Unlike :c:func:`nrn_object_new`, which runs the HOC constructor and consumes
+    arguments from the stack, this backs the new object directly with a pointer
+    the caller already holds. It is the primitive behind wrapping a foreign C++
+    object (for example a Python object or an NMODL ``RANDOM`` state) as a HOC
+    object. The returned object has reference count 0; call
+    :c:func:`nrn_object_ref` to keep it alive.
+
+    .. seealso::
+
+        :c:func:`nrn_object_new`,
+        :c:func:`nrn_object_ref`
+
 .. c:function:: Symbol* nrn_method_symbol(const Object* obj, const char* name)
 
     Get a method symbol from an object by name.

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -371,6 +371,16 @@ Object* nrn_object_new(Symbol* sym, int narg) {
     return hoc_newobj1(sym, narg);
 }
 
+Object* nrn_object_new_wrap(Symbol* sym, void* cpp_object) {
+    // Wrap an existing C++ payload as a HOC Object of the class `sym` (which
+    // must be a C++/CPLUSOBJECT template). Unlike nrn_object_new, which runs the
+    // HOC constructor and pulls arguments off the stack, this backs the new
+    // object directly with `cpp_object`, stored as its this_pointer. Pass
+    // nullptr to construct an unbacked instance to fill in later. The returned
+    // object has refcount 0; ref it (nrn_object_ref) to keep it alive.
+    return hoc_new_object(sym, cpp_object);
+}
+
 Symbol* nrn_method_symbol(const Object* obj, char const* const name) {
     return hoc_table_lookup(name, obj->ctemplate->symtable);
 }

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -95,6 +95,7 @@ Object* nrn_object_pop(void);
 nrn_stack_types_t nrn_stack_type(void);
 char const* nrn_stack_type_name(nrn_stack_types_t id);
 Object* nrn_object_new(Symbol* sym, int narg);
+Object* nrn_object_new_wrap(Symbol* sym, void* cpp_object);
 Symbol* nrn_method_symbol(const Object* obj, const char* name);
 // TODO: the next two functions throw exceptions in C++; need a version that
 //       returns a bool success indicator instead (this is actually the

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -4,6 +4,7 @@ foreach(
   hh_sim.cpp
   netcon.cpp
   node_index.cpp
+  object_new_wrap.cpp
   segment_diam.cpp
   sections.cpp
   vclamp.cpp)

--- a/test/api/object_new_wrap.cpp
+++ b/test/api/object_new_wrap.cpp
@@ -1,0 +1,55 @@
+// NOTE: this assumes neuronapi.h is on your CPLUS_INCLUDE_PATH
+// Exercises nrn_object_new_wrap, which wraps a caller-owned C++ payload as a HOC
+// object of a C++ class, storing the payload as the object's this_pointer. This
+// is distinct from nrn_object_new, which runs the HOC constructor. SectionList
+// is a convenient always-present C++ class here: the public nrn_sectionlist_data
+// reads an object's this_pointer back, so the payload round-trip is observable
+// without depending on Python or a custom mechanism.
+#include <array>
+#include <cstring>
+#include <iostream>
+#include "neuronapi.h"
+
+using std::cerr;
+using std::endl;
+
+extern "C" void modl_reg(){/* No modl_reg */};
+
+static bool check(bool cond, const char* msg) {
+    if (!cond) {
+        cerr << "FAIL: " << msg << endl;
+    }
+    return cond;
+}
+
+int main(void) {
+    static std::array<const char*, 4> argv = {"object_new_wrap", "-nogui", "-nopython", nullptr};
+    nrn_init(3, argv.data());
+
+    bool ok = true;
+
+    Symbol* sl_sym = nrn_symbol("SectionList");
+    ok &= check(sl_sym != nullptr, "SectionList symbol exists");
+
+    // Wrap a stand-in payload. `backing` is never dereferenced as a SectionList;
+    // we only confirm the pointer is stored and read back. The wrapped object is
+    // ref'd (refcount 0 -> 1) so it is not destroyed, and no SectionList method
+    // is called on it.
+    int backing = 0;
+    Object* wrapped = nrn_object_new_wrap(sl_sym, &backing);
+    ok &= check(wrapped != nullptr, "wrap returns a non-null object");
+    nrn_object_ref(wrapped);
+    ok &= check(std::strcmp(nrn_class_name(wrapped), "SectionList") == 0,
+                "wrapped object's class is SectionList");
+    ok &= check(static_cast<void*>(nrn_sectionlist_data(wrapped)) == static_cast<void*>(&backing),
+                "the payload was stored as the object's backing pointer");
+
+    // A null payload is valid too (construct now, fill in the backing later) and
+    // yields an object with a null this_pointer.
+    Object* empty = nrn_object_new_wrap(sl_sym, nullptr);
+    ok &= check(empty != nullptr, "null-payload wrap returns a non-null object");
+    nrn_object_ref(empty);
+    ok &= check(nrn_sectionlist_data(empty) == nullptr, "null payload stored as null backing");
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
Adds `nrn_object_new_wrap(Symbol\* sym, void\* cpp_object)` to the public C API.

## What and why

`nrn_object_new(Symbol\*, int narg)` runs a HOC constructor, pulling arguments off the stack. It cannot wrap a C++ object the caller already holds. The internal path for that is `hoc_new_object(Symbol\*, void\*)`, which allocates a HOC Object of a C++ (`CPLUSOBJECT`) template and stores the supplied pointer as its `this_pointer`.

This is the primitive behind wrapping a foreign C++ payload as a HOC object (for example a Python object, or an NMODL `RANDOM` state). Bindings that need it (myneuron's Python-object path, and equivalently other non-CPython consumers) currently reach for the C++-mangled `hoc_new_object` symbol because the public header offers only the constructor form. This adds the missing Python-free primitive.

## Changes

- `src/nrniv/neuronapi.h`, `src/nrniv/neuronapi.cpp`: declare and define `nrn_object_new_wrap`, a thin wrapper over `hoc_new_object`.
- `docs/capi.rst`: documented, cross-linked to `nrn_object_new` / `nrn_object_ref`.
- `test/api/object_new_wrap.cpp`: wraps a payload into a `SectionList` (an always-present C++ class) and reads it back through the public `nrn_sectionlist_data`, confirming the payload is stored as the object's backing pointer; also covers the null-payload (construct-then-fill) case. Registered in `test/api/CMakeLists.txt`.

Same structure as #3810. `make format-pr` clean (clang-format 12.0.1, cmakelang 0.6.13). The api test passes locally (`ctest -R object_new_wrap`).

Companion to #3823 (`nrn_object_ref_push`); the two are independent and can merge in either order.