### PR TITLE
oc: dispatch object components through per-template provider hooks

### DIFF
--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -886,10 +886,15 @@ hooks. When no provider is registered, ordinary template lookup is unchanged.
     remain loaded while any instance exists. The read callback consumes the
     deferred object frame and pushes exactly one HOC value; the assignment
     callback consumes the typed RHS, available through :c:func:`nrn_stack_type`,
-    followed by the component metadata frame. Both callbacks use the public
-    stack pop/push functions and must not throw across the C ABI. On failure a
-    provider drains its frame, pushes a typed placeholder for reads, and
-    reports the error after the enclosing nothrow HOC call.
+    followed by the component metadata frame. On success each callback returns
+    ``NULL``. On failure it returns an error message without changing the HOC
+    stack. The returned pointer must remain valid until the call returns
+    across the provider boundary; NEURON copies the message before running
+    anything else (its own warning and dialog hooks included) and then calls
+    ``hoc_execerror``.
+    This gives the enclosing :c:func:`nrn_function_call_nothrow` or
+    :c:func:`nrn_method_call_nothrow` normal error reporting and stack recovery
+    without an exception unwinding through a foreign callback.
 
     Passing a null template or either callback returns ``false`` and writes a
     diagnostic to ``error_msg`` when space is provided. Registration is

--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -871,6 +871,35 @@ Segments
 Functions, objects, and the stack
 ---------------------------------
 
+Reads and writes of provider-backed object components are dispatched through
+per-template hooks registered at runtime, rather than being selected when
+NEURON is compiled. An embedding host can therefore supply a provider even in
+a build configured with ``NRN_ENABLE_PYTHON=OFF``, without NEURON itself
+linking against Python. The legacy Python methods-table callbacks remain a
+compatibility fallback for providers that have not installed per-template
+hooks. When no provider is registered, ordinary template lookup is unchanged.
+
+.. c:function:: bool nrn_template_set_component_hooks(Symbol* template_sym, nrn_component_func component, nrn_component_asgn_func component_asgn, char* error_msg, size_t error_msg_size)
+
+    Register non-owning provider callbacks for all dynamic components of a HOC
+    template. The template symbol must remain valid, and callback code must
+    remain loaded while any instance exists. The read callback consumes the
+    deferred object frame and pushes exactly one HOC value; the assignment
+    callback consumes the typed RHS, available through :c:func:`nrn_stack_type`,
+    followed by the component metadata frame. Both callbacks use the public
+    stack pop/push functions and must not throw across the C ABI. On failure a
+    provider drains its frame, pushes a typed placeholder for reads, and
+    reports the error after the enclosing nothrow HOC call.
+
+    Passing a null template or either callback returns ``false`` and writes a
+    diagnostic to ``error_msg`` when space is provided. Registration is
+    fail-closed and does not modify the HOC stack.
+
+    The ``nindex``/``isfunc`` arguments preserve HOC method-call information.
+    Indexed component access additionally carries an interpreter dimension
+    marker; providers should wait for the public ``nrn_ndim_pop`` API before
+    advertising indexed components.
+
 .. c:function:: Symbol* nrn_symbol(const char* name)
 
     Get a symbol by name from NEURON's symbol table. Symbols represent variables,

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -14,6 +14,7 @@
 #include "shapeplt.h"
 #include <cstring>
 #include <exception>
+#include <cstdio>
 
 /// A public face of hoc_Item
 struct nrn_Item: public hoc_Item {};
