### PR TITLE
Fix empty neuron.__version__ when git describe fails in shallow clones

### DIFF
--- a/cmake/MacroHelper.cmake
+++ b/cmake/MacroHelper.cmake
@@ -256,9 +256,9 @@ endfunction()
 function(add_cpp_git_information target scope)
   find_program(GIT git)
   if(EXISTS "${PROJECT_SOURCE_DIR}/.git" AND GIT)
-    # Shallow clones: tags may not be ancestors of HEAD, so describe fails and
-    # GIT_DESCRIBE would stay empty (neuron.__version__ / nrnversion(5)). Fall
-    # back to PROJECT_VERSION so release dry-run and ship wheels match.
+    # Shallow clones: tags may not be ancestors of HEAD, so describe fails and GIT_DESCRIBE would
+    # stay empty (neuron.__version__ / nrnversion(5)). Fall back to PROJECT_VERSION so release
+    # dry-run and ship wheels match.
     execute_process(
       COMMAND "${GIT}" -C "${PROJECT_SOURCE_DIR}" describe
       OUTPUT_VARIABLE GIT_DESCRIBE

--- a/cmake/MacroHelper.cmake
+++ b/cmake/MacroHelper.cmake
@@ -256,10 +256,20 @@ endfunction()
 function(add_cpp_git_information target scope)
   find_program(GIT git)
   if(EXISTS "${PROJECT_SOURCE_DIR}/.git" AND GIT)
+    # Shallow clones: tags may not be ancestors of HEAD, so describe fails and
+    # GIT_DESCRIBE would stay empty (neuron.__version__ / nrnversion(5)). Fall
+    # back to PROJECT_VERSION so release dry-run and ship wheels match.
     execute_process(
       COMMAND "${GIT}" -C "${PROJECT_SOURCE_DIR}" describe
       OUTPUT_VARIABLE GIT_DESCRIBE
+      RESULT_VARIABLE GIT_DESCRIBE_RESULT
       OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+
+    if(GIT_DESCRIBE_RESULT OR "${GIT_DESCRIBE}" STREQUAL "")
+      set(GIT_DESCRIBE "${PROJECT_VERSION}")
+      message(
+        STATUS "git describe failed or empty; falling back to PROJECT_VERSION=${PROJECT_VERSION}")
+    endif()
 
     execute_process(
       COMMAND "${GIT}" -C "${PROJECT_SOURCE_DIR}" rev-parse --abbrev-ref HEAD

--- a/packaging/python/test_wheels.sh
+++ b/packaging/python/test_wheels.sh
@@ -256,6 +256,8 @@ $python_exe -m uv pip install -r packaging/python/test_requirements.txt
 $python_exe -m uv pip install --force-reinstall $python_wheel
 $python_exe -m uv pip show neuron || $python_exe -m uv pip show neuron-nightly
 
+# neuron.__version__ is nrnversion(5)/GIT_DESCRIBE; empty breaks ModelDB workdir naming
+$python_exe -c "import neuron; v = neuron.__version__; assert v and str(v).strip(), repr(v)"
 
 # check the existence of coreneuron support
 compile_options="$(nrniv -nobanner -nogui -c 'nrnversion(6)')"


### PR DESCRIPTION
## Summary

- Release dry-run wheels use a depth-1 checkout and do not create the release tag, so `git describe` fails while `.git` still exists.
- `add_cpp_git_information` left `GIT_DESCRIBE` empty in that case, so `neuron.__version__` (`nrnversion(5)`) was `""` and ModelDB CI failed on `runmodels --workdir=$nrn_ver` (`mkdir('')`).
- Fall back to `PROJECT_VERSION` when describe fails/empty so dry-run and ship wheels get the same non-empty string (e.g. `9.0.2`).
- Assert non-empty `__version__` in `test_wheels.sh`.

## Test plan

- [ ] Wheel CI / NEURON Release dry-run: `python -c "import neuron; print(repr(neuron.__version__))"` is non-empty (e.g. `'9.0.2'`)
- [ ] ModelDB V2 no longer fails with empty workdir after installing dry-run wheels
- [ ] Ship path (`upload=true`, tag checkout) still reports the tag version via describe