### PR TITLE
neuronapi: add nrn_symbol_pop; make nrn_object_pop nil-safe

### DIFF
--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -977,31 +977,20 @@ Functions, objects, and the stack
 
     Pop an object from the stack.
 
-    :returns: Pointer to object from the top of the stack.
+    Returns ``NULL`` for a nil object reference (an unset ``objref``) rather than
+    crashing, so it is safe to use when unwinding a stack that may carry a nil
+    object -- for example a HOC-to-Python write-back whose right-hand side is an
+    unset ``objref``.
+
+    :returns: Pointer to the object from the top of the stack, or ``NULL`` if it
+        is a nil object reference.
 
     **Usage Pattern:**
 
     Used to retrieve function/method return values. Use :c:func:`nrn_stack_type` to check the type
     before popping, or use the type of the function/method to know the expected return type in
-    advance.
-
-.. c:function:: Object* nrn_object_pop_safe(void)
-
-    Pop an object from the stack, tolerating a nil object reference.
-
-    Same as :c:func:`nrn_object_pop`, except it returns ``NULL`` for a nil
-    object reference instead of crashing. :c:func:`nrn_object_pop`
-    unconditionally takes a reference on the popped object, which dereferences
-    a ``NULL`` when the stack entry is a nil ``objref``. Use this when the stack
-    may carry a nil object -- for example when unwinding a HOC-to-Python
-    write-back whose right-hand side is an unset ``objref``.
-
-    :returns: Pointer to the object from the top of the stack, or ``NULL`` if it
-        is a nil object reference.
-
-    As with :c:func:`nrn_object_pop`, a non-``NULL`` result is reference-counted
-    and should be released with :c:func:`nrn_object_unref` when no longer
-    needed.
+    advance. A non-``NULL`` result is reference-counted and should be released with
+    :c:func:`nrn_object_unref` when no longer needed.
 
 .. c:function:: nrn_stack_types_t nrn_stack_type(void)
 

--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -710,6 +710,18 @@ Functions, objects, and the stack
 
     :param sym: Pointer to the symbol to push.
 
+.. c:function:: Symbol* nrn_symbol_pop(void)
+
+    Pop a Symbol from the top of the stack.
+
+    The interpreter puts a Symbol on the stack when accessing an object
+    component (reading or assigning ``pyobj.attr``); a binding that unwinds
+    such a stack frame uses this to pop the attribute's Symbol. Use
+    :c:func:`nrn_stack_type` to confirm the top is a ``STACK_IS_SYM`` entry
+    before popping.
+
+    :returns: The Symbol from the top of the stack.
+
 .. c:function:: int nrn_symbol_type(const Symbol* sym)
 
     Get the type of a symbol (e.g., function, variable, mechanism).
@@ -972,6 +984,24 @@ Functions, objects, and the stack
     Used to retrieve function/method return values. Use :c:func:`nrn_stack_type` to check the type
     before popping, or use the type of the function/method to know the expected return type in
     advance.
