### PR TITLE
neuronapi: add nrn_setpointer_pop / nrn_pp_setpointer_pop for POINTER wiring

### DIFF
--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -688,6 +688,12 @@ Segments
         ``pointer_sym`` is not a ``POINTER`` variable or its mechanism is not
         present at the target segment.
 
+    This addresses the target by ``(sec, x)``, which identifies a density
+    mechanism's single instance at a segment. For a **point process**, where
+    several instances may share one location, use
+    :c:func:`nrn_pp_setpointer_pop`, which addresses the target by instance
+    object instead.
+
     This is the C-API equivalent of the HOC ``setpointer`` statement and of
     assigning a ``_ref_`` to a POINTER in Python. It stores a data handle to the
     source, so the connection survives internal data reordering.
@@ -696,13 +702,14 @@ Segments
 
     .. code-block:: c
 
-        // Wire a half-gap mechanism's vgap POINTER to the peer cell's voltage:
-        // cell2's membrane potential drives the gap current in cell1.
-        Symbol* vgap = nrn_symbol("vgap_halfgap");
+        // A density mechanism `cufl` has a POINTER `pv`. Wire dend's instance to
+        // read soma(0.5).v instead of its own segment's voltage. A density
+        // mechanism has one instance per segment, so (dend, 0.5) names it.
+        Symbol* pv = nrn_symbol("pv_cufl");
         Symbol* v = nrn_symbol("v");
         char err[256];
