### PR TITLE
neuronapi: add nrn_sectionlist_to_array for batched section-list access

### DIFF
--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -419,6 +419,45 @@ Sections
     :returns: The next sibling Section, or ``NULL`` (also if ``sec`` is
         ``NULL``).
 
+.. c:function:: int nrn_sectionlist_to_array(nrn_Item* sl, Section** buf, int maxlen)
+
+    Snapshot a section list into a caller-provided array in one call.
+
+    This is the batched form of :c:func:`nrn_sectionlist_iterator_new`: it fills
+    ``buf`` with the live Sections of ``sl`` in a single crossing of the API
+    boundary rather than one crossing per Section, which speeds up building a
+    section array (for example an ``allsec`` gather, rebuilt whenever the
+    topology changes). Semi-deleted Sections are skipped; the list is not
+    modified.
+
+    Up to ``maxlen`` Sections are written, but the return value is always the
+    **total** number of live Sections, so a return greater than ``maxlen`` means
+    the buffer was too small and the snapshot is truncated. Call once with
+    ``buf = NULL`` and ``maxlen = 0`` to get that total first, then size the
+    buffer to it. (Detecting whether a *cached* snapshot has since gone stale is
+    a separate concern, handled by watching ``structure_change_cnt``, not by
+    re-counting.)
+
+    :param sl: A section list from :c:func:`nrn_allsec` or
+        :c:func:`nrn_sectionlist_data`.
+    :param buf: Array that receives up to ``maxlen`` ``Section*`` entries. May be
+        ``NULL`` only if ``maxlen`` is 0 (to count without writing).
+    :param maxlen: Capacity of ``buf``.
+    :returns: The total number of live Sections in ``sl``, or 0 if ``sl`` is
+        ``NULL``.
+
+    **C Usage:**
+
+    .. code-block:: c
+
+        int n = nrn_sectionlist_to_array(nrn_allsec(), NULL, 0);  // count pass
+        Section** secs = malloc(n * sizeof(Section*));
+        int total = nrn_sectionlist_to_array(nrn_allsec(), secs, n);
+        for (int i = 0; i < total; i++) {
+            printf("%s\n", nrn_secname(secs[i]));
+        }
+        free(secs);
+
 .. c:function:: bool nrn_section_is_active(const Section* sec)
 
     Check if a Section is active (exists and is valid).

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -278,6 +278,37 @@ Section* nrn_section_sibling(Section* sec) {
     return sec->sibling;
 }
 
+int nrn_sectionlist_to_array(nrn_Item* sl, Section** buf, int maxlen) {
+    // Snapshot a section list (from nrn_allsec() or nrn_sectionlist_data(obj))
+    // into buf in a single call -- the batched form of the section-list
+    // iterator, which crosses the API boundary once per section. Building a
+    // section array this way (an allsec gather, rebuilt whenever the topology
+    // changes) becomes one crossing instead of one per section. The list is a
+    // circular doubly-linked list of hoc_Item with sl as the sentinel, so walk
+    // from sl->next back around to sl. Semi-deleted sections (no Section, or a
+    // freed prop) are skipped, matching SectionListIterator; read-only, it does
+    // not prune them.
+    //
+    // Fills up to maxlen entries and returns the TOTAL number of live sections,
+    // which may exceed maxlen when buf is too small. Call with buf=NULL and
+    // maxlen=0 to obtain just the count in one pass. Detecting whether a cached
+    // snapshot has gone stale is a separate matter -- watch structure_change_cnt.
+    if (!sl) {
+        return 0;
+    }
+    int total = 0;
+    for (hoc_Item* q = sl->next; q && q != sl; q = q->next) {
+        Section* sec = q->element.sec;
+        if (sec && sec->prop != nullptr) {
+            if (buf && total < maxlen) {
+                buf[total] = sec;
+            }
+            ++total;
+        }
+    }
+    return total;
+}
+
 /****************************************
  * Functions, objects, and the stack
  ****************************************/

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -60,6 +60,7 @@ Section* nrn_section_parent(Section* sec);
 Section* nrn_section_trueparent(Section* sec);
 Section* nrn_section_child(Section* sec);
 Section* nrn_section_sibling(Section* sec);
