### PR TITLE
CI/release: dry-run fixes (empty __version__, artifact-url, MPICH arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,9 @@ jobs:
     needs:
       - build-wheels
     outputs:
-      artifacts-url: ${{ steps.merge-artifacts.outputs.artifacts-url }}
+      # upload-artifact/merge@v4 exports artifact-url (singular), not artifacts-url.
+      # Job output key stays artifacts-url for existing consumers (modeldb-ci, build-ci).
+      artifacts-url: ${{ steps.merge-artifacts.outputs.artifact-url }}
     steps:
       - name: Merge Artifacts
         id: merge-artifacts

--- a/ci/deps/MANIFEST.yml
+++ b/ci/deps/MANIFEST.yml
@@ -49,6 +49,28 @@ assets:
       - ci/deps/install_mpich_noble.sh
     notes: Runtime library package for mpich-noble-4.2.0-5.1.
 
+  - id: mpich-noble-4.2.0-5.1-arm64
+    file: mpich_4.2.0-5.1_arm64.deb
+    sha256: c790342026ca5786bdad889af5b2c6f4c249bb07968aaf5435feb6b2771df452
+    upstream_url: https://launchpad.net/ubuntu/+source/mpich/4.2.0-5.1/+build/28285883/+files/mpich_4.2.0-5.1_arm64.deb
+    managed: true
+    consumers:
+      - .github/workflows/wheels-template.yml
+      - ci/deps/install_mpich_noble.sh
+    notes: >
+      arm64 counterpart of mpich-noble-4.2.0-5.1 (Launchpad build 28285883).
+      Pair with libmpich12-noble-4.2.0-5.1-arm64. Used by ubuntu-24.04-arm wheel tests.
+
+  - id: libmpich12-noble-4.2.0-5.1-arm64
+    file: libmpich12_4.2.0-5.1_arm64.deb
+    sha256: 4fdbdcdcf23a36f3f7fcd2f2fe2fdaff24629a107fa9f0c6904dd1c3aa662ae1
+    upstream_url: https://launchpad.net/ubuntu/+source/mpich/4.2.0-5.1/+build/28285883/+files/libmpich12_4.2.0-5.1_arm64.deb
+    managed: true
+    consumers:
+      - .github/workflows/wheels-template.yml
+      - ci/deps/install_mpich_noble.sh
+    notes: Runtime library package for mpich-noble-4.2.0-5.1-arm64.
+
   # --- P0/P1: static readline/ncurses sources (GNU mirrors flake) ---
   - id: ncurses-6.4-src
     file: ncurses-6.4.tar.gz

--- a/ci/deps/README.md
+++ b/ci/deps/README.md
@@ -76,7 +76,7 @@ There is no automatic upgrade. `check-upstream.sh` is awareness only.
 
 Hosted on **nrn-ci-deps** release **`ci-deps-v1`**:
 
-- `mpich_4.2.0-5.1_amd64.deb` + `libmpich12_4.2.0-5.1_amd64.deb` — Ubuntu 24.04 wheel tests (LP#2072338)
+- `mpich_4.2.0-5.1_{amd64,arm64}.deb` + `libmpich12_4.2.0-5.1_{amd64,arm64}.deb` — Ubuntu 24.04 wheel tests (LP#2072338); `install_mpich_noble.sh` selects by `dpkg --print-architecture`
 - `ncurses-6.4.tar.gz`, `readline-8.3.tar.gz` — Mac static readline (`build_static_readline_osx.bash`)
 - `readline-7.0.tar.gz`, `ncurses-6.4.tar.gz` — manylinux wheel image (`packaging/python/Dockerfile`)
 - `automake-1.16.5.tar.xz` — Ubuntu MUSIC path in `neuron-ci.yml`

--- a/ci/deps/install_mpich_noble.sh
+++ b/ci/deps/install_mpich_noble.sh
@@ -30,6 +30,26 @@ if [[ "$(id -u)" -ne 0 ]]; then
   exit 1
 fi
 
+arch="$(dpkg --print-architecture)"
+case "${arch}" in
+  amd64)
+    mpich_id="mpich-noble-4.2.0-5.1"
+    lib_id="libmpich12-noble-4.2.0-5.1"
+    mpich_deb="mpich_4.2.0-5.1_amd64.deb"
+    lib_deb="libmpich12_4.2.0-5.1_amd64.deb"
+    ;;
+  arm64)
+    mpich_id="mpich-noble-4.2.0-5.1-arm64"
+    lib_id="libmpich12-noble-4.2.0-5.1-arm64"
+    mpich_deb="mpich_4.2.0-5.1_arm64.deb"
+    lib_deb="libmpich12_4.2.0-5.1_arm64.deb"
+    ;;
+  *)
+    echo "error: unsupported architecture '${arch}' for pinned mpich (need amd64 or arm64)" >&2
+    exit 1
+    ;;
+esac
+
 WORKDIR="$(mktemp -d -t nrn-mpich-noble.XXXXXX)"
 cleanup() { rm -rf "${WORKDIR}"; }
 trap cleanup EXIT