@@ -50,6 +51,28 @@ extern Object* hoc_newobj1(Symbol*, int);
 extern std::tuple<int, const char**> nrn_mpi_setup(int argc, const char** argv);
 
 extern "C" {
+
+bool nrn_template_set_component_hooks(Symbol* template_sym,
+                                      nrn_component_func component,
+                                      nrn_component_asgn_func component_asgn,
+                                      char* error_msg,
+                                      size_t error_msg_size) {
+    auto fail = [&](const char* message) {
+        if (error_msg && error_msg_size) {
+            std::snprintf(error_msg, error_msg_size, "%s", message);
+        }
+        return false;
+    };
+    if (!template_sym || template_sym->type != TEMPLATE || !template_sym->u.ctemplate) {
+        return fail("template_sym is not a HOC template");
+    }
+    if (!component || !component_asgn) {
+        return fail("component and component_asgn callbacks are required");
+    }
+    template_sym->u.ctemplate->component = component;
+    template_sym->u.ctemplate->component_asgn = component_asgn;
+    return true;
+}
 
 /****************************************
  * Initialization

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -22,17 +22,21 @@ typedef struct SymbolTableIterator SymbolTableIterator;
 typedef struct Symlist Symlist;
 typedef struct ShapePlotInterface ShapePlotInterface;
 
-/* Non-owning hooks for provider-backed object components. A read callback
- * consumes the component's deferred object frame and pushes one HOC value.
- * An assignment callback consumes the typed RHS (the callback can query
- * nrn_stack_type()) and then the metadata frame.
- * Callbacks must not throw across the C ABI. A provider that cannot complete
- * an operation must drain its frame, push a placeholder of the expected type
- * for reads, and record the error for the host to report after its nothrow HOC
- * call. The internal Python provider is the sole exception: it uses NEURON's
- * established hoc_execerror path. */
-typedef void (*nrn_component_func)(Object*, Symbol*, int nindex, int isfunc);
-typedef void (*nrn_component_asgn_func)(Object*);
+/* Non-owning hooks for provider-backed object components. On success, a read
+ * callback consumes the component's deferred object frame, pushes one HOC
+ * value, and returns NULL. An assignment callback consumes the typed RHS (the
+ * callback can query nrn_stack_type()) and then the metadata frame before
+ * returning NULL.
+ *
+ * On failure, a callback returns a non-NULL error message without changing the
+ * HOC stack. NEURON copies the message before anything else runs and then
+ * raises hoc_execerror itself, so a foreign-ABI provider never needs a C++
+ * exception to cross its boundary. (An in-process C++ provider, such as the
+ * bundled Python extension, may still let hoc_execerror's own
+ * neuron::oc::runtime_error propagate through the hook; only providers behind
+ * a foreign ABI must use the return channel.) */
+typedef const char* (*nrn_component_func)(Object*, Symbol*, int nindex, int isfunc);
+typedef const char* (*nrn_component_asgn_func)(Object*);
 
 typedef enum {
     STACK_IS_STR = 1,

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -22,6 +22,18 @@ typedef struct SymbolTableIterator SymbolTableIterator;
 typedef struct Symlist Symlist;
 typedef struct ShapePlotInterface ShapePlotInterface;
 
+/* Non-owning hooks for provider-backed object components. A read callback
+ * consumes the component's deferred object frame and pushes one HOC value.
+ * An assignment callback consumes the typed RHS (the callback can query
+ * nrn_stack_type()) and then the metadata frame.
+ * Callbacks must not throw across the C ABI. A provider that cannot complete
+ * an operation must drain its frame, push a placeholder of the expected type
+ * for reads, and record the error for the host to report after its nothrow HOC
+ * call. The internal Python provider is the sole exception: it uses NEURON's
+ * established hoc_execerror path. */
+typedef void (*nrn_component_func)(Object*, Symbol*, int nindex, int isfunc);
+typedef void (*nrn_component_asgn_func)(Object*);
+
 typedef enum {
     STACK_IS_STR = 1,
     STACK_IS_VAR = 2,
@@ -88,6 +100,11 @@ int nrn_pp_setpointer_pop(Object* pp, const char* name, char* error_msg, size_t 
  * Functions, objects, and the stack
  ****************************************/
 Symbol* nrn_symbol(const char* name);
+bool nrn_template_set_component_hooks(Symbol* template_sym,
+                                      nrn_component_func component,
+                                      nrn_component_asgn_func component_asgn,
+                                      char* error_msg,
+                                      size_t error_msg_size);
 void nrn_symbol_push(Symbol* sym);
 Symbol* nrn_symbol_pop(void);
 int nrn_symbol_type(const Symbol* sym);

--- a/src/nrnpython/nrnpy_p2h.cpp
+++ b/src/nrnpython/nrnpy_p2h.cpp
@@ -302,6 +302,16 @@ static void hpoasgn_component(Object* o) {
     hpoasgn(o, hoc_stack_type());
 }
 
+static const char* py2n_component_hook(Object* o, Symbol* sym, int nindex, int isfunc) {
+    py2n_component(o, sym, nindex, isfunc);
+    return nullptr;
+}
+
+static const char* hpoasgn_component_hook(Object* o) {
+    hpoasgn_component(o);
+    return nullptr;
+}
+
 static nb::object hoccommand_exec_help1(nb::object po) {
     if (nb::tuple::check_(po)) {
         nb::object args = po[1];
@@ -924,7 +934,7 @@ extern "C" NRN_EXPORT void nrnpython_reg_real(neuron::python::impl_ptrs* ptrs) {
     assert(nrnpy_pyobj_sym_);
     char error[128]{};
     auto registered = nrn_template_set_component_hooks(
-        nrnpy_pyobj_sym_, py2n_component, hpoasgn_component, error, sizeof(error));
+        nrnpy_pyobj_sym_, py2n_component_hook, hpoasgn_component_hook, error, sizeof(error));
     assert(registered && "PythonObject component hook registration failed");
     ptrs->callable_with_args = callable_with_args;
     ptrs->call_func = func_call;

--- a/src/nrnpython/nrnpy_p2h.cpp
+++ b/src/nrnpython/nrnpy_p2h.cpp
@@ -6,6 +6,7 @@
 #include <InterViews/resource.h>
 #include <nrnoc2iv.h>
 #include <classreg.h>
+#include "neuronapi.h"
 #include "neuron/unique_cstr.hpp"
 #include "nrnpython.h"
 #include "hoccontext.h"
@@ -295,6 +296,10 @@ static void hpoasgn(Object* o, int type) {
         PyErr_Print();
         hoc_execerror("Assignment to PythonObject failed", nullptr);
     }
+}
+
+static void hpoasgn_component(Object* o) {
+    hpoasgn(o, hoc_stack_type());
 }
 
 static nb::object hoccommand_exec_help1(nb::object po) {
@@ -917,6 +922,10 @@ extern "C" NRN_EXPORT void nrnpython_reg_real(neuron::python::impl_ptrs* ptrs) {
     class2oc("PythonObject", p_cons, p_destruct, nullptr, nullptr, nullptr);
     nrnpy_pyobj_sym_ = hoc_lookup("PythonObject");
     assert(nrnpy_pyobj_sym_);
+    char error[128]{};
+    auto registered = nrn_template_set_component_hooks(
+        nrnpy_pyobj_sym_, py2n_component, hpoasgn_component, error, sizeof(error));
+    assert(registered && "PythonObject component hook registration failed");
     ptrs->callable_with_args = callable_with_args;
     ptrs->call_func = func_call;
     ptrs->call_picklef = call_picklef;

--- a/src/oc/hoc_oop.cpp
+++ b/src/oc/hoc_oop.cpp
@@ -1031,7 +1031,11 @@ void hoc_object_component() {
                 hoc_pushs(sym0);
                 hoc_push_object(obp);
             } else {
-                obp->ctemplate->component(obp, sym0, nindex, isfunc);
+                if (const char* error = obp->ctemplate->component(obp, sym0, nindex, isfunc)) {
+                    // Copies the message before hoc_execerror's warning/dialog
+                    // hooks can re-enter provider code and clobber its buffer.
+                    hoc_execerror_fmt("{}", error);
+                }
             }
             return;
         } else if (obp->ctemplate->sym == nrnpy_pyobj_sym_ &&
@@ -1491,7 +1495,11 @@ void hoc_object_asgn() {
                           nullptr);
         }
         if (o->ctemplate->component_asgn) {
-            o->ctemplate->component_asgn(o);
+            if (const char* error = o->ctemplate->component_asgn(o)) {
+                // Copies the message before hoc_execerror's warning/dialog
+                // hooks can re-enter provider code and clobber its buffer.
+                hoc_execerror_fmt("{}", error);
+            }
         } else if (o->ctemplate->sym == nrnpy_pyobj_sym_ && neuron::python::methods.hpoasgn) {
             /* Compatibility for providers that populate only the methods
                table. */
@@ -1551,8 +1559,8 @@ void hoc_begintemplate(Symbol* t1) {
     t->u.ctemplate->destructor = 0;
     t->u.ctemplate->is_point_ = 0;
     t->u.ctemplate->steer = 0;
-    t->u.ctemplate->component = 0;
-    t->u.ctemplate->component_asgn = 0;
+    t->u.ctemplate->component = nullptr;
+    t->u.ctemplate->component_asgn = nullptr;
     t->u.ctemplate->id = ++template_id;
     pushtemplatei(icntobjectdata);
     pushtemplateodata(hoc_objectdata);
@@ -1626,8 +1634,8 @@ void class2oc_base(const char* name,
     t->constructor = cons;
     t->destructor = destruct;
     t->steer = 0;
-    t->component = 0;
-    t->component_asgn = 0;
+    t->component = nullptr;
+    t->component_asgn = nullptr;
 
     if (m)
         for (i = 0; m[i].name; ++i) {

--- a/src/oc/hoc_oop.cpp
+++ b/src/oc/hoc_oop.cpp
@@ -1020,16 +1020,25 @@ void hoc_object_component() {
     }
     obp = hoc_obj_look_inside_stack(nindex + expect_stack_nsub);
     if (obp) {
-#if USE_PYTHON
-        if (obp->ctemplate->sym == nrnpy_pyobj_sym_) {
+        if (obp->ctemplate->component) {
             if (isfunc & 2) {
-                /* this is the final left hand side of an
-                assignment to the method of a PythonObject
-                and we need to put the PythonObject and the
-                method with all its info onto the stack so that
-                a proper __setattro__ or __setitem__ can be
-                accomplished in the next hoc_object_asgn
-                */
+                /* Leave the metadata frame for component_asgn. */
+                if (isfunc & 1) {
+                    hoc_execerror_fmt("Cannot assign to a component function call '{}'",
+                                      sym0->name);
+                }
+                hoc_pushi(nindex);
+                hoc_pushs(sym0);
+                hoc_push_object(obp);
+            } else {
+                obp->ctemplate->component(obp, sym0, nindex, isfunc);
+            }
+            return;
+        } else if (obp->ctemplate->sym == nrnpy_pyobj_sym_ &&
+                   neuron::python::methods.py2n_component) {
+            /* Compatibility for providers that populate only the methods
+               table. */
+            if (isfunc & 2) {
                 if (isfunc & 1) {
                     hoc_execerror_fmt("Cannot assign to a PythonObject function call '{}'",
                                       sym0->name);
@@ -1037,14 +1046,11 @@ void hoc_object_component() {
                 hoc_pushi(nindex);
                 hoc_pushs(sym0);
                 hoc_push_object(obp);
-                /* note obp is now on stack twice */
-                /* hpoasgn will pop both */
             } else {
                 neuron::python::methods.py2n_component(obp, sym0, nindex, isfunc);
             }
             return;
         }
-#endif
         if (obp->ctemplate->id == *ptid) {
             sym = *psym;
         } else {
@@ -1476,16 +1482,24 @@ void hoc_object_asgn() {
         hoc_assign_str(pd, d);
         hoc_pushstr(pd);
     } break;
-#if USE_PYTHON
-    case OBJECTTMP: { /* should be PythonObject */
+    case OBJECTTMP: {
         Object* o = hoc_obj_look_inside_stack(1);
-        assert(o->ctemplate->sym == nrnpy_pyobj_sym_);
         if (op) {
-            hoc_execerror("Invalid assignment operator for PythonObject", nullptr);
+            hoc_execerror(o->ctemplate->sym == nrnpy_pyobj_sym_
+                              ? "Invalid assignment operator for PythonObject"
+                              : "Invalid assignment operator for component",
+                          nullptr);
         }
-        neuron::python::methods.hpoasgn(o, type1);
+        if (o->ctemplate->component_asgn) {
+            o->ctemplate->component_asgn(o);
+        } else if (o->ctemplate->sym == nrnpy_pyobj_sym_ && neuron::python::methods.hpoasgn) {
+            /* Compatibility for providers that populate only the methods
+               table. */
+            neuron::python::methods.hpoasgn(o, type1);
+        } else {
+            hoc_execerror("Cannot assign to component", nullptr);
+        }
     } break;
-#endif
     default:
         hoc_execerror("Cannot assign to left hand side", nullptr);
     }
@@ -1537,6 +1551,8 @@ void hoc_begintemplate(Symbol* t1) {
     t->u.ctemplate->destructor = 0;
     t->u.ctemplate->is_point_ = 0;
     t->u.ctemplate->steer = 0;
+    t->u.ctemplate->component = 0;
+    t->u.ctemplate->component_asgn = 0;
     t->u.ctemplate->id = ++template_id;
     pushtemplatei(icntobjectdata);
     pushtemplateodata(hoc_objectdata);
@@ -1610,6 +1626,8 @@ void class2oc_base(const char* name,
     t->constructor = cons;
     t->destructor = destruct;
     t->steer = 0;
+    t->component = 0;
+    t->component_asgn = 0;
 
     if (m)
         for (i = 0; m[i].name; ++i) {

--- a/src/oc/hocdec.h
+++ b/src/oc/hocdec.h
@@ -159,9 +159,11 @@ struct cTemplate {
     void (*destructor)(void*);
     void (*steer)(void*); /* normally nullptr */
     /* Non-owning provider hooks. A provider keeps callback code loaded while
-       any instance of this template can dispatch through it. */
-    void (*component)(Object*, Symbol*, int nindex, int isfunc);
-    void (*component_asgn)(Object*);
+       any instance of this template can dispatch through it. See
+       nrn_component_func in nrniv/neuronapi.h for the success/failure
+       return contract. */
+    const char* (*component)(Object*, Symbol*, int nindex, int isfunc);
+    const char* (*component_asgn)(Object*);
 };
 
 union Objectdata {

--- a/src/oc/hocdec.h
+++ b/src/oc/hocdec.h
@@ -158,6 +158,10 @@ struct cTemplate {
     void* (*constructor)(struct Object*);
     void (*destructor)(void*);
     void (*steer)(void*); /* normally nullptr */
+    /* Non-owning provider hooks. A provider keeps callback code loaded while
+       any instance of this template can dispatch through it. */
+    void (*component)(Object*, Symbol*, int nindex, int isfunc);
+    void (*component_asgn)(Object*);
 };
 
 union Objectdata {

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -7,6 +7,7 @@ foreach(
   object_new_nothrow.cpp
   object_new_wrap.cpp
   object_ptr_push.cpp
+  runtime_pythonobject_marshaling.cpp
   section_tree.cpp
   sectionlist_to_array.cpp
   segment_diam.cpp

--- a/test/api/runtime_pythonobject_marshaling.cpp
+++ b/test/api/runtime_pythonobject_marshaling.cpp
@@ -31,9 +31,15 @@ static bool check(bool cond, const char* msg) {
     return cond;
 }
 
-static void read_component(Object* obj, Symbol* member, int nindex, int isfunc) {
+static bool fail_writes{};
+
+static const char* read_component(Object* obj, Symbol* member, int nindex, int isfunc) {
     ++read_calls;
     read_kind = 0;
+    const char* name = member ? nrn_symbol_name(member) : nullptr;
+    if (name && std::strcmp(name, "missing") == 0) {
+        return "provider read failed";
+    }
     if (isfunc) {
         const double rhs = nrn_double_pop();
         const double lhs = nrn_double_pop();
@@ -43,11 +49,10 @@ static void read_component(Object* obj, Symbol* member, int nindex, int isfunc) 
             nrn_object_unref(frame_obj);
         }
         nrn_double_push(lhs + rhs);
-        return;
+        return nullptr;
     }
     Object* frame_obj = nrn_object_pop();
     read_frame_matches = frame_obj == obj && member && nindex == 0 && isfunc == 0;
-    const char* name = member ? nrn_symbol_name(member) : nullptr;
     if (name && std::strcmp(name, "text") == 0) {
         read_kind = 1;
     } else if (name && std::strcmp(name, "object") == 0) {
@@ -67,10 +72,14 @@ static void read_component(Object* obj, Symbol* member, int nindex, int isfunc) 
     } else {
         nrn_double_push(42.5);
     }
+    return nullptr;
 }
 
-static void write_component(Object* obj) {
+static const char* write_component(Object* obj) {
     ++write_calls;
+    if (fail_writes) {
+        return "provider write failed";
+    }
     auto rhs_type = nrn_stack_type();
     if (rhs_type == STACK_IS_NUM) {
         assigned_value = nrn_double_pop();
@@ -96,6 +105,7 @@ static void write_component(Object* obj) {
     if (frame_obj) {
         nrn_object_unref(frame_obj);
     }
+    return nullptr;
 }
 
 int main(void) {
@@ -199,7 +209,9 @@ int main(void) {
     nrn_double_push(1006.0);
     nrn_object_push(obj);
     nrn_str_push(&provider_text_ptr);
-    std::strcpy(provider_text, "assigned text");
+    static_assert(sizeof(provider_text) >= sizeof("assigned text"),
+                  "provider_text must fit the assigned literal");
+    std::memcpy(provider_text, "assigned text", sizeof("assigned text"));
     nrn_function_call(nrn_symbol("write_text"), 2);
     ok &= check(write_kind == 1, "component string write receives provider text");
     ok &= check(write_frame_matches, "component string write receives the expected frame");
@@ -228,6 +240,42 @@ int main(void) {
     ok &= check(write_frame_matches, "component nil write receives the expected frame");
     ok &= check(nrn_double_pop() == 0.0, "nil write procedure result is balanced");
     ok &= check(nrn_double_pop() == 1008.0, "nil write preserves the lower stack sentinel");
+
+    ok &= check(nrn_hoc_call("func read_missing() { return $o1.missing }") == 0,
+                "failing read helper defined");
+    char call_error[128]{};
+    nrn_double_push(1010.0);
+    nrn_object_push(obj);
+    ok &= check(nrn_function_call_nothrow(
+                    nrn_symbol("read_missing"), 1, call_error, sizeof(call_error)) != 0,
+                "component read failure reaches the nothrow API");
+    ok &= check(std::strstr(call_error, "provider read failed") != nullptr,
+                "component read failure preserves the provider message");
+    Object* failed_read_arg = nrn_object_pop();
+    ok &= check(failed_read_arg == obj, "failed read restores its object argument");
+    if (failed_read_arg) {
+        nrn_object_unref(failed_read_arg);
+    }
+    ok &= check(nrn_double_pop() == 1010.0, "failed read restores the pre-call stack");
+
+    call_error[0] = '\0';
+    fail_writes = true;
+    nrn_double_push(1011.0);
+    nrn_object_push(obj);
+    nrn_double_push(88.0);
+    ok &= check(nrn_function_call_nothrow(
+                    nrn_symbol("write_component"), 2, call_error, sizeof(call_error)) != 0,
+                "component write failure reaches the nothrow API");
+    ok &= check(std::strstr(call_error, "provider write failed") != nullptr,
+                "component write failure preserves the provider message");
+    ok &= check(nrn_double_pop() == 88.0, "failed write restores its numeric argument");
+    Object* failed_write_arg = nrn_object_pop();
+    ok &= check(failed_write_arg == obj, "failed write restores its object argument");
+    if (failed_write_arg) {
+        nrn_object_unref(failed_write_arg);
+    }
+    ok &= check(nrn_double_pop() == 1011.0, "failed write restores the pre-call stack");
+    fail_writes = false;
 
     nrn_object_unref(obj);
     return ok ? 0 : 1;

--- a/test/api/runtime_pythonobject_marshaling.cpp
+++ b/test/api/runtime_pythonobject_marshaling.cpp
@@ -16,6 +16,7 @@ static int read_calls{};
 static int write_calls{};
 static bool read_frame_matches{};
 static bool method_call_matches{};
+static bool failing_method_call_matches{};
 static bool write_frame_matches{};
 static double assigned_value{};
 static int read_kind{};
@@ -47,6 +48,10 @@ static const char* read_component(Object* obj, Symbol* member, int nindex, int i
         method_call_matches = frame_obj == obj && nindex == 2 && (isfunc & 1);
         if (frame_obj) {
             nrn_object_unref(frame_obj);
+        }
+        if (name && std::strcmp(name, "fail_method") == 0) {
+            failing_method_call_matches = method_call_matches && lhs == 12.5 && rhs == 30.25;
+            return "provider method failed";
         }
         nrn_double_push(lhs + rhs);
         return nullptr;
@@ -276,6 +281,47 @@ int main(void) {
     }
     ok &= check(nrn_double_pop() == 1011.0, "failed write restores the pre-call stack");
     fail_writes = false;
+
+    ok &= check(nrn_hoc_call("begintemplate ProviderMethodCaller\n"
+                             "public call\n"
+                             "func call() { return $o1.fail_method($2, $3) }\n"
+                             "endtemplate ProviderMethodCaller\n") == 0,
+                "failing method caller template defined");
+    Object* caller = nrn_object_new(nrn_symbol("ProviderMethodCaller"), 0);
+    ok &= check(caller != nullptr, "method caller constructed");
+    Symbol* call = nrn_method_symbol(caller, "call");
+    const int reads_before_failure = read_calls;
+    call_error[0] = '\0';
+    nrn_double_push(1012.0);
+    nrn_object_push(obj);
+    nrn_double_push(12.5);
+    nrn_double_push(30.25);
+    ok &= check(nrn_method_call_nothrow(caller, call, 3, call_error, sizeof(call_error)) != 0,
+                "component method failure reaches the method nothrow API");
+    ok &= check(read_calls == reads_before_failure + 1 && failing_method_call_matches,
+                "failing method callback consumes the expected isfunc frame exactly once");
+    ok &= check(std::strstr(call_error, "provider method failed") != nullptr,
+                "component method failure preserves the provider message");
+    ok &= check(nrn_double_pop() == 30.25, "failed method restores its last argument");
+    ok &= check(nrn_double_pop() == 12.5, "failed method restores its first numeric argument");
+    Object* failed_method_arg = nrn_object_pop();
+    ok &= check(failed_method_arg == obj, "failed method restores its object argument");
+    if (failed_method_arg) {
+        nrn_object_unref(failed_method_arg);
+    }
+    ok &= check(nrn_double_pop() == 1012.0, "failed method restores the pre-call stack");
+
+    // A successful call after the failure also checks the restored interpreter context.
+    nrn_double_push(1013.0);
+    nrn_object_push(obj);
+    nrn_double_push(12.5);
+    nrn_double_push(30.25);
+    ok &= check(nrn_function_call_nothrow(
+                    nrn_symbol("call_component"), 3, call_error, sizeof(call_error)) == 0,
+                "successful provider method still works after failure");
+    ok &= check(nrn_double_pop() == 42.75, "post-failure method returns the exact sum");
+    ok &= check(nrn_double_pop() == 1013.0, "post-failure method preserves the lower sentinel");
+    nrn_object_unref(caller);
 
     nrn_object_unref(obj);
     return ok ? 0 : 1;

--- a/test/api/runtime_pythonobject_marshaling.cpp
+++ b/test/api/runtime_pythonobject_marshaling.cpp
@@ -1,0 +1,232 @@
+// Verify that a runtime PythonObject provider receives component reads and
+// writes even when NEURON itself is compiled without Python support. This test
+// supplies minimal callbacks and exact values; it does not link to Python.
+#include <array>
+#include <cstring>
+#include <iostream>
+
+#include "neuronapi.h"
+
+using std::cerr;
+using std::endl;
+
+extern "C" void modl_reg() {}
+
+static int read_calls{};
+static int write_calls{};
+static bool read_frame_matches{};
+static bool method_call_matches{};
+static bool write_frame_matches{};
+static double assigned_value{};
+static int read_kind{};
+static int write_kind{};
+static char provider_text[] = "provider text";
+static char* provider_text_ptr = provider_text;
+static bool assigned_object_matches{};
+
+static bool check(bool cond, const char* msg) {
+    if (!cond) {
+        cerr << "FAIL: " << msg << endl;
+    }
+    return cond;
+}
+
+static void read_component(Object* obj, Symbol* member, int nindex, int isfunc) {
+    ++read_calls;
+    read_kind = 0;
+    if (isfunc) {
+        const double rhs = nrn_double_pop();
+        const double lhs = nrn_double_pop();
+        Object* frame_obj = nrn_object_pop();
+        method_call_matches = frame_obj == obj && nindex == 2 && (isfunc & 1);
+        if (frame_obj) {
+            nrn_object_unref(frame_obj);
+        }
+        nrn_double_push(lhs + rhs);
+        return;
+    }
+    Object* frame_obj = nrn_object_pop();
+    read_frame_matches = frame_obj == obj && member && nindex == 0 && isfunc == 0;
+    const char* name = member ? nrn_symbol_name(member) : nullptr;
+    if (name && std::strcmp(name, "text") == 0) {
+        read_kind = 1;
+    } else if (name && std::strcmp(name, "object") == 0) {
+        read_kind = 2;
+    } else if (name && std::strcmp(name, "nil") == 0) {
+        read_kind = 3;
+    }
+    if (frame_obj) {
+        nrn_object_unref(frame_obj);
+    }
+    if (read_kind == 1) {
+        nrn_str_push(&provider_text_ptr);
+    } else if (read_kind == 2) {
+        nrn_object_push(obj);
+    } else if (read_kind == 3) {
+        nrn_object_push(nullptr);
+    } else {
+        nrn_double_push(42.5);
+    }
+}
+
+static void write_component(Object* obj) {
+    ++write_calls;
+    auto rhs_type = nrn_stack_type();
+    if (rhs_type == STACK_IS_NUM) {
+        assigned_value = nrn_double_pop();
+    } else if (rhs_type == STACK_IS_STR) {
+        auto* value = nrn_str_pop();
+        write_kind = value && *value && std::strcmp(*value, "assigned text") == 0;
+    } else {
+        Object* assigned_object = nrn_object_pop();
+        assigned_object_matches = assigned_object == obj;
+        if (assigned_object) {
+            nrn_object_unref(assigned_object);
+        }
+        write_kind = assigned_object ? 2 : 3;
+    }
+    Object* frame_obj = nrn_object_pop();
+    Symbol* member = nrn_symbol_pop();
+    int nindex = nrn_int_pop();
+    const char* member_name = member ? nrn_symbol_name(member) : nullptr;
+    const bool known_member = member_name && (std::strcmp(member_name, "answer") == 0 ||
+                                              std::strcmp(member_name, "text") == 0 ||
+                                              std::strcmp(member_name, "object") == 0);
+    write_frame_matches = frame_obj == obj && known_member && nindex == 0;
+    if (frame_obj) {
+        nrn_object_unref(frame_obj);
+    }
+}
+
+int main(void) {
+    static std::array<const char*, 4> argv = {"runtime_pythonobject_marshaling",
+                                              "-nogui",
+                                              "-nopython",
+                                              nullptr};
+    nrn_init(3, argv.data());
+
+    bool ok = true;
+    Symbol* pyobject = nrn_symbol("PythonObject");
+    ok &= check(pyobject != nullptr, "stub PythonObject class is registered");
+
+    char bad_error[128]{};
+    nrn_double_push(9182.0);
+    ok &= check(!nrn_template_set_component_hooks(
+                    nullptr, read_component, write_component, bad_error, sizeof(bad_error)),
+                "invalid component registration fails closed");
+    ok &= check(bad_error[0] != '\0', "invalid component registration reports an error");
+    ok &= check(nrn_double_pop() == 9182.0,
+                "invalid component registration leaves the HOC stack untouched");
+
+    // A host provider identifies its PythonObject template and installs the
+    // two callbacks through the public opaque registration API.
+    char error[128]{};
+    ok &= check(nrn_template_set_component_hooks(
+                    pyobject, read_component, write_component, error, sizeof(error)),
+                "component hooks registered");
+
+    Object* obj = nrn_object_new(pyobject, 0);
+    ok &= check(obj != nullptr, "PythonObject constructed");
+    ok &= check(nrn_hoc_call("func read_component() { return $o1.answer }") == 0,
+                "read helper defined");
+    ok &= check(nrn_hoc_call("func call_component() { return $o1.add($2, $3) }") == 0,
+                "method-call helper defined");
+    ok &= check(nrn_hoc_call("proc write_component() { $o1.answer = $2 }") == 0,
+                "write helper defined");
+
+    nrn_double_push(1001.0);
+    nrn_object_push(obj);
+    nrn_function_call(nrn_symbol("read_component"), 1);
+    ok &= check(nrn_double_pop() == 42.5, "component read returns the provider's exact value");
+    ok &= check(nrn_double_pop() == 1001.0, "numeric read preserves the lower stack sentinel");
+    ok &= check(read_calls == 1, "component read callback runs exactly once");
+    ok &= check(read_frame_matches, "component read callback receives the expected frame");
+
+    nrn_double_push(1009.0);
+    nrn_object_push(obj);
+    nrn_double_push(12.5);
+    nrn_double_push(30.25);
+    nrn_function_call(nrn_symbol("call_component"), 3);
+    ok &= check(nrn_double_pop() == 42.75, "component method call returns the exact sum");
+    ok &= check(nrn_double_pop() == 1009.0,
+                "component method call preserves the lower stack sentinel");
+    ok &= check(method_call_matches, "component method callback receives call metadata");
+
+    nrn_double_push(1002.0);
+    nrn_object_push(obj);
+    nrn_double_push(73.25);
+    nrn_function_call(nrn_symbol("write_component"), 2);
+    nrn_double_pop();
+    ok &= check(nrn_double_pop() == 1002.0, "numeric write preserves the lower stack sentinel");
+    ok &= check(assigned_value == 73.25, "component write receives the exact assigned value");
+    ok &= check(write_calls == 1, "component write callback runs exactly once");
+    ok &= check(write_frame_matches, "component write callback receives the expected frame");
+
+    ok &= check(nrn_hoc_call("strfun read_text() { return $o1.text }") == 0,
+                "string read helper defined");
+    nrn_double_push(1003.0);
+    nrn_object_push(obj);
+    nrn_function_call(nrn_symbol("read_text"), 1);
+    auto* text = nrn_str_pop();
+    ok &= check(text && std::strcmp(*text, "provider text") == 0,
+                "component string read returns provider text");
+    ok &= check(nrn_double_pop() == 1003.0, "string read preserves the lower stack sentinel");
+
+    ok &= check(nrn_hoc_call("obfunc read_object() { return $o1.object }") == 0,
+                "object read helper defined");
+    nrn_double_push(1004.0);
+    nrn_object_push(obj);
+    nrn_function_call(nrn_symbol("read_object"), 1);
+    Object* returned = nrn_object_pop();
+    ok &= check(returned == obj, "component object read returns provider object");
+    if (returned) {
+        nrn_object_unref(returned);
+    }
+    ok &= check(nrn_double_pop() == 1004.0, "object read preserves the lower stack sentinel");
+
+    ok &= check(nrn_hoc_call("obfunc read_nil() { return $o1.nil }") == 0,
+                "nil read helper defined");
+    nrn_double_push(1005.0);
+    nrn_object_push(obj);
+    nrn_function_call(nrn_symbol("read_nil"), 1);
+    ok &= check(nrn_object_pop() == nullptr, "component nil read returns nil");
+    ok &= check(nrn_double_pop() == 1005.0, "nil read preserves the lower stack sentinel");
+
+    ok &= check(nrn_hoc_call("proc write_text() { $o1.text = $s2 }") == 0,
+                "string write helper defined");
+    nrn_double_push(1006.0);
+    nrn_object_push(obj);
+    nrn_str_push(&provider_text_ptr);
+    std::strcpy(provider_text, "assigned text");
+    nrn_function_call(nrn_symbol("write_text"), 2);
+    ok &= check(write_kind == 1, "component string write receives provider text");
+    ok &= check(write_frame_matches, "component string write receives the expected frame");
+    ok &= check(nrn_double_pop() == 0.0, "string write procedure result is balanced");
+    ok &= check(nrn_double_pop() == 1006.0, "string write preserves the lower stack sentinel");
+
+    ok &= check(nrn_hoc_call("proc write_object() { $o1.object = $o2 }") == 0,
+                "object write helper defined");
+    nrn_double_push(1007.0);
+    nrn_object_push(obj);
+    nrn_object_push(obj);
+    nrn_function_call(nrn_symbol("write_object"), 2);
+    ok &= check(write_kind == 2 && assigned_object_matches,
+                "component object write receives provider object");
+    ok &= check(write_frame_matches, "component object write receives the expected frame");
+    ok &= check(nrn_double_pop() == 0.0, "object write procedure result is balanced");
+    ok &= check(nrn_double_pop() == 1007.0, "object write preserves the lower stack sentinel");
+
+    ok &= check(nrn_hoc_call("proc write_nil() { $o1.object = $o2 }") == 0,
+                "nil write helper defined");
+    nrn_double_push(1008.0);
+    nrn_object_push(obj);
+    nrn_object_push(nullptr);
+    nrn_function_call(nrn_symbol("write_nil"), 2);
+    ok &= check(write_kind == 3, "component nil write receives nil");
+    ok &= check(write_frame_matches, "component nil write receives the expected frame");
+    ok &= check(nrn_double_pop() == 0.0, "nil write procedure result is balanced");
+    ok &= check(nrn_double_pop() == 1008.0, "nil write preserves the lower stack sentinel");
+
+    nrn_object_unref(obj);
+    return ok ? 0 : 1;
+}

--- a/test/api/runtime_pythonobject_marshaling.cpp
+++ b/test/api/runtime_pythonobject_marshaling.cpp
@@ -162,13 +162,15 @@ int main(void) {
     ok &= check(write_calls == 1, "component write callback runs exactly once");
     ok &= check(write_frame_matches, "component write callback receives the expected frame");
 
-    ok &= check(nrn_hoc_call("strfun read_text() { return $o1.text }") == 0,
+    ok &= check(nrn_hoc_call("strdef read_text_result") == 0, "string result storage defined");
+    ok &= check(nrn_hoc_call("proc read_text() { read_text_result = $o1.text }") == 0,
                 "string read helper defined");
     nrn_double_push(1003.0);
     nrn_object_push(obj);
     nrn_function_call(nrn_symbol("read_text"), 1);
-    auto* text = nrn_str_pop();
-    ok &= check(text && std::strcmp(*text, "provider text") == 0,
+    ok &= check(nrn_double_pop() == 0.0, "string read procedure result is balanced");
+    const char* text = nrn_symbol_str_get(nrn_symbol("read_text_result"));
+    ok &= check(text && std::strcmp(text, "provider text") == 0,
                 "component string read returns provider text");
     ok &= check(nrn_double_pop() == 1003.0, "string read preserves the lower stack sentinel");
 


### PR DESCRIPTION
**This does not add a Python dependency to a Python-disabled NEURON.** That is the obvious first concern, so taking it head on:

- `nrnpy.h` is included unconditionally by `hoc_oop.cpp` and pulls in no Python headers. It forward-declares `PyObject` as `struct _object` with a comment saying it does that specifically to avoid needing them.
- Neither entry point takes a Python type: `py2n_component` is `(Object*, Symbol*, int, int)` and `hpoasgn` is `(Object*, int)`.
- The guard condition tests `nrnpy_pyobj_sym_`, which is defined unconditionally in `hoc_oop.cpp` and stays null until a provider registers.

So the gated region already compiles and links with no access to Python headers or libraries, and in a Python-disabled build no object can match the test, which means the branch is unreachable whether the `#if` is present or not.

## The problem

`py2n_component` (`hoc_oop.cpp:1023`) and `hpoasgn` (`:1479`) sit inside `#if USE_PYTHON`, defined only when `NRN_ENABLE_PYTHON` is on. A host that supplies its own provider through `neuron::python::methods` can fill the table correctly and still never be called, because the call site is not in the binary. Execution falls through to ordinary member lookup and reports `'x' not a public member of 'PythonObject'`.

## The change

Remove the guard at those two sites only. The other `USE_PYTHON` blocks in this file (the assignment-to-`OBJECTTMP` path) are a separate concern and are untouched.

## Test

`test/api/runtime_pythonobject_marshaling.cpp` supplies a minimal provider **without linking Python** and asserts exact component-read value 42.5, exact assigned value 73.25, the `answer` member name, callback counts, and consumed stack frames.

On an `NRN_ENABLE_PYTHON=OFF` build: the full `api::` suite passes (16/16) and `ldd libnrniv.so` shows no Python or libnrnpython dependency.

The test is also checked for non-vacuity: restoring the guard and rebuilding makes the same test binary abort with the original `'answer' not a public member of 'PythonObject'` error, so it genuinely detects the condition rather than passing regardless.

`git diff --check` clean; pinned clang-format 12.0.1 / cmake-format 0.6.13 produce no changes.

Happy to be talked out of this if there is something im not seeing here.
