### PR TITLE
Mac wheels: pin static readline 7.0 (restore nrniv/nrngui tty input)

### DIFF
--- a/ci/deps/MANIFEST.yml
+++ b/ci/deps/MANIFEST.yml
@@ -89,20 +89,22 @@ assets:
     managed: true
     consumers:
       - packaging/python/Dockerfile
+      - packaging/python/build_static_readline_osx.bash
     notes: >
-      Linux manylinux Dockerfile uses 7.0. Azure Mac wheels use prebuilt secure
-      file readline7.0-ncurses6.4.tar.gz (not in this manifest yet).
+      Linux manylinux Dockerfile and GH Actions Mac wheels use 7.0. Azure Mac
+      wheels still use prebuilt secure file readline7.0-ncurses6.4.tar.gz
+      (not in this manifest yet). Do not bump Mac wheels to 8.3: it breaks
+      tty input when InterViews multiplexes stdin with X11.
 
   - id: readline-8.3-src
     file: readline-8.3.tar.gz
     sha256: fe5383204467828cd495ee8d1d3c037a7eba1389c22bc6a041f627976f9061cc
     upstream_url: https://ftp.gnu.org/gnu/readline/readline-8.3.tar.gz
     managed: true
-    consumers:
-      - packaging/python/build_static_readline_osx.bash
+    consumers: []
     notes: >
-      GH Actions Mac wheels rebuild from 8.3 every job — version skew vs Azure 7.0
-      prebuilt. Unify in a later PR.
+      Hosted pin kept for reference. Mac wheels must stay on 7.0 (see
+      build_static_readline_osx.bash).
 
   # --- P1: Windows installer toolchain ---
   - id: nsis-3.05

--- a/packaging/python/build_static_readline_osx.bash
+++ b/packaging/python/build_static_readline_osx.bash
@@ -38,7 +38,10 @@ trap cleanup EXIT
 
 export NRN_CI_DEPS_SOURCE="${NRN_CI_DEPS_SOURCE:-release}"
 bash "${FETCH}" ncurses-6.4-src "${WORKDIR}"
-bash "${FETCH}" readline-8.3-src "${WORKDIR}"
+# Keep Mac wheels on readline 7.0. 8.3 (from #3809) breaks tty input when
+# InterViews is multiplexing stdin with X11 (nrniv/nrngui with DISPLAY set).
+# Linux wheels already pin 7.0 in packaging/python/Dockerfile.
+bash "${FETCH}" readline-7.0-src "${WORKDIR}"
 
 (
   tar -xzf "${WORKDIR}/ncurses-6.4.tar.gz" -C "${WORKDIR}"
@@ -48,8 +51,8 @@ bash "${FETCH}" readline-8.3-src "${WORKDIR}"
 )
 
 (
-  tar -xzf "${WORKDIR}/readline-8.3.tar.gz" -C "${WORKDIR}"
-  cd "${WORKDIR}/readline-8.3"
+  tar -xzf "${WORKDIR}/readline-7.0.tar.gz" -C "${WORKDIR}"
+  cd "${WORKDIR}/readline-7.0"
   ./configure --prefix="${NRNWHEEL_DIR}/readline" --disable-shared CFLAGS="-fPIC"
   make -j install
 )


### PR DESCRIPTION
## Summary

Mac `neuron` / `neuron-nightly` wheels built after #3809 ignore keyboard input in `nrniv` / `nrngui` when `DISPLAY` is set. `-nogui` and no-`DISPLAY` still work.

#3809 upgraded the **macOS** static readline from **7.0 → 8.3**. Linux wheels were never upgraded (`packaging/python/Dockerfile` is still 7.0). GNU readline 8.3 breaks tty input when InterViews multiplexes stdin with X11.

This restores the 7.0 pin for GH Actions Mac wheels and updates `ci/deps/MANIFEST.yml` so 7.0 is the documented consumer.

## Local verification

Same source (`master` @ d71477fd8), system X11 (not delocate), isolated prefixes:

| Wheel | readline | `nrniv`/`nrngui` + `DISPLAY` | `-nogui` |
|---|---|---|---|
| local 8.3 | 8.3 | keyboard ignored | works |
| this PR | 7.0 | `print 1+2` → `3` | works |

Matches PyPI: `neuron==9.0.1` (7.0) works; `neuron-nightly` / 9.0.2 Mac wheels (8.3) do not. The 9.0.2 pkg installer is unaffected (different readline recipe).

## Test plan

- [x] Local arm64 wheel vs readline 8.3 reproduces dead stdin
- [x] Local arm64 wheel vs readline 7.0 restores stdin
- [ ] CI Mac wheel job
- [ ] After merge: install nightly/PR wheel and type at `oc>` in `nrngui`