### PR TITLE
ivoc: give HocCommand a single boolean status convention

### DIFF
--- a/src/ivoc/objcmd.cpp
+++ b/src/ivoc/objcmd.cpp
@@ -95,14 +95,17 @@ int HocCommand::execute(bool notify) {
     int err;
     if (po_) {
         assert(neuron::python::methods.hoccommand_exec);
+        // hoccommand_exec returns a boolean success flag.
         err = neuron::python::methods.hoccommand_exec(po_);
     } else {
         if (!s_) {
-            return 0;
+            return 1;
         }
         char buf[256];
         Sprintf(buf, "{%s}\n", s_->c_str());
-        err = hoc_obj_run(buf, obj_);
+        // hoc_obj_run returns an error code, so invert it to match the boolean
+        // success convention used by the Python callback.
+        err = !hoc_obj_run(buf, obj_);
     }
 #if HAVE_IV
     if (notify) {
@@ -114,6 +117,7 @@ int HocCommand::execute(bool notify) {
 }
 int HocCommand::exec_strret(char* buf, int size, bool notify) {
     assert(po_);
+    // hoccommand_exec_strret returns a boolean success flag.
     int err = neuron::python::methods.hoccommand_exec_strret(po_, buf, size);
 #if HAVE_IV
     if (notify) {
@@ -127,7 +131,9 @@ int HocCommand::execute(const char* s, bool notify) {
     assert(po_ == NULL);
     char buf[256];
     Sprintf(buf, "{%s}\n", s);
-    int err = hoc_obj_run(buf, obj_);
+    // hoc_obj_run returns an error code, so invert it to match HocCommand's
+    // boolean success convention.
+    int err = !hoc_obj_run(buf, obj_);
 #if HAVE_IV
     if (notify) {
         Oc oc;

--- a/src/ivoc/oclist.cpp
+++ b/src/ivoc/oclist.cpp
@@ -664,7 +664,7 @@ void OcListBrowser::change_name(GlyphIndex i) {
         }
     } else if (plabel_) {
         hoc_ac_ = i;
-        if (label_action_->execute(bool(false)) == 0) {
+        if (label_action_->execute(bool(false))) {
             change_item(i, *plabel_);
         } else {
             change_item(i, "label error");

--- a/src/nrniv/spaceplt.cpp
+++ b/src/nrniv/spaceplt.cpp
@@ -750,7 +750,7 @@ void RangeExpr::fill() {
             nrn_popsec();
             continue;
         }
-        if (cmd_->execute(bool(false)) == 0) {
+        if (cmd_->execute(bool(false))) {
             exist_[i] = true;
             val_[i] = 0.;
         } else {

--- a/test/unit_tests/oc/hoc_interpreter.cpp
+++ b/test/unit_tests/oc/hoc_interpreter.cpp
@@ -7,7 +7,10 @@
 #include "hocdec.h"
 #include "classreg.h"
 #include "ocfunc.h"
+#include "objcmd.h"
+#include "nrnpy.h"
 
+#include <cstring>
 #include <sstream>
 
 TEST_CASE("Test hoc interpreter", "[NEURON][hoc_interpreter]") {
@@ -16,6 +19,18 @@ TEST_CASE("Test hoc interpreter", "[NEURON][hoc_interpreter]") {
     hoc_pushx(5.0);
     hoc_add();
     REQUIRE(hoc_xpop() == 9.0);
+}
+
+TEST_CASE("HocCommand normalizes HOC execution success", "[NEURON][hoc_interpreter]") {
+    HocCommand command("hoc_ac_ = 42");
+    REQUIRE(command.execute(false) == 1);
+
+    HocCommand failing_command("hoc_ac_ =");
+    REQUIRE(failing_command.execute(false) == 0);
+
+    HocCommand overload_command("unused");
+    REQUIRE(overload_command.execute("hoc_ac_ = 43", false) == 1);
+    REQUIRE(overload_command.execute("hoc_ac_ =", false) == 0);
 }
 
 constexpr static auto check_tempobj_canary = 0xDEADBEEF;
@@ -190,6 +205,71 @@ SCENARIO("Test calling code from HOC that throws exceptions", "[NEURON][hoc_inte
 }
 
 #if USE_PYTHON
+namespace {
+int fake_hoccommand_exec_success(Object*) {
+    return 1;
+}
+int fake_hoccommand_exec_failure(Object*) {
+    return 0;
+}
+int fake_hoccommand_exec_strret_success(Object*, char* buf, int size) {
+    constexpr char result[] = "callback result";
+    std::strncpy(buf, result, size);
+    if (size > 0) {
+        buf[size - 1] = '\0';
+    }
+    return 1;
+}
+int fake_hoccommand_exec_strret_failure(Object*, char*, int) {
+    return 0;
+}
+}  // namespace
+
+TEST_CASE("HocCommand normalizes Python callback success", "[NEURON][hoc_interpreter][nrnpython]") {
+    char python_object_name[] = "PythonObject";
+    Symbol python_object_symbol{};
+    python_object_symbol.name = python_object_name;
+    cTemplate python_object_template{};
+    python_object_template.sym = &python_object_symbol;
+    Object python_object{};
+    python_object.refcount = 1;
+    python_object.ctemplate = &python_object_template;
+
+    auto const original_hoccommand_exec = neuron::python::methods.hoccommand_exec;
+    neuron::python::methods.hoccommand_exec = fake_hoccommand_exec_success;
+    int const success_status = [&] {
+        HocCommand command(&python_object);
+        return command.execute(false);
+    }();
+    neuron::python::methods.hoccommand_exec = fake_hoccommand_exec_failure;
+    int const failure_status = [&] {
+        HocCommand command(&python_object);
+        return command.execute(false);
+    }();
+    auto const original_hoccommand_exec_strret = neuron::python::methods.hoccommand_exec_strret;
+    neuron::python::methods.hoccommand_exec_strret = fake_hoccommand_exec_strret_success;
+    char success_buf[32]{};
+    int const strret_success_status = [&] {
+        HocCommand command(&python_object);
+        return command.exec_strret(success_buf, sizeof(success_buf), false);
+    }();
+    neuron::python::methods.hoccommand_exec_strret = fake_hoccommand_exec_strret_failure;
+    char failure_buf[32] = "unchanged";
+    int const strret_failure_status = [&] {
+        HocCommand command(&python_object);
+        return command.exec_strret(failure_buf, sizeof(failure_buf), false);
+    }();
+    neuron::python::methods.hoccommand_exec = original_hoccommand_exec;
+    neuron::python::methods.hoccommand_exec_strret = original_hoccommand_exec_strret;
+
+    REQUIRE(success_status == 1);
+    REQUIRE(failure_status == 0);
+    REQUIRE(strret_success_status == 1);
+    REQUIRE(std::strcmp(success_buf, "callback result") == 0);
+    REQUIRE(strret_failure_status == 0);
+    REQUIRE(std::strcmp(failure_buf, "unchanged") == 0);
+}
+
 TEST_CASE("Test hoc_array_access", "[NEURON][hoc_interpreter][nrnpython][array_access]") {
     REQUIRE(hoc_oc("nrnpython(\"avec = [0,1,2]\")\n"
                    "objref po\n"


### PR DESCRIPTION
`HocCommand::execute` returned opposite senses depending on which kind of callback it was holding.

The Python branch returned `hoccommand_exec`'s boolean, which is `r.is_valid()` (`nrnpython/nrnpy_p2h.cpp:354`), so 1 means success. The HOC branch returned `hoc_obj_run`, which forwards `hoc_oc`, which returns 1 from inside its catch (`oc/hoc.cpp:1348`), so 0 means success. Both landed in the same `err` and were returned unchanged. `exec_strret` had the same shape.

## The convention

**1 == success**, matching the provider interface rather than the HOC error code. Every int-returning member of `neuron::python::methods` is a boolean where 1 is success — `hoccommand_exec` and `hoccommand_exec_strret` both return `r.is_valid()`, `pysame` is a predicate — and the two callers that reach `hoccommand_exec` directly rather than through `HocCommand` already test it that way: `cvodeobj.cpp:511` and `linmod.cpp:66`, both `if (!...)`.

The cost is that `execute` no longer forwards `hoc_obj_run` transparently; the HOC branch inverts it. That seemed the better trade than having the wrapper disagree with the interface it wraps, but it is the real argument against this direction and worth saying out loud.

## Call sites

Three check the return. All three were correct before this change, because each only ever holds one kind of callback:

- `oclist.cpp:660` — `exec_strret`, Python-only (`label_pystract_`).
- `oclist.cpp:667` — `execute`, HOC-only (`label_action_`; the two members are set in mutually exclusive constructors at `:535` and `:557`).
- `spaceplt.cpp:753` — `execute`, HOC-only (the Python case returns earlier through `cmd_->pyobject()` and `func_call`).

The latter two are updated here. The rest discard the return. The methods-table entry points are untouched, so the direct callers are unaffected.

To be explicit: there is no pre-existing bug being fixed. The two conventions were structurally insulated, each path only ever seeing one kind of callback, which is why this never surfaced. What it removes is a trap for the next caller that holds both kinds — which is how it came up, while looking at making `extra_scatter_gather` accept a HOC function.

## Test

`test/unit_tests/oc/hoc_interpreter.cpp` covers both methods in both senses, across HOC and Python callbacks, with the string path also asserting the buffer is written on success and left alone on failure.

`clang-format` 12.0.1 clean.
