### PR TITLE
neuronapi: resolve point-process POINTER properties through their data handle

### DIFF
--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -1936,7 +1936,9 @@ Miscellaneous
     **Usage Pattern:**
 
     Used to read object properties dynamically by name. Essential for
-    generic property access.
+    generic property access. For an NMODL ``POINTER`` property on a point
+    process, this returns the value referenced by the pointer. An unset or
+    opaque pointer returns NaN.
 
     **C Usage:**
     
@@ -1965,6 +1967,10 @@ Miscellaneous
 
     Used for properties that are arrays.
 
+    Point-process properties use the same data-handle resolution as
+    :c:func:`nrn_property_get` for the selected element, including returning NaN
+    for an unset or opaque pointer.
+
     **C Usage:**
 
     .. code-block:: c
@@ -1986,6 +1992,10 @@ Miscellaneous
     :param obj: Pointer to the object.
     :param name: Name of the property.
     :param value: Value to set.
+
+    For an NMODL ``POINTER`` property on a point process, this writes through
+    the pointer to the referenced value. A write to an unset or opaque pointer
+    is ignored.
 
     **C Usage:**
     
@@ -2010,6 +2020,10 @@ Miscellaneous
     :param i: Index into the array (0-based).
     :param value: Value to set at the specified index.
 
+    Point-process properties use the same data-handle resolution as
+    :c:func:`nrn_property_set` for the selected element, including ignoring a
+    write to an unset or opaque pointer.
+
 .. c:function:: void nrn_property_push(Object* obj, const char* name)
 
     Push a property value onto the NEURON stack.
@@ -2023,6 +2037,11 @@ Miscellaneous
     is how NEURON can implement non-square-wave current clamps. Here ``iclamp._ref_amp`` is a reference
     to the ``amp`` property of the ``IClamp`` object.
 
+    For an NMODL ``POINTER`` property on a point process, this pushes the
+    referenced data handle. It can, for example, be consumed by
+    :c:func:`nrn_pp_setpointer_pop` to wire another point-process pointer to
+    the same source. An unset or opaque pointer pushes an empty handle.
+
 .. c:function:: void nrn_property_array_push(Object* obj, const char* name, int i)
 
     Push a property array element onto the NEURON stack.
@@ -2030,6 +2049,10 @@ Miscellaneous
     :param obj: Pointer to the object.
     :param name: Name of the property array.
     :param i: Index into the array (0-based).
+
+    Point-process properties use the same data-handle resolution as
+    :c:func:`nrn_property_push` for the selected element, including pushing an
+    empty handle for an unset or opaque pointer.
 
 .. c:function:: char const* nrn_symbol_name(const Symbol* sym)
 

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -14,6 +14,7 @@
 #include "shapeplt.h"
 #include <cstring>
 #include <exception>
+#include <limits>
 
 /// A public face of hoc_Item
 struct nrn_Item: public hoc_Item {};
@@ -891,8 +892,8 @@ double nrn_property_get(const Object* obj, const char* name) {
         obj->ctemplate->steer(obj->u.this_pointer);
         return *hoc_pxpop();
     } else {
-        int index = sym->u.rng.index;
-        return ob2pntproc_0(const_cast<Object*>(obj))->prop->param_legacy(index);
+        auto handle = point_process_pointer(ob2pntproc_0(const_cast<Object*>(obj)), sym, 0);
+        return handle ? *handle : std::numeric_limits<double>::quiet_NaN();
     }
 }
 
@@ -904,8 +905,8 @@ double nrn_property_array_get(const Object* obj, const char* name, int i) {
         obj->ctemplate->steer(obj->u.this_pointer);
         return hoc_pxpop()[i];
     } else {
-        int index = sym->u.rng.index;
-        return ob2pntproc_0(const_cast<Object*>(obj))->prop->param_legacy(index + i);
+        auto handle = point_process_pointer(ob2pntproc_0(const_cast<Object*>(obj)), sym, i);
+        return handle ? *handle : std::numeric_limits<double>::quiet_NaN();
     }
 }
 
@@ -917,8 +918,10 @@ void nrn_property_set(Object* obj, const char* name, double value) {
         obj->ctemplate->steer(obj->u.this_pointer);
         *hoc_pxpop() = value;
     } else {
-        int index = sym->u.rng.index;
-        ob2pntproc_0(obj)->prop->param_legacy(index) = value;
+        auto handle = point_process_pointer(ob2pntproc_0(obj), sym, 0);
+        if (handle) {
+            *handle = value;
+        }
     }
 }
 
