### PR TITLE
Fix KSChan point-process OOB write of dparam[2]

### DIFF
--- a/src/nrniv/kschan.cpp
+++ b/src/nrniv/kschan.cpp
@@ -2328,9 +2328,6 @@ void KSChan::alloc(Prop* prop) {
     if (!is_point() || nrn_point_prop_ == 0) {
         if (ppsize > 0) {
             prop->dparam = nrn_prop_datum_alloc(prop->_type, ppsize, prop);
-            if (is_point()) {
-                prop->dparam[2] = nullptr;
-            }
         } else {
             prop->dparam = 0;
         }


### PR DESCRIPTION
## Summary

- Removes a latent out-of-bounds write in `KSChan::alloc` that always did `prop->dparam[2] = nullptr` for point processes.
- That slot only exists when single-channel mode (or later ion/ligand fields) makes `ppsize > 2`. Plain point KSChan instances allocate only `area` and `pnt`, so index 2 was past the allocated `Datum` vector.
- Default `ArrayPool` freelist order hid the overflow inside the next free slab row; a reversed freelist exposes it under ASAN (see #3843).
- `nrn_prop_datum_alloc` already default-constructs every `Datum` to the null handle state, and `dparam[0]`/`[1]` are filled by `point.cpp` after `nrn_alloc`. The redundant nulling is removed; `single_->alloc` still runs when `single_` is set and the singleptr slot is null.

## Test plan

- [ ] Rebuild and run `hoctests::test_kschan_py` (with and without ASAN).
- [ ] Optionally re-apply the reverse freelist seed in `arraypool.h` from #3843 and confirm ASAN no longer fails on that test.
- [ ] Exercise single-channel paths in the same test (`ks.single(1)`, etc.) to confirm singleptr allocation still works.

Fixes #3843