### PR TITLE
docs: GHA-first release templates and ModelDB reuse-wheels

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-patch.md
+++ b/.github/ISSUE_TEMPLATE/release-patch.md
@@ -10,38 +10,49 @@ assignees: ''
 Action items
 ============
 
+GHA release knobs
+---
+[NEURON Release](https://github.com/neuronsimulator/nrn/actions/workflows/release.yml) is the release path (wheels, ModelDB CI, nrn-build-ci, full-src, Windows installer, tag, PyPI). Three knobs:
+
+* **Controller** — branch whose workflow YAML runs (`Use workflow from`). Ship from **`master`**.
+* **`rel_branch`** — content to build (usually `release/x.y`).
+* **`rel_tag`** — version name (`x.y.z`).
+
+`upload=false` is a dry-run (no git tag, no GitHub release, no PyPI). `upload=true` ships. See [wheel publishing](https://nrn.readthedocs.io/en/latest/install/python_wheels.html#publishing-the-wheels-on-pypi-via-github-actions).
+
 Pre-release
 ---
 - [ ] Create a cherrypicks branch where all commits go into new release and open a PR against `release/x.y` branch
-- [ ] Make sure to look out for ModelDB regressions by manually submitting and analyzing [nrn-modeldb-ci](https://github.com/neuronsimulator/nrn-modeldb-ci/actions/workflows/nrn-modeldb-ci.yaml?query=event%3Aschedule++) for the cherrypicks branch vs previous version
+- [ ] Watch for ModelDB regressions (dry-run ModelDB below, or [ModelDB CI (reuse wheels)](https://github.com/neuronsimulator/nrn/actions/workflows/modeldb-ci-reuse-wheels.yml) against a prior `wheels` artifact vs the previous PyPI version). Local `nrn-modeldb-ci` is optional.
 - [ ] Update cherrypicks PR:
   - [ ] Update semantic version in `CMakeLists.txt`
   - [ ] Update changelog below and agree on it with everyone; then commit it to `docs/changelog` in the cherrypicks PR (copy structure as-is)
-- [ ] Activate ReadtheDocs for the cherry-pick branch and ensure the documentation builds (when logged in, go to [the versions page](https://readthedocs.org/projects/nrn/versions/) and set the version for your branch to Active and Hidden)
-- [ ] Run a test wheel build WITHOUT upload on the cherry-pick branch to ensure all the wheels build ([see details](https://nrn.readthedocs.io/en/latest/install/python_wheels.html#publishing-the-wheels-on-pypi-via-azure))
+- [ ] Activate ReadTheDocs for the cherry-pick branch and ensure the documentation builds (when logged in, go to [the versions page](https://readthedocs.org/projects/nrn/versions/) and set the version to Active and Hidden; if the branch is missing, use **+ Add version**)
+- [ ] Optional: [NEURON Release](https://github.com/neuronsimulator/nrn/actions/workflows/release.yml) dry-run on the cherry-pick branch (`Use workflow from` = `master`, `rel_branch` = the cherry-pick branch, `rel_tag` = `x.y.z`, **`upload=false`**) to confirm wheels build before merge
 
 Sanity checks
 ---
-- [ ] After cherrypicks PR is merged, make sure GitHub and Azure builds pass for `release/x.y` branch
-- [ ] Run [nrn-build-ci](https://github.com/neuronsimulator/nrn-build-ci/actions/workflows/build-neuron.yml) for the `release/x.y` branch; see [nrn-build-ci guide](https://github.com/neuronsimulator/nrn-build-ci#azure-wheels-testing---manual-workflow)
-- [ ] Activate ReadTheDocs build for `release/x.y` & make it hidden. Check docs are fine after build is done.
+- [ ] After cherrypicks PR is merged, make sure GitHub Actions pass for `release/x.y` (Azure still runs on `release/*` if enabled; it is not the publish path)
+- [ ] Dry-run [NEURON Release](https://github.com/neuronsimulator/nrn/actions/workflows/release.yml) from **`master`**: `rel_branch=release/x.y`, `rel_tag=x.y.z`, **`upload=false`**. Confirm wheels are green, `neuron.__version__` is non-empty, and ModelDB V2 uses **this run’s** `wheels` artifact
+- [ ] If only ModelDB failed, do **not** rebuild wheels: [ModelDB CI (reuse wheels)](https://github.com/neuronsimulator/nrn/actions/workflows/modeldb-ci-reuse-wheels.yml) with the dry-run `wheels` artifact id or URL, `neuron_v1=neuron==<previous>`, `modeldb_ci_ref=master` (optional `models_to_run` for a subset)
+- [ ] nrn-build-ci runs inside NEURON Release; optional extra run: [nrn-build-ci](https://github.com/neuronsimulator/nrn-build-ci/actions/workflows/build-neuron.yml) with the same GHA `wheels` artifact URL ([manual workflow](https://github.com/neuronsimulator/nrn-build-ci#wheels-testing---manual-workflow))
+- [ ] Activate ReadTheDocs build for `release/x.y` and make it hidden. Check docs after the build. If the branch is missing, **+ Add version**.
 - [ ] Run BBP Simulation Stack & other relevant tests
+- [ ] Freeze SHAs: dry-run `rel_branch` tip == the commit you will ship
 
 
 Releasing
 ---
-- [ ] Create new release+tag on GitHub via [release workflow](https://github.com/neuronsimulator/nrn/actions/workflows/release.yml?query=workflow%3A%22NEURON+Release%22). Note that the GitHub release will be marked as pre-release and  will contain the full-src-package and the Windows installer at the end of the release workflow.
-- [ ] Build release wheels but WITHOUT upload ([see details](https://nrn.readthedocs.io/en/latest/install/python_wheels.html#publishing-the-wheels-on-pypi-via-azure))
+- [ ] Ship with the **same** controller (`master`), `rel_branch`, `rel_tag`, and SHAs as the last green dry-run, **`upload=true`**. This creates the annotated tag, a **pre-release** on GitHub (full-src-package and Windows installer attach when those jobs finish), and publishes wheels to PyPI.
 - [ ] Create, test and upload manual artifacts
   - [ ] MacOS package installer (manual task, ask Michael)
-- [ ] Publish the `x.y.z` wheels on PyPI; see [wheel publishing instructions](https://nrn.readthedocs.io/en/latest/install/python_wheels.html#publishing-the-wheels-on-pypi-via-azure)
-- [ ] Once wheels are published, activate the `x.y.z` tag on ReadTheDocs
+- [ ] Once wheels are on PyPI, activate the `x.y.z` **tag** on ReadTheDocs: [versions page](https://readthedocs.org/projects/nrn/versions/) → **+ Add version** if the tag is not listed (new/unbuilt tags are hidden under “Recently built”). Leave it **not** Hidden.
 - [ ] Publish release on GitHub (edit https://github.com/neuronsimulator/nrn/releases/tag/x.y.z and un-tick the pre-release checkbox)
 
 
 Post-release
 ---
-- [ ] Deactivate ReadTheDocs build for `release/x.y`
+- [ ] Deactivate ReadTheDocs build for `release/x.y` (keep the `x.y.z` tag active)
 - [ ] Go to [ReadTheDocs advanced settings](https://readthedocs.org/dashboard/nrn/advanced/) and set `Default version` to `x.y.z`
 - [ ] Let people know :rocket:
 - [ ] Cherrypick changelog to `master`

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -10,21 +10,34 @@ assignees: ''
 Action items
 ============
 
+GHA release knobs
+---
+[NEURON Release](https://github.com/neuronsimulator/nrn/actions/workflows/release.yml) is the release path (wheels, ModelDB CI, nrn-build-ci, full-src, Windows installer, tag, PyPI). Three knobs:
+
+* **Controller** — branch whose workflow YAML runs (`Use workflow from`). Ship from **`master`**.
+* **`rel_branch`** — content to build (`release/x.y`).
+* **`rel_tag`** — version name (`x.y.z`).
+
+`upload=false` is a dry-run (no git tag, no GitHub release, no PyPI). `upload=true` ships. See [wheel publishing](https://nrn.readthedocs.io/en/latest/install/python_wheels.html#publishing-the-wheels-on-pypi-via-github-actions).
+
 Sanity checks
 ---
-- [ ] Create `release/x.y` branch and make sure GitHub and Azure builds pass
+- [ ] Create `release/x.y` branch and make sure GitHub Actions pass (Azure still runs on `release/*` if enabled; it is not the publish path)
+- [ ] Dry-run [NEURON Release](https://github.com/neuronsimulator/nrn/actions/workflows/release.yml) from **`master`**: `rel_branch=release/x.y`, `rel_tag=x.y.z`, **`upload=false`**. Confirm wheels are green, `neuron.__version__` is non-empty, and ModelDB V2 uses **this run’s** `wheels` artifact
+- [ ] If only ModelDB failed, do **not** rebuild wheels: [ModelDB CI (reuse wheels)](https://github.com/neuronsimulator/nrn/actions/workflows/modeldb-ci-reuse-wheels.yml) with the dry-run `wheels` artifact id or URL, `neuron_v1=neuron==<previous>`, `modeldb_ci_ref=master` (optional `models_to_run` for a subset)
 - [ ] Run any tests not contained in `nrn-build-ci` and `nrn-modeldb-ci`
+- [ ] Freeze SHAs: dry-run `rel_branch` tip == the commit you will ship
 
 
 Releasing
 ---
 - [ ] Update semantic version in `CMakeLists.txt`
 - [ ] Update changelog below and agree on it with everyone; then commit it to `docs/changelog` (copy structure as-is)
-- [ ] Run the ReadTheDocs build again for `release/x.y`, make sure the build passes and inspect the Changelog page.
+- [ ] Activate ReadTheDocs for `release/x.y` (Hidden until ship). If the branch is missing from [the versions page](https://readthedocs.org/projects/nrn/versions/), use **+ Add version**. Inspect the Changelog page after the build.
 - [ ] Create, test and upload manual artifacts
   - [ ] MacOS package installer (manual task, ask Michael)
-- [ ] Create new release+tag on GitHub via [release workflow](https://github.com/neuronsimulator/nrn/actions/workflows/release.yml?query=workflow%3A%22NEURON+Release%22). Note that the GitHub release will be marked as pre-release and will contain the full-src-package and the Windows installer at the end of the release workflow.
-- [ ] Once wheels are published, activate the `x.y.z` tag on ReadTheDocs
+- [ ] Ship with the **same** controller (`master`), `rel_branch`, `rel_tag`, and SHAs as the last green dry-run, **`upload=true`**. This creates the annotated tag, a **pre-release** on GitHub (full-src-package and Windows installer attach when those jobs finish), and publishes wheels to PyPI.
+- [ ] Once wheels are on PyPI, activate the `x.y.z` **tag** on ReadTheDocs: [versions page](https://readthedocs.org/projects/nrn/versions/) → **+ Add version** if the tag is not listed (new/unbuilt tags are hidden under “Recently built”). Leave it **not** Hidden.
 - [ ] Publish release on GitHub (edit https://github.com/neuronsimulator/nrn/releases/tag/x.y.z and un-tick the pre-release checkbox)
 
 
@@ -33,7 +46,7 @@ Post-release
 - [ ] To mark the start of a new development cycle, tag `master` as follows:
   - minor version: `x.(y+1).dev`
   - major version: `(x+1).0.dev`
-- [ ] Deactivate ReadTheDocs build for `release/x.y`
+- [ ] Deactivate ReadTheDocs build for `release/x.y` (keep the `x.y.z` tag active)
 - [ ] Go to [ReadTheDocs advanced settings](https://readthedocs.org/dashboard/nrn/advanced/) and set `Default version` to `x.y.z`
 - [ ] Let people know :rocket:
 - [ ] Cherrypick changelog to `master`

--- a/docs/README.md
+++ b/docs/README.md
@@ -99,6 +99,6 @@ To create a new public release on RTD, follow these steps:
 
 * create a new release (see [GHA Neuron Release - Manual Workflow](https://github.com/neuronsimulator/nrn/actions?query=workflow%3A%22NEURON+Release%22))
 * publish the wheels (these will be pip-installed by RTD)
-* go to [NRN RTD Versions page](https://readthedocs.org/projects/nrn/versions/) and activate the new tag. Make sure that the version is not marked as hidden.
+* go to [NRN RTD Versions page](https://readthedocs.org/projects/nrn/versions/) and activate the new **tag**. If the tag is missing from the list (new tags often do not appear under “Recently built” until they have been built once), click **+ Add version**, choose the tag, and save. Make sure the version is **not** marked as hidden.
 
 **NOTE**: builds can be re-launched as many times as needed

--- a/docs/install/python_wheels.md
+++ b/docs/install/python_wheels.md
@@ -19,18 +19,19 @@ When required (i.e. update packages, add new software), `NEURON maintainers` are
 updating the NEURON docker images published on Docker Hub under
 [neuronsimulator/neuron_wheel](https://hub.docker.com/r/neuronsimulator/neuron_wheel).
 
-Azure pipelines pull this image off DockerHub for Linux wheels building.
+GitHub Actions (and the remaining Azure pipeline) pull this image off DockerHub for Linux wheels building.
 
 Updating and publishing the public images are done by a manual process that relies on a
 `Docker file`  (see [packaging/python/Dockerfile](../../packaging/python/Dockerfile)).
 Any official update of these files shall imply a PR reviewed and merged before `DockerHub` publishing.
 
-All wheels built on Azure are:
+Release and nightly wheels are published from **GitHub Actions**:
 
-* Published to `pypi.org` as
-  * `neuron-nightly` -> when the pipeline is launched in CRON mode
-  * `neuron-x.y.z` -> when the pipeline is manually triggered for release `x.y.z`
-* Stored as `Azure artifacts` in the Azure pipeline for every run.
+* `neuron-nightly` from the [nightly wheels workflow](https://github.com/neuronsimulator/nrn/actions/workflows/wheels-nightly.yml)
+* `neuron-x.y.z` from the [NEURON Release](https://github.com/neuronsimulator/nrn/actions/workflows/release.yml) workflow (`upload=true`)
+* Merged as a GHA artifact named `wheels` on each of those runs
+
+An Azure pipeline still builds some PR/nightly wheels and stores them as Azure `drop` artifacts; it is **not** the release publish path.
 
 Refer to the following image for the NEURON Docker Image workflow:
 ![](images/docker-workflow.png)
@@ -187,99 +188,53 @@ bash packaging/python/test_wheels.sh python3.9 "-i https://test.pypi.org/simple/
 On MacOS, launching `nrniv -python` or `special -python` can fail to load `neuron` module due to security restrictions.
 For this specific purpose, please `export SKIP_EMBEDED_PYTHON_TEST=true` before launching the tests.
 
-## Publishing the wheels on Pypi via Azure
+## Publishing the wheels on Pypi via GitHub Actions
 
-### Variables that drive PyPI upload
+Release wheels are built and published by the
+[NEURON Release](https://github.com/neuronsimulator/nrn/actions/workflows/release.yml)
+workflow, not Azure.
 
-We need to manipulate the following three predefined variables, listed hereafter with their default values:
-   * `NRN_NIGHTLY_UPLOAD` : `true`
-   * `NRN_RELEASE_UPLOAD` : `false`
-   * `NEURON_NIGHTLY_TAG` : `-nightly`
+### Three knobs
 
-### Release wheels
+When you click **Run workflow**:
 
-Head over to the [neuronsimulator.nrn](https://dev.azure.com/neuronsimulator/nrn/_build?definitionId=1) pipeline on Azure.
+* **Use workflow from** (controller) — which checkout provides `release.yml`. Use **`master`** for dry-run and ship.
+* **`rel_branch`** — the git ref whose sources are built (usually `release/x.y`).
+* **`rel_tag`** — the version name (`x.y.z`).
 
-After creating the tag on the `release/x.y` or on the `master` branch, perform the following steps:
+`upload` is a fourth input: `false` = dry-run, `true` = create the tag, attach artifacts to a GitHub pre-release, and publish wheels to PyPI.
 
-1) Click on `Run pipeline`
-2) Input the release tag ref `refs/tags/x.y.z`
-3) Click on `Advanced options` then select `Variables`
-4) Update driving variables to:
-   * `NRN_NIGHTLY_UPLOAD` : `false`
-   * `NRN_RELEASE_UPLOAD` : `false`
-   * `NEURON_NIGHTLY_TAG` : undefined (leave empty)
+### Release wheels (dry-run, then ship)
 
-   Do so by clicking `Variables` in `Advanced options` and update/clear the variable values.
-5) Click on `Run`
+1. Open [NEURON Release](https://github.com/neuronsimulator/nrn/actions/workflows/release.yml) → **Run workflow**.
+2. **Use workflow from:** `master`.
+3. Set `rel_branch` to `release/x.y` (or the cherry-pick branch for a pre-merge smoke).
+4. Set `rel_tag` to `x.y.z`.
+5. Leave Python/OS lists at the defaults unless you are deliberately narrowing the matrix.
+6. Set **`upload` to `false`** and run. This builds and tests wheels, runs ModelDB CI and nrn-build-ci against **this run’s** merged `wheels` artifact, and builds the full-src package and Windows installer. It does **not** push a tag or upload to PyPI.
+7. Confirm `neuron.__version__` is non-empty on a wheel from the artifact, and that ModelDB V2 used this run’s artifact URL (not a nightly fallback).
+8. If only ModelDB failed, retest without rebuilding wheels: [ModelDB CI (reuse wheels)](https://github.com/neuronsimulator/nrn/actions/workflows/modeldb-ci-reuse-wheels.yml). Pass the dry-run `wheels` artifact id or `https://github.com/neuronsimulator/nrn/actions/artifacts/<id>` URL, `neuron_v1=neuron==<previous>`, and `modeldb_ci_ref=master`.
+9. When the dry-run is green **and** `rel_branch` still points at the same SHA, run the same workflow again with **`upload=true`**.
 
-![](images/azure-release-no-upload.png)
+Do not treat Azure `NRN_RELEASE_UPLOAD` as the release path.
 
-With above, wheel will be created like release from the provided tag but they won't be uploaded to the pypi.org ( as we have set  `NRN_RELEASE_UPLOAD=false`). These wheels now you can download from artifacts section and perform thorough testing. Once you are happy with the testing result, set `NRN_RELEASE_UPLOAD` to `true` and trigger the pipeline same way:
-   * `NRN_NIGHTLY_UPLOAD` : `false`
-   * `NRN_RELEASE_UPLOAD` : `true`
-   * `NEURON_NIGHTLY_TAG` : undefined (leave empty)
+### Nightly wheels
 
-
+Nightly wheels are published from `master` by
+[wheels-nightly.yml](https://github.com/neuronsimulator/nrn/actions/workflows/wheels-nightly.yml)
+on a schedule (and can be dispatched manually).
 
 ## Publishing the wheels on Pypi via CircleCI
 
-Currently CircleCI doesn't have automated pipeline for uploading `release` wheels to pypi.org (nightly wheels are uploaded automatically though). Currently we are using a **hacky**, semi-automated approach described below:
+Linux/arm64 release wheels are now part of the GHA matrix (`ubuntu-24.04-arm`). There is no `.circleci` config in this repository; do not use CircleCI for a release.
 
-* Checkout your tag as a new branch
-* Update `.circleci/config.yml` as shown below
-* Trigger CI pipeline manually for [the nrn project](https://app.circleci.com/pipelines/github/neuronsimulator/nrn)
-* Upload wheels from artifacts manually
+## How to test GHA wheels locally
 
-```
-# checkout release tag as a new branch
-$ git checkout 8.1a -b release/8.1a-aarch64
-
-# manually updated `.circleci/config.yml`
-$ git diff
-
-@@ -14,6 +14,11 @@ jobs:
-
-     machine:
-       image: ubuntu-2004:202101-01
-+    environment:
-+      SETUPTOOLS_SCM_PRETEND_VERSION: 8.2.6
-+      NEURON_NIGHTLY_TAG: ""
-+      NRN_NIGHTLY_UPLOAD: false
-+      NRN_RELEASE_UPLOAD: false
-
-     resource_class: arm.medium
-
-@@ -54,6 +59,7 @@ jobs:
-               310) pyenv_py_ver="3.10.1" ;;
-               311) pyenv_py_ver="3.11.0" ;;
-+              312) pyenv_py_ver="3.12.2" ;;
-               *) echo "Error: pyenv python version not specified!" && exit 1;;
-             esac
-
-@@ -95,7 +101,7 @@ workflows:
-                 - /circleci\/.*/
-           matrix:
-             parameters:
--              NRN_PYTHON_VERSION: ["311"]
-+              NRN_PYTHON_VERSION: ["310", "311", "312"]
-               NRN_NIGHTLY_UPLOAD: ["false"]
-
-   nightly:
-```
-
-The reason we are setting `SETUPTOOLS_SCM_PRETEND_VERSION` to a desired version `8.1a` because `pyproject.toml` uses `setuptools-scm` and it will give different version name as we are now on a new branch!
-`SETUPTOOLS_SCM_PRETEND_VERSION` will also stop your wheels from getting extra numbers on the version.
-
-
-## Nightly wheels
-
-Nightly wheels get automatically published from `master` in CRON mode.
-
+Download the merged `wheels` artifact from a [NEURON Release](https://github.com/neuronsimulator/nrn/actions/workflows/release.yml) or [wheels-ci](https://github.com/neuronsimulator/nrn/actions/workflows/wheels-ci.yml) run, unzip it, and pass a `.whl` to `packaging/python/test_wheels.sh`.
 
 ## How to test Azure wheels locally
 
-After retrieving the Azure drop URL (i.e. from the GitHub PR comment, or by going to Azure for a specific build):
+Azure still publishes a `drop` zip for some PR/nightly builds. After retrieving the Azure drop URL (i.e. from the GitHub PR comment, or by going to Azure for a specific build):
 
 ```bash
 python3 -m pip wheel neuron-gpu-nightly --wheel-dir tmp --find-links 'https://dev.azure.com/neuronsimulator/aa1fb98d-a914-45c3-a215-5e5ef1bd7687/_apis/build/builds/7600/artifacts?artifactName=drop&api-version=7.0&%24format=zip'


### PR DESCRIPTION
## Summary

Post–9.0.2 process docs on **master** (follows #3842 / #3838; no workflow or `__version__` code changes).

1. **Release issue templates** (`release.md`, `release-patch.md`)
   - GHA [NEURON Release](https://github.com/neuronsimulator/nrn/actions/workflows/release.yml) is the publish path
   - Three knobs: controller / `rel_branch` / `rel_tag`
   - Dry-run (`upload=false`) then ship (`upload=true`) on the same SHAs
   - [ModelDB CI (reuse wheels)](https://github.com/neuronsimulator/nrn/actions/workflows/modeldb-ci-reuse-wheels.yml) instead of rebuilding wheels
   - RTD **+ Add version** for new/unbuilt tags
2. **`docs/install/python_wheels.md`** — Azure/CircleCI publish steps replaced with the GHA dry-run → ship loop
3. **`docs/README.md`** — RTD **+ Add version** note

Azure still exists for some PR/nightly wheel builds; it is not the release publish path.

## Test plan

- [ ] Skim the two templates as if filling a new release issue
- [ ] Confirm workflow links resolve (NEURON Release, ModelDB CI reuse wheels)
- [ ] Confirm the python_wheels heading still anchors as `#publishing-the-wheels-on-pypi-via-github-actions`