### PR TITLE
Use getc_hook so Mac wheels can use readline 8.3 with InterViews

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,11 +392,10 @@ endif()
 
 find_package(Readline REQUIRED)
 if(READLINE_FOUND)
-  # Always use getc_hook (src/oc/hoc.cpp) with InterViews, even when GNU
-  # readline exports rl_event_hook. Mac libedit lacks rl_event_hook and already
-  # used this path. GNU readline 8.x + rl_event_hook + run_til_stdin() swallows
-  # tty input (nrniv/nrngui with DISPLAY). getc_hook waits in run_til_stdin()
-  # then read(0), matching readline 8's rl_getc. Must be set before nrniv/.
+  # Always use getc_hook (src/oc/hoc.cpp) with InterViews, even when GNU readline exports
+  # rl_event_hook. Mac libedit lacks rl_event_hook and already used this path. GNU readline 8.x +
+  # rl_event_hook + run_til_stdin() swallows tty input (nrniv/nrngui with DISPLAY). getc_hook waits
+  # in run_til_stdin() then read(0), matching readline 8's rl_getc. Must be set before nrniv/.
   set(DEF_RL_GETC_FUNCTION use_rl_getc_function)
   # If we are not using self contained, static readline library created for building wheel then only
   # look for curses and termcap

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,14 +392,12 @@ endif()
 
 find_package(Readline REQUIRED)
 if(READLINE_FOUND)
-  # MAC libedit.3.dylib does not have rl_event_hook Readline_LIBRARY may be a binary lib or (on the
-  # MAC) a tbd file that points to the library and mentions all its definitions. this part has to be
-  # prior to adding the nrniv subdirectory.
-  execute_process(COMMAND grep -q rl_event_hook ${Readline_LIBRARY} RESULT_VARIABLE result)
-  if(NOT result EQUAL 0)
-    # define for src/oc/hoc.cpp
-    set(DEF_RL_GETC_FUNCTION use_rl_getc_function)
-  endif()
+  # Always use getc_hook (src/oc/hoc.cpp) with InterViews, even when GNU
+  # readline exports rl_event_hook. Mac libedit lacks rl_event_hook and already
+  # used this path. GNU readline 8.x + rl_event_hook + run_til_stdin() swallows
+  # tty input (nrniv/nrngui with DISPLAY). getc_hook waits in run_til_stdin()
+  # then read(0), matching readline 8's rl_getc. Must be set before nrniv/.
+  set(DEF_RL_GETC_FUNCTION use_rl_getc_function)
   # If we are not using self contained, static readline library created for building wheel then only
   # look for curses and termcap
   if(NOT NRN_WHEEL_STATIC_READLINE)

--- a/ci/deps/MANIFEST.yml
+++ b/ci/deps/MANIFEST.yml
@@ -89,22 +89,21 @@ assets:
     managed: true
     consumers:
       - packaging/python/Dockerfile
-      - packaging/python/build_static_readline_osx.bash
     notes: >
-      Linux manylinux Dockerfile and GH Actions Mac wheels use 7.0. Azure Mac
-      wheels still use prebuilt secure file readline7.0-ncurses6.4.tar.gz
-      (not in this manifest yet). Do not bump Mac wheels to 8.3: it breaks
-      tty input when InterViews multiplexes stdin with X11.
+      Linux manylinux Dockerfile uses 7.0. Azure Mac wheels still use the
+      prebuilt secure file readline7.0-ncurses6.4.tar.gz (not in this
+      manifest yet).
 
   - id: readline-8.3-src
     file: readline-8.3.tar.gz
     sha256: fe5383204467828cd495ee8d1d3c037a7eba1389c22bc6a041f627976f9061cc
     upstream_url: https://ftp.gnu.org/gnu/readline/readline-8.3.tar.gz
     managed: true
-    consumers: []
+    consumers:
+      - packaging/python/build_static_readline_osx.bash
     notes: >
-      Hosted pin kept for reference. Mac wheels must stay on 7.0 (see
-      build_static_readline_osx.bash).
+      GH Actions Mac wheels use 8.3. Safe with InterViews because hoc.cpp
+      always compiles use_rl_getc_function (not rl_event_hook).
 
   # --- P1: Windows installer toolchain ---
   - id: nsis-3.05

--- a/packaging/python/build_static_readline_osx.bash
+++ b/packaging/python/build_static_readline_osx.bash
@@ -38,10 +38,9 @@ trap cleanup EXIT
 
 export NRN_CI_DEPS_SOURCE="${NRN_CI_DEPS_SOURCE:-release}"
 bash "${FETCH}" ncurses-6.4-src "${WORKDIR}"
-# Keep Mac wheels on readline 7.0. 8.3 (from #3809) breaks tty input when
-# InterViews is multiplexing stdin with X11 (nrniv/nrngui with DISPLAY set).
-# Linux wheels already pin 7.0 in packaging/python/Dockerfile.
-bash "${FETCH}" readline-7.0-src "${WORKDIR}"
+# GNU readline 8.3 is OK for Mac wheels now that hoc.cpp always uses
+# getc_hook (not rl_event_hook) with InterViews. Linux Docker stays on 7.0.
+bash "${FETCH}" readline-8.3-src "${WORKDIR}"
 
 (
   tar -xzf "${WORKDIR}/ncurses-6.4.tar.gz" -C "${WORKDIR}"
@@ -51,8 +50,8 @@ bash "${FETCH}" readline-7.0-src "${WORKDIR}"
 )
 
 (
-  tar -xzf "${WORKDIR}/readline-7.0.tar.gz" -C "${WORKDIR}"
-  cd "${WORKDIR}/readline-7.0"
+  tar -xzf "${WORKDIR}/readline-8.3.tar.gz" -C "${WORKDIR}"
+  cd "${WORKDIR}/readline-8.3"
   ./configure --prefix="${NRNWHEEL_DIR}/readline" --disable-shared CFLAGS="-fPIC"
   make -j install
 )

--- a/src/oc/hoc.cpp
+++ b/src/oc/hoc.cpp
@@ -52,7 +52,7 @@ void (*p_nrnpython_finalize)();
 int nrn_inpython_;
 int (*p_nrnpy_pyrun)(const char* fname);
 
-#if 0 /* defined by cmake if rl_event_hook is not available */
+#if 0 /* defined by cmake (always, including when GNU readline has rl_event_hook) */
 #define use_rl_getc_function
 #endif
 


### PR DESCRIPTION
GNU readline 8.x plus rl_event_hook plus InterViews run_til_stdin() swallows tty input: nrniv / nrngui with DISPLAY set ignore the keyboard. -nogui still works. That was the 9.0.1 → 9.0.2 Mac-wheel regression (#3847 pinned GHA Mac wheels back to 7.0).

The real fix is the HOC glue, not staying on readline 7. Always compile hoc.cpp with use_rl_getc_function (the existing libedit path): wait in run_til_stdin() then read(0), matching readline 8's rl_getc.

With that in place, restore the GHA Mac static readline pin to 8.3. Linux Docker and the Azure Mac 7.0 secure tarball are unchanged.

Commits
1. InterViews: always use readline getc_hook
2. Mac wheels: restore static readline 8.3

Local verification (system X11, isolated static readline 8.3):
• 8.3 + rl_event_hook: keyboard ignored
• 8.3 + getc_hook (this PR): print 1+2 → 3 for nrniv and nrngui