+
+.. c:function:: Object* nrn_object_pop_safe(void)
+
+    Pop an object from the stack, tolerating a nil object reference.
+
+    Same as :c:func:`nrn_object_pop`, except it returns ``NULL`` for a nil
+    object reference instead of crashing. :c:func:`nrn_object_pop`
+    unconditionally takes a reference on the popped object, which dereferences
+    a ``NULL`` when the stack entry is a nil ``objref``. Use this when the stack
+    may carry a nil object -- for example when unwinding a HOC-to-Python
+    write-back whose right-hand side is an unset ``objref``.
+
+    :returns: Pointer to the object from the top of the stack, or ``NULL`` if it
+        is a nil object reference.
+
+    As with :c:func:`nrn_object_pop`, a non-``NULL`` result is reference-counted
+    and should be released with :c:func:`nrn_object_unref` when no longer
+    needed.
 
 .. c:function:: nrn_stack_types_t nrn_stack_type(void)
 

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -397,23 +397,12 @@ void nrn_object_ptr_push(Object** obj_ref) {
 }
 
 Object* nrn_object_pop(void) {
-    // NOTE: the returned object should be unref'd when no longer needed
-    Object** obptr = hoc_objpop();
-    Object* new_ob_ptr = *obptr;
-    new_ob_ptr->refcount++;
-    hoc_tobj_unref(obptr);
-    return new_ob_ptr;
-}
-
-Object* nrn_object_pop_safe(void) {
-    // Like nrn_object_pop, but returns NULL for a nil object reference instead
-    // of crashing. nrn_object_pop unconditionally does (*obptr)->refcount++ to
-    // hand back a reference, which dereferences NULL when the stack entry is a
-    // nil objref. Unwinding a stack that may carry a nil object -- e.g. the
-    // HOC-to-Python write-back path, where an objref RHS can be nil -- needs a
-    // pop that tolerates it. The stack-slot handling is identical to
-    // nrn_object_pop; only the ref is guarded. As there, a non-NULL result is
-    // reffed and should be unref'd (nrn_object_unref) when no longer needed.
+    // Returns NULL for a nil object reference (an unset objref) rather than
+    // crashing: the ref-count bump that hands back a reference would otherwise
+    // dereference NULL. This matters when unwinding a stack that may carry a nil
+    // object -- e.g. the HOC-to-Python write-back path, where an objref RHS can
+    // be nil. A non-NULL result is reference-counted and should be unref'd
+    // (nrn_object_unref) when no longer needed.
     Object** obptr = hoc_objpop();
     Object* ob = *obptr;
     if (ob) {

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -341,6 +341,14 @@ void nrn_symbol_push(Symbol* sym) {
     hoc_pushpx(sym->u.pval);
 }
 
+Symbol* nrn_symbol_pop(void) {
+    // Pop a Symbol (a STACK_IS_SYM entry) off the interpreter stack. Interpreter
+    // frames for object-component access (e.g. reading or assigning pyobj.attr)
+    // carry the attribute's Symbol on the stack; a binding that unwinds such a
+    // frame needs to pop it. Public counterpart to the internal hoc_spop.
+    return hoc_spop();
+}
+
 void nrn_double_push(double val) {
     hoc_pushx(val);
 }
@@ -395,6 +403,24 @@ Object* nrn_object_pop(void) {
     new_ob_ptr->refcount++;
     hoc_tobj_unref(obptr);
     return new_ob_ptr;
+}
+
+Object* nrn_object_pop_safe(void) {
+    // Like nrn_object_pop, but returns NULL for a nil object reference instead
+    // of crashing. nrn_object_pop unconditionally does (*obptr)->refcount++ to
+    // hand back a reference, which dereferences NULL when the stack entry is a
+    // nil objref. Unwinding a stack that may carry a nil object -- e.g. the
+    // HOC-to-Python write-back path, where an objref RHS can be nil -- needs a
+    // pop that tolerates it. The stack-slot handling is identical to
+    // nrn_object_pop; only the ref is guarded. As there, a non-NULL result is
+    // reffed and should be unref'd (nrn_object_unref) when no longer needed.
+    Object** obptr = hoc_objpop();
+    Object* ob = *obptr;
+    if (ob) {
+        ob->refcount++;
+    }
+    hoc_tobj_unref(obptr);
+    return ob;
 }
 
 nrn_stack_types_t nrn_stack_type(void) {

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -78,6 +78,7 @@ void nrn_rangevar_set(Symbol* sym, Section* sec, double x, double value);
  ****************************************/
 Symbol* nrn_symbol(const char* name);
 void nrn_symbol_push(Symbol* sym);
+Symbol* nrn_symbol_pop(void);
 int nrn_symbol_type(const Symbol* sym);
 int nrn_symbol_subtype(const Symbol* sym);
 double* nrn_symbol_dataptr(const Symbol* sym);
@@ -97,6 +98,7 @@ int nrn_int_pop(void);
 void nrn_object_push(Object* obj);
 void nrn_object_ptr_push(Object** obj_ref);
 Object* nrn_object_pop(void);
+Object* nrn_object_pop_safe(void);
 nrn_stack_types_t nrn_stack_type(void);
 char const* nrn_stack_type_name(nrn_stack_types_t id);
 Object* nrn_object_new(Symbol* sym, int narg);

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -98,7 +98,6 @@ int nrn_int_pop(void);
 void nrn_object_push(Object* obj);
 void nrn_object_ptr_push(Object** obj_ref);
 Object* nrn_object_pop(void);
-Object* nrn_object_pop_safe(void);
 nrn_stack_types_t nrn_stack_type(void);
 char const* nrn_stack_type_name(nrn_stack_types_t id);
 Object* nrn_object_new(Symbol* sym, int narg);

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -9,6 +9,7 @@ foreach(
   object_ptr_push.cpp
   segment_diam.cpp
   sections.cpp
+  stack_pops.cpp
   symbol_object_string.cpp
   vclamp.cpp)
   string(REPLACE "." "_" api_test_name "${api_test_file}")

--- a/test/api/stack_pops.cpp
+++ b/test/api/stack_pops.cpp
@@ -1,9 +1,9 @@
 // NOTE: this assumes neuronapi.h is on your CPLUS_INCLUDE_PATH
-// Exercises nrn_symbol_pop and nrn_object_pop_safe, the stack-pop primitives
-// used to unwind an interpreter frame from a binding (the HOC-to-Python
-// component read/write-back path). nrn_symbol_pop pops a Symbol the interpreter
-// left on the stack; nrn_object_pop_safe pops an object but returns NULL for a
-// nil objref instead of dereferencing it the way nrn_object_pop would.
+// Exercises nrn_symbol_pop and nrn_object_pop's nil handling, the stack-pop
+// primitives used to unwind an interpreter frame from a binding (the
+// HOC-to-Python component read/write-back path). nrn_symbol_pop pops a Symbol
+// the interpreter left on the stack; nrn_object_pop pops an object but returns
+// NULL for a nil objref instead of dereferencing it to take a reference.
 #include <array>
 #include <iostream>
 #include "neuronapi.h"
@@ -41,21 +41,21 @@ int main(void) {
     ok &= check(nrn_symbol_pop() == t, "symbol pop returns the last pushed symbol");
     ok &= check(nrn_symbol_pop() == v, "symbol pop returns the earlier symbol (LIFO)");
 
-    // nrn_object_pop_safe returns a real object (reference-counted).
+    // nrn_object_pop returns a real object (reference-counted).
     Object* vec = nrn_object_new(nrn_symbol("Vector"), 0);
     ok &= check(vec != nullptr, "Vector constructed");
     nrn_object_push(vec);
-    Object* got = nrn_object_pop_safe();
-    ok &= check(got == vec, "safe pop returns the pushed object");
+    Object* got = nrn_object_pop();
+    ok &= check(got == vec, "object pop returns the pushed object");
     if (got) {
         nrn_object_unref(got);
     }
 
-    // nrn_object_pop_safe returns NULL for a nil object reference instead of
-    // crashing -- nrn_object_pop would dereference the NULL to ref it and
+    // nrn_object_pop returns NULL for a nil object reference instead of
+    // crashing -- a naive pop would dereference the NULL to take a reference and
     // segfault here.
     nrn_object_push(nullptr);
-    ok &= check(nrn_object_pop_safe() == nullptr, "safe pop returns NULL for a nil objref");
+    ok &= check(nrn_object_pop() == nullptr, "object pop returns NULL for a nil objref");
 
     // Stack balance: the pops above consumed exactly what was pushed.
     nrn_double_push(5.0);

--- a/test/api/stack_pops.cpp
+++ b/test/api/stack_pops.cpp
@@ -31,6 +31,15 @@ int main(void) {
 
     bool ok = true;
 
+    // Push a sentinel FIRST, below everything else the test does. The stack is
+    // LIFO, so if every push below is matched by exactly one pop the sentinel
+    // resurfaces on top at the end; recovering it then proves the pops neither
+    // over-popped into what lay beneath them nor left anything behind. A
+    // sentinel pushed *after* the pops could prove neither -- it would only ever
+    // probe the current top.
+    const double SENTINEL = 424242.0;
+    nrn_double_push(SENTINEL);
+
     // nrn_symbol_pop returns the Symbol on top of the stack, LIFO.
     Symbol* v = nrn_symbol("v");
     Symbol* t = nrn_symbol("t");
@@ -57,9 +66,10 @@ int main(void) {
     nrn_object_push(nullptr);
     ok &= check(nrn_object_pop() == nullptr, "object pop returns NULL for a nil objref");
 
-    // Stack balance: the pops above consumed exactly what was pushed.
-    nrn_double_push(5.0);
-    ok &= check(nrn_double_pop() == 5.0, "stack is balanced after the pops");
+    // Balance: with every push above consumed by exactly one pop, the sentinel
+    // from the very start is what remains on top.
+    ok &= check(nrn_double_pop() == SENTINEL,
+                "sentinel from before the pops is intact -- the stack is balanced");
 
     return ok ? 0 : 1;
 }

--- a/test/api/stack_pops.cpp
+++ b/test/api/stack_pops.cpp
@@ -1,0 +1,65 @@
+// NOTE: this assumes neuronapi.h is on your CPLUS_INCLUDE_PATH
+// Exercises nrn_symbol_pop and nrn_object_pop_safe, the stack-pop primitives
+// used to unwind an interpreter frame from a binding (the HOC-to-Python
+// component read/write-back path). nrn_symbol_pop pops a Symbol the interpreter
+// left on the stack; nrn_object_pop_safe pops an object but returns NULL for a
+// nil objref instead of dereferencing it the way nrn_object_pop would.
+#include <array>
+#include <iostream>
+#include "neuronapi.h"
+
+using std::cerr;
+using std::endl;
+
+// No public API leaves a bare Symbol (STACK_IS_SYM) on the stack -- the
+// interpreter pushes one during object-component access -- so the test uses the
+// internal push to put a Symbol there, the way nrniv would mid-expression.
+extern void hoc_pushs(Symbol*);
+
+extern "C" void modl_reg() {}
+
+static bool check(bool cond, const char* msg) {
+    if (!cond) {
+        cerr << "FAIL: " << msg << endl;
+    }
+    return cond;
+}
+
+int main(void) {
+    static std::array<const char*, 4> argv = {"stack_pops", "-nogui", "-nopython", nullptr};
+    nrn_init(3, argv.data());
+
+    bool ok = true;
+
+    // nrn_symbol_pop returns the Symbol on top of the stack, LIFO.
+    Symbol* v = nrn_symbol("v");
+    Symbol* t = nrn_symbol("t");
+    ok &= check(v != nullptr && t != nullptr, "symbols v and t resolve");
+    hoc_pushs(v);
+    hoc_pushs(t);
+    ok &= check(nrn_stack_type() == STACK_IS_SYM, "stack top is a symbol before nrn_symbol_pop");
+    ok &= check(nrn_symbol_pop() == t, "symbol pop returns the last pushed symbol");
+    ok &= check(nrn_symbol_pop() == v, "symbol pop returns the earlier symbol (LIFO)");
+
+    // nrn_object_pop_safe returns a real object (reference-counted).
+    Object* vec = nrn_object_new(nrn_symbol("Vector"), 0);
+    ok &= check(vec != nullptr, "Vector constructed");
+    nrn_object_push(vec);
+    Object* got = nrn_object_pop_safe();
+    ok &= check(got == vec, "safe pop returns the pushed object");
+    if (got) {
+        nrn_object_unref(got);
+    }
+
+    // nrn_object_pop_safe returns NULL for a nil object reference instead of
+    // crashing -- nrn_object_pop would dereference the NULL to ref it and
+    // segfault here.
+    nrn_object_push(nullptr);
+    ok &= check(nrn_object_pop_safe() == nullptr, "safe pop returns NULL for a nil objref");
+
+    // Stack balance: the pops above consumed exactly what was pushed.
+    nrn_double_push(5.0);
+    ok &= check(nrn_double_pop() == 5.0, "stack is balanced after the pops");
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
Adds `nrn_symbol_pop` to the public C API and makes `nrn_object_pop` nil-safe.

## What and why

Unwinding an interpreter stack frame from a binding -- the HOC-to-Python component read/write-back path (`pyobj.attr`) -- needs a symbol pop the public API does not provide, and needs the object pop to tolerate a nil `objref`. Without both, a consumer (myneuron, and equivalently the MATLAB interface) reaches for the C++-mangled internals instead.

```c
Symbol* nrn_symbol_pop(void);
Object* nrn_object_pop(void);  // now returns NULL on a nil objref instead of crashing
```

- **`nrn_symbol_pop`** wraps `hoc_spop`. The interpreter leaves the attribute's `Symbol` on the stack during object-component access, and unwinding that frame has to pop it. There is no public counterpart today.

- **`nrn_object_pop` nil-safe.** Previously it unconditionally did `(*obptr)->refcount++` to hand back a reference, which dereferences `NULL` when the stack entry is a nil `objref` (an unset `objref` right-hand side in a write-back, for example). It now guards that single ref and returns `NULL` for a nil object. This is strictly more permissive: identical for a real object, `NULL` instead of a segfault for nil. Per review, this replaces the earlier separate `nrn_object_pop_safe` -- the crashing behavior was not useful to any caller, so there is no reason to keep a safe copy beside it. A non-`NULL` result is still reference-counted and should be released with `nrn_object_unref`.

## Changes

- `src/nrniv/neuronapi.h`, `src/nrniv/neuronapi.cpp`: declare `nrn_symbol_pop`; fold the nil guard into `nrn_object_pop`.
- `docs/capi.rst`: documented `nrn_symbol_pop`, and noted the nil-safe return on `nrn_object_pop`.
- `test/api/stack_pops.cpp`: pushes symbols and pops them LIFO (checking `nrn_stack_type` reports `STACK_IS_SYM`), round-trips a real object through `nrn_object_pop`, and confirms a nil `objref` pops to `NULL` rather than crashing, with the stack left balanced.

Same structure as #3810. `make format-pr` clean (clang-format 12.0.1, cmakelang 0.6.13). `ctest -R stack_pops` passes; the `api::` group (12 tests) is green.

These are the last stack primitives needed to finish the HOC-to-Python read/write-back for the no-libnrnpython case without binding mangled symbols.