### PR TITLE
neuronapi: expose NMODL RANDOM objects

### DIFF
--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -761,6 +761,39 @@ Segments
         for seg in dend:
             seg.g_pas = 0.001  # S/cm²
 
+.. c:function:: Object* nrn_segment_nmodlrandom_get(Section* sec, double x, Symbol* sym)
+
+    Wrap a density mechanism's NMODL ``RANDOM`` variable as an
+    ``NMODLRandom`` object.
+
+    :param sec: Section containing the density mechanism.
+    :param x: Normalized position (0.0 to 1.0) of the mechanism instance.
+    :param sym: ``RANDOM`` range-object symbol, such as
+        ``nrn_symbol("rng_mechanism")``.
+    :returns: A retained ``NMODLRandom`` object, or ``NULL`` for an invalid
+        section or position, a null or non-``RANDOM`` symbol, or when the
+        mechanism is absent at ``(sec, x)``.
+
+    The returned object shares the mechanism-owned random state. Release the
+    retained reference with :c:func:`nrn_object_unref` after use.
+
+.. c:function:: Object* nrn_pntproc_nmodlrandom_get(Object* point_process, Symbol* sym)
+
+    Wrap a point process's NMODL ``RANDOM`` variable as an ``NMODLRandom``
+    object.
+
+    :param point_process: Point-process instance owning the random state.
+    :param sym: ``RANDOM`` symbol from the point process's symbol table, as
+        returned by ``nrn_method_symbol(point_process, "rng")``.
+    :returns: A retained ``NMODLRandom`` object, or ``NULL`` if the inputs do
+        not identify a located point process and one of its ``RANDOM``
+        variables.
+
+    Release the returned reference with :c:func:`nrn_object_unref`. Density and
+    point-process RANDOM variables require separate entry points because a
+    density instance is identified by ``(sec, x)``, while a point process is
+    identified by its object even when several instances share one location.
+
 
 .. c:function:: int nrn_setpointer_pop(Symbol* pointer_sym, Section* sec, double x, char* error_msg, size_t error_msg_size)
 

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -230,6 +230,35 @@ void nrn_rangevar_push(Symbol* sym, Section* sec, double x) {
     hoc_push(nrn_rangepointer(sec, sym, x));
 }
 