-        nrn_rangevar_push(v, cell2, 0.5);  // push the source pointer
-        if (nrn_setpointer_pop(vgap, cell1, 0.5, err, sizeof(err))) {
+        nrn_rangevar_push(v, soma, 0.5);  // push the source pointer
+        if (nrn_setpointer_pop(pv, dend, 0.5, err, sizeof(err))) {
             fprintf(stderr, "setpointer failed: %s\n", err);
         }
 
@@ -710,7 +717,53 @@ Segments
 
     .. code-block:: python
 
-        # halfgap1 is a POINT_PROCESS with a POINTER vgap
+        # cufl is a density mechanism (SUFFIX) with a POINTER pv
+        dend(0.5).cufl._ref_pv = soma(0.5)._ref_v
+
+
+.. c:function:: int nrn_pp_setpointer_pop(Object* pp, const char* name, char* error_msg, size_t error_msg_size)
+
+    Wire a point process's NMODL ``POINTER`` variable to the source pointer on
+    top of the stack.
+
+    This is the point-process counterpart to :c:func:`nrn_setpointer_pop`. A
+    point process is addressed by its instance object rather than by ``(sec,
+    x)``: several point processes may occupy one location (two half-gaps at one
+    segment, say), so the segment alone cannot identify which instance owns the
+    ``POINTER`` slot. The ``POINTER`` is named within the point process's own
+    symbol table, exactly as in :c:func:`nrn_property_get`.
+
+    As with :c:func:`nrn_setpointer_pop`, the source is whatever pointer the
+    caller has pushed (e.g. with :c:func:`nrn_rangevar_push` or
+    :c:func:`nrn_property_push`), and it is consumed even on the error paths, so
+    the stack is left balanced.
+
+    :param pp: The point process instance whose ``POINTER`` is the target.
+    :param name: Name of the ``POINTER`` variable within the point process.
+    :param error_msg: Buffer filled with a message on failure (may be ``NULL``).
+    :param error_msg_size: Size of ``error_msg``.
+    :returns: 0 on success; nonzero on error, with ``error_msg`` populated when
+        ``pp`` is not a point process, ``name`` is not one of its ``POINTER``
+        variables, or the point process is not located in a section.
+
+    **C Usage:**
+
+    .. code-block:: c
+
+        // Wire a half-gap point process's vgap POINTER to the peer cell's
+        // voltage: cell2's membrane potential drives the gap current the
+        // HalfGap instance on cell1 computes. A true half gap wires both ways.
+        char err[256];
+        nrn_rangevar_push(nrn_symbol("v"), cell2, 0.5);  // push the source pointer
+        if (nrn_pp_setpointer_pop(halfgap1, "vgap", err, sizeof(err))) {
+            fprintf(stderr, "setpointer failed: %s\n", err);
+        }
+
+    **Python Equivalent:**
+
+    .. code-block:: python
+
+        # halfgap1 is a POINT_PROCESS instance with a POINTER vgap
         halfgap1._ref_vgap = cell2(0.5)._ref_v
 
 

--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -720,6 +720,9 @@ Segments
         # cufl is a density mechanism (SUFFIX) with a POINTER pv
         dend(0.5).cufl._ref_pv = soma(0.5)._ref_v
 
+    .. seealso::
+
+        :c:func:`nrn_pp_setpointer_pop`, :c:func:`nrn_rangevar_push`
 
 .. c:function:: int nrn_pp_setpointer_pop(Object* pp, const char* name, char* error_msg, size_t error_msg_size)
 
@@ -765,6 +768,10 @@ Segments
 
         # halfgap1 is a POINT_PROCESS instance with a POINTER vgap
         halfgap1._ref_vgap = cell2(0.5)._ref_v
+
+    .. seealso::
+
+        :c:func:`nrn_setpointer_pop`, :c:func:`nrn_property_push`, :c:func:`nrn_rangevar_push`
 
 
 Functions, objects, and the stack

--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -668,6 +668,48 @@ Segments
             seg.g_pas = 0.001  # S/cm²
 
 
+.. c:function:: int nrn_setpointer(Symbol* pointer_sym, Section* sec, double x, Symbol* src_sym, Section* src_sec, double src_x, char* error_msg, size_t error_msg_size)
+
+    Wire an NMODL ``POINTER`` variable to a source variable's storage.
+
+    :param pointer_sym: Symbol of the ``POINTER`` range variable to wire (the
+        target).
+    :param sec: Section of the mechanism instance owning the POINTER.
+    :param x: Normalized position (0.0 to 1.0) of that instance.
+    :param src_sym: Symbol of the source range variable.
+    :param src_sec: Section of the source variable.
+    :param src_x: Normalized position of the source variable.
+    :param error_msg: Buffer filled with a message on failure (may be ``NULL``).
+    :param error_msg_size: Size of ``error_msg``.
+    :returns: 0 on success; nonzero on error, with ``error_msg`` populated when
+        ``pointer_sym`` is not a ``POINTER`` variable or its mechanism is not
+        present at the target segment.
+
+    This is the C-API equivalent of the HOC ``setpointer`` statement and of
+    assigning a ``_ref_`` to a POINTER in Python. It stores a data handle to the
+    source, so the connection survives internal data reordering.
+
+    **C Usage:**
+
+    .. code-block:: c
+
+        // Wire a half-gap mechanism's vgap POINTER to the peer cell's voltage:
+        // cell2's membrane potential drives the gap current in cell1.
+        Symbol* vgap = nrn_symbol("vgap_halfgap");
+        Symbol* v = nrn_symbol("v");
+        char err[256];
+        if (nrn_setpointer(vgap, cell1, 0.5, v, cell2, 0.5, err, sizeof(err))) {
+            fprintf(stderr, "setpointer failed: %s\n", err);
+        }
+
+    **Python Equivalent:**
+
+    .. code-block:: python
+
+        # halfgap1 is a POINT_PROCESS with a POINTER vgap
+        halfgap1._ref_vgap = cell2(0.5)._ref_v
+
+
 Functions, objects, and the stack
 ---------------------------------
 

--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -668,17 +668,20 @@ Segments
             seg.g_pas = 0.001  # S/cm²
 
 
-.. c:function:: int nrn_setpointer(Symbol* pointer_sym, Section* sec, double x, Symbol* src_sym, Section* src_sec, double src_x, char* error_msg, size_t error_msg_size)
+.. c:function:: int nrn_setpointer_pop(Symbol* pointer_sym, Section* sec, double x, char* error_msg, size_t error_msg_size)
 
-    Wire an NMODL ``POINTER`` variable to a source variable's storage.
+    Wire an NMODL ``POINTER`` variable to the source pointer on top of the stack.
+
+    The source is whatever pointer the caller has pushed, e.g. with
+    :c:func:`nrn_rangevar_push`. Pushing the source rather than naming it lets
+    this single function accept a pointer obtained any way the stack supports,
+    instead of enumerating source kinds. The pushed pointer is consumed (popped)
+    even on the error paths, so the stack is left balanced.
 
     :param pointer_sym: Symbol of the ``POINTER`` range variable to wire (the
         target).
     :param sec: Section of the mechanism instance owning the POINTER.
     :param x: Normalized position (0.0 to 1.0) of that instance.
-    :param src_sym: Symbol of the source range variable.
-    :param src_sec: Section of the source variable.
-    :param src_x: Normalized position of the source variable.
     :param error_msg: Buffer filled with a message on failure (may be ``NULL``).
     :param error_msg_size: Size of ``error_msg``.
     :returns: 0 on success; nonzero on error, with ``error_msg`` populated when
@@ -698,7 +701,8 @@ Segments
         Symbol* vgap = nrn_symbol("vgap_halfgap");
         Symbol* v = nrn_symbol("v");
         char err[256];
-        if (nrn_setpointer(vgap, cell1, 0.5, v, cell2, 0.5, err, sizeof(err))) {
+        nrn_rangevar_push(v, cell2, 0.5);  // push the source pointer
+        if (nrn_setpointer_pop(vgap, cell1, 0.5, err, sizeof(err))) {
             fprintf(stderr, "setpointer failed: %s\n", err);
         }
 

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -230,6 +230,50 @@ void nrn_rangevar_push(Symbol* sym, Section* sec, double x) {
     hoc_push(nrn_rangepointer(sec, sym, x));
 }
 
+int nrn_setpointer(Symbol* pointer_sym,
+                   Section* sec,
+                   double x,
+                   Symbol* src_sym,
+                   Section* src_sec,
+                   double src_x,
+                   char* error_msg,
+                   size_t error_msg_size) {
+    if (error_msg && error_msg_size > 0) {
+        error_msg[0] = '\0';
+    }
+    auto fail = [&](const char* msg) {
+        if (error_msg && error_msg_size > 0) {
+            strncpy(error_msg, msg, error_msg_size - 1);
+            error_msg[error_msg_size - 1] = '\0';
+        }
+        return 1;
+    };
+    // Only a mechanism POINTER range variable can be a setpointer target; the
+    // slot it wires lives in the mechanism's dparam array (mirrors the guard in
+    // nrn_pointer_assign / nrnpy_nrn.cpp).
+    if (!pointer_sym || pointer_sym->type != RANGEVAR || pointer_sym->subtype != NRNPOINTER) {
+        return fail("target is not a POINTER range variable");
+    }
+    // Locate the mechanism instance that owns this POINTER at (sec, x).
+    Node* const nd = node_exact(sec, x);
+    Prop* prop = nullptr;
+    for (Prop* p = nd->prop; p; p = p->next) {
+        if (p->_type == pointer_sym->u.rng.type) {
+            prop = p;
+            break;
+        }
+    }
+    if (!prop) {
+        return fail("the POINTER's mechanism is not present at the target segment");
+    }
+    // Wire the POINTER to the source variable's storage. nrn_rangepointer yields
+    // a data handle (stable across data permutation), which is exactly what the
+    // dparam slot stores -- the same assignment nrn_pointer_assign performs,
+    // without the PyObject* source.
+    prop->dparam[pointer_sym->u.rng.index] = nrn_rangepointer(src_sec, src_sym, src_x);
+    return 0;
+}
+
 nrn_Item* nrn_allsec(void) {
     return static_cast<nrn_Item*>(section_list);
 }

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -274,6 +274,45 @@ int nrn_setpointer_pop(Symbol* pointer_sym,
     return 0;
 }
 
+int nrn_pp_setpointer_pop(Object* pp, const char* name, char* error_msg, size_t error_msg_size) {
+    if (error_msg && error_msg_size > 0) {
+        error_msg[0] = '\0';
+    }
+    auto fail = [&](const char* msg) {
+        if (error_msg && error_msg_size > 0) {
+            std::snprintf(error_msg, error_msg_size, "%s", msg);
+        }
+        return 1;
+    };
+    // Pop the source first (as nrn_setpointer_pop does) so the stack stays
+    // balanced on every error path below. It is the same data handle a dparam
+    // slot holds, obtained any way the stack supports (nrn_rangevar_push,
+    // nrn_property_push, ...).
+    neuron::container::data_handle<double> src = hoc_pop_handle<double>();
+    // A point process is addressed by its instance object, not by (sec, x):
+    // several point processes may share one location, so the segment alone
+    // cannot say which instance owns the POINTER slot. This is the difference
+    // from nrn_setpointer_pop, whose (sec, x) uniquely identifies the single
+    // density-mechanism instance at a segment.
+    if (!pp || !pp->ctemplate || !pp->ctemplate->is_point_) {
+        return fail("object is not a point process");
+    }
+    // Resolve the POINTER by name in the point process's own symbol table, the
+    // same lookup nrn_property_get uses (bare name, e.g. "vgap").
+    Symbol* pointer_sym = hoc_table_lookup(name, pp->ctemplate->symtable);
+    if (!pointer_sym || pointer_sym->type != RANGEVAR || pointer_sym->subtype != NRNPOINTER) {
+        return fail("target is not a POINTER variable of this point process");
+    }
+    auto* const pnt = ob2pntproc_0(pp);
+    if (!pnt || !pnt->prop) {
+        return fail("point process is not located in a section");
+    }
+    // Wire the POINTER to the popped source handle -- the same slot assignment
+    // nrn_setpointer_pop and nrn_pointer_assign perform, minus the PyObject*.
+    pnt->prop->dparam[pointer_sym->u.rng.index] = src;
+    return 0;
+}
+
 nrn_Item* nrn_allsec(void) {
     return static_cast<nrn_Item*>(section_list);
 }

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -230,24 +230,25 @@ void nrn_rangevar_push(Symbol* sym, Section* sec, double x) {
     hoc_push(nrn_rangepointer(sec, sym, x));
 }
 
-int nrn_setpointer(Symbol* pointer_sym,
-                   Section* sec,
-                   double x,
-                   Symbol* src_sym,
-                   Section* src_sec,
-                   double src_x,
-                   char* error_msg,
-                   size_t error_msg_size) {
+int nrn_setpointer_pop(Symbol* pointer_sym,
+                       Section* sec,
+                       double x,
+                       char* error_msg,
+                       size_t error_msg_size) {
     if (error_msg && error_msg_size > 0) {
         error_msg[0] = '\0';
     }
     auto fail = [&](const char* msg) {
         if (error_msg && error_msg_size > 0) {
-            strncpy(error_msg, msg, error_msg_size - 1);
-            error_msg[error_msg_size - 1] = '\0';
+            std::snprintf(error_msg, error_msg_size, "%s", msg);
         }
         return 1;
     };
+    // The source pointer is whatever the caller pushed (e.g. via
+    // nrn_rangevar_push), which reuses every existing way of obtaining one. Pop
+    // it first, before the validations below, so the stack stays balanced even
+    // on the error paths. It is the same data handle a dparam slot holds.
+    neuron::container::data_handle<double> src = hoc_pop_handle<double>();
     // Only a mechanism POINTER range variable can be a setpointer target; the
     // slot it wires lives in the mechanism's dparam array (mirrors the guard in
     // nrn_pointer_assign / nrnpy_nrn.cpp).
@@ -266,11 +267,10 @@ int nrn_setpointer(Symbol* pointer_sym,
     if (!prop) {
         return fail("the POINTER's mechanism is not present at the target segment");
     }
-    // Wire the POINTER to the source variable's storage. nrn_rangepointer yields
-    // a data handle (stable across data permutation), which is exactly what the
-    // dparam slot stores -- the same assignment nrn_pointer_assign performs,
-    // without the PyObject* source.
-    prop->dparam[pointer_sym->u.rng.index] = nrn_rangepointer(src_sec, src_sym, src_x);
+    // Wire the POINTER to the popped source handle (stable across data
+    // permutation), the same assignment nrn_pointer_assign performs without the
+    // PyObject* source.
+    prop->dparam[pointer_sym->u.rng.index] = src;
     return 0;
 }
 

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -77,6 +77,7 @@ int nrn_setpointer_pop(Symbol* pointer_sym,
                        double x,
                        char* error_msg,
                        size_t error_msg_size);
+int nrn_pp_setpointer_pop(Object* pp, const char* name, char* error_msg, size_t error_msg_size);
 
 /****************************************
  * Functions, objects, and the stack

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -72,14 +72,11 @@ int nrn_segment_node_index(Section* sec, double x);
 void nrn_rangevar_push(Symbol* sym, Section* sec, double x);
 double nrn_rangevar_get(Symbol* sym, Section* sec, double x);
 void nrn_rangevar_set(Symbol* sym, Section* sec, double x, double value);
-int nrn_setpointer(Symbol* pointer_sym,
-                   Section* sec,
-                   double x,
-                   Symbol* src_sym,
-                   Section* src_sec,
-                   double src_x,
-                   char* error_msg,
-                   size_t error_msg_size);
+int nrn_setpointer_pop(Symbol* pointer_sym,
+                       Section* sec,
+                       double x,
+                       char* error_msg,
+                       size_t error_msg_size);
 
 /****************************************
  * Functions, objects, and the stack

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -72,6 +72,14 @@ int nrn_segment_node_index(Section* sec, double x);
 void nrn_rangevar_push(Symbol* sym, Section* sec, double x);
 double nrn_rangevar_get(Symbol* sym, Section* sec, double x);
 void nrn_rangevar_set(Symbol* sym, Section* sec, double x, double value);
+int nrn_setpointer(Symbol* pointer_sym,
+                   Section* sec,
+                   double x,
+                   Symbol* src_sym,
+                   Section* src_sec,
+                   double src_x,
+                   char* error_msg,
+                   size_t error_msg_size);
 
 /****************************************
  * Functions, objects, and the stack

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -22,3 +22,38 @@ foreach(
   set_property(TEST "${test_name}" PROPERTY ENVIRONMENT "${NRN_RUN_FROM_BUILD_DIR_ENV}"
                                             "CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
 endforeach()
+
+# The nrn_setpointer test needs a mechanism with a POINTER, which no built-in provides. Generate one
+# from ptrtest.mod with nocmodl and compile it into the test executable, the same codegen path nrniv
+# uses for its built-in mechanisms.
+set(setpointer_mod "${CMAKE_CURRENT_SOURCE_DIR}/ptrtest.mod")
+set(setpointer_mod_copy "${CMAKE_CURRENT_BINARY_DIR}/ptrtest.mod")
+set(setpointer_gen "${CMAKE_CURRENT_BINARY_DIR}/ptrtest.cpp")
+configure_file("${setpointer_mod}" "${setpointer_mod_copy}" COPYONLY)
+add_custom_command(
+  OUTPUT ${setpointer_gen}
+  COMMAND
+    ${CMAKE_COMMAND} -E env "MODLUNIT=${PROJECT_BINARY_DIR}/share/nrn/lib/nrnunits.lib"
+    "NMODLHOME=${PROJECT_BINARY_DIR}" $<TARGET_FILE:${NRN_CODEGENERATOR_TARGET}>
+    ${setpointer_mod_copy} ${NRN_NMODL_--neuron} -o ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${NRN_CODEGENERATOR_TARGET} ${setpointer_mod}
+          ${PROJECT_BINARY_DIR}/share/nrn/lib/nrnunits.lib
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_executable(setpointer_cpp setpointer.cpp ${setpointer_gen})
+cpp_cc_configure_sanitizers(TARGET setpointer_cpp)
+# The generated mechanism includes NEURON internal headers (mech_api.h, the mechanism-cache headers,
+# ...); inherit them from nrniv_lib, plus the build's generated-header dir (nrnsemanticversion.h
+# etc.), which is a directory-scoped include not carried on the nrniv_lib target.
+target_include_directories(setpointer_cpp PRIVATE $<TARGET_PROPERTY:nrniv_lib,INCLUDE_DIRECTORIES>
+                                                  ${PROJECT_BINARY_DIR}/include)
+target_compile_definitions(setpointer_cpp PRIVATE $<TARGET_PROPERTY:nrniv_lib,COMPILE_DEFINITIONS>)
+target_link_libraries(setpointer_cpp ${CMAKE_DL_LIBS})
+target_link_libraries(setpointer_cpp nrniv_lib)
+target_link_options(setpointer_cpp PRIVATE -rdynamic)
+if(NRN_ENABLE_CORENEURON)
+  target_compile_definitions(setpointer_cpp PUBLIC CORENEURON_ENABLED)
+endif()
+add_test(NAME "api::setpointer_cpp" COMMAND setpointer_cpp)
+set_property(TEST "api::setpointer_cpp" PROPERTY ENVIRONMENT "${NRN_RUN_FROM_BUILD_DIR_ENV}"
+                                                 "CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -23,7 +23,7 @@ foreach(
                                             "CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
 endforeach()
 
-# The nrn_setpointer test needs a mechanism with a POINTER, which no built-in provides. Generate one
+# The nrn_setpointer_pop test needs a mechanism with a POINTER, which no built-in provides. Generate one
 # from ptrtest.mod with nocmodl and compile it into the test executable, the same codegen path nrniv
 # uses for its built-in mechanisms. NRN_NOCMODL_SANITIZER_ENVIRONMENT disables LeakSanitizer for the
 # nocmodl run (nocmodl leaks, which would otherwise fail the generation step under an asan build),

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -25,7 +25,9 @@ endforeach()
 
 # The nrn_setpointer test needs a mechanism with a POINTER, which no built-in provides. Generate one
 # from ptrtest.mod with nocmodl and compile it into the test executable, the same codegen path nrniv
-# uses for its built-in mechanisms.
+# uses for its built-in mechanisms. NRN_NOCMODL_SANITIZER_ENVIRONMENT disables LeakSanitizer for the
+# nocmodl run (nocmodl leaks, which would otherwise fail the generation step under an asan build),
+# matching nocmodl_mod_to_cpp in cmake/MacroHelper.cmake.
 set(setpointer_mod "${CMAKE_CURRENT_SOURCE_DIR}/ptrtest.mod")
 set(setpointer_mod_copy "${CMAKE_CURRENT_BINARY_DIR}/ptrtest.mod")
 set(setpointer_gen "${CMAKE_CURRENT_BINARY_DIR}/ptrtest.cpp")
@@ -34,8 +36,9 @@ add_custom_command(
   OUTPUT ${setpointer_gen}
   COMMAND
     ${CMAKE_COMMAND} -E env "MODLUNIT=${PROJECT_BINARY_DIR}/share/nrn/lib/nrnunits.lib"
-    "NMODLHOME=${PROJECT_BINARY_DIR}" $<TARGET_FILE:${NRN_CODEGENERATOR_TARGET}>
-    ${setpointer_mod_copy} ${NRN_NMODL_--neuron} -o ${CMAKE_CURRENT_BINARY_DIR}
+    "NMODLHOME=${PROJECT_BINARY_DIR}" ${NRN_NOCMODL_SANITIZER_ENVIRONMENT}
+    $<TARGET_FILE:${NRN_CODEGENERATOR_TARGET}> ${setpointer_mod_copy} ${NRN_NMODL_--neuron} -o
+    ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ${NRN_CODEGENERATOR_TARGET} ${setpointer_mod}
           ${PROJECT_BINARY_DIR}/share/nrn/lib/nrnunits.lib
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -23,11 +23,11 @@ foreach(
                                             "CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
 endforeach()
 
-# The nrn_setpointer_pop test needs a mechanism with a POINTER, which no built-in provides. Generate one
-# from ptrtest.mod with nocmodl and compile it into the test executable, the same codegen path nrniv
-# uses for its built-in mechanisms. NRN_NOCMODL_SANITIZER_ENVIRONMENT disables LeakSanitizer for the
-# nocmodl run (nocmodl leaks, which would otherwise fail the generation step under an asan build),
-# matching nocmodl_mod_to_cpp in cmake/MacroHelper.cmake.
+# The nrn_setpointer_pop test needs a mechanism with a POINTER, which no built-in provides. Generate
+# one from ptrtest.mod with nocmodl and compile it into the test executable, the same codegen path
+# nrniv uses for its built-in mechanisms. NRN_NOCMODL_SANITIZER_ENVIRONMENT disables LeakSanitizer
+# for the nocmodl run (nocmodl leaks, which would otherwise fail the generation step under an asan
+# build), matching nocmodl_mod_to_cpp in cmake/MacroHelper.cmake.
 set(setpointer_mod "${CMAKE_CURRENT_SOURCE_DIR}/ptrtest.mod")
 set(setpointer_mod_copy "${CMAKE_CURRENT_BINARY_DIR}/ptrtest.mod")
 set(setpointer_gen "${CMAKE_CURRENT_BINARY_DIR}/ptrtest.cpp")

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -23,27 +23,33 @@ foreach(
                                             "CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
 endforeach()
 
-# The nrn_setpointer_pop test needs a mechanism with a POINTER, which no built-in provides. Generate
-# one from ptrtest.mod with nocmodl and compile it into the test executable, the same codegen path
-# nrniv uses for its built-in mechanisms. NRN_NOCMODL_SANITIZER_ENVIRONMENT disables LeakSanitizer
-# for the nocmodl run (nocmodl leaks, which would otherwise fail the generation step under an asan
-# build), matching nocmodl_mod_to_cpp in cmake/MacroHelper.cmake.
-set(setpointer_mod "${CMAKE_CURRENT_SOURCE_DIR}/ptrtest.mod")
-set(setpointer_mod_copy "${CMAKE_CURRENT_BINARY_DIR}/ptrtest.mod")
-set(setpointer_gen "${CMAKE_CURRENT_BINARY_DIR}/ptrtest.cpp")
-configure_file("${setpointer_mod}" "${setpointer_mod_copy}" COPYONLY)
-add_custom_command(
-  OUTPUT ${setpointer_gen}
-  COMMAND
-    ${CMAKE_COMMAND} -E env "MODLUNIT=${PROJECT_BINARY_DIR}/share/nrn/lib/nrnunits.lib"
-    "NMODLHOME=${PROJECT_BINARY_DIR}" ${NRN_NOCMODL_SANITIZER_ENVIRONMENT}
-    $<TARGET_FILE:${NRN_CODEGENERATOR_TARGET}> ${setpointer_mod_copy} ${NRN_NMODL_--neuron} -o
-    ${CMAKE_CURRENT_BINARY_DIR}
-  DEPENDS ${NRN_CODEGENERATOR_TARGET} ${setpointer_mod}
-          ${PROJECT_BINARY_DIR}/share/nrn/lib/nrnunits.lib
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+# The setpointer tests need mechanisms with a POINTER, which no built-in provides: a density
+# mechanism (ptrtest.mod) for nrn_setpointer_pop and a point process (ppptrtest.mod) for
+# nrn_pp_setpointer_pop. Generate each from its .mod with nocmodl and compile them into the test
+# executable, the same codegen path nrniv uses for its built-in mechanisms.
+# NRN_NOCMODL_SANITIZER_ENVIRONMENT disables LeakSanitizer for the nocmodl run (nocmodl leaks, which
+# would otherwise fail the generation step under an asan build), matching nocmodl_mod_to_cpp in
+# cmake/MacroHelper.cmake.
+set(setpointer_gens "")
+foreach(setpointer_mod_name ptrtest ppptrtest)
+  set(setpointer_mod "${CMAKE_CURRENT_SOURCE_DIR}/${setpointer_mod_name}.mod")
+  set(setpointer_mod_copy "${CMAKE_CURRENT_BINARY_DIR}/${setpointer_mod_name}.mod")
+  set(setpointer_gen "${CMAKE_CURRENT_BINARY_DIR}/${setpointer_mod_name}.cpp")
+  configure_file("${setpointer_mod}" "${setpointer_mod_copy}" COPYONLY)
+  add_custom_command(
+    OUTPUT ${setpointer_gen}
+    COMMAND
+      ${CMAKE_COMMAND} -E env "MODLUNIT=${PROJECT_BINARY_DIR}/share/nrn/lib/nrnunits.lib"
+      "NMODLHOME=${PROJECT_BINARY_DIR}" ${NRN_NOCMODL_SANITIZER_ENVIRONMENT}
+      $<TARGET_FILE:${NRN_CODEGENERATOR_TARGET}> ${setpointer_mod_copy} ${NRN_NMODL_--neuron} -o
+      ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${NRN_CODEGENERATOR_TARGET} ${setpointer_mod}
+            ${PROJECT_BINARY_DIR}/share/nrn/lib/nrnunits.lib
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  list(APPEND setpointer_gens ${setpointer_gen})
+endforeach()
 
-add_executable(setpointer_cpp setpointer.cpp ${setpointer_gen})
+add_executable(setpointer_cpp setpointer.cpp ${setpointer_gens})
 cpp_cc_configure_sanitizers(TARGET setpointer_cpp)
 # The generated mechanism includes NEURON internal headers (mech_api.h, the mechanism-cache headers,
 # ...); inherit them from nrniv_lib, plus the build's generated-header dir (nrnsemanticversion.h

--- a/test/api/ppptrtest.mod
+++ b/test/api/ppptrtest.mod
@@ -1,0 +1,36 @@
+TITLE minimal POINT_PROCESS with a POINTER for the nrn_pp_setpointer_pop api test
+
+: A point process (not a density mechanism) with a single POINTER (src), a
+: settable source value (feed), and a readback (out). INITIAL copies the
+: pointed-to value into out, so a test can cross-wire two instances that sit at
+: the SAME segment -- each src pointed at the OTHER instance's feed, exactly the
+: HalfGap shape -- call finitialize, and read out back to confirm each instance
+: read its own wired source. That disambiguation is impossible to address by
+: (section, x) alone, which is why point processes need nrn_pp_setpointer_pop
+: (object-addressed) rather than nrn_setpointer_pop (segment-addressed).
+:
+: feed is a PARAMETER so it survives finitialize and is not touched by dynamics,
+: giving each instance a stable, distinct source value.
+
+NEURON {
+    POINT_PROCESS PPPtr
+    POINTER src
+    RANGE out, feed
+}
+
+PARAMETER {
+    feed = 0
+}
+
+ASSIGNED {
+    src
+    out
+}
+
+INITIAL {
+    out = src
+}
+
+BREAKPOINT {
+    out = src
+}

--- a/test/api/ptrtest.mod
+++ b/test/api/ptrtest.mod
@@ -1,0 +1,25 @@
+TITLE minimal POINTER density mechanism for the nrn_setpointer api test
+
+: A density mechanism with a single POINTER (src) and a plain range variable
+: (out). INITIAL copies the pointed-to value into out, so a test can wire src
+: with nrn_setpointer, call finitialize, and read out back to confirm the
+: POINTER now aliases the source's storage.
+
+NEURON {
+    SUFFIX ptrtest
+    POINTER src
+    RANGE out
+}
+
+ASSIGNED {
+    src
+    out
+}
+
+INITIAL {
+    out = src
+}
+
+BREAKPOINT {
+    out = src
+}

--- a/test/api/ptrtest.mod
+++ b/test/api/ptrtest.mod
@@ -1,8 +1,8 @@
-TITLE minimal POINTER density mechanism for the nrn_setpointer api test
+TITLE minimal POINTER density mechanism for the nrn_setpointer_pop api test
 
 : A density mechanism with a single POINTER (src) and a plain range variable
 : (out). INITIAL copies the pointed-to value into out, so a test can wire src
-: with nrn_setpointer, call finitialize, and read out back to confirm the
+: with nrn_setpointer_pop, call finitialize, and read out back to confirm the
 : POINTER now aliases the source's storage.
 
 NEURON {

--- a/test/api/setpointer.cpp
+++ b/test/api/setpointer.cpp
@@ -64,15 +64,28 @@ int main(void) {
     ok &= check(src_sym != nullptr && out_sym != nullptr && v_sym != nullptr,
                 "ptrtest range-variable symbols resolve");
 
+    // Stack hygiene is checked inline on every call with a sentinel pushed
+    // *below* the source: the HOC stack is LIFO, so a correct call pops exactly
+    // the one source it was given and leaves the sentinel on top. Popping the
+    // sentinel back afterward proves the call neither under-popped (left the
+    // source behind) nor over-popped (ate into the sentinel). A sentinel pushed
+    // *after* the calls could catch neither -- it only ever probes the current
+    // top. SENTINEL is a distinctive value unlikely to arise by chance.
+    const double SENTINEL = 424242.0;
+
     // Wire dend(0.5).ptrtest.src -> soma(0.5).v. Push the source pointer, then
     // let setpointer_pop consume it and assign it to the POINTER's dparam slot.
     char err[256];
-    nrn_rangevar_push(v_sym, soma, 0.5);
+    nrn_double_push(SENTINEL);            // sentinel below
+    nrn_rangevar_push(v_sym, soma, 0.5);  // source on top
     int rc = nrn_setpointer_pop(src_sym, dend, 0.5, err, sizeof(err));
     ok &= check(rc == 0, "nrn_setpointer_pop succeeds for a valid POINTER wiring");
     if (rc != 0) {
         cerr << "  error_msg: " << err << endl;
     }
+    ok &= eq(nrn_double_pop(),
+             SENTINEL,
+             "setpointer_pop consumed exactly its source (sentinel below intact)");
 
     // finitialize(-42): every segment's v becomes -42, and ptrtest's INITIAL
     // copies its POINTER (now soma.v) into out. So dend(0.5).out == -42.
@@ -85,24 +98,26 @@ int main(void) {
 
     // Error path 1: a non-POINTER target (out is a plain RANGE var) is rejected
     // with a nonzero return and a message, not a crash. The pushed source is
-    // still consumed (popped) before the validation fails, so the stack stays
-    // balanced.
+    // still consumed (popped) before the validation fails, so the sentinel
+    // below comes back untouched.
+    nrn_double_push(SENTINEL);
     nrn_rangevar_push(v_sym, soma, 0.5);
     int rc_bad = nrn_setpointer_pop(out_sym, dend, 0.5, err, sizeof(err));
     ok &= check(rc_bad != 0, "non-POINTER target is rejected");
     ok &= check(err[0] != '\0', "rejection fills the error message");
+    ok &= eq(nrn_double_pop(),
+             SENTINEL,
+             "rejected setpointer_pop still consumed exactly its source (sentinel intact)");
 
     // Error path 2: the POINTER's mechanism is absent at the target segment
-    // (soma has no ptrtest). Rejected, not a crash.
+    // (soma has no ptrtest). Rejected, not a crash; the source is still consumed.
+    nrn_double_push(SENTINEL);
     nrn_rangevar_push(v_sym, soma, 0.5);
     int rc_absent = nrn_setpointer_pop(src_sym, soma, 0.5, err, sizeof(err));
     ok &= check(rc_absent != 0, "POINTER target on a segment without the mechanism is rejected");
-
-    // Stack hygiene: every call above (success and error paths) consumed
-    // exactly the one source it was given. Push a sentinel and confirm it comes
-    // straight back, proving nothing was left on or over-popped from the stack.
-    nrn_double_push(17.0);
-    ok &= eq(nrn_double_pop(), 17.0, "the stack is balanced after the setpointer_pop calls");
+    ok &= eq(nrn_double_pop(),
+             SENTINEL,
+             "rejected setpointer_pop (absent mechanism) still consumed exactly its source");
 
     // -------------------------------------------------------------------------
     // Point-process path: nrn_pp_setpointer_pop. Unlike a density mechanism, a
@@ -125,15 +140,24 @@ int main(void) {
 
     // Cross-wire: pp1.src -> pp2.feed, pp2.src -> pp1.feed. Push the source
     // handle with nrn_property_push, then let nrn_pp_setpointer_pop consume it.
+    // Same sentinel-below hygiene check as the density calls above.
+    nrn_double_push(SENTINEL);
     nrn_property_push(pp2, "feed");
     int rc_pp1 = nrn_pp_setpointer_pop(pp1, "src", err, sizeof(err));
     ok &= check(rc_pp1 == 0, "nrn_pp_setpointer_pop wires pp1.src -> pp2.feed");
     if (rc_pp1 != 0) {
         cerr << "  error_msg: " << err << endl;
     }
+    ok &= eq(nrn_double_pop(),
+             SENTINEL,
+             "pp_setpointer_pop consumed exactly its source (sentinel intact)");
+    nrn_double_push(SENTINEL);
     nrn_property_push(pp1, "feed");
     int rc_pp2 = nrn_pp_setpointer_pop(pp2, "src", err, sizeof(err));
     ok &= check(rc_pp2 == 0, "nrn_pp_setpointer_pop wires pp2.src -> pp1.feed");
+    ok &= eq(nrn_double_pop(),
+             SENTINEL,
+             "second pp_setpointer_pop consumed exactly its source (sentinel intact)");
 
     // finitialize(-65): INITIAL runs out = src, so pp1.out reads pp2.feed (20)
     // and pp2.out reads pp1.feed (10). If the wiring were segment-addressed and
@@ -145,16 +169,16 @@ int main(void) {
     ok &= eq(nrn_property_get(pp2, "out"), 10.0, "pp2 read its own wired source (pp1.feed)");
 
     // Error path: a non-POINTER target name (out is a plain RANGE var) is
-    // rejected, with the pushed source still consumed so the stack stays
-    // balanced.
+    // rejected, with the pushed source still consumed so the sentinel below
+    // comes back untouched.
+    nrn_double_push(SENTINEL);
     nrn_property_push(pp2, "feed");
     int rc_pp_bad = nrn_pp_setpointer_pop(pp1, "out", err, sizeof(err));
     ok &= check(rc_pp_bad != 0, "non-POINTER point-process target is rejected");
     ok &= check(err[0] != '\0', "point-process rejection fills the error message");
-
-    // Stack hygiene across the point-process calls too.
-    nrn_double_push(23.0);
-    ok &= eq(nrn_double_pop(), 23.0, "the stack is balanced after the pp setpointer calls");
+    ok &= eq(nrn_double_pop(),
+             SENTINEL,
+             "rejected pp_setpointer_pop still consumed exactly its source (sentinel intact)");
 
     return ok ? 0 : 1;
 }

--- a/test/api/setpointer.cpp
+++ b/test/api/setpointer.cpp
@@ -16,11 +16,15 @@
 using std::cerr;
 using std::endl;
 
-// The nocmodl-generated ptrtest.cpp defines this; nrniv_lib calls modl_reg at
-// startup, so registering ptrtest here makes the mechanism available.
+// The nocmodl-generated ptrtest.cpp / ppptrtest.cpp define these; nrniv_lib
+// calls modl_reg at startup, so registering them here makes both mechanisms
+// available: ptrtest (a density mechanism) for nrn_setpointer_pop, and PPPtr (a
+// point process) for nrn_pp_setpointer_pop.
 extern "C" void _ptrtest_reg();
+extern "C" void _ppptrtest_reg();
 extern "C" void modl_reg() {
     _ptrtest_reg();
+    _ppptrtest_reg();
 }
 
 static bool check(bool cond, const char* msg) {
@@ -99,6 +103,58 @@ int main(void) {
     // straight back, proving nothing was left on or over-popped from the stack.
     nrn_double_push(17.0);
     ok &= eq(nrn_double_pop(), 17.0, "the stack is balanced after the setpointer_pop calls");
+
+    // -------------------------------------------------------------------------
+    // Point-process path: nrn_pp_setpointer_pop. Unlike a density mechanism, a
+    // point process is addressed by its instance Object, because several can
+    // share one segment. Put TWO PPPtr point processes at the SAME location,
+    // soma(0.5), and cross-wire them (each src -> the other's feed) -- the
+    // HalfGap shape, where both sides point at the other. (sec, x) cannot tell
+    // the two instances apart; the object can.
+    nrn_section_push(soma);
+    nrn_double_push(0.5);
+    Object* pp1 = nrn_object_new(nrn_symbol("PPPtr"), 1);
+    nrn_double_push(0.5);
+    Object* pp2 = nrn_object_new(nrn_symbol("PPPtr"), 1);
+    nrn_section_pop();
+    ok &= check(pp1 != nullptr && pp2 != nullptr, "two PPPtr point processes created at soma(0.5)");
+
+    // Distinct, finitialize-stable source values (feed is a PARAMETER).
+    nrn_property_set(pp1, "feed", 10);
+    nrn_property_set(pp2, "feed", 20);
+
+    // Cross-wire: pp1.src -> pp2.feed, pp2.src -> pp1.feed. Push the source
+    // handle with nrn_property_push, then let nrn_pp_setpointer_pop consume it.
+    nrn_property_push(pp2, "feed");
+    int rc_pp1 = nrn_pp_setpointer_pop(pp1, "src", err, sizeof(err));
+    ok &= check(rc_pp1 == 0, "nrn_pp_setpointer_pop wires pp1.src -> pp2.feed");
+    if (rc_pp1 != 0) {
+        cerr << "  error_msg: " << err << endl;
+    }
+    nrn_property_push(pp1, "feed");
+    int rc_pp2 = nrn_pp_setpointer_pop(pp2, "src", err, sizeof(err));
+    ok &= check(rc_pp2 == 0, "nrn_pp_setpointer_pop wires pp2.src -> pp1.feed");
+
+    // finitialize(-65): INITIAL runs out = src, so pp1.out reads pp2.feed (20)
+    // and pp2.out reads pp1.feed (10). If the wiring were segment-addressed and
+    // had grabbed the wrong instance, these would come back swapped or equal.
+    nrn_double_push(-65);
+    nrn_function_call(nrn_symbol("finitialize"), 1);
+    nrn_double_pop();
+    ok &= eq(nrn_property_get(pp1, "out"), 20.0, "pp1 read its own wired source (pp2.feed)");
+    ok &= eq(nrn_property_get(pp2, "out"), 10.0, "pp2 read its own wired source (pp1.feed)");
+
+    // Error path: a non-POINTER target name (out is a plain RANGE var) is
+    // rejected, with the pushed source still consumed so the stack stays
+    // balanced.
+    nrn_property_push(pp2, "feed");
+    int rc_pp_bad = nrn_pp_setpointer_pop(pp1, "out", err, sizeof(err));
+    ok &= check(rc_pp_bad != 0, "non-POINTER point-process target is rejected");
+    ok &= check(err[0] != '\0', "point-process rejection fills the error message");
+
+    // Stack hygiene across the point-process calls too.
+    nrn_double_push(23.0);
+    ok &= eq(nrn_double_pop(), 23.0, "the stack is balanced after the pp setpointer calls");
 
     return ok ? 0 : 1;
 }

--- a/test/api/setpointer.cpp
+++ b/test/api/setpointer.cpp
@@ -1,11 +1,13 @@
 // NOTE: this assumes neuronapi.h is on your CPLUS_INCLUDE_PATH
-// Exercises nrn_setpointer, which wires an NMODL POINTER range variable to a
-// source variable's storage (the Python-free form of the HOC `setpointer`
-// statement / nrn_pointer_assign). The ptrtest density mechanism copies its
-// POINTER `src` into the range variable `out` in INITIAL, so after wiring
-// src -> a source double and calling finitialize, reading out confirms the
-// POINTER now aliases the source. modl_reg registers ptrtest (its generated
-// _ptrtest_reg is compiled into this test), the way nrniv registers built-ins.
+// Exercises nrn_setpointer_pop, which wires an NMODL POINTER range variable to
+// the source pointer the caller has pushed onto the stack (the Python-free form
+// of the HOC `setpointer` statement / nrn_pointer_assign). Pushing the source
+// rather than naming it reuses every existing way of obtaining a pointer. The
+// ptrtest density mechanism copies its POINTER `src` into the range variable
+// `out` in INITIAL, so after wiring src -> a source double and calling
+// finitialize, reading out confirms the POINTER now aliases the source.
+// modl_reg registers ptrtest (its generated _ptrtest_reg is compiled into this
+// test), the way nrniv registers built-ins.
 #include <array>
 #include <cstring>
 #include <iostream>
@@ -58,10 +60,12 @@ int main(void) {
     ok &= check(src_sym != nullptr && out_sym != nullptr && v_sym != nullptr,
                 "ptrtest range-variable symbols resolve");
 
-    // Wire dend(0.5).ptrtest.src -> soma(0.5).v
+    // Wire dend(0.5).ptrtest.src -> soma(0.5).v. Push the source pointer, then
+    // let setpointer_pop consume it and assign it to the POINTER's dparam slot.
     char err[256];
-    int rc = nrn_setpointer(src_sym, dend, 0.5, v_sym, soma, 0.5, err, sizeof(err));
-    ok &= check(rc == 0, "nrn_setpointer succeeds for a valid POINTER wiring");
+    nrn_rangevar_push(v_sym, soma, 0.5);
+    int rc = nrn_setpointer_pop(src_sym, dend, 0.5, err, sizeof(err));
+    ok &= check(rc == 0, "nrn_setpointer_pop succeeds for a valid POINTER wiring");
     if (rc != 0) {
         cerr << "  error_msg: " << err << endl;
     }
@@ -76,15 +80,25 @@ int main(void) {
              "POINTER reads the wired source's value after finitialize");
 
     // Error path 1: a non-POINTER target (out is a plain RANGE var) is rejected
-    // with a nonzero return and a message, not a crash.
-    int rc_bad = nrn_setpointer(out_sym, dend, 0.5, v_sym, soma, 0.5, err, sizeof(err));
+    // with a nonzero return and a message, not a crash. The pushed source is
+    // still consumed (popped) before the validation fails, so the stack stays
+    // balanced.
+    nrn_rangevar_push(v_sym, soma, 0.5);
+    int rc_bad = nrn_setpointer_pop(out_sym, dend, 0.5, err, sizeof(err));
     ok &= check(rc_bad != 0, "non-POINTER target is rejected");
     ok &= check(err[0] != '\0', "rejection fills the error message");
 
     // Error path 2: the POINTER's mechanism is absent at the target segment
     // (soma has no ptrtest). Rejected, not a crash.
-    int rc_absent = nrn_setpointer(src_sym, soma, 0.5, v_sym, soma, 0.5, err, sizeof(err));
+    nrn_rangevar_push(v_sym, soma, 0.5);
+    int rc_absent = nrn_setpointer_pop(src_sym, soma, 0.5, err, sizeof(err));
     ok &= check(rc_absent != 0, "POINTER target on a segment without the mechanism is rejected");
+
+    // Stack hygiene: every call above (success and error paths) consumed
+    // exactly the one source it was given. Push a sentinel and confirm it comes
+    // straight back, proving nothing was left on or over-popped from the stack.
+    nrn_double_push(17.0);
+    ok &= eq(nrn_double_pop(), 17.0, "the stack is balanced after the setpointer_pop calls");
 
     return ok ? 0 : 1;
 }

--- a/test/api/setpointer.cpp
+++ b/test/api/setpointer.cpp
@@ -1,0 +1,90 @@
+// NOTE: this assumes neuronapi.h is on your CPLUS_INCLUDE_PATH
+// Exercises nrn_setpointer, which wires an NMODL POINTER range variable to a
+// source variable's storage (the Python-free form of the HOC `setpointer`
+// statement / nrn_pointer_assign). The ptrtest density mechanism copies its
+// POINTER `src` into the range variable `out` in INITIAL, so after wiring
+// src -> a source double and calling finitialize, reading out confirms the
+// POINTER now aliases the source. modl_reg registers ptrtest (its generated
+// _ptrtest_reg is compiled into this test), the way nrniv registers built-ins.
+#include <array>
+#include <cstring>
+#include <iostream>
+#include "neuronapi.h"
+
+using std::cerr;
+using std::endl;
+
+// The nocmodl-generated ptrtest.cpp defines this; nrniv_lib calls modl_reg at
+// startup, so registering ptrtest here makes the mechanism available.
+extern "C" void _ptrtest_reg();
+extern "C" void modl_reg() {
+    _ptrtest_reg();
+}
+
+static bool check(bool cond, const char* msg) {
+    if (!cond) {
+        cerr << "FAIL: " << msg << endl;
+    }
+    return cond;
+}
+
+static bool eq(double got, double want, const char* msg) {
+    if (got != want) {
+        cerr << "FAIL: " << msg << " -- got " << got << ", want " << want << endl;
+        return false;
+    }
+    return true;
+}
+
+int main(void) {
+    static std::array<const char*, 4> argv = {"setpointer", "-nogui", "-nopython", nullptr};
+    nrn_init(3, argv.data());
+
+    bool ok = true;
+
+    // Two sections. dend's ptrtest.src will be wired to soma(0.5).v, so it reads
+    // soma's membrane potential rather than its own.
+    Section* soma = nrn_section_new("soma");
+    Section* dend = nrn_section_new("dend");
+    nrn_section_connect(dend, 0, soma, 1);
+
+    Symbol* ptrtest = nrn_symbol("ptrtest");
+    ok &= check(ptrtest != nullptr, "ptrtest mechanism registered");
+    nrn_mechanism_insert(dend, ptrtest);
+
+    Symbol* src_sym = nrn_symbol("src_ptrtest");  // the POINTER range variable
+    Symbol* out_sym = nrn_symbol("out_ptrtest");  // plain range variable
+    Symbol* v_sym = nrn_symbol("v");
+    ok &= check(src_sym != nullptr && out_sym != nullptr && v_sym != nullptr,
+                "ptrtest range-variable symbols resolve");
+
+    // Wire dend(0.5).ptrtest.src -> soma(0.5).v
+    char err[256];
+    int rc = nrn_setpointer(src_sym, dend, 0.5, v_sym, soma, 0.5, err, sizeof(err));
+    ok &= check(rc == 0, "nrn_setpointer succeeds for a valid POINTER wiring");
+    if (rc != 0) {
+        cerr << "  error_msg: " << err << endl;
+    }
+
+    // finitialize(-42): every segment's v becomes -42, and ptrtest's INITIAL
+    // copies its POINTER (now soma.v) into out. So dend(0.5).out == -42.
+    nrn_double_push(-42);
+    nrn_function_call(nrn_symbol("finitialize"), 1);
+    nrn_double_pop();
+    ok &= eq(nrn_rangevar_get(out_sym, dend, 0.5),
+             -42.0,
+             "POINTER reads the wired source's value after finitialize");
+
+    // Error path 1: a non-POINTER target (out is a plain RANGE var) is rejected
+    // with a nonzero return and a message, not a crash.
+    int rc_bad = nrn_setpointer(out_sym, dend, 0.5, v_sym, soma, 0.5, err, sizeof(err));
+    ok &= check(rc_bad != 0, "non-POINTER target is rejected");
+    ok &= check(err[0] != '\0', "rejection fills the error message");
+
+    // Error path 2: the POINTER's mechanism is absent at the target segment
+    // (soma has no ptrtest). Rejected, not a crash.
+    int rc_absent = nrn_setpointer(src_sym, soma, 0.5, v_sym, soma, 0.5, err, sizeof(err));
+    ok &= check(rc_absent != 0, "POINTER target on a segment without the mechanism is rejected");
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
Adds `nrn_setpointer_pop` (density mechanisms) and `nrn_pp_setpointer_pop` (point processes) to the public C API, so an NMODL `POINTER` can be wired from a non-CPython consumer.

## What and why

Wiring an NMODL `POINTER` to a source (gap junctions, any POINTER coupling) has no public primitive. The HOC `setpointer` statement and Python's `seg.mech._ref_PTR = src._ref_X` both do it, but the only internal entry point is `nrn_pointer_assign`, which takes a `PyObject*` and lives in libnrnpython, unreachable from a ctypes / MATLAB / C++ consumer. Those bindings currently route through a HOC `setpointer` string shim.

The source is **pushed onto the stack** (per the earlier review): pushing it rather than naming it reuses every existing way of obtaining a pointer (`nrn_rangevar_push`, `nrn_property_push`, ...) and keeps the API to a single "wire the popped pointer" call per target kind. The pushed source is consumed even on the error paths, so the stack is left balanced.

## Density vs. point process

Density and point-process assignment converge on the **same** slot write -- `prop->dparam[sym->u.rng.index] = <data handle>`, the assignment `nrn_pointer_assign` performs. They differ only in how the target `Prop` is resolved, and that difference is why they cannot be one function:

- **Density** (`nrn_setpointer_pop`): addressed by `(sec, x)`. A density mechanism has exactly one instance per segment, so the segment names it. There is no per-instance object to hand in.
- **Point process** (`nrn_pp_setpointer_pop`): addressed by the **instance object**. Several point processes may share one location (two HalfGaps at one segment), so `(sec, x)` is ambiguous; the object is what disambiguates. `nrn_pp_setpointer_pop(Object* pp, const char* name, ...)` resolves the POINTER by bare name in the point process's own symbol table -- the same lookup `nrn_property_get` uses -- and reaches the `Prop` via `ob2pntproc_0`.

## Changes

- `src/nrniv/neuronapi.h`, `src/nrniv/neuronapi.cpp`: declare + define both functions.
- `docs/capi.rst`: documented both. The `nrn_setpointer_pop` example previously used a HalfGap, which is a `POINT_PROCESS` and would not actually work with the density path -- fixed to a density mechanism; the HalfGap example now lives on `nrn_pp_setpointer_pop`, cross-referenced.
- `test/api/setpointer.cpp`, `test/api/ptrtest.mod`, `test/api/ppptrtest.mod`: no built-in mechanism has a POINTER, so the test generates minimal fixtures with nocmodl and compiles them in (the same codegen path nrniv uses for built-ins; the mod codegen is refactored into a `foreach` over both fixtures). `ptrtest` (density) exercises `nrn_setpointer_pop`; `ppptrtest` (a `POINT_PROCESS`) exercises `nrn_pp_setpointer_pop` with **two instances at one location**, cross-wired HalfGap-style -- each `src` pointed at the other instance's `feed`. After `finitialize` they read back distinct values (20 and 10), which segment addressing could not produce. Both error paths (non-POINTER target, absent/mislocated mechanism) and stack balance are checked for each.

Same structure as #3810. `make format-pr` clean (clang-format 12.0.1, cmakelang 0.6.13). `ctest -R setpointer` passes; the full `api::` group is green.

This retires myneuron's HOC `setpointer` shim (and the equivalent MATLAB detour) for both mechanism kinds.
