### PR TITLE
neuronapi: complete the zero-diam recompute without a HOC error

### DIFF
--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -624,6 +624,8 @@ Segments
     segment diameter is derived from those points. This getter triggers that
     recompute if it is pending, so the value is correct even before an explicit
     geometry pass such as :func:`define_shape` or :func:`finitialize`.
+    Non-positive segment diameters are clamped to ``1e-6`` during this
+    recompute without propagating a HOC error across the C API.
 
     **C Usage:**
 

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -200,7 +200,11 @@ double nrn_segment_diam_get(Section* const sec, const double x) {
     // recalc_area_. Mirror the range-variable read path (nrnpy_nrn.cpp) so a
     // diam read after pt3dadd returns the 3d-derived value, not a stale default.
     if (sec && sec->recalc_area_) {
-        nrn_area_ri(sec);
+        // nrn_area_ri normally reports a non-positive diameter with
+        // hoc_execerror after clamping it to 1e-6. A C value accessor cannot
+        // let that C++ exception unwind across its ABI, so complete the same
+        // recompute without raising the HOC-level diagnostic.
+        nrn_area_ri_no_diam_error(sec);
     }
     Node* const node = node_exact(sec, x);
     for (auto prop = node->prop; prop; prop = prop->next) {

--- a/src/nrnoc/nrn_ansi.h
+++ b/src/nrnoc/nrn_ansi.h
@@ -64,6 +64,7 @@ extern void single_prop_free(Prop*);
 extern void prop_free(Prop**);
 extern int can_change_morph(Section*);
 extern void nrn_area_ri(Section* sec);
+extern void nrn_area_ri_no_diam_error(Section* sec);
 extern void nrn_diam_change(Section*);
 extern void sec_free(hoc_Item*);
 extern void extcell_node_create(Node*);

--- a/src/nrnoc/treeset.cpp
+++ b/src/nrnoc/treeset.cpp
@@ -749,7 +749,7 @@ sections */
 static double diam_from_list(Section* sec, int inode, Prop* p, double rparent);
 
 int recalc_diam_count_, nrn_area_ri_nocount_, nrn_area_ri_count_;
-void nrn_area_ri(Section* sec) {
+static void nrn_area_ri_impl(Section* sec, bool report_diam_error) {
     int j;
     double ra, dx, rright, rleft;
     Prop* p;
@@ -790,7 +790,9 @@ void nrn_area_ri(Section* sec) {
             auto& diam = p->param(0);
             if (diam <= 0.) {
                 diam = 1e-6;
-                hoc_execerror(secname(sec), "diameter diam = 0. Setting to 1e-6");
+                if (report_diam_error) {
+                    hoc_execerror(secname(sec), "diameter diam = 0. Setting to 1e-6");
+                }
             }
             nd->area() = PI * diam * dx;                            // um^2
             rleft = 1e-2 * ra * (dx / 2) / (PI * diam * diam / 4.); /*left half segment Megohms*/
@@ -804,6 +806,14 @@ void nrn_area_ri(Section* sec) {
     NODERINV(sec->pnode[j]) = 1. / rright;
     sec->recalc_area_ = 0;
     diam_changed = 1;
+}
+
+void nrn_area_ri(Section* sec) {
+    nrn_area_ri_impl(sec, true);
+}
+
+void nrn_area_ri_no_diam_error(Section* sec) {
+    nrn_area_ri_impl(sec, false);
 }
 
 Node* nrn_parent_node(Node* nd) {

--- a/test/api/segment_diam.cpp
+++ b/test/api/segment_diam.cpp
@@ -54,5 +54,25 @@ int main(void) {
     nrn_double_pop();
     ok &= close_to(nrn_segment_diam_get(s, 0.5), 10.0, "diam read after finitialize");
 
+    // A non-positive diameter is clamped during the pending area/resistance
+    // recompute. The C accessor must finish that recompute without allowing
+    // hoc_execerror's C++ exception to cross the C ABI. Use multiple segments
+    // so a fix that merely catches the first clamp error cannot pass.
+    Section* zero_diam = nrn_section_new("zero_diam");
+    nrn_nseg_set(zero_diam, 3);
+    for (int i = 0; i < 3; ++i) {
+        double x = (i + 0.5) / 3.0;
+        nrn_segment_diam_set(zero_diam, x, 0.0);
+    }
+    ok &= close_to(nrn_segment_diam_get(zero_diam, 5.0 / 6.0),
+                   1e-6,
+                   "one getter completes the full zero-diam recompute");
+    for (int i = 0; i < 3; ++i) {
+        double x = (i + 0.5) / 3.0;
+        ok &= close_to(nrn_segment_diam_get(zero_diam, x),
+                       1e-6,
+                       "zero diam clamped without aborting");
+    }
+
     return ok ? 0 : 1;
 }


### PR DESCRIPTION
Fixes a crash in an existing API function: `nrn_segment_diam_get` can terminate the calling process when a section has a non-positive segment diameter.

This is a bug fix to an existing function, not a new API addition.

## First: this does not touch the spine convention

The obvious worry on reading the title is that NEURON uses a negative diameter to flag a spine, so treating a non-positive diameter as an error would break that. It would, but this PR is in a different branch of the function and never sees a spine.

`nrn_area_ri` splits on whether the section has a 3d point list:

| | `sec->npt3d > 1` | `sec->npt3d <= 1` |
|---|---|---|
| Path | `diam_from_list()` | the `else` at `treeset.cpp:788` |
| Reads | `sec->pt3d[j].d` (the 3d points) | `p->param(0)` (the `diam` range variable) |
| Negative value means | **a spine** (`NTS_SPINE`, `options.h:22`) | nothing; there is no convention here |
| Handling | `fabs()` everywhere, negatives counted into `nspine` | `diam <= 0` clamped to `1e-6` |
| Can it raise? | **no** | yes, `hoc_execerror`, and it already does today |

A morphology with spines has a 3d point list, so it goes through `diam_from_list`, which takes the absolute value of every point diameter and never calls `hoc_execerror`. This PR does not modify `diam_from_list`.

The error this PR deals with is in the stylized-geometry branch, where `diam` is the range variable itself and a non-positive value has been an error for as long as the function has existed:

```c
auto& diam = p->param(0);
if (diam <= 0.) {
    diam = 1e-6;
    hoc_execerror(secname(sec), "diameter diam = 0. Setting to 1e-6");
}
```

**Nothing that was legal before becomes an error here.** The clamp, the threshold and the message are all unchanged. What changes is only who the report can safely reach.

## The problem

`nrn_segment_diam_get` triggers the pending per-section area/resistance recompute (added in #3814) so a `diam` read reflects 3d-derived geometry. Inside that recompute, `nrn_area_ri` clamps a non-positive diameter to `1e-6` and then reports the adjustment with `hoc_execerror`, which is a C++ exception in this NEURON.

A plain value-returning C accessor cannot let that exception unwind across its ABI. It reaches a caller with no matching handler, for example a ctypes or C reader of `seg.diam`, and the process terminates. The clamp itself is a recoverable adjustment, not a fatal condition.

## Why catching it is not enough

Wrapping the `nrn_area_ri` call in a `try`/`catch` looks sufficient but is not. The raise happens inside the per-segment loop, so unwinding out of it leaves the remaining segments unclamped, area and resistance only partly recomputed, and the trailing `diam_changed` update skipped. The section is then in a half-recomputed state with `recalc_area_` still pending.

## The change

Factor the body into `nrn_area_ri_impl(sec, report_diam_error)`:

- `nrn_area_ri` keeps its current behavior for HOC and interpreter callers, diagnostic included, so nothing user-visible changes there.
- `nrn_segment_diam_get` uses a new internal entry point `nrn_area_ri_no_diam_error`, which applies the same clamp and completes the same recompute without raising.

`nrn_area_ri_no_diam_error` is declared in the internal `src/nrnoc/nrn_ansi.h`, not in `neuronapi.h`, so the public API surface is unchanged.

## Test

`test/api/segment_diam.cpp` sets all three segments of a section to diameter 0 and reads the **last** segment first, then verifies every segment reads `1e-6`. An implementation that only catches the first clamp error fails on the unclamped remainder, so the test distinguishes the two approaches rather than just checking that nothing crashed.

`api::segment_diam_cpp` passes; the test file is already wired into `test/api/CMakeLists.txt`. clang-format 12 dry-run and `git diff --check` are clean.

Found while running myneuron against 9.0.2, where a zero-diameter section aborted the interpreter instead of returning the clamped value.