+Object* nrn_segment_nmodlrandom_get(Section* sec, double x, Symbol* sym) {
+    if (!sec || !nrn_section_is_active(sec) || !(x >= 0.0 && x <= 1.0) || !sym ||
+        sym->type != RANGEOBJ || sym->subtype != NMODLRANDOM) {
+        return nullptr;
+    }
+    Prop* prop = nrn_mechanism(sym->u.rng.type, node_exact(sec, x));
+    if (!prop) {
+        return nullptr;
+    }
+    Object* obj = nrn_nmodlrandom_wrap(prop, sym);
+    hoc_obj_ref(obj);
+    return obj;
+}
+
+Object* nrn_pntproc_nmodlrandom_get(Object* point_process, Symbol* sym) {
+    if (!point_process || !point_process->ctemplate || !point_process->ctemplate->is_point_ ||
+        !sym || sym->type != RANGEOBJ || sym->subtype != NMODLRANDOM ||
+        hoc_table_lookup(sym->name, point_process->ctemplate->symtable) != sym) {
+        return nullptr;
+    }
+    auto* pnt = ob2pntproc_0(point_process);
+    if (!pnt || !pnt->prop) {
+        return nullptr;
+    }
+    Object* obj = nrn_pntproc_nmodlrandom_wrap(pnt, sym);
+    hoc_obj_ref(obj);
+    return obj;
+}
+
 int nrn_setpointer_pop(Symbol* pointer_sym,
                        Section* sec,
                        double x,

--- a/src/nrniv/neuronapi.h
+++ b/src/nrniv/neuronapi.h
@@ -77,6 +77,8 @@ int nrn_segment_node_index(Section* sec, double x);
 void nrn_rangevar_push(Symbol* sym, Section* sec, double x);
 double nrn_rangevar_get(Symbol* sym, Section* sec, double x);
 void nrn_rangevar_set(Symbol* sym, Section* sec, double x, double value);
+Object* nrn_segment_nmodlrandom_get(Section* sec, double x, Symbol* sym);
+Object* nrn_pntproc_nmodlrandom_get(Object* point_process, Symbol* sym);
 int nrn_setpointer_pop(Symbol* pointer_sym,
                        Section* sec,
                        double x,

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -73,3 +73,39 @@ endif()
 add_test(NAME "api::setpointer_cpp" COMMAND setpointer_cpp)
 set_property(TEST "api::setpointer_cpp" PROPERTY ENVIRONMENT "${NRN_RUN_FROM_BUILD_DIR_ENV}"
                                                  "CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
+
+# Generate a density mechanism and a point process with NMODL RANDOM variables to exercise both
+# public wrapper APIs without Python support.
+set(nmodlrandom_gens "")
+foreach(nmodlrandom_mod_name randomdensity randompoint)
+  set(nmodlrandom_mod "${CMAKE_CURRENT_SOURCE_DIR}/${nmodlrandom_mod_name}.mod")
+  set(nmodlrandom_mod_copy "${CMAKE_CURRENT_BINARY_DIR}/${nmodlrandom_mod_name}.mod")
+  set(nmodlrandom_gen "${CMAKE_CURRENT_BINARY_DIR}/${nmodlrandom_mod_name}.cpp")
+  configure_file("${nmodlrandom_mod}" "${nmodlrandom_mod_copy}" COPYONLY)
+  add_custom_command(
+    OUTPUT ${nmodlrandom_gen}
+    COMMAND
+      ${CMAKE_COMMAND} -E env "MODLUNIT=${PROJECT_BINARY_DIR}/share/nrn/lib/nrnunits.lib"
+      "NMODLHOME=${PROJECT_BINARY_DIR}" ${NRN_NOCMODL_SANITIZER_ENVIRONMENT}
+      $<TARGET_FILE:${NRN_CODEGENERATOR_TARGET}> ${nmodlrandom_mod_copy} ${NRN_NMODL_--neuron} -o
+      ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${NRN_CODEGENERATOR_TARGET} ${nmodlrandom_mod}
+            ${PROJECT_BINARY_DIR}/share/nrn/lib/nrnunits.lib
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  list(APPEND nmodlrandom_gens ${nmodlrandom_gen})
+endforeach()
+
+add_executable(nmodlrandom_cpp nmodlrandom.cpp ${nmodlrandom_gens})
+cpp_cc_configure_sanitizers(TARGET nmodlrandom_cpp)
+target_include_directories(nmodlrandom_cpp PRIVATE $<TARGET_PROPERTY:nrniv_lib,INCLUDE_DIRECTORIES>
+                                                   ${PROJECT_BINARY_DIR}/include)
+target_compile_definitions(nmodlrandom_cpp PRIVATE $<TARGET_PROPERTY:nrniv_lib,COMPILE_DEFINITIONS>)
+target_link_libraries(nmodlrandom_cpp ${CMAKE_DL_LIBS})
+target_link_libraries(nmodlrandom_cpp nrniv_lib)
+target_link_options(nmodlrandom_cpp PRIVATE -rdynamic)
+if(NRN_ENABLE_CORENEURON)
+  target_compile_definitions(nmodlrandom_cpp PUBLIC CORENEURON_ENABLED)
+endif()
+add_test(NAME "api::nmodlrandom_cpp" COMMAND nmodlrandom_cpp)
+set_property(TEST "api::nmodlrandom_cpp" PROPERTY ENVIRONMENT "${NRN_RUN_FROM_BUILD_DIR_ENV}"
+                                                  "CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")

--- a/test/api/nmodlrandom.cpp
+++ b/test/api/nmodlrandom.cpp
@@ -1,0 +1,108 @@
+// Exercises the public NMODL RANDOM wrappers for density mechanisms and point
+// processes. The generated mechanisms provide one RANDOM variable each.
+#include <array>
+#include <iostream>
+
+#include "neuronapi.h"
+
+using std::cerr;
+using std::endl;
+
+extern "C" void _randomdensity_reg();
+extern "C" void _randompoint_reg();
+extern "C" void modl_reg() {
+    _randomdensity_reg();
+    _randompoint_reg();
+}
+
+static bool check(bool condition, const char* message) {
+    if (!condition) {
+        cerr << "FAIL: " << message << endl;
+    }
+    return condition;
+}
+
+static bool set_seq(Object* random, double sequence) {
+    nrn_double_push(sequence);
+    nrn_method_call(random, nrn_method_symbol(random, "set_seq"), 1);
+    Object* returned = nrn_object_pop();
+    bool const ok = returned == random;
+    nrn_object_unref(returned);
+    return ok;
+}
+
+static double get_seq(Object* random) {
+    nrn_method_call(random, nrn_method_symbol(random, "get_seq"), 0);
+    return nrn_double_pop();
+}
+
+int main() {
+    static std::array<const char*, 4> argv = {"nmodlrandom", "-nogui", "-nopython", nullptr};
+    nrn_init(3, argv.data());
+
+    bool ok = true;
+    Section* cable = nrn_section_new("cable");
+    nrn_nseg_set(cable, 3);
+    Symbol* mechanism = nrn_symbol("randomdensity");
+    Symbol* density_rng = nrn_symbol("rng_randomdensity");
+    ok &= check(mechanism && density_rng, "density RANDOM symbols registered");
+    nrn_mechanism_insert(cable, mechanism);
+
+    Object* density_left = nrn_segment_nmodlrandom_get(cable, 1.0 / 6.0, density_rng);
+    Object* density_right = nrn_segment_nmodlrandom_get(cable, 5.0 / 6.0, density_rng);
+    ok &= check(density_left && density_right, "density RANDOM instances wrapped");
+    ok &= check(set_seq(density_left, 17), "density setter returns its wrapper");
+    ok &= check(set_seq(density_right, 29), "second density setter returns its wrapper");
+    ok &= check(get_seq(density_left) == 17, "density wrapper addresses the requested segment");
+    ok &= check(get_seq(density_right) == 29, "density RANDOM states remain independent");
+
+    // Public wrappers return retained objects. Releasing one wrapper must not
+    // affect the mechanism-owned RANDOM state, which a fresh wrapper can read.
+    nrn_object_unref(density_left);
+    density_left = nrn_segment_nmodlrandom_get(cable, 1.0 / 6.0, density_rng);
+    ok &= check(density_left && get_seq(density_left) == 17,
+                "density RANDOM survives wrapper release and rewrap");
+
+    Section* empty = nrn_section_new("empty");
+    ok &= check(!nrn_segment_nmodlrandom_get(nullptr, 0.5, density_rng), "null section rejected");
+    ok &= check(!nrn_segment_nmodlrandom_get(cable, 0.5, nullptr), "null density symbol rejected");
+    ok &= check(!nrn_segment_nmodlrandom_get(cable, 0.5, nrn_symbol("v")),
+                "non-RANDOM density symbol rejected");
+    ok &= check(!nrn_segment_nmodlrandom_get(cable, -0.1, density_rng),
+                "out-of-range density position rejected");
+    ok &= check(!nrn_segment_nmodlrandom_get(empty, 0.5, density_rng),
+                "absent density mechanism rejected");
+
+    nrn_section_push(cable);
+    nrn_double_push(0.5);
+    Object* point = nrn_object_new(nrn_symbol("RandomPoint"), 1);
+    nrn_section_pop();
+    Symbol* point_rng = nrn_method_symbol(point, "rng");
+    Object* point_random = nrn_pntproc_nmodlrandom_get(point, point_rng);
+    ok &= check(point_random, "point-process RANDOM instance wrapped");
+    ok &= check(set_seq(point_random, 41), "point-process setter returns its wrapper");
+    ok &= check(get_seq(point_random) == 41, "point-process wrapper preserves setter state");
+    nrn_object_unref(point_random);
+    point_random = nrn_pntproc_nmodlrandom_get(point, point_rng);
+    ok &= check(point_random && get_seq(point_random) == 41,
+                "point-process RANDOM survives wrapper release and rewrap");
+
+    nrn_double_push(1);
+    Object* vector = nrn_object_new(nrn_symbol("Vector"), 1);
+    Object* unlocated = nrn_object_new(nrn_symbol("RandomPoint"), 0);
+    ok &= check(!nrn_pntproc_nmodlrandom_get(nullptr, point_rng), "null point process rejected");
+    ok &= check(!nrn_pntproc_nmodlrandom_get(point, nullptr), "null point symbol rejected");
+    ok &= check(!nrn_pntproc_nmodlrandom_get(vector, point_rng), "non-point object rejected");
+    ok &= check(!nrn_pntproc_nmodlrandom_get(point, density_rng),
+                "RANDOM symbol from another mechanism rejected");
+    ok &= check(!nrn_pntproc_nmodlrandom_get(unlocated, nrn_method_symbol(unlocated, "rng")),
+                "unlocated point process rejected");
+
+    nrn_object_unref(density_left);
+    nrn_object_unref(density_right);
+    nrn_object_unref(point_random);
+    nrn_object_unref(point);
+    nrn_object_unref(vector);
+    nrn_object_unref(unlocated);
+    return ok ? 0 : 1;
+}

--- a/test/api/randomdensity.mod
+++ b/test/api/randomdensity.mod
@@ -1,0 +1,6 @@
+TITLE minimal density mechanism with an NMODL RANDOM variable
+
+NEURON {
+    SUFFIX randomdensity
+    RANDOM rng
+}

--- a/test/api/randompoint.mod
+++ b/test/api/randompoint.mod
@@ -1,0 +1,6 @@
+TITLE minimal point process with an NMODL RANDOM variable
+
+NEURON {
+    POINT_PROCESS RandomPoint
+    RANDOM rng
+}


### PR DESCRIPTION
NMODL `RANDOM` variables have been usable from HOC and from the Python extension since #2627, but they are not reachable through the C API.

The wrappers that do the work — `nrn_nmodlrandom_wrap` and `nrn_pntproc_nmodlrandom_wrap` — take internal types (`Prop*`, `Point_process*`) and are exported C++-mangled only, so an external host cannot get at a RANDOM variable at all.

## The change

Two public adapters, taking only types `neuronapi.h` already exposes:

```c
Object* nrn_segment_nmodlrandom_get(Section* sec, double x, Symbol* sym);
Object* nrn_pntproc_nmodlrandom_get(Object* point_process, Symbol* sym);
```

A section plus position for the density case, the point-process `Object` for the point case. Each returns one owned reference.

Both **fail closed**: they return NULL for anything that is not a live NMODL RANDOM variable, rather than asserting or crashing. That is deliberate, and useful beyond safety — a caller can use a successful wrap as the runtime test for "is this symbol a RANDOM variable", which matters because there is no RANGEOBJ symbol to probe until a RANDOM-bearing mod file has been loaded.

Validation is load-bearing because the internal wrappers `assert` their preconditions. The adapters check symbol type and subtype, that the section is alive and `x` is in `[0,1]`, and for the point-process case that the symbol actually belongs to that template.

## Naming

These originally reused the names of the internal functions as C-linkage overloads. Renamed at review request, so the public adapters are `nrn_segment_nmodlrandom_get` / `nrn_pntproc_nmodlrandom_get` and the internal `nrn_nmodlrandom_wrap` / `nrn_pntproc_nmodlrandom_wrap` keep theirs. No identifier now means two different things.

## Test

`test/api/nmodlrandom.cpp` generates a density mod and a point-process mod that each declare a RANDOM variable, then checks exact sequence values, that passing the wrong symbol returns NULL rather than aborting, and that the returned object outlives the scope it was created in.

Verified on an `NRN_ENABLE_PYTHON=OFF` build: the full `api::` suite passes (16/16). `git diff --check` clean; pinned clang-format 12.0.1 / cmake-format 0.6.13 produce no changes.

Found while implementing type-320 dispatch in myneuron, which is currently the only piece of NEURON's range-variable surface it cannot reach.
