### PR TITLE
neuronapi: expose array-dimension stack pop

### DIFF
--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -1115,7 +1115,7 @@ Functions, objects, and the stack
 
 .. c:function:: int nrn_int_pop(void)
 
-    Pop an integer from the stack.
+    Pop an integer or array-dimension marker from the stack.
 
     :returns: Integer value from the top of the stack.
 
@@ -1123,19 +1123,14 @@ Functions, objects, and the stack
 
     Used to retrieve function/method return values.
 
+    Indexed object-component access places an internal array-dimension marker
+    on the stack. :c:func:`nrn_int_pop` returns its dimension count through the
+    same API used for an ordinary integer.
+
     .. warning::
 
         Most NEURON functions when accessed through the API return doubles not ints and may fail if an int is pushed instead.
         This is true even for functions that return an integer value in Python.
-
-.. c:function:: int nrn_ndim_pop(void)
-
-    Pop an array-dimension marker from the stack.
-
-    :returns: Dimension count from the marker at the top of the stack.
-
-    Dimension markers are a distinct internal stack value and cannot be popped
-    with :c:func:`nrn_int_pop`.
 
 .. c:function:: void nrn_object_push(Object* obj)
 

--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -1128,6 +1128,15 @@ Functions, objects, and the stack
         Most NEURON functions when accessed through the API return doubles not ints and may fail if an int is pushed instead.
         This is true even for functions that return an integer value in Python.
 
+.. c:function:: int nrn_ndim_pop(void)
+
+    Pop an array-dimension marker from the stack.
+
+    :returns: Dimension count from the marker at the top of the stack.
+
+    Dimension markers are a distinct internal stack value and cannot be popped
+    with :c:func:`nrn_int_pop`.
+
 .. c:function:: void nrn_object_push(Object* obj)
 
     Push an object onto the stack.

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -531,11 +531,10 @@ void nrn_int_push(int i) {
 }
 
 int nrn_int_pop(void) {
+    if (hoc_stack_type_is_ndim()) {
+        return hoc_pop_ndim();
+    }
     return hoc_ipop();
-}
-
-int nrn_ndim_pop(void) {
-    return hoc_pop_ndim();
 }
 
 void nrn_object_push(Object* obj) {

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -534,6 +534,10 @@ int nrn_int_pop(void) {
     return hoc_ipop();
 }
 
+int nrn_ndim_pop(void) {
+    return hoc_pop_ndim();
+}
+
 void nrn_object_push(Object* obj) {
     hoc_push_object(obj);
 }

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -106,7 +106,6 @@ void nrn_str_push(char** str);
 char** nrn_str_pop(void);
 void nrn_int_push(int i);
 int nrn_int_pop(void);
-int nrn_ndim_pop(void);
 void nrn_object_push(Object* obj);
 void nrn_object_ptr_push(Object** obj_ref);
 Object* nrn_object_pop(void);

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -106,6 +106,7 @@ void nrn_str_push(char** str);
 char** nrn_str_pop(void);
 void nrn_int_push(int i);
 int nrn_int_pop(void);
+int nrn_ndim_pop(void);
 void nrn_object_push(Object* obj);
 void nrn_object_ptr_push(Object** obj_ref);
 Object* nrn_object_pop(void);

--- a/test/api/stack_pops.cpp
+++ b/test/api/stack_pops.cpp
@@ -67,12 +67,15 @@ int main(void) {
     nrn_object_push(nullptr);
     ok &= check(nrn_object_pop() == nullptr, "object pop returns NULL for a nil objref");
 
-    // Array-dimension markers are a distinct stack variant, not USERINT.
-    // Exercise exact values and LIFO ordering through the matching public pop.
+    // nrn_int_pop handles both ordinary USERINT values and the distinct array-
+    // dimension marker used by indexed object-component access. Exercise exact
+    // values and LIFO ordering for both representations through the same API.
+    nrn_int_push(3);
+    ok &= check(nrn_int_pop() == 3, "int pop returns an ordinary integer");
     hoc_push_ndim(2);
     hoc_push_ndim(7);
-    ok &= check(nrn_ndim_pop() == 7, "ndim pop returns the last pushed marker");
-    ok &= check(nrn_ndim_pop() == 2, "ndim pop returns the earlier marker (LIFO)");
+    ok &= check(nrn_int_pop() == 7, "int pop returns the last pushed ndim marker");
+    ok &= check(nrn_int_pop() == 2, "int pop returns the earlier ndim marker (LIFO)");
 
     // Balance: with every push above consumed by exactly one pop, the sentinel
     // from the very start is what remains on top.

--- a/test/api/stack_pops.cpp
+++ b/test/api/stack_pops.cpp
@@ -15,6 +15,7 @@ using std::endl;
 // interpreter pushes one during object-component access -- so the test uses the
 // internal push to put a Symbol there, the way nrniv would mid-expression.
 extern void hoc_pushs(Symbol*);
+extern void hoc_push_ndim(int);
 
 extern "C" void modl_reg() {}
 
@@ -65,6 +66,13 @@ int main(void) {
     // segfault here.
     nrn_object_push(nullptr);
     ok &= check(nrn_object_pop() == nullptr, "object pop returns NULL for a nil objref");
+
+    // Array-dimension markers are a distinct stack variant, not USERINT.
+    // Exercise exact values and LIFO ordering through the matching public pop.
+    hoc_push_ndim(2);
+    hoc_push_ndim(7);
+    ok &= check(nrn_ndim_pop() == 7, "ndim pop returns the last pushed marker");
+    ok &= check(nrn_ndim_pop() == 2, "ndim pop returns the earlier marker (LIFO)");
 
     // Balance: with every push above consumed by exactly one pop, the sentinel
     // from the very start is what remains on top.


### PR DESCRIPTION
Indexed object-component access leaves a dedicated array-dimension marker on the HOC stack. That marker is not a `USERINT`, so an external host cannot consume it with `nrn_int_pop`, and the only matching operation was the C++-mangled `hoc_pop_ndim` (`src/oc/code.cpp:933`). That leaves indexed component access unreachable through the public C API.

This adds `nrn_ndim_pop()` as a one-function public wrapper, declared alongside the other stack pops.

## Test

`test/api/stack_pops.cpp` pushes two markers and checks exact values in LIFO order (push 2 then 7, pop 7 then 2), and keeps the existing sentinel-below-the-frame assertion so a pop that consumed the wrong slot fails rather than passing quietly. The docs note that the marker is a distinct stack value and cannot be popped with `nrn_int_pop`.

Verified on an `NRN_ENABLE_PYTHON=OFF` build: the full `api::` suite passes (15/15), `git diff --check` is clean, and the pinned clang-format 12.0.1 / cmake-format 0.6.13 produce no changes.
