### PR TITLE
Make `neuron` the default package name (#3807)

### DIFF
--- a/.github/workflows/wheels-template.yml
+++ b/.github/workflows/wheels-template.yml
@@ -114,12 +114,12 @@ jobs:
           sudo bash packaging/python/build_static_readline_osx.bash
 
       - name: Change name of package for release
-        if: inputs.build_type == 'release'
+        if: inputs.build_type == 'nightly'
         run: |
           python3 -m venv venv
           source venv/bin/activate
           python3 -m pip install tomli tomli-w
-          python3 packaging/python/change_name.py ./pyproject.toml neuron
+          python3 packaging/python/change_name.py ./pyproject.toml neuron-nightly
 
       - name: Optimize RX3D Python module
         if: inputs.optimize_rxd == true

--- a/docs/install/python_wheels.md
+++ b/docs/install/python_wheels.md
@@ -27,7 +27,7 @@ Any official update of these files shall imply a PR reviewed and merged before `
 
 All wheels built on Azure are:
 
-* Published to `Pypi.org` as
+* Published to `pypi.org` as
   * `neuron-nightly` -> when the pipeline is launched in CRON mode
   * `neuron-x.y.z` -> when the pipeline is manually triggered for release `x.y.z`
 * Stored as `Azure artifacts` in the Azure pipeline for every run.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requires = [
 # when making a release since PEP 621 disallows dynamic names.
 # Note that this only affects the name of the _wheel_, not the importable package name,
 # nor the CMake project name.
-name = "neuron-nightly"
+name = "neuron"
 description = "Empirically-based simulator for modeling neurons and networks of neurons"
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { file = "Copyright" }


### PR DESCRIPTION
9.0.2 release attempt failed because
master’s #3807 workflow plus release/9.0 still shipping the old default name without the old “rename on release” step.
This solution is to cherry pick c8289d44, merge this to release/9.0 and restart the NEURON release workflow.

Note: the former github Release 9.0.2 (in prerelease state) has been removed as well at the former 9.0.2 tag.
They will be re-created by the NEURON release workflow. This is ok because no wheels were uploaded during the previous release attempt.