### PR TITLE
neuronapi: report array-dimension markers as STACK_IS_INT

### DIFF
--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -1234,6 +1234,8 @@ Functions, objects, and the stack
 .. c:function:: nrn_stack_types_t nrn_stack_type(void)
 
     Get the type of the value on top of the stack without removing it.
+    Both ordinary integers and array-dimension markers are reported as
+    ``STACK_IS_INT`` and can be consumed with :c:func:`nrn_int_pop`.
 
     :returns: Enumeration value indicating the stack top type.
 

--- a/src/nrniv/neuronapi.cpp
+++ b/src/nrniv/neuronapi.cpp
@@ -615,6 +615,7 @@ nrn_stack_types_t nrn_stack_type(void) {
     case OBJECTTMP:
         return STACK_IS_OBJTMP;
     case USERINT:
+        // Includes the distinct array-dimension marker accepted by nrn_int_pop.
         return STACK_IS_INT;
     case SYMBOL:
         return STACK_IS_SYM;

--- a/src/oc/code.cpp
+++ b/src/oc/code.cpp
@@ -293,7 +293,9 @@ int get_legacy_int_type(StackDatum const& entry) {
         return OBJECTVAR;
     } else if (std::holds_alternative<Object*>(entry)) {
         return OBJECTTMP;
-    } else if (std::holds_alternative<int>(entry)) {
+    } else if (std::holds_alternative<int>(entry) ||
+               std::holds_alternative<stack_ndim_datum>(entry)) {
+        // nrn_int_pop consumes both representations, so probe-before-pop must agree.
         return USERINT;
     } else if (std::holds_alternative<Symbol*>(entry)) {
         return SYMBOL;

--- a/test/api/stack_pops.cpp
+++ b/test/api/stack_pops.cpp
@@ -5,6 +5,7 @@
 // the interpreter left on the stack; nrn_object_pop pops an object but returns
 // NULL for a nil objref instead of dereferencing it to take a reference.
 #include <array>
+#include <cstring>
 #include <iostream>
 #include "neuronapi.h"
 
@@ -15,7 +16,6 @@ using std::endl;
 // interpreter pushes one during object-component access -- so the test uses the
 // internal push to put a Symbol there, the way nrniv would mid-expression.
 extern void hoc_pushs(Symbol*);
-extern void hoc_push_ndim(int);
 
 extern "C" void modl_reg() {}
 
@@ -24,6 +24,46 @@ static bool check(bool cond, const char* msg) {
         cerr << "FAIL: " << msg << endl;
     }
     return cond;
+}
+
+static bool awaiting_dimension{};
+static bool dimension_is_int{};
+static int observed_dimension{-1};
+
+static int inspect_indexed_error(int, char* message) {
+    if (awaiting_dimension && std::strstr(message, "not a public member")) {
+        awaiting_dimension = false;
+        dimension_is_int = nrn_stack_type() == STACK_IS_INT;
+        observed_dimension = nrn_int_pop();
+    }
+    return 0;
+}
+
+// The public HOC call produces an indexed-component frame before member lookup
+// fails. Its diagnostic callback can therefore inspect/pop the real ndim marker
+// using only public APIs. Error recovery below must restore the caller's frame;
+// this avoids depending on internal hoc_push_ndim or Python provider hooks.
+static bool inspect_dimension(Object* object, const char* function, int expected) {
+    observed_dimension = -1;
+    dimension_is_int = false;
+    awaiting_dimension = true;
+    char error[256]{};
+    nrn_double_push(424243.0);
+    nrn_object_push(object);
+    const int status = nrn_function_call_nothrow(nrn_symbol(function), 1, error, sizeof(error));
+    bool ok = check(status != 0, "indexed missing member fails through the nothrow API");
+    ok &= check(std::strstr(error, "not a public member") != nullptr,
+                "indexed lookup preserves its original error");
+    ok &= check(!awaiting_dimension, "diagnostic callback inspected the indexed frame");
+    ok &= check(dimension_is_int, "ndim marker probes as STACK_IS_INT before popping");
+    ok &= check(observed_dimension == expected, "int pop returns the API-produced ndim marker");
+    Object* restored = nrn_object_pop();
+    ok &= check(restored == object, "failed indexed lookup restores the object argument");
+    if (restored) {
+        nrn_object_unref(restored);
+    }
+    ok &= check(nrn_double_pop() == 424243.0, "failed indexed lookup preserves its lower sentinel");
+    return ok;
 }
 
 int main(void) {
@@ -69,13 +109,19 @@ int main(void) {
 
     // nrn_int_pop handles both ordinary USERINT values and the distinct array-
     // dimension marker used by indexed object-component access. Exercise exact
-    // values and LIFO ordering for both representations through the same API.
+    // values for both representations through the same public probe/pop APIs.
     nrn_int_push(3);
+    ok &= check(nrn_stack_type() == STACK_IS_INT, "ordinary integer probes as STACK_IS_INT");
     ok &= check(nrn_int_pop() == 3, "int pop returns an ordinary integer");
-    hoc_push_ndim(2);
-    hoc_push_ndim(7);
-    ok &= check(nrn_int_pop() == 7, "int pop returns the last pushed ndim marker");
-    ok &= check(nrn_int_pop() == 2, "int pop returns the earlier ndim marker (LIFO)");
+    ok &= check(nrn_hoc_call("func missing_1() { return $o1.missing[7] }") == 0,
+                "one-dimensional indexed helper defined");
+    ok &= check(nrn_hoc_call("func missing_2() { return $o1.missing[2][7] }") == 0,
+                "two-dimensional indexed helper defined");
+    nrn_stdout_redirect(inspect_indexed_error);
+    ok &= inspect_dimension(vec, "missing_1", 1);
+    ok &= inspect_dimension(vec, "missing_2", 2);
+    nrn_stdout_redirect(nullptr);
+    nrn_object_unref(vec);
 
     // Balance: with every push above consumed by exactly one pop, the sentinel
     // from the very start is what remains on top.

--- a/test/api/stack_pops.cpp
+++ b/test/api/stack_pops.cpp
@@ -26,37 +26,31 @@ static bool check(bool cond, const char* msg) {
     return cond;
 }
 
-static bool awaiting_dimension{};
-static bool dimension_is_int{};
 static int observed_dimension{-1};
 
-static int inspect_indexed_error(int, char* message) {
-    if (awaiting_dimension && std::strstr(message, "not a public member")) {
-        awaiting_dimension = false;
-        dimension_is_int = nrn_stack_type() == STACK_IS_INT;
-        observed_dimension = nrn_int_pop();
-    }
-    return 0;
-}
-
-// The public HOC call produces an indexed-component frame before member lookup
-// fails. Its diagnostic callback can therefore inspect/pop the real ndim marker
-// using only public APIs. Error recovery below must restore the caller's frame;
-// this avoids depending on internal hoc_push_ndim or Python provider hooks.
-static bool inspect_dimension(Object* object, const char* function, int expected) {
+static bool check_indexed_dimension(Object* object, const char* function, int expected) {
     observed_dimension = -1;
-    dimension_is_int = false;
-    awaiting_dimension = true;
+    // HOC pushes a real dimension marker before reporting the missing member.
+    // Inspect it here, BEFORE nothrow recovery removes it. This is a stack
+    // inspection hook, not output capture; it avoids an internal marker-push API.
+    nrn_stdout_redirect([](int, char* message) {
+        if (observed_dimension == -1 && std::strstr(message, "not a public member")) {
+            if (nrn_stack_type() == STACK_IS_INT) {
+                observed_dimension = nrn_int_pop();
+            }
+        }
+        return 0;
+    });
     char error[256]{};
     nrn_double_push(424243.0);
     nrn_object_push(object);
     const int status = nrn_function_call_nothrow(nrn_symbol(function), 1, error, sizeof(error));
+    nrn_stdout_redirect(nullptr);
     bool ok = check(status != 0, "indexed missing member fails through the nothrow API");
     ok &= check(std::strstr(error, "not a public member") != nullptr,
                 "indexed lookup preserves its original error");
-    ok &= check(!awaiting_dimension, "diagnostic callback inspected the indexed frame");
-    ok &= check(dimension_is_int, "ndim marker probes as STACK_IS_INT before popping");
-    ok &= check(observed_dimension == expected, "int pop returns the API-produced ndim marker");
+    ok &= check(observed_dimension == expected,
+                "indexed access produces a STACK_IS_INT marker with the expected dimension");
     Object* restored = nrn_object_pop();
     ok &= check(restored == object, "failed indexed lookup restores the object argument");
     if (restored) {
@@ -117,10 +111,8 @@ int main(void) {
                 "one-dimensional indexed helper defined");
     ok &= check(nrn_hoc_call("func missing_2() { return $o1.missing[2][7] }") == 0,
                 "two-dimensional indexed helper defined");
-    nrn_stdout_redirect(inspect_indexed_error);
-    ok &= inspect_dimension(vec, "missing_1", 1);
-    ok &= inspect_dimension(vec, "missing_2", 2);
-    nrn_stdout_redirect(nullptr);
+    ok &= check_indexed_dimension(vec, "missing_1", 1);
+    ok &= check_indexed_dimension(vec, "missing_2", 2);
     nrn_object_unref(vec);
 
     // Balance: with every push above consumed by exactly one pop, the sentinel


### PR DESCRIPTION
Follow-up to #3857. `nrn_int_pop` accepts array-dimension markers, but
`nrn_stack_type` currently throws `std::runtime_error("get_legacy_int_type")`
when one is on top. That breaks the documented probe-before-pop pattern.

Map the marker to the existing USERINT / STACK_IS_INT category. No new public
function or enum value is needed. Document that both integer representations
can be inspected and consumed through the existing API.

The test replaces the internal `hoc_push_ndim` producer with a genuine indexed
HOC component access through `nrn_function_call_nothrow`. A component hook
installed with the public `nrn_template_set_component_hooks` (#3859) probes and
pops the runtime's real dimension marker, then returns a deliberate provider
error. The test verifies one- and two-dimensional values, preservation of that
error, the restored object argument, released owned references, and lower
stack sentinels. It runs without Python. The unrelated pre-existing symbol-pop
test still uses `hoc_pushs`.

Validation:

- The updated test linked against the unfixed core exits nonzero on the
  marker-type, marker-value, and error checks for both indexed expressions.
  The enclosing nothrow call catches the accessor exception; this reproducer
  demonstrates the wrong error, not a process abort.
- Release build with `NRN_ENABLE_PYTHON=OFF`: all 17 `api::` CTests pass.
- Upstream C++ formatter and `git diff --check` pass.

The same public integer API now supports both probing and popping.