@@ -930,8 +933,10 @@ void nrn_property_array_set(Object* obj, const char* name, int i, double value) 
         obj->ctemplate->steer(obj->u.this_pointer);
         hoc_pxpop()[i] = value;
     } else {
-        int index = sym->u.rng.index;
-        ob2pntproc_0(obj)->prop->param_legacy(index + i) = value;
+        auto handle = point_process_pointer(ob2pntproc_0(obj), sym, i);
+        if (handle) {
+            *handle = value;
+        }
     }
 }
 
@@ -942,8 +947,7 @@ void nrn_property_push(Object* obj, const char* name) {
         // put the pointer for the memory location on the stack
         obj->ctemplate->steer(obj->u.this_pointer);
     } else {
-        int index = sym->u.rng.index;
-        hoc_push(ob2pntproc_0(obj)->prop->param_handle_legacy(index));
+        hoc_push(point_process_pointer(ob2pntproc_0(obj), sym, 0));
     }
 }
 
@@ -955,8 +959,7 @@ void nrn_property_array_push(Object* obj, const char* name, int i) {
         obj->ctemplate->steer(obj->u.this_pointer);
         hoc_pushpx(hoc_pxpop() + i);
     } else {
-        int index = sym->u.rng.index;
-        hoc_push(ob2pntproc_0(obj)->prop->param_handle_legacy(index + i));
+        hoc_push(point_process_pointer(ob2pntproc_0(obj), sym, i));
     }
 }
 

--- a/test/api/setpointer.cpp
+++ b/test/api/setpointer.cpp
@@ -9,6 +9,7 @@
 // modl_reg registers ptrtest (its generated _ptrtest_reg is compiled into this
 // test), the way nrniv registers built-ins.
 #include <array>
+#include <cmath>
 #include <cstring>
 #include <iostream>
 #include "neuronapi.h"
