### PR TITLE
neuronapi: expose property data-handle validity

### DIFF
--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -2031,6 +2031,29 @@ Miscellaneous
     :param name: Name of the property array.
     :param i: Index into the array (0-based).
 
+.. c:function:: bool nrn_property_data_handle_is_valid(const Object* obj, const char* name, int i)
+
+    Report whether an object's numeric property has a non-empty data handle.
+
+    This is intended as a second-line check after :c:func:`nrn_property_get` or
+    :c:func:`nrn_property_array_get` returns NaN. An unset or opaque NMODL
+    ``POINTER`` has an empty handle, while NaN is also a valid value in a
+    non-empty handle. The common path therefore needs only the value-accessor
+    call; callers use this predicate only when they need to distinguish those
+    two cases.
+
+    :param obj: Pointer to the object.
+    :param name: Name of the property or property array.
+    :param i: Element index for a point-process array property. Ignored for a
+        scalar property, and for an object that is not a point process, whose
+        storage is present or absent as a whole rather than per element.
+    :returns: true if the property's data handle is non-empty, false otherwise.
+
+    .. seealso::
+
+        :c:func:`nrn_property_get`,
+        :c:func:`nrn_property_array_get`
+
 .. c:function:: char const* nrn_symbol_name(const Symbol* sym)
 
     Get the name of a symbol as a string.

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -960,6 +960,16 @@ void nrn_property_array_push(Object* obj, const char* name, int i) {
     }
 }
 
+bool nrn_property_data_handle_is_valid(const Object* obj, const char* name, int i) {
+    auto sym = hoc_table_lookup(name, obj->ctemplate->symtable);
+    if (!obj->ctemplate->is_point_) {
+        hoc_pushs(sym);
+        obj->ctemplate->steer(obj->u.this_pointer);
+        return static_cast<bool>(hoc_pop_handle<double>());
+    }
+    return static_cast<bool>(point_process_pointer(ob2pntproc_0(const_cast<Object*>(obj)), sym, i));
+}
+
 char const* nrn_symbol_name(const Symbol* sym) {
     return sym->name;
 }

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -165,6 +165,7 @@ void nrn_property_set(Object* obj, const char* name, double value);
 void nrn_property_array_set(Object* obj, const char* name, int i, double value);
 void nrn_property_push(Object* obj, const char* name);
 void nrn_property_array_push(Object* obj, const char* name, int i);
+bool nrn_property_data_handle_is_valid(const Object* obj, const char* name, int i);
 char const* nrn_symbol_name(const Symbol* sym);
 Symlist* nrn_symbol_table(const Symbol* sym);
 Symlist* nrn_global_symbol_table(void);

--- a/test/api/setpointer.cpp
+++ b/test/api/setpointer.cpp
@@ -9,8 +9,10 @@
 // modl_reg registers ptrtest (its generated _ptrtest_reg is compiled into this
 // test), the way nrniv registers built-ins.
 #include <array>
+#include <cmath>
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include "neuronapi.h"
 
 using std::cerr;
@@ -134,6 +136,20 @@ int main(void) {
     nrn_section_pop();
     ok &= check(pp1 != nullptr && pp2 != nullptr, "two PPPtr point processes created at soma(0.5)");
 
+    // An unset POINTER has an empty data handle, while an ordinary PARAMETER
+    // already has storage. The predicate is the second-line check for callers
+    // that receive NaN from a value accessor and need to distinguish an empty
+    // handle from a legitimate NaN value.
+    ok &= check(!nrn_property_data_handle_is_valid(pp1, "src", 0),
+                "unset point-process POINTER has no valid data handle");
+    ok &= check(nrn_property_data_handle_is_valid(pp1, "feed", 0),
+                "ordinary point-process property has a valid data handle");
+    nrn_property_set(pp1, "feed", std::numeric_limits<double>::quiet_NaN());
+    ok &= check(std::isnan(nrn_property_get(pp1, "feed")),
+                "ordinary property preserves a legitimate NaN value");
+    ok &= check(nrn_property_data_handle_is_valid(pp1, "feed", 0),
+                "legitimate NaN value still has a valid data handle");
+
     // Distinct, finitialize-stable source values (feed is a PARAMETER).
     nrn_property_set(pp1, "feed", 10);
     nrn_property_set(pp2, "feed", 20);
@@ -158,6 +174,10 @@ int main(void) {
     ok &= eq(nrn_double_pop(),
              SENTINEL,
              "second pp_setpointer_pop consumed exactly its source (sentinel intact)");
+    ok &= check(nrn_property_data_handle_is_valid(pp1, "src", 0),
+                "wired point-process POINTER has a valid data handle");
+    ok &= check(nrn_property_data_handle_is_valid(pp2, "src", 0),
+                "second wired point-process POINTER has a valid data handle");
 
     // finitialize(-65): INITIAL runs out = src, so pp1.out reads pp2.feed (20)
     // and pp2.out reads pp1.feed (10). If the wiring were segment-addressed and

--- a/test/api/vclamp.cpp
+++ b/test/api/vclamp.cpp
@@ -51,6 +51,12 @@ int main(void) {
     // voltage clamp at soma(0.5)
     nrn_double_push(0.5);
     Object* vclamp = nrn_object_new(nrn_symbol("VClamp"), 1);
+    for (int index = 0; index < 3; ++index) {
+        if (!nrn_property_data_handle_is_valid(vclamp, "amp", index)) {
+            std::cerr << "FAIL: VClamp amp[" << index << "] has an empty data handle" << std::endl;
+            return 1;
+        }
+    }
     // 0 mV for 1 ms; 10 mV for the next 2 ms; 5 mV for the next 3 ms
     int i = 0;
     for (auto& [amp, dur]: std::initializer_list<std::pair<int, double>>{{0, 1}, {10, 2}, {5, 3}}) {


### PR DESCRIPTION
An unset or opaque NMODL `POINTER` has an empty data handle, and the six `nrn_property_*` value accessors report that as NaN (see #3855). NaN is also a perfectly good double, so a caller receiving one cannot tell an absent handle from a legitimately stored NaN.

This adds `nrn_property_data_handle_is_valid()`, which resolves the same data handle as the existing accessors and reports whether it is non-empty.

It is deliberately a **second-line** check. The value accessors are unchanged, so the common path still costs one call; a caller consults this predicate only after seeing NaN and needing to distinguish the two cases. That keeps the one-call common path we discussed, rather than making every read pay for a validity check.

This does not change #3855 or stack on it.

## Test

Tests assert the distinction rather than the happy path:

- unset point-process `POINTER` -> false
- ordinary scalar storage -> true
- a deliberately stored NaN -> still true (this is the case the predicate exists for)
- two wired `POINTER`s -> true
- every element of VClamp's three-element `amp` array -> true

Note on `i`: it selects the element for a point-process array property. It is ignored for a scalar property and for an object that is not a point process, whose storage is present or absent as a whole rather than per element. The parameter docs say so.

Verified on an `NRN_ENABLE_PYTHON=OFF` build: the full `api::` suite passes (15/15), `git diff --check` clean, pinned clang-format 12.0.1 / cmake-format 0.6.13 produce no changes.
