### PR TITLE
Azure: rename nightly wheels to neuron-nightly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,12 @@ stages:
 
       - script: |
           python3 -m pip install tomli tomli-w
+          python3 packaging/python/change_name.py ./pyproject.toml neuron-nightly
+        condition: and(in(variables['Build.Reason'], 'Manual', 'Schedule'), ne(variables['NRN_NIGHTLY_UPLOAD'], 'false'))
+        displayName: 'Change name of package for nightly'
+
+      - script: |
+          python3 -m pip install tomli tomli-w
           python3 packaging/python/change_name.py ./pyproject.toml neuron
         condition: and(in(variables['Build.Reason'], 'Manual'), eq(variables['NRN_RELEASE_UPLOAD'], 'true'))
         displayName: 'Change name of package for release'
@@ -160,6 +166,12 @@ stages:
         displayName: 'Download readline secure file'
         inputs:
           secureFile: 'readline7.0-ncurses6.4.tar.gz'
+
+      - script: |
+          python3 -m pip install tomli tomli-w
+          python3 packaging/python/change_name.py ./pyproject.toml neuron-nightly
+        condition: and(in(variables['Build.Reason'], 'Manual', 'Schedule'), ne(variables['NRN_NIGHTLY_UPLOAD'], 'false'))
+        displayName: 'Change name of package for nightly'
 
       - script: |
           python3 -m pip install tomli tomli-w

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ requires = [
 ]
 
 [project]
-# We use the `packaging/python/change_name.py` to change the name to `neuron`
-# when making a release since PEP 621 disallows dynamic names.
+# Default wheel name is `neuron`. Nightly CI runs change_name.py to
+# `neuron-nightly`. PEP 621 disallows a dynamic project name.
 # Note that this only affects the name of the _wheel_, not the importable package name,
 # nor the CMake project name.
 name = "neuron"


### PR DESCRIPTION
## Problem

`pip install neuron-nightly` on x86_64 Linux currently has no matching wheel.

x86_64 Linux nightlies are built by Azure `ManyLinuxWheels`, not by GHA `wheels-nightly.yml` (that matrix is only `macos-14` and `ubuntu-24.04-arm`). After #3807 the default `pyproject.toml` name is `neuron`, and GHA nightly remames to `neuron-nightly` before building. Azure did not, so scheduled nightlies produce `neuron-*.whl` and the upload step 403s:

```
Invalid API Token: project-scoped token is not valid for project: 'neuron'
```

Last x86_64 Linux `neuron-nightly` on PyPI was `9.0.2.dev91` (2026-08-05, before #3807). Latest (`9.0.2.dev104`) is ARM-only. Azure scheduled builds (e.g. [16779](https://dev.azure.com/neuronsimulator/nrn/_build/results?buildId=16779)) still compile and test the manylinux x86_64 wheels; only the nightly upload fails.

## Change

- On Azure Manual/Schedule when `NRN_NIGHTLY_UPLOAD` is not `false`, run `change_name.py` to `neuron-nightly` in both `ManyLinuxWheels` and `MacOSWheels`.
- Leave the existing release rename to `neuron` unchanged.
- Update the `pyproject.toml` comment so it matches the #3807 default.

PR/push Azure CI will not run the new step (Manual/Schedule only). That is expected.

## After merge

Trigger the Azure `neuronsimulator.nrn` pipeline on `master` with default nightly variables (`NRN_NIGHTLY_UPLOAD=true`, `NRN_RELEASE_UPLOAD=false`), or wait for the 00:00 UTC cron. Confirm the upload log shows `neuron_nightly-*-manylinux_*_x86_64.whl`, then that those files appear on the latest https://pypi.org/project/neuron-nightly/ version.