@@ -134,6 +135,31 @@ int main(void) {
     nrn_section_pop();
     ok &= check(pp1 != nullptr && pp2 != nullptr, "two PPPtr point processes created at soma(0.5)");
 
+    // An unset POINTER has no double data handle. Plain C value accessors
+    // cannot propagate an exception across the ABI: reads return NaN, writes
+    // are ignored, and push accessors preserve the empty handle as nullptr.
+    nrn_section_push(soma);
+    nrn_double_push(0.5);
+    Object* pp_unset = nrn_object_new(nrn_symbol("PPPtr"), 1);
+    nrn_section_pop();
+    ok &= check(std::isnan(nrn_property_get(pp_unset, "src")),
+                "property_get returns NaN for an unset POINTER");
+    ok &= check(std::isnan(nrn_property_array_get(pp_unset, "src", 0)),
+                "property_array_get returns NaN for an unset POINTER");
+    nrn_property_set(pp_unset, "src", 1.0);
+    ok &= check(std::isnan(nrn_property_get(pp_unset, "src")),
+                "property_set ignores an unset POINTER");
+    nrn_property_array_set(pp_unset, "src", 0, 2.0);
+    ok &= check(std::isnan(nrn_property_array_get(pp_unset, "src", 0)),
+                "property_array_set ignores an unset POINTER");
+    nrn_property_push(pp_unset, "src");
+    ok &= check(nrn_double_ptr_pop() == nullptr,
+                "property_push preserves an unset POINTER as an empty handle");
+    nrn_property_array_push(pp_unset, "src", 0);
+    ok &= check(nrn_double_ptr_pop() == nullptr,
+                "property_array_push preserves an unset POINTER as an empty handle");
+    nrn_object_unref(pp_unset);
+
     // Distinct, finitialize-stable source values (feed is a PARAMETER).
     nrn_property_set(pp1, "feed", 10);
     nrn_property_set(pp2, "feed", 20);
@@ -167,6 +193,24 @@ int main(void) {
     nrn_double_pop();
     ok &= eq(nrn_property_get(pp1, "out"), 20.0, "pp1 read its own wired source (pp2.feed)");
     ok &= eq(nrn_property_get(pp2, "out"), 10.0, "pp2 read its own wired source (pp1.feed)");
+
+    // Property access to a point-process POINTER must follow its dparam data
+    // handle. Reading src returns the referenced feed value, and writing src
+    // mutates that referenced feed rather than unrelated parameter storage.
+    ok &= eq(nrn_property_get(pp1, "src"), 20.0, "property_get follows pp1.src -> pp2.feed");
+    ok &= eq(nrn_property_get(pp2, "src"), 10.0, "property_get follows pp2.src -> pp1.feed");
+    nrn_property_set(pp1, "src", 25.0);
+    ok &= eq(nrn_property_get(pp2, "feed"), 25.0, "property_set through pp1.src mutates pp2.feed");
+
+    // A pushed POINTER property must carry the referenced data handle. Rewire
+    // pp2.src from pp1.feed to pp1.src (which itself points at pp2.feed), then
+    // mutate pp2.feed and confirm both POINTER properties observe the change.
+    nrn_property_push(pp1, "src");
+    int rc_pp_chain = nrn_pp_setpointer_pop(pp2, "src", err, sizeof(err));
+    ok &= check(rc_pp_chain == 0, "property_push supplies a POINTER source handle");
+    nrn_property_set(pp2, "feed", 30.0);
+    ok &= eq(nrn_property_get(pp1, "src"), 30.0, "pp1.src still aliases pp2.feed");
+    ok &= eq(nrn_property_get(pp2, "src"), 30.0, "pp2.src aliases the pushed pp1.src handle");
 
     // Error path: a non-POINTER target name (out is a plain RANGE var) is
     // rejected, with the pushed source still consumed so the sentinel below

--- a/test/api/vclamp.cpp
+++ b/test/api/vclamp.cpp
@@ -58,6 +58,18 @@ int main(void) {
         nrn_property_array_set(vclamp, "dur", i, dur);
         ++i;
     }
+    // Array property handles use the same point-process property resolution as
+    // scalar handles. Verify that the pushed handle aliases the selected item.
+    nrn_property_array_push(vclamp, "amp", 1);
+    double* amp1 = nrn_double_ptr_pop();
+    if (*amp1 != 10) {
+        return 1;
+    }
+    *amp1 = 11;
+    if (nrn_property_array_get(vclamp, "amp", 1) != 11) {
+        return 1;
+    }
+    nrn_property_array_set(vclamp, "amp", 1, 10);
     // setup recording
     Object* v = nrn_object_new(nrn_symbol("Vector"), 0);
     nrn_rangevar_push(nrn_symbol("v"), soma, 0.5);


### PR DESCRIPTION
Fixes #3852. This is a bug fix to existing functions, not a new API addition.

## The problem

The six point-process property accessors resolve every member as ordinary `PARAMETER` storage:

```cpp
int index = sym->u.rng.index;
return ob2pntproc_0(const_cast<Object*>(obj))->prop->param_legacy(index);
```

An NMODL `POINTER` member does not live there. It lives in `prop->dparam[sym->u.rng.index]`. So reading one returned whatever double happened to occupy that parameter slot, and writing one corrupted a parameter instead of writing through the pointer.

Measured before the fix, with a `POINT_PROCESS` whose `POINTER vgap` was wired to another section's `v`, after `finitialize(-65)`:

```
nrn_property_get(pp,"vgap") = -0.106103     <- a parameter slot
actual source voltage v     = -65.000000
mechanism-computed i        = 0             <- wiring is correct; only the read was wrong
```

The mechanism's own `BREAKPOINT` computes `i = (vgap - v)/r = 0`, so the POINTER was wired correctly and the dereference inside the mechanism saw `-65.0`. Only the C-API read disagreed. Reading the same member through the Python extension returns `-65.0`.

This has been the behavior since the API was formalized in #2357; none of the recent additions touched these functions. It surfaced now because `nrn_pp_setpointer_pop` (#3828) made POINTER wiring reachable from the C API, so there was finally a reason to read one back.

## The change

Route all six through `point_process_pointer(Point_process*, Symbol*, int)`, which already branches on `sym->subtype == NRNPOINTER` and is what the interpreter path uses via `steer_point_process`. This makes the C API agree with HOC and the Python extension.

## Empty handles, and a question 

An unset or opaque `POINTER` yields an empty `data_handle`, and `data_handle::operator*` throws when dereferenced. That exception must not unwind out of a plain value-returning C function and across the ABI, which would terminate a ctypes or C caller. It is handled explicitly:

- reads return NaN
- writes are ignored
- pushes put the empty handle on the stack, which is what `steer_point_process` already does

I picked those because there is no error channel in `neuronapi.h` for a function returning a bare `double`. Worth noting the Python extension raises `ValueError: Invalid data_handle` for the same read, so it reports the condition rather than returning a sentinel. **If we would rather these signal an error than return NaN, that is a larger question about the value API's error model and I am happy to follow up separately.** I have documented the current choice as-is rather than assume it.

## Tests

The assertions are exact values, not absence of a crash:

- POINTER reads resolve to the referenced `feed` values on the two cross-wired `PPPtr` instances
- a write through a POINTER mutates the referenced storage rather than a parameter
- a pushed POINTER handle is consumed by `nrn_pp_setpointer_pop` to wire a second pointer to the same source, then both observe a change to it
- all six accessors are exercised against an unset POINTER
- the array forms are covered on the existing VClamp fixture, whose simulation expectation is unchanged

`api::setpointer_cpp` and `api::vclamp_cpp` pass. Run against the pre-fix library, the new assertions fail, so the coverage is not vacuous. clang-format 12 dry-run and `git diff --check` are clean.

Found while retiring myneuron's internal shims onto the public API.