+int nrn_sectionlist_to_array(nrn_Item* sl, Section** buf, int maxlen);
 bool nrn_section_is_active(const Section* sec);
 void nrn_section_ref(Section* sec);
 void nrn_section_unref(Section* sec);

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -8,6 +8,7 @@ foreach(
   object_new_wrap.cpp
   object_ptr_push.cpp
   section_tree.cpp
+  sectionlist_to_array.cpp
   segment_diam.cpp
   sections.cpp
   symbol_object_string.cpp

--- a/test/api/sectionlist_to_array.cpp
+++ b/test/api/sectionlist_to_array.cpp
@@ -1,0 +1,119 @@
+// NOTE: this assumes neuronapi.h is on your CPLUS_INCLUDE_PATH
+// Exercises nrn_sectionlist_to_array, the batched snapshot of a section list.
+// It walks a section list (nrn_allsec() or nrn_sectionlist_data(obj)) in a
+// single crossing, skipping semi-deleted sections, where the older iterator
+// crosses once per section. The array must agree with the iterator
+// element-for-element; a NULL/zero-length call returns the total (the count
+// pass); and a buffer shorter than the list must truncate while still reporting
+// the true total.
+#include <array>
+#include <iostream>
+#include <vector>
+#include "neuronapi.h"
+
+using std::cerr;
+using std::endl;
+
+extern "C" void modl_reg() {}
+
+static bool check(bool cond, const char* msg) {
+    if (!cond) {
+        cerr << "FAIL: " << msg << endl;
+    }
+    return cond;
+}
+
+// Gather a section list with the existing one-at-a-time iterator, for comparison
+// against the batched array.
+static std::vector<Section*> gather_with_iterator(nrn_Item* sl) {
+    std::vector<Section*> out;
+    SectionListIterator* it = nrn_sectionlist_iterator_new(sl);
+    while (!nrn_sectionlist_iterator_done(it)) {
+        Section* sec = nrn_sectionlist_iterator_next(it);
+        if (sec) {
+            out.push_back(sec);
+        }
+    }
+    nrn_sectionlist_iterator_free(it);
+    return out;
+}
+
+// Compare the batched array against the iterator's result for one list.
+static bool array_matches_iterator(nrn_Item* sl, const char* what) {
+    bool ok = true;
+    std::vector<Section*> expected = gather_with_iterator(sl);
+    // The count pass: buf = NULL, maxlen = 0 returns the total without writing.
+    int count = nrn_sectionlist_to_array(sl, nullptr, 0);
+    ok &= check(count == static_cast<int>(expected.size()), what);
+    if (count != static_cast<int>(expected.size())) {
+        cerr << "  " << what << ": count " << count << " != iterator " << expected.size() << endl;
+    }
+
+    std::vector<Section*> buf(count ? count : 1, nullptr);
+    int total = nrn_sectionlist_to_array(sl, buf.data(), count);
+    ok &= check(total == count,
+                "to_array total equals the count pass when the buffer is large enough");
+    for (int i = 0; i < count; ++i) {
+        if (buf[i] != expected[i]) {
+            ok = false;
+            cerr << "  " << what << ": array[" << i << "] != iterator[" << i << "]" << endl;
+        }
+    }
+    return ok;
+}
+
+int main(void) {
+    static std::array<const char*, 4> argv = {"sectionlist_to_array",
+                                              "-nogui",
+                                              "-nopython",
+                                              nullptr};
+    nrn_init(3, argv.data());
+
+    bool ok = true;
+
+    // topology: five sections in a small tree
+    Section* soma = nrn_section_new("soma");
+    Section* dend1 = nrn_section_new("dend1");
+    Section* dend2 = nrn_section_new("dend2");
+    Section* dend3 = nrn_section_new("dend3");
+    Section* axon = nrn_section_new("axon");
+    nrn_section_connect(dend1, 0, soma, 1);
+    nrn_section_connect(dend2, 0, dend1, 1);
+    nrn_section_connect(dend3, 0, dend1, 1);
+    nrn_section_connect(axon, 0, soma, 0);
+
+    // allsec: every section created above. The array must agree with the
+    // iterator, and the count pass must report 5.
+    ok &= check(nrn_sectionlist_to_array(nrn_allsec(), nullptr, 0) == 5,
+                "allsec count pass reports all five sections");
+    ok &= array_matches_iterator(nrn_allsec(), "allsec array agrees with allsec iterator");
+
+    // A SectionList object: dend1's subtree (dend1, dend2, dend3).
+    Object* seclist = nrn_object_new(nrn_symbol("SectionList"), 0);
+    nrn_section_push(dend1);
+    nrn_method_call(seclist, nrn_method_symbol(seclist, "subtree"), 0);
+    nrn_section_pop();
+    ok &= check(nrn_sectionlist_to_array(nrn_sectionlist_data(seclist), nullptr, 0) == 3,
+                "subtree SectionList count pass reports three sections");
+    ok &= array_matches_iterator(nrn_sectionlist_data(seclist),
+                                 "SectionList array agrees with SectionList iterator");
+
+    // Truncation: a buffer shorter than the list fills only maxlen entries but
+    // still returns the true total, so a caller can detect it undersized.
+    std::array<Section*, 5> tbuf;
+    tbuf.fill(reinterpret_cast<Section*>(-1));  // sentinel to detect writes
+    int total = nrn_sectionlist_to_array(nrn_allsec(), tbuf.data(), 2);
+    ok &= check(total == 5, "to_array returns the full total even when the buffer is too small");
+    ok &= check(tbuf[0] != reinterpret_cast<Section*>(-1) &&
+                    tbuf[1] != reinterpret_cast<Section*>(-1),
+                "to_array fills the first maxlen entries");
+    ok &= check(tbuf[2] == reinterpret_cast<Section*>(-1), "to_array does not write past maxlen");
+
+    // Null safety: the call does not crash or miscount on a null list.
+    ok &= check(nrn_sectionlist_to_array(nullptr, nullptr, 0) == 0,
+                "count pass of a null list is zero");
+    ok &= check(nrn_sectionlist_to_array(nullptr, tbuf.data(), 5) == 0,
+                "to_array of a null list is zero");
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
Adds `nrn_sectionlist_to_array` to the public C API for batched, whole-list access to a section list.

## What and why

Iterating a section list from a binding goes one FFI crossing per section through the `nrn_sectionlist_iterator_*` functions. That is right for streaming, but for a **whole-list snapshot** -- building a `Section*` array, e.g. an `allsec` gather and every rebuild when the topology changes -- it is a crossing per section where a single crossing would do. For a several-thousand-section model that is thousands of crossings versus one.

```c
int nrn_sectionlist_to_array(nrn_Item* sl, Section** buf, int maxlen);
```

It fills `buf` with up to `maxlen` sections in one crossing and returns the **total** live-section count, so a return greater than `maxlen` means the buffer was too small and the snapshot is truncated. Call once with `buf = NULL`, `maxlen = 0` to get the total first, then size the buffer to it -- no separate count function and no retry loop. It operates on any section list handle (`nrn_allsec()` or `nrn_sectionlist_data(obj)`), so it works for a whole `SectionList` too, not just `allsec`. Semi-deleted sections (no `Section`, or a freed `prop`) are skipped, the same ones `SectionListIterator` skips, but unlike the iterator it is read-only and does not prune them.

## On the earlier revision

This replaces the two-function version (`nrn_sectionlist_count` + `nrn_sectionlist_to_array`). You were right on both counts: **staleness is not what this is for** -- `structure_change_cnt` is the staleness signal, and myneuron already watches it -- so the "counting as a staleness check" justification was wrong and is gone. And the separate `count` bought nothing, since `to_array(sl, NULL, 0)` already returns the total in one pass. What remains is purely the batched-retrieval win.

## Changes

- `src/nrniv/neuronapi.h`, `src/nrniv/neuronapi.cpp`: declare + define the one function.
- `docs/capi.rst`: documented it, with a C snippet showing the count-pass-then-fill pattern, and a note that snapshot staleness is `structure_change_cnt`'s job.
- `test/api/sectionlist_to_array.cpp`: checks the array against the one-at-a-time iterator element-for-element, for both an `allsec` list and a `SectionList` subtree; that the count pass matches; that a buffer shorter than the list truncates while still returning the true total; and null-list safety.

Rebased onto master (the earlier conflict is resolved). Same structure as #3810. `make format-pr` clean (clang-format 12.0.1, cmakelang 0.6.13). `ctest -R sectionlist_to_array` passes; the `api::` group is green.