@@ -39,15 +59,15 @@ trap cleanup EXIT
 # Override with NRN_CI_DEPS_SOURCE=local if debugging with a gitignored assets/ copy.
 export NRN_CI_DEPS_SOURCE="${NRN_CI_DEPS_SOURCE:-release}"
 
-"${SCRIPT_DIR}/fetch.sh" mpich-noble-4.2.0-5.1 "${WORKDIR}"
-"${SCRIPT_DIR}/fetch.sh" libmpich12-noble-4.2.0-5.1 "${WORKDIR}"
+"${SCRIPT_DIR}/fetch.sh" "${mpich_id}" "${WORKDIR}"
+"${SCRIPT_DIR}/fetch.sh" "${lib_id}" "${WORKDIR}"
 
 # Ensure base packages exist (headers etc.) then overwrite with pinned debs.
 apt-get install -y -qq mpich libmpich-dev || true
 dpkg --install \
-  "${WORKDIR}/libmpich12_4.2.0-5.1_amd64.deb" \
-  "${WORKDIR}/mpich_4.2.0-5.1_amd64.deb"
+  "${WORKDIR}/${lib_deb}" \
+  "${WORKDIR}/${mpich_deb}"
 
-echo "installed pinned mpich 4.2.0-5.1 for Ubuntu 24.04"
+echo "installed pinned mpich 4.2.0-5.1 for Ubuntu 24.04 (${arch})"
 mpichversion 2>/dev/null || true
 mpirun.mpich --version 2>/dev/null || mpirun --version 2>/dev/null || true

--- a/cmake/MacroHelper.cmake
+++ b/cmake/MacroHelper.cmake
@@ -256,9 +256,9 @@ endfunction()
 function(add_cpp_git_information target scope)
   find_program(GIT git)
   if(EXISTS "${PROJECT_SOURCE_DIR}/.git" AND GIT)
