### PR TITLE
Make ninja format work in git worktrees

### DIFF
--- a/docs/install/formatting.md
+++ b/docs/install/formatting.md
@@ -22,9 +22,9 @@ brew install clang-format
 
 ## Instructions
 
-Clone the nrn repository and configure with cmake. Cmake will
-automatically clone a subrepository into nrn/external/coding-conventions
-No special cmake formatting options are needed.
+Clone the nrn repository (a ``git worktree add`` checkout is fine) and
+configure with cmake. Cmake will automatically clone a subrepository into
+``external/coding-conventions``. No special cmake formatting options are needed.
 
 ```
 # from the CMake build directory (or with cmake --build)


### PR DESCRIPTION
## Summary

`ninja format` / `ninja format-pr` was a silent no-op in a linked git worktree (checkout whose `.git` is a gitfile, e.g. `git worktree add`). The coding-conventions `source_dir()` helper treated `parent(git-dir)` as the repo root, which is `<primary>/.git/worktrees` rather than the worktree, so `.bbp-project.yaml` was not found and no tools ran (exit 0).

This pins `external/coding-conventions` at merged master `4bb2c5f` ([coding-conventions#4](https://github.com/neuronsimulator/coding-conventions/pull/4)), which uses `git rev-parse --show-superproject-working-tree`. Docs note that a `git worktree add` checkout is a supported way to run format.

Black version / Python 3.14 is **not** in this PR.

## Test plan

* Local: `PYENV_VERSION=3.12 ninja format` (or `bin/format -q --lang python <one .py>`) from a `git worktree add` checkout prints the Black version banner and does **not** print `No tool enabled for task format`
* Local: same from a primary clone still works
* CI: Check formatting on this PR