### PR TITLE
CI: ModelDB CI workflow that reuses an existing wheels artifact

### DIFF
--- a/.github/workflows/modeldb-ci-reuse-wheels.yml
+++ b/.github/workflows/modeldb-ci-reuse-wheels.yml
@@ -83,9 +83,8 @@ jobs:
     name: Run modelDB CI (reuse wheels)
     needs:
       - normalize
-    # Use @master once hines-grok/modeldb-ci-ref-input (ref input) is merged.
-    # Until then, the callable workflow with `ref` lives on that branch.
-    uses: neuronsimulator/nrn-modeldb-ci/.github/workflows/nrn-modeldb-ci.yaml@hines-grok/modeldb-ci-ref-input
+    # ref input: neuronsimulator/nrn-modeldb-ci#154 (on master)
+    uses: neuronsimulator/nrn-modeldb-ci/.github/workflows/nrn-modeldb-ci.yaml@master
     with:
       neuron_v1: ${{ inputs.neuron_v1 }}
       neuron_v2: ${{ needs.normalize.outputs.neuron_v2 }}

--- a/.github/workflows/modeldb-ci-reuse-wheels.yml
+++ b/.github/workflows/modeldb-ci-reuse-wheels.yml
@@ -1,0 +1,94 @@
+name: ModelDB CI (reuse wheels)
+
+# Retest ModelDB against an existing multi-wheel artifact from a prior NEURON
+# Release (or other) run — without rebuilding wheels.
+#
+# Operator flow:
+#   1. Open a Release (or other) run that already uploaded artifact "wheels".
+#   2. Copy the wheels artifact id (or a github.com .../artifacts/<id> URL).
+#   3. Actions → ModelDB CI (reuse wheels) → Run workflow:
+#        wheels_artifact  = that id or URL
+#        neuron_v1        = baseline, e.g. neuron==9.0.1
+#        modeldb_ci_ref   = master, or a nrn-modeldb-ci branch (e.g. a fix PR)
+#        models_to_run    = optional subset; empty = all ModelDB NEURON models
+#
+# Note: ModelDB installs one compatible wheel from the zip (first that pip
+# accepts on ubuntu-latest / configured Python), not the full OS×Python matrix.
+
+on:
+  workflow_dispatch:
+    inputs:
+      wheels_artifact:
+        description: 'GHA wheels artifact id, or URL ending in that id (from a prior run)'
+        required: true
+        type: string
+      neuron_v1:
+        description: 'Baseline NEURON (PyPI), e.g. neuron==9.0.1 or neuron'
+        required: true
+        default: 'neuron'
+        type: string
+      modeldb_ci_ref:
+        description: 'nrn-modeldb-ci git ref (branch/tag/SHA) to checkout for the package'
+        required: false
+        default: 'master'
+        type: string
+      models_to_run:
+        description: 'Empty for all models; or space-separated ModelDB accession numbers'
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  # Normalize bare artifact ids to a URL shape that nrn-modeldb-ci understands
+  # (starts with https://github.com/neuronsimulator/ and ends with the id).
+  normalize:
+    name: Normalize wheels artifact reference
+    runs-on: ubuntu-latest
+    outputs:
+      neuron_v2: ${{ steps.norm.outputs.neuron_v2 }}
+      modeldb_ci_ref: ${{ steps.norm.outputs.modeldb_ci_ref }}
+    steps:
+      - name: Build neuron_v2 string for modeldb-ci
+        id: norm
+        env:
+          RAW: ${{ inputs.wheels_artifact }}
+          REF: ${{ inputs.modeldb_ci_ref }}
+        run: |
+          set -euo pipefail
+          raw="$(echo "${RAW}" | tr -d '[:space:]')"
+          if [[ -z "${raw}" ]]; then
+            echo "wheels_artifact is empty" >&2
+            exit 1
+          fi
+          if [[ "${raw}" =~ ^[0-9]+$ ]]; then
+            v2="https://github.com/neuronsimulator/nrn/actions/artifacts/${raw}"
+          elif [[ "${raw}" =~ ^https://github.com/neuronsimulator/ ]]; then
+            v2="${raw}"
+          else
+            # Allow other strings that still end with an artifact id
+            if [[ "${raw}" =~ ([0-9]+)$ ]]; then
+              v2="https://github.com/neuronsimulator/nrn/actions/artifacts/${BASH_REMATCH[1]}"
+            else
+              echo "Cannot parse wheels_artifact: ${raw}" >&2
+              exit 1
+            fi
+          fi
+          ref="${REF:-master}"
+          echo "neuron_v2=${v2}"
+          echo "modeldb_ci_ref=${ref}"
+          echo "neuron_v2=${v2}" >> "${GITHUB_OUTPUT}"
+          echo "modeldb_ci_ref=${ref}" >> "${GITHUB_OUTPUT}"
+
+  nrn-modeldb-ci:
+    name: Run modelDB CI (reuse wheels)
+    needs:
+      - normalize
+    # Use @master once hines-grok/modeldb-ci-ref-input (ref input) is merged.
+    # Until then, the callable workflow with `ref` lives on that branch.
+    uses: neuronsimulator/nrn-modeldb-ci/.github/workflows/nrn-modeldb-ci.yaml@hines-grok/modeldb-ci-ref-input
+    with:
+      neuron_v1: ${{ inputs.neuron_v1 }}
+      neuron_v2: ${{ needs.normalize.outputs.neuron_v2 }}
+      ref: ${{ needs.normalize.outputs.modeldb_ci_ref }}
+      models_to_run: ${{ inputs.models_to_run }}
+      repo: neuronsimulator/nrn-modeldb-ci


### PR DESCRIPTION
## Summary

When a **NEURON Release** (or other wheel-building run) is green through the
wheel matrix but fails only at **ModelDB CI**, rebuilding every wheel just to
retest ModelDB is wasteful.

This PR adds a manual workflow, **ModelDB CI (reuse wheels)**, that:

- Takes an existing GitHub Actions **`wheels`** artifact (id or URL)
- Calls `nrn-modeldb-ci` with that artifact as `neuron_v2`
- Lets the operator choose **`modeldb_ci_ref`** (branch/tag/SHA of
  `nrn-modeldb-ci` to checkout for `modeldb-run.yaml` / `runmodels`)
- Optionally limits the suite via **`models_to_run`** (space-separated
  accessions; empty = all)

No wheels are built in this workflow.

### Operator flow

1. Open a prior run that uploaded artifact **`wheels`**.
2. Copy the artifact id (e.g. `8935275231`) or a
   `https://github.com/neuronsimulator/nrn/actions/artifacts/<id>` URL.
3. **Actions → ModelDB CI (reuse wheels) → Run workflow** (or `gh workflow run`
   after this file is on the default branch — GitHub only *registers*
   `workflow_dispatch` workflows from `master`).
4. Set `neuron_v1` (e.g. `neuron==9.0.1`), `modeldb_ci_ref` (usually `master`),
   and optional `models_to_run` (e.g. `2018023 2020504` for a smoke test).

### Scope note

ModelDB installs **one** compatible wheel from the multi-wheel zip (first that
pip accepts on the job's Python), not the full OS×Python matrix. That matches
existing `nrn-modeldb-ci` behavior.

### Dependency

Requires the `ref` input on the callable modeldb-ci workflow:

- neuronsimulator/nrn-modeldb-ci#154

Until that is merged, this workflow temporarily uses:

```yaml
uses: neuronsimulator/nrn-modeldb-ci/.github/workflows/nrn-modeldb-ci.yaml@hines-grok/modeldb-ci-ref-input
```

**Before merge to nrn master**, switch that line to `@master` once
neuronsimulator/nrn-modeldb-ci#154 is on modeldb-ci master (or land that PR
first, then flip in this PR).

### Follow-ups (out of scope here)

- Add `modeldb_ci_ref` to the full **NEURON Release** panel (same `ref`
  pass-through).
- Drop the temporary `@hines-grok/modeldb-ci-ref-input` pin after
  neuronsimulator/nrn-modeldb-ci#154 merges.

## Test plan

- [ ] Merge or land `modeldb-ci-reuse-wheels.yml` so the workflow is registered
      on the default branch (GitHub requirement for `workflow_dispatch` UI/`gh`)
- [ ] Ensure neuronsimulator/nrn-modeldb-ci#154 is available (`@master` or keep
      temporary `@hines-grok/modeldb-ci-ref-input`)
- [ ] Run with wheels artifact from a completed Release (e.g. run 30997749624,
      artifact `8935275231` while unexpired), `neuron_v1=neuron==9.0.1`,
      `modeldb_ci_ref=master`, `models_to_run=2018023 2020504`
- [ ] Confirm normalize job builds a github.com artifact URL; ModelDB jobs
      checkout the requested ref; smoke accessions do not reintroduce the old
      "4 failed model builds" gate for those ids
      (neuronsimulator/nrn-modeldb-ci#153 on master)
- [ ] Optional: full suite (`models_to_run` empty) as a longer check
- [ ] Before merge: `uses@master` once neuronsimulator/nrn-modeldb-ci#154 is
      merged