-    # Shallow clones: tags may not be ancestors of HEAD, so describe fails and
-    # GIT_DESCRIBE would stay empty (neuron.__version__ / nrnversion(5)). Fall
-    # back to PROJECT_VERSION so release dry-run and ship wheels match.
+    # Shallow clones: tags may not be ancestors of HEAD, so describe fails and GIT_DESCRIBE would
+    # stay empty (neuron.__version__ / nrnversion(5)). Fall back to PROJECT_VERSION so release
+    # dry-run and ship wheels match.
     execute_process(
       COMMAND "${GIT}" -C "${PROJECT_SOURCE_DIR}" describe
       OUTPUT_VARIABLE GIT_DESCRIBE

--- a/cmake/MacroHelper.cmake
+++ b/cmake/MacroHelper.cmake
@@ -256,10 +256,20 @@ endfunction()
 function(add_cpp_git_information target scope)
   find_program(GIT git)
   if(EXISTS "${PROJECT_SOURCE_DIR}/.git" AND GIT)
+    # Shallow clones: tags may not be ancestors of HEAD, so describe fails and
+    # GIT_DESCRIBE would stay empty (neuron.__version__ / nrnversion(5)). Fall
+    # back to PROJECT_VERSION so release dry-run and ship wheels match.
     execute_process(
       COMMAND "${GIT}" -C "${PROJECT_SOURCE_DIR}" describe
       OUTPUT_VARIABLE GIT_DESCRIBE
+      RESULT_VARIABLE GIT_DESCRIBE_RESULT
       OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+
+    if(GIT_DESCRIBE_RESULT OR "${GIT_DESCRIBE}" STREQUAL "")
+      set(GIT_DESCRIBE "${PROJECT_VERSION}")
+      message(
+        STATUS "git describe failed or empty; falling back to PROJECT_VERSION=${PROJECT_VERSION}")
+    endif()
 
     execute_process(
       COMMAND "${GIT}" -C "${PROJECT_SOURCE_DIR}" rev-parse --abbrev-ref HEAD

--- a/docs/install/ci_deps.md
+++ b/docs/install/ci_deps.md
@@ -39,12 +39,16 @@ ci/deps/fetch.sh --list
 
 # Download a managed asset from nrn-ci-deps (default for install helpers)
 NRN_CI_DEPS_SOURCE=release ci/deps/fetch.sh mpich-noble-4.2.0-5.1 /tmp/out
+# arm64 pin (ubuntu-24.04-arm wheel tests):
+# NRN_CI_DEPS_SOURCE=release ci/deps/fetch.sh mpich-noble-4.2.0-5.1-arm64 /tmp/out
 
 # Ubuntu 24.04 wheel tests: install pinned MPICH from the Release
+# (selects amd64 or arm64 debs via dpkg --print-architecture)
 ci/deps/install_mpich_noble.sh
 
 # Compare pins to upstream (awareness only; does not auto-upgrade)
 ci/deps/check-upstream.sh mpich-noble-4.2.0-5.1
+# ci/deps/check-upstream.sh mpich-noble-4.2.0-5.1-arm64
 ```
 
 Promote a new pin (files stay local/transient; then upload to **nrn-ci-deps**):
@@ -60,7 +64,8 @@ rm -f ci/deps/assets/*   # optional; assets/ is gitignored
 
 On **nrn-ci-deps** release **`ci-deps-v1`**:
 
-- Ubuntu 24.04 MPICH packages for wheel tests (LP#2072338)
+- Ubuntu 24.04 MPICH packages for wheel tests (LP#2072338), **amd64 and arm64**
+
 - GNU **ncurses** / **readline** sources for Mac static readline and the manylinux Dockerfile
 - **automake** 1.16.5 for the Ubuntu MUSIC job in `neuron-ci`
 

--- a/packaging/python/test_wheels.sh
+++ b/packaging/python/test_wheels.sh
@@ -268,6 +268,8 @@ $python_exe -m uv pip install -r packaging/python/test_requirements.txt
 $python_exe -m uv pip install --force-reinstall $python_wheel
 $python_exe -m uv pip show neuron || $python_exe -m uv pip show neuron-nightly
 
+# neuron.__version__ is nrnversion(5)/GIT_DESCRIBE; empty breaks ModelDB workdir naming
+$python_exe -c "import neuron; v = neuron.__version__; assert v and str(v).strip(), repr(v)"
 
 # check the existence of coreneuron support
 compile_options="$(nrniv -nobanner -nogui -c 'nrnversion(6)')"


### PR DESCRIPTION
## Summary

Port post–9.0.2 release hygiene to **master** so dry-runs controlled from master behave like the successful 9.0.2 ship path:

1. **Empty `neuron.__version__`** — when shallow clones make `git describe` fail, fall back to `PROJECT_VERSION` in `add_cpp_git_information` (plus wheel test assert). Cherry-picked from #3840 / `release/9.0`.
2. **merge-wheels artifact URL** — use `artifact-url` (not `artifacts-url`) so ModelDB/build-ci get this run’s wheels, not a nightly fallback. From `hines-grok/release-modeldb-artifact-url`.
3. **Ubuntu 24.04 arm64 MPICH pin** — select amd64 vs arm64 debs in `install_mpich_noble.sh` so arm wheel tests don’t install wrong packages. From `release/9.0`.

## Test plan

- [ ] CI green on this PR
- [ ] Optional: NEURON Release dry-run with workflow from this branch/`master` after merge, `rel_branch=release/9.0` (or tip), `upload=false` — confirm non-empty `__version__` and ModelDB V2 uses the run’s wheels artifact URL

## Out of scope

- #3838 (ModelDB reuse-wheels workflow)
- Local annotated tags on dry-run
- Release checklist / Azure→GHA docs